### PR TITLE
Add changed-file mini diff and project dashboard

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-remote-web",
-  "version": "1.2.5",
+  "version": "1.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-remote-web",
-      "version": "1.2.5",
+      "version": "1.3.9",
       "dependencies": {
         "@capacitor/android": "^8.3.4",
         "@capacitor/cli": "^8.3.4",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencode-remote-web",
   "private": true,
-  "version": "1.2.5",
+  "version": "1.3.9",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import { api } from "./api"
 import { createTranslator, languageOptions, normalizeLanguage, type LanguageCode } from "./i18n"
-import type { CommandInfo, MessageEnvelope, ServerConfig, SessionView, TodoItem } from "./types"
+import type { CommandInfo, DiffFile, FileStatusEntry, MessageEnvelope, ProjectDashboard, ServerConfig, SessionView, TodoItem } from "./types"
 import {
   SettingsIcon,
   FolderIcon,
@@ -81,6 +81,21 @@ function toDisplayLines(text: string): string[] {
     .filter((line, idx, arr) => line.length > 0 || (idx > 0 && arr[idx - 1].length > 0))
 }
 
+function toFileStatusList(input: FileStatusEntry[] | Record<string, FileStatusEntry>): FileStatusEntry[] {
+  if (Array.isArray(input)) return input
+  return Object.entries(input).map(([path, value]) => ({ path, ...value }))
+}
+
+function pickString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null
+}
+
+function summarizeJson(value: unknown): string {
+  if (value === null || value === undefined) return "-"
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return String(value)
+  return JSON.stringify(value)
+}
+
 function App() {
   type NoticeType = "info" | "success" | "error"
 
@@ -112,6 +127,11 @@ function App() {
   const [selectedID, setSelectedID] = useState<string | null>(null)
   const [messages, setMessages] = useState<MessageEnvelope[]>([])
   const [todos, setTodos] = useState<TodoItem[]>([])
+  const [diffFiles, setDiffFiles] = useState<DiffFile[]>([])
+  const [selectedDiffFile, setSelectedDiffFile] = useState<string | null>(null)
+  const [projectDashboard, setProjectDashboard] = useState<ProjectDashboard | null>(null)
+  const [loadingProjectDashboard, setLoadingProjectDashboard] = useState(false)
+  const [dashboardError, setDashboardError] = useState<string | null>(null)
   const [todosExpanded, setTodosExpanded] = useState(false)
   const [query, setQuery] = useState("")
   const [composer, setComposer] = useState("")
@@ -136,6 +156,19 @@ function App() {
     () => sessions.find((session) => session.id === selectedID) ?? null,
     [sessions, selectedID]
   )
+  const selectedDiff = useMemo(
+    () => diffFiles.find((file) => file.file === selectedDiffFile) ?? diffFiles[0] ?? null,
+    [diffFiles, selectedDiffFile]
+  )
+  const projectPath = projectDashboard?.project
+    ? pickString(projectDashboard.project.path) || pickString(projectDashboard.project.directory) || pickString(projectDashboard.project.root)
+    : null
+  const projectName = projectDashboard?.project
+    ? pickString(projectDashboard.project.name) || (projectPath ? projectPath.split("/").filter(Boolean).pop() ?? projectPath : null)
+    : null
+  const vcsBranch = projectDashboard?.vcs
+    ? pickString(projectDashboard.vcs.branch) || pickString(projectDashboard.vcs.status) || summarizeJson(projectDashboard.vcs)
+    : null
 
   const filteredSessions = useMemo(() => {
     const text = query.trim().toLowerCase()
@@ -176,6 +209,10 @@ function App() {
     setSelectedID(sessionID)
     setMessages([])
     setTodos([])
+    setDiffFiles([])
+    setSelectedDiffFile(null)
+    setProjectDashboard(null)
+    setDashboardError(null)
     setAwaitingAssistantReply(false)
     setRuntimeError(null)
     setView("detail")
@@ -256,12 +293,33 @@ function App() {
   }
 
   async function loadSelected(sessionID: string, directory: string) {
-    const [msg, todo] = await Promise.all([
+    const [msg, todo, diff] = await Promise.all([
       api.loadMessages(config, sessionID, directory),
-      api.loadTodo(config, sessionID)
+      api.loadTodo(config, sessionID),
+      api.loadDiff(config, sessionID).catch(() => [])
     ])
     setMessages(msg)
     setTodos(todo)
+    setDiffFiles(diff)
+    setSelectedDiffFile((current) => (current && diff.some((file) => file.file === current) ? current : diff[0]?.file ?? null))
+    await loadProjectDashboard(directory)
+  }
+
+  async function loadProjectDashboard(directory: string) {
+    setLoadingProjectDashboard(true)
+    setDashboardError(null)
+    try {
+      const [project, vcs, fileStatus] = await Promise.all([
+        api.loadProjectCurrent(config, directory).catch(() => null),
+        api.loadVcs(config, directory).catch(() => null),
+        api.loadFileStatus(config, directory).catch(() => [])
+      ])
+      setProjectDashboard({ project, vcs, files: toFileStatusList(fileStatus) })
+    } catch (err) {
+      setDashboardError((err as Error).message)
+    } finally {
+      setLoadingProjectDashboard(false)
+    }
   }
 
   function syncChatBottomClearance() {
@@ -350,6 +408,10 @@ function App() {
         setSelectedID(null)
         setMessages([])
         setTodos([])
+        setDiffFiles([])
+        setSelectedDiffFile(null)
+        setProjectDashboard(null)
+        setDashboardError(null)
         setView("sessions")
       }
       setSessionToDelete(null)
@@ -706,6 +768,72 @@ function App() {
                 )}
               </div>
             </div>
+
+          {selectedSession && (
+            <section className="project-dashboard" aria-label={t('detail.projectDashboardLabel')}>
+              <div className="dashboard-card">
+                <span className="dashboard-label">{t('detail.projectLabel')}</span>
+                <strong>{projectName || selectedSession.directory}</strong>
+                <small>{projectPath || selectedSession.directory}</small>
+              </div>
+              <div className="dashboard-card">
+                <span className="dashboard-label">{t('detail.vcsLabel')}</span>
+                <strong>{loadingProjectDashboard ? t('detail.loadingProject') : vcsBranch || t('detail.unavailable')}</strong>
+                {projectDashboard?.vcs && (
+                  <small>
+                    {t('detail.aheadBehind', { ahead: projectDashboard.vcs.ahead ?? 0, behind: projectDashboard.vcs.behind ?? 0 })}
+                  </small>
+                )}
+              </div>
+              <div className="dashboard-card">
+                <span className="dashboard-label">{t('detail.fileStatusLabel')}</span>
+                <strong>{projectDashboard?.files.length ?? 0}</strong>
+                <small>{dashboardError ? t('detail.dashboardError', { message: dashboardError }) : t('detail.fileStatusSource')}</small>
+              </div>
+            </section>
+          )}
+
+          {diffFiles.length > 0 && (
+            <section className="diff-panel" aria-label={t('detail.miniDiffAria')}>
+              <div className="diff-panel-header">
+                <div>
+                  <h3>{t('detail.changedFilesTitle')}</h3>
+                  <p className="subtle">{t('detail.changedFilesHint')}</p>
+                </div>
+                <span className="change-summary">
+                  <strong>{t('detail.filesCount', { count: diffFiles.length })}</strong>
+                  <strong className="positive">+{diffFiles.reduce((sum, file) => sum + file.additions, 0)}</strong>
+                  <strong className="negative">-{diffFiles.reduce((sum, file) => sum + file.deletions, 0)}</strong>
+                </span>
+              </div>
+              <div className="diff-file-list">
+                {diffFiles.map((file) => (
+                  <button
+                    type="button"
+                    key={file.file}
+                    className={selectedDiff?.file === file.file ? "diff-file active" : "diff-file"}
+                    onClick={() => setSelectedDiffFile(file.file)}
+                  >
+                    <span>{file.file}</span>
+                    <span>
+                      <strong className="positive">+{file.additions}</strong>{" "}
+                      <strong className="negative">-{file.deletions}</strong>
+                    </span>
+                  </button>
+                ))}
+              </div>
+              {selectedDiff && (
+                <div className="mini-diff-card">
+                  <strong>{selectedDiff.file}</strong>
+                  <div className="mini-diff-bars" aria-hidden="true">
+                    <span className="mini-diff-add" style={{ flexGrow: Math.max(selectedDiff.additions, 1) }} />
+                    <span className="mini-diff-del" style={{ flexGrow: Math.max(selectedDiff.deletions, 1) }} />
+                  </div>
+                  <p className="subtle">{t('detail.linesAddedDeleted', { additions: selectedDiff.additions, deletions: selectedDiff.deletions })}</p>
+                </div>
+              )}
+            </section>
+          )}
 
           {todos.length > 0 && (
             <div className="todo-box">

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -2,12 +2,15 @@ import { Capacitor, CapacitorHttp } from "@capacitor/core"
 import type {
   CommandInfo,
   DiffFile,
+  FileStatusEntry,
   HealthResponse,
   MessageEnvelope,
+  ProjectCurrent,
   ServerConfig,
   Session,
   SessionStatus,
-  TodoItem
+  TodoItem,
+  VcsStatus
 } from "./types"
 
 function authHeader(config: ServerConfig): string {
@@ -142,6 +145,18 @@ export const api = {
 
   loadDiff(config: ServerConfig, sessionID: string) {
     return request<DiffFile[]>(config, `/session/${sessionID}/diff`)
+  },
+
+  loadProjectCurrent(config: ServerConfig, directory?: string) {
+    return request<ProjectCurrent>(config, withDirectory("/project/current", directory))
+  },
+
+  loadVcs(config: ServerConfig, directory?: string) {
+    return request<VcsStatus>(config, withDirectory("/vcs", directory))
+  },
+
+  loadFileStatus(config: ServerConfig, directory?: string) {
+    return request<FileStatusEntry[] | Record<string, FileStatusEntry>>(config, withDirectory("/file/status", directory))
   },
 
   sendPrompt(config: ServerConfig, sessionID: string, text: string, directory?: string) {

--- a/web/src/i18n.test.mjs
+++ b/web/src/i18n.test.mjs
@@ -20,5 +20,16 @@ assert.equal(zh('session.deleteTitle'), '刪除工作階段？')
 
 // Unknown keys should remain visible during development instead of rendering blank UI.
 assert.equal(en('missing.key'), 'missing.key')
+assert.equal(en('detail.opencode'), '🤖 OpenCode')
+assert.equal(it('detail.changedFilesTitle'), 'File modificati')
+assert.equal(zh('detail.changedFilesTitle'), '已變更檔案')
+assert.equal(en('detail.linesAddedDeleted', { additions: 3, deletions: 1 }), '+3 lines · -1 lines')
+assert.equal(it('detail.aheadBehind', { ahead: 1, behind: 2 }), '1 avanti · 2 indietro')
+assert.equal(zh('detail.fileStatusSource'), '來自 /file/status')
+assert.equal(en('detail.fileStatusLabel'), 'Changed files')
+assert.equal(it('detail.fileStatusLabel'), 'File modificati')
+assert.equal(zh('detail.fileStatusLabel'), '已變更檔案')
+
+assert.equal(en('todo.title'), 'Todo Items')
 
 console.log('i18n tests passed')

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -53,6 +53,20 @@ type TranslationKey =
   | 'detail.jumpToLatest'
   | 'detail.you'
   | 'detail.opencode'
+  | 'detail.projectDashboardLabel'
+  | 'detail.projectLabel'
+  | 'detail.vcsLabel'
+  | 'detail.loadingProject'
+  | 'detail.unavailable'
+  | 'detail.aheadBehind'
+  | 'detail.fileStatusLabel'
+  | 'detail.fileStatusSource'
+  | 'detail.dashboardError'
+  | 'detail.changedFilesTitle'
+  | 'detail.changedFilesHint'
+  | 'detail.filesCount'
+  | 'detail.miniDiffAria'
+  | 'detail.linesAddedDeleted'
   | 'todo.title'
   | 'todo.hide'
   | 'todo.show'
@@ -121,6 +135,20 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.jumpToLatest': 'Go to latest',
     'detail.you': '👤 You',
     'detail.opencode': '🤖 OpenCode',
+    'detail.projectDashboardLabel': 'Project and VCS dashboard',
+    'detail.projectLabel': 'Project',
+    'detail.vcsLabel': 'VCS',
+    'detail.loadingProject': 'Loading...',
+    'detail.unavailable': 'Unavailable',
+    'detail.aheadBehind': '{ahead} ahead · {behind} behind',
+    'detail.fileStatusLabel': 'Changed files',
+    'detail.fileStatusSource': 'From /file/status',
+    'detail.dashboardError': 'Error: {message}',
+    'detail.changedFilesTitle': 'Changed files',
+    'detail.changedFilesHint': 'Tap a file to see the mini diff.',
+    'detail.filesCount': '{count} files',
+    'detail.miniDiffAria': 'Changed files mini diff',
+    'detail.linesAddedDeleted': '+{additions} lines · -{deletions} lines',
     'todo.title': 'Todo Items',
     'todo.hide': 'Hide',
     'todo.show': 'Show',
@@ -188,6 +216,20 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.jumpToLatest': 'Vai alla fine',
     'detail.you': '👤 Tu',
     'detail.opencode': '🤖 OpenCode',
+    'detail.projectDashboardLabel': 'Dashboard progetto e VCS',
+    'detail.projectLabel': 'Progetto',
+    'detail.vcsLabel': 'VCS',
+    'detail.loadingProject': 'Caricamento...',
+    'detail.unavailable': 'Non disponibile',
+    'detail.aheadBehind': '{ahead} avanti · {behind} indietro',
+    'detail.fileStatusLabel': 'File modificati',
+    'detail.fileStatusSource': 'Da /file/status',
+    'detail.dashboardError': 'Errore: {message}',
+    'detail.changedFilesTitle': 'File modificati',
+    'detail.changedFilesHint': 'Tocca un file per vedere il mini diff.',
+    'detail.filesCount': '{count} file',
+    'detail.miniDiffAria': 'Mini diff dei file modificati',
+    'detail.linesAddedDeleted': '+{additions} righe · -{deletions} righe',
     'todo.title': 'Todo',
     'todo.hide': 'Nascondi',
     'todo.show': 'Mostra',
@@ -255,6 +297,20 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.jumpToLatest': '前往最新',
     'detail.you': '👤 你',
     'detail.opencode': '🤖 OpenCode',
+    'detail.projectDashboardLabel': '專案與 VCS 儀表板',
+    'detail.projectLabel': '專案',
+    'detail.vcsLabel': 'VCS',
+    'detail.loadingProject': '載入中...',
+    'detail.unavailable': '無法取得',
+    'detail.aheadBehind': '超前 {ahead} · 落後 {behind}',
+    'detail.fileStatusLabel': '已變更檔案',
+    'detail.fileStatusSource': '來自 /file/status',
+    'detail.dashboardError': '錯誤：{message}',
+    'detail.changedFilesTitle': '已變更檔案',
+    'detail.changedFilesHint': '點選檔案查看迷你 diff。',
+    'detail.filesCount': '{count} 個檔案',
+    'detail.miniDiffAria': '已變更檔案迷你 diff',
+    'detail.linesAddedDeleted': '+{additions} 行 · -{deletions} 行',
     'todo.title': '待辦事項',
     'todo.hide': '隱藏',
     'todo.show': '顯示',

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -437,6 +437,103 @@ p {
   flex: 0 0 auto;
 }
 
+.project-dashboard,
+.diff-panel {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface-subtle);
+  padding: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.project-dashboard {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.dashboard-card {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.dashboard-card strong,
+.dashboard-card small,
+.diff-file span:first-child,
+.mini-diff-card strong {
+  overflow-wrap: anywhere;
+}
+
+.dashboard-card small {
+  color: var(--muted);
+}
+
+.dashboard-label {
+  color: var(--muted-strong);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.diff-panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.diff-file-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.diff-file {
+  width: 100%;
+  min-height: 44px;
+  justify-content: space-between;
+  border-color: var(--border);
+  background: var(--surface);
+  text-align: left;
+}
+
+.diff-file.active {
+  border-color: var(--primary);
+  background: var(--primary-soft);
+}
+
+.mini-diff-card {
+  margin-top: var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  padding: var(--space-3);
+}
+
+.mini-diff-bars {
+  height: 10px;
+  display: flex;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--surface-strong);
+  margin: var(--space-2) 0;
+}
+
+.mini-diff-add {
+  background: var(--success);
+}
+
+.mini-diff-del {
+  background: var(--danger);
+}
+
 .messages-wrap {
   position: relative;
   flex: 1 1 auto;
@@ -839,6 +936,19 @@ p {
 
   .session-stats {
     gap: var(--space-2);
+  }
+
+  .project-dashboard {
+    grid-template-columns: 1fr;
+  }
+
+  .diff-panel-header {
+    flex-direction: column;
+  }
+
+  .diff-file {
+    align-items: flex-start;
+    flex-direction: column;
   }
 
   .detail {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -62,6 +62,32 @@ export type DiffFile = {
   deletions: number
 }
 
+export type ProjectCurrent = Record<string, unknown> & {
+  name?: string
+  path?: string
+  directory?: string
+  root?: string
+}
+
+export type VcsStatus = Record<string, unknown> & {
+  branch?: string
+  status?: string
+  ahead?: number
+  behind?: number
+}
+
+export type FileStatusEntry = Record<string, unknown> & {
+  path?: string
+  file?: string
+  status?: string
+}
+
+export type ProjectDashboard = {
+  project: ProjectCurrent | null
+  vcs: VcsStatus | null
+  files: FileStatusEntry[]
+}
+
 export type SessionView = {
   id: string
   title: string

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -27,6 +27,15 @@ assert.ok(app.includes('typing-bubble'), 'detail view should render a temporary 
 assert.ok(app.includes('typing-dot'), 'typing bubble should show animated dots')
 assert.ok(app.includes('awaitingAssistantReply'), 'typing bubble should stay visible after the send request returns and until a new assistant message arrives')
 assert.ok(app.includes('assistantResponseSignature'), 'typing bubble should be replaced by the next assistant response')
+assert.ok(app.includes('api.loadDiff(config, sessionID)'), 'detail view should load /session/:id/diff for changed-file details')
+assert.ok(app.includes('diffFiles.length > 0'), 'changed-file panel should be hidden when there are no changed files')
+assert.ok(app.includes('className={selectedDiff?.file === file.file ? "diff-file active" : "diff-file"}'), 'changed files should be clickable and show selected state')
+assert.ok(app.includes('mini-diff-card'), 'detail view should render a compact per-file mini diff card')
+assert.ok(app.includes('api.loadProjectCurrent(config, directory)'), 'project dashboard should use /project/current')
+assert.ok(app.includes('api.loadVcs(config, directory)'), 'project dashboard should use /vcs')
+assert.ok(app.includes('api.loadFileStatus(config, directory)'), 'project dashboard should use /file/status')
+assert.ok(/\.project-dashboard[\s\S]*?grid-template-columns:\s*repeat\(3/.test(styles), 'project dashboard should render as compact cards on wide screens')
+assert.ok(/@media \(max-width: 780px\)[\s\S]*?\.project-dashboard[\s\S]*?grid-template-columns:\s*1fr/.test(styles), 'project dashboard should stack on mobile')
 
 assert.match(icons, /export const RefreshIcon/, 'RefreshIcon should exist for idle refresh UI')
 


### PR DESCRIPTION
## Summary
- add a localized Project/VCS dashboard in session detail using /project/current, /vcs, and /file/status
- add clickable changed-file list from /session/:id/diff with a compact per-file mini diff
- update i18n coverage for en, it, and zh-TW
- bump debug APK version to 1.3.9 / 10309

## Verification
- npm run test:i18n
- npm run test:ui
- npm run build
- npx cap sync android
- JAVA_HOME=/home/giulio/.cache/hermes-jdks/jdk-21 ANDROID_HOME=/home/giulio/Android/Sdk ./gradlew assembleDebug --stacktrace --no-daemon
- aapt dump badging app-debug.apk => versionName 1.3.9, versionCode 10309
- apksigner verify --verbose --print-certs app-debug.apk => v2 verified
