### PR TITLE
Add per-session project folder picker

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import { api } from "./api"
 import { createTranslator, languageOptions, normalizeLanguage, type LanguageCode } from "./i18n"
-import type { CommandInfo, DiffFile, FileStatusEntry, MessageEnvelope, ModelOption, ModelSelection, ProjectDashboard, ServerConfig, SessionView, TodoItem } from "./types"
+import type { CommandInfo, DiffFile, FileEntry, FileStatusEntry, MessageEnvelope, ModelOption, ModelSelection, ProjectDashboard, ServerConfig, SessionView, TodoItem } from "./types"
 import {
   SettingsIcon,
   FolderIcon,
@@ -21,6 +21,7 @@ import {
 const STORAGE_KEY = "opencode.remote.server"
 const LANGUAGE_STORAGE_KEY = "opencode.remote.language"
 const MODEL_STORAGE_KEY = "opencode.remote.model"
+const NEW_SESSION_DIRECTORY_STORAGE_KEY = "opencode.remote.newSessionDirectory"
 
 const defaultConfig: ServerConfig = {
   host: "",
@@ -131,6 +132,11 @@ function sameModel(a: ModelSelection | null | undefined, b: ModelSelection | nul
   return Boolean(a && b && a.providerID === b.providerID && a.modelID === b.modelID && (a.variant ?? "") === (b.variant ?? ""))
 }
 
+function normalizeDirectory(value: string): string | undefined {
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
 function formatLimit(value?: number): string {
   if (!value) return "-"
   if (value >= 1_000_000) return `${Math.round(value / 1_000_000)}M`
@@ -189,6 +195,12 @@ function App() {
 
   const [sessions, setSessions] = useState<SessionView[]>([])
   const [selectedID, setSelectedID] = useState<string | null>(null)
+  const [newSessionDirectory, setNewSessionDirectory] = useState(() => localStorage.getItem(NEW_SESSION_DIRECTORY_STORAGE_KEY) ?? "")
+  const [showNewSessionPicker, setShowNewSessionPicker] = useState(false)
+  const [pickerPath, setPickerPath] = useState("")
+  const [pickerItems, setPickerItems] = useState<FileEntry[]>([])
+  const [pickerLoading, setPickerLoading] = useState(false)
+  const [pickerError, setPickerError] = useState<string | null>(null)
   const [messages, setMessages] = useState<MessageEnvelope[]>([])
   const [optimisticUserMessages, setOptimisticUserMessages] = useState<MessageEnvelope[]>([])
   const [todos, setTodos] = useState<TodoItem[]>([])
@@ -266,6 +278,7 @@ function App() {
       return session.title.toLowerCase().includes(text) || session.directory.toLowerCase().includes(text)
     })
   }, [sessions, query])
+  const selectedNewSessionDirectory = normalizeDirectory(newSessionDirectory)
 
   const renderedMessages = useMemo(() => {
     return [...messages, ...optimisticUserMessages]
@@ -442,7 +455,7 @@ function App() {
   async function loadModels() {
     if (!config.host || config.port <= 0) return
     try {
-      const list = await api.listModels(config, selectedSession?.directory)
+      const list = await api.listModels(config, selectedSession?.directory ?? selectedNewSessionDirectory)
       setModelOptions(list)
       setModelLoadError(null)
       const saved = modelFromKey(selectedModelKey)
@@ -469,8 +482,8 @@ function App() {
     const requestID = ++loadSelectedRequestRef.current
     const [msg, todo, diff] = await Promise.all([
       api.loadMessages(config, sessionID, directory),
-      api.loadTodo(config, sessionID),
-      api.loadDiff(config, sessionID).catch(() => [])
+      api.loadTodo(config, sessionID, directory),
+      api.loadDiff(config, sessionID, directory).catch(() => [])
     ])
     if (requestID !== loadSelectedRequestRef.current) return
     setMessages((current) => {
@@ -533,12 +546,53 @@ function App() {
     })
   }
 
-  async function createSession() {
+  async function browseNewSessionDirectory(path: string) {
+    setPickerLoading(true)
+    setPickerError(null)
+    try {
+      const items = await api.listFiles(config, path, path)
+      setPickerPath(path)
+      setPickerItems(items.filter((item) => item.type === "directory").sort((a, b) => a.name.localeCompare(b.name)))
+    } catch (err) {
+      setPickerError((err as Error).message)
+      setPickerItems([])
+    } finally {
+      setPickerLoading(false)
+    }
+  }
+
+  async function openNewSessionPicker() {
+    if (creatingSession) return
+    setRuntimeError(null)
+    setShowNewSessionPicker(true)
+    setPickerError(null)
+    try {
+      const pathInfo = await api.loadPath(config, selectedNewSessionDirectory)
+      await browseNewSessionDirectory(selectedNewSessionDirectory ?? pathInfo.directory)
+    } catch (err) {
+      setPickerError((err as Error).message)
+    }
+  }
+
+  function parentDirectory(path: string): string | null {
+    if (!path || path === "/") return null
+    const normalized = path.replace(/[/\\]+$/, "")
+    const separator = normalized.includes("\\") ? "\\" : "/"
+    const index = normalized.lastIndexOf(separator)
+    if (index <= 0) return separator === "/" ? "/" : null
+    return normalized.slice(0, index)
+  }
+
+  async function createSession(directory = selectedNewSessionDirectory) {
     if (creatingSession) return
     setCreatingSession(true)
     setRuntimeError(null)
     try {
-      const created = await api.createSession(config, "Mobile session", activeModel)
+      const created = await api.createSession(config, "Mobile session", activeModel, directory)
+      if (directory) {
+        setNewSessionDirectory(directory)
+      }
+      setShowNewSessionPicker(false)
       await refreshSessions()
       setSelectedID(created.id)
       setView("detail")
@@ -590,7 +644,7 @@ function App() {
 
   async function deleteSession(sessionID: string) {
     try {
-      await api.deleteSession(config, sessionID)
+      await api.deleteSession(config, sessionID, sessionToDelete?.directory)
       if (selectedID === sessionID) {
         setSelectedID(null)
         setMessages([])
@@ -612,7 +666,7 @@ function App() {
   async function abortSession() {
     if (!selectedSession) return
     try {
-      await api.abort(config, selectedSession.id)
+      await api.abort(config, selectedSession.id, selectedSession.directory)
       completionShouldPlayRef.current = false
       setAwaitingAssistantReply(false)
       await refreshSessions()
@@ -625,6 +679,10 @@ function App() {
   useEffect(() => {
     localStorage.setItem(LANGUAGE_STORAGE_KEY, language)
   }, [language])
+
+  useEffect(() => {
+    localStorage.setItem(NEW_SESSION_DIRECTORY_STORAGE_KEY, newSessionDirectory)
+  }, [newSessionDirectory])
 
   useEffect(() => {
     if (!config.host || config.port <= 0) {
@@ -646,7 +704,7 @@ function App() {
       }
     }, 3500)
     return () => clearInterval(timer)
-  }, [config.host, config.port, config.username, config.password, selectedSession?.id])
+  }, [config.host, config.port, config.username, config.password, selectedSession?.id, selectedNewSessionDirectory])
 
   useEffect(() => {
     if (!hasConfiguredServer) {
@@ -868,7 +926,7 @@ function App() {
                 {refreshingSessions ? <LoadingIcon size={18} /> : <RefreshIcon size={18} />}
                 {t('sessions.refresh')}
               </button>
-              <button onClick={createSession} className="btn-primary" disabled={creatingSession}>
+              <button onClick={openNewSessionPicker} className="btn-primary" disabled={creatingSession}>
                 {creatingSession ? <LoadingIcon size={18} /> : <PlusIcon size={18} />}
                 {creatingSession ? t('sessions.creating') : t('sessions.new')}
               </button>
@@ -960,6 +1018,62 @@ function App() {
           
           {runtimeError && <div className="error fade-in">✗ {runtimeError}</div>}
         </section>
+      )}
+
+      {showNewSessionPicker && (
+        <div className="modal-backdrop" role="presentation" onClick={() => setShowNewSessionPicker(false)}>
+          <section
+            className="modal-card folder-picker fade-in"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="new-session-title"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <h2 id="new-session-title">{t('sessions.newSessionTitle')}</h2>
+            <p className="subtle">{t('sessions.projectDirectoryDefault')}</p>
+            <div className="folder-picker-current">
+              <span>{t('sessions.projectDirectoryLabel')}</span>
+              <strong>{pickerPath || t('detail.loadingProject')}</strong>
+            </div>
+            <div className="inline-actions">
+              <button type="button" className="btn-secondary" onClick={() => createSession("").catch(() => undefined)} disabled={creatingSession}>
+                {t('sessions.useServerDefault')}
+              </button>
+              <button type="button" className="btn-primary" onClick={() => createSession(pickerPath).catch(() => undefined)} disabled={creatingSession || !pickerPath}>
+                {creatingSession ? <LoadingIcon size={16} /> : <PlusIcon size={16} />}
+                {t('sessions.useThisFolder')}
+              </button>
+            </div>
+            {pickerError && <div className="error fade-in">✗ {pickerError}</div>}
+            <div className="folder-list">
+              {pickerLoading ? (
+                <div className="empty-state compact"><LoadingIcon size={28} /><p>{t('sessions.folderPickerLoading')}</p></div>
+              ) : (
+                <>
+                  {parentDirectory(pickerPath) && (
+                    <button type="button" className="folder-row" onClick={() => browseNewSessionDirectory(parentDirectory(pickerPath) ?? pickerPath).catch(() => undefined)}>
+                      <FolderIcon size={16} />
+                      <span>{t('sessions.parentFolder')}</span>
+                    </button>
+                  )}
+                  {pickerItems.length === 0 ? (
+                    <p className="subtle">{t('sessions.folderPickerEmpty')}</p>
+                  ) : pickerItems.map((item) => (
+                    <button key={item.absolute} type="button" className="folder-row" onClick={() => browseNewSessionDirectory(item.absolute).catch(() => undefined)}>
+                      <FolderIcon size={16} />
+                      <span>{item.name}</span>
+                    </button>
+                  ))}
+                </>
+              )}
+            </div>
+            <div className="modal-actions">
+              <button className="btn-secondary" onClick={() => setShowNewSessionPicker(false)}>
+                {t('session.cancel')}
+              </button>
+            </div>
+          </section>
+        </div>
       )}
 
       {view === "detail" && (

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -3,11 +3,13 @@ import type {
   CommandInfo,
   DiffFile,
   FileStatusEntry,
+  FileEntry,
   HealthResponse,
   MessageEnvelope,
   ModelOption,
   ModelSelection,
   ProjectCurrent,
+  PathInfo,
   ServerConfig,
   Session,
   SessionStatus,
@@ -151,12 +153,20 @@ export const api = {
     return request<HealthResponse>(config, "/global/health")
   },
 
-  listSessions(config: ServerConfig) {
-    return request<Session[]>(config, "/session")
+  listSessions(config: ServerConfig, directory?: string) {
+    return request<Session[]>(config, withDirectory("/session", directory))
   },
 
-  listStatuses(config: ServerConfig) {
-    return request<Record<string, SessionStatus>>(config, "/session/status")
+  listStatuses(config: ServerConfig, directory?: string) {
+    return request<Record<string, SessionStatus>>(config, withDirectory("/session/status", directory))
+  },
+
+  loadPath(config: ServerConfig, directory?: string) {
+    return request<PathInfo>(config, withDirectory("/path", directory))
+  },
+
+  listFiles(config: ServerConfig, path: string, directory?: string) {
+    return request<FileEntry[]>(config, withDirectory(`/file?path=${encodeURIComponent(path)}`, directory))
   },
 
   listCommands(config: ServerConfig) {
@@ -189,28 +199,28 @@ export const api = {
     })
   },
 
-  createSession(config: ServerConfig, title?: string, model?: ModelSelection) {
-    return request<Session>(config, "/session", { method: "POST", body: { title, model: toCreateSessionModel(model) } })
+  createSession(config: ServerConfig, title?: string, model?: ModelSelection, directory?: string) {
+    return request<Session>(config, withDirectory("/session", directory), { method: "POST", body: { title, model: toCreateSessionModel(model) } })
   },
 
-  renameSession(config: ServerConfig, id: string, title: string) {
-    return request<Session>(config, `/session/${id}`, { method: "PATCH", body: { title } })
+  renameSession(config: ServerConfig, id: string, title: string, directory?: string) {
+    return request<Session>(config, withDirectory(`/session/${id}`, directory), { method: "PATCH", body: { title } })
   },
 
-  deleteSession(config: ServerConfig, id: string) {
-    return request<boolean>(config, `/session/${id}`, { method: "DELETE" })
+  deleteSession(config: ServerConfig, id: string, directory?: string) {
+    return request<boolean>(config, withDirectory(`/session/${id}`, directory), { method: "DELETE" })
   },
 
   loadMessages(config: ServerConfig, sessionID: string, directory?: string) {
     return request<MessageEnvelope[]>(config, withDirectory(`/session/${sessionID}/message?limit=100`, directory))
   },
 
-  loadTodo(config: ServerConfig, sessionID: string) {
-    return request<TodoItem[]>(config, `/session/${sessionID}/todo`)
+  loadTodo(config: ServerConfig, sessionID: string, directory?: string) {
+    return request<TodoItem[]>(config, withDirectory(`/session/${sessionID}/todo`, directory))
   },
 
-  loadDiff(config: ServerConfig, sessionID: string) {
-    return request<DiffFile[]>(config, `/session/${sessionID}/diff`)
+  loadDiff(config: ServerConfig, sessionID: string, directory?: string) {
+    return request<DiffFile[]>(config, withDirectory(`/session/${sessionID}/diff`, directory))
   },
 
   loadProjectCurrent(config: ServerConfig, directory?: string) {
@@ -239,8 +249,8 @@ export const api = {
     })
   },
 
-  abort(config: ServerConfig, sessionID: string) {
-    return request<boolean>(config, `/session/${sessionID}/abort`, {
+  abort(config: ServerConfig, sessionID: string, directory?: string) {
+    return request<boolean>(config, withDirectory(`/session/${sessionID}/abort`, directory), {
       method: "POST",
       body: {}
     })

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -51,6 +51,16 @@ type TranslationKey =
   | 'sessions.new'
   | 'sessions.creating'
   | 'sessions.refresh'
+  | 'sessions.projectDirectoryLabel'
+  | 'sessions.projectDirectoryPlaceholder'
+  | 'sessions.projectDirectoryActive'
+  | 'sessions.projectDirectoryDefault'
+  | 'sessions.newSessionTitle'
+  | 'sessions.useServerDefault'
+  | 'sessions.useThisFolder'
+  | 'sessions.parentFolder'
+  | 'sessions.folderPickerLoading'
+  | 'sessions.folderPickerEmpty'
   | 'sessions.searchPlaceholder'
   | 'sessions.emptyTitle'
   | 'sessions.emptyHint'
@@ -166,6 +176,16 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'sessions.new': 'New Session',
     'sessions.creating': 'Creating...',
     'sessions.refresh': 'Refresh',
+    'sessions.projectDirectoryLabel': 'Selected folder',
+    'sessions.projectDirectoryPlaceholder': '/home/you/project or C:\\Projects\\App',
+    'sessions.projectDirectoryActive': 'New sessions use {directory}.',
+    'sessions.projectDirectoryDefault': 'Choose the folder for this new session, or use the server default directory.',
+    'sessions.newSessionTitle': 'New session folder',
+    'sessions.useServerDefault': 'Use server default',
+    'sessions.useThisFolder': 'Create here',
+    'sessions.parentFolder': 'Parent folder',
+    'sessions.folderPickerLoading': 'Loading folders...',
+    'sessions.folderPickerEmpty': 'No folders here.',
     'sessions.searchPlaceholder': 'Search sessions by title or directory...',
     'sessions.emptyTitle': 'No sessions found',
     'sessions.emptyHint': 'Create a new session to get started',
@@ -283,6 +303,16 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'sessions.new': 'Nuova sessione',
     'sessions.creating': 'Creazione...',
     'sessions.refresh': 'Aggiorna',
+    'sessions.projectDirectoryLabel': 'Cartella selezionata',
+    'sessions.projectDirectoryPlaceholder': '/home/utente/progetto o C:\\Projects\\App',
+    'sessions.projectDirectoryActive': 'La nuova sessione userà {directory}.',
+    'sessions.projectDirectoryDefault': 'Scegli la cartella per questa nuova sessione, oppure usa la directory predefinita del server.',
+    'sessions.newSessionTitle': 'Cartella nuova sessione',
+    'sessions.useServerDefault': 'Usa default server',
+    'sessions.useThisFolder': 'Crea qui',
+    'sessions.parentFolder': 'Cartella superiore',
+    'sessions.folderPickerLoading': 'Caricamento cartelle...',
+    'sessions.folderPickerEmpty': 'Nessuna cartella qui.',
     'sessions.searchPlaceholder': 'Cerca sessioni per titolo o directory...',
     'sessions.emptyTitle': 'Nessuna sessione trovata',
     'sessions.emptyHint': 'Crea una nuova sessione per iniziare',
@@ -400,6 +430,16 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'sessions.new': '新增工作階段',
     'sessions.creating': '建立中...',
     'sessions.refresh': '重新整理',
+    'sessions.projectDirectoryLabel': '已選資料夾',
+    'sessions.projectDirectoryPlaceholder': '/home/you/project 或 C:\\Projects\\App',
+    'sessions.projectDirectoryActive': '新工作階段會使用 {directory}。',
+    'sessions.projectDirectoryDefault': '為這個新工作階段選擇資料夾，或使用伺服器預設目錄。',
+    'sessions.newSessionTitle': '新工作階段資料夾',
+    'sessions.useServerDefault': '使用伺服器預設',
+    'sessions.useThisFolder': '在這裡建立',
+    'sessions.parentFolder': '上一層資料夾',
+    'sessions.folderPickerLoading': '正在載入資料夾...',
+    'sessions.folderPickerEmpty': '這裡沒有資料夾。',
     'sessions.searchPlaceholder': '依標題或目錄搜尋工作階段...',
     'sessions.emptyTitle': '找不到工作階段',
     'sessions.emptyHint': '建立新的工作階段以開始',

--- a/web/src/model-regression.test.mjs
+++ b/web/src/model-regression.test.mjs
@@ -16,7 +16,7 @@ assert.ok(app.includes('session-context-strip'), 'detail UX should expose compac
 assert.ok(app.includes('activeDetailSheet === "ai"'), 'model picker should open in the bottom sheet')
 assert.ok(app.includes("t('detail.modelHint')"), 'model picker should explain when the change applies')
 assert.ok(app.includes('disabled={isWorking}'), 'model picker should be disabled while a session is running')
-assert.ok(app.includes('api.createSession(config, "Mobile session", activeModel)'), 'new sessions should inherit the selected model')
+assert.ok(app.includes('api.createSession(config, "Mobile session", activeModel, directory)'), 'new sessions should inherit the selected model')
 assert.ok(app.includes('api.sendPrompt(config, selectedSession.id, text, selectedSession.directory, activeModel)'), 'chat prompts should use selected model')
 assert.ok(app.includes('showFilesChip = diffFiles.length > 0'), 'file diff chip should be hidden for dialogue-only sessions')
 assert.ok(i18n.includes("'detail.contextStripLabel'"), 'context chip strings should be translated')

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -360,6 +360,46 @@ p {
   margin-bottom: var(--space-3);
 }
 
+.folder-picker {
+  max-height: min(80vh, 680px);
+  overflow: hidden;
+}
+
+.folder-picker-current {
+  display: grid;
+  gap: var(--space-1);
+  margin: var(--space-3) 0;
+  padding: var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-subtle);
+  overflow-wrap: anywhere;
+}
+
+.folder-picker-current span {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.folder-list {
+  display: grid;
+  gap: var(--space-2);
+  max-height: 42vh;
+  margin-top: var(--space-3);
+  overflow-y: auto;
+}
+
+.folder-row {
+  justify-content: flex-start;
+  width: 100%;
+  background: var(--surface);
+  border-color: var(--border);
+  color: var(--text);
+}
+
 .search {
   margin: 0;
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -104,6 +104,22 @@ export type FileStatusEntry = Record<string, unknown> & {
   status?: string
 }
 
+export type FileEntry = {
+  name: string
+  path: string
+  absolute: string
+  type: "file" | "directory"
+  ignored?: boolean
+}
+
+export type PathInfo = {
+  home: string
+  state: string
+  config: string
+  worktree: string
+  directory: string
+}
+
 export type ProjectDashboard = {
   project: ProjectCurrent | null
   vcs: VcsStatus | null

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 
 const app = readFileSync(new URL('./App.tsx', import.meta.url), 'utf8')
+const api = readFileSync(new URL('./api.ts', import.meta.url), 'utf8')
 const icons = readFileSync(new URL('./Icons.tsx', import.meta.url), 'utf8')
 const styles = readFileSync(new URL('./styles.css', import.meta.url), 'utf8')
 
@@ -39,7 +40,7 @@ assert.ok(app.includes('assistantPayloadLength(current) > assistantPayloadLength
 assert.ok(app.includes('SendIcon') && app.includes('<SendIcon size={18} />'), 'composer send button should use the clear paper-plane SendIcon')
 assert.ok(app.includes('StopCircleIcon') && app.includes('<StopCircleIcon size={18} />'), 'composer waiting button should use a clear stop-task icon')
 assert.match(icons, /export const StopCircleIcon/, 'StopCircleIcon should exist in the shared SVG icon set')
-assert.ok(app.includes('api.loadDiff(config, sessionID)'), 'detail view should load /session/:id/diff for changed-file details')
+assert.ok(app.includes('api.loadDiff(config, sessionID, directory)'), 'detail view should load /session/:id/diff for changed-file details')
 assert.ok(app.includes('diffFiles.length > 0'), 'changed-file panel should be hidden when there are no changed files')
 assert.ok(app.includes('className={selectedDiff?.file === file.file ? "diff-file active" : "diff-file"}'), 'changed files should be clickable and show selected state')
 assert.ok(app.includes('mini-diff-card'), 'detail view should render a compact per-file mini diff card')
@@ -54,6 +55,17 @@ assert.ok(app.includes('backgroundFailureCountRef.current >= 3'), 'transient 1-2
 assert.ok(app.includes('connection-pending'), 'initial slow connection should show an explicit loading state instead of an empty sessions list')
 assert.ok(app.includes("t('connection.reconnecting')"), 'slow reconnecting state should be translated and shown quietly')
 assert.ok(styles.includes('.connection-status'), 'connection status should have a dedicated non-error visual treatment')
+assert.ok(app.includes('NEW_SESSION_DIRECTORY_STORAGE_KEY'), 'last new-session folder should persist separately from connection settings')
+assert.ok(app.includes('showNewSessionPicker'), 'New Session should open a per-session folder picker instead of applying one global folder')
+assert.ok(app.includes('api.loadPath(config, selectedNewSessionDirectory)'), 'folder picker should start from OpenCode /path')
+assert.ok(api.includes('listFiles(config: ServerConfig, path: string, directory?: string)'), 'API should expose OpenCode /file for directory browsing')
+assert.ok(app.includes("t('sessions.projectDirectoryLabel')"), 'folder picker should be localized')
+assert.ok(app.includes('api.createSession(config, "Mobile session", activeModel, directory)'), 'new sessions should pass only the picked directory to OpenCode')
+assert.ok(api.includes('createSession(config: ServerConfig, title?: string, model?: ModelSelection, directory?: string)'), 'createSession API should accept a directory')
+assert.ok(api.includes('withDirectory("/session", directory)'), 'new session creation should append ?directory= when set')
+assert.ok(api.includes('loadTodo(config: ServerConfig, sessionID: string, directory?: string)'), 'todo requests should be directory-aware')
+assert.ok(api.includes('loadDiff(config: ServerConfig, sessionID: string, directory?: string)'), 'diff requests should be directory-aware')
+assert.ok(api.includes('abort(config: ServerConfig, sessionID: string, directory?: string)'), 'abort requests should be directory-aware')
 
 assert.match(icons, /export const RefreshIcon/, 'RefreshIcon should exist for idle refresh UI')
 


### PR DESCRIPTION
## Summary
- Replace the global project-directory field with a per-new-session folder picker
- Browse folders via the official OpenCode `/path` and `/file` APIs; no manual path typing required
- Create the selected new session with OpenCode `?directory=` while existing sessions keep their own directory
- Keep session message/todo/diff/abort and project/VCS/file/model calls directory-aware for the selected session
- Add EN/IT/zh-TW translations and regression checks

## Verification
- `npm run test:ui`
- `npm run test:i18n`
- `npm run test:settings`
- `npm run test:model`
- `npm run build`
- `npx cap sync android`
- `JAVA_HOME=/home/giulio/.cache/hermes-jdks/jdk-21 ANDROID_HOME=$HOME/Android/Sdk ./gradlew assembleDebug --stacktrace --no-daemon`
- `aapt dump badging web/android/app/build/outputs/apk/debug/app-debug.apk`
- `apksigner verify --verbose --print-certs web/android/app/build/outputs/apk/debug/app-debug.apk`