### PR TITLE
Use OpenCode async prompt endpoint

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -163,6 +163,15 @@ function createOptimisticUserMessage(sessionID: string, text: string): MessageEn
   }
 }
 
+function hasMatchingUserMessage(messages: MessageEnvelope[], optimistic: MessageEnvelope): boolean {
+  const text = extractText(optimistic)
+  return messages.some((message) => (
+    message.info.sessionID === optimistic.info.sessionID &&
+    message.info.role === "user" &&
+    extractText(message) === text
+  ))
+}
+
 function App() {
   type NoticeType = "info" | "success" | "error"
 
@@ -490,6 +499,7 @@ function App() {
       if (assistantPayloadLength(current) > assistantPayloadLength(msg)) return current
       return msg
     })
+    setOptimisticUserMessages((current) => current.filter((message) => !hasMatchingUserMessage(msg, message)))
     setTodos(todo)
     setDiffFiles(diff)
     setSelectedDiffFile((current) => (current && diff.some((file) => file.file === current) ? current : diff[0]?.file ?? null))
@@ -625,11 +635,12 @@ function App() {
         const args = normalized.slice(command.length).trim()
         if (!command) return
         await api.sendCommand(config, selectedSession.id, command, args, selectedSession.directory, activeModel)
+        await loadSelected(selectedSession.id, selectedSession.directory)
+        setOptimisticUserMessages((current) => current.filter((message) => message.info.id !== optimisticMessage.info.id))
       } else {
         await api.sendPrompt(config, selectedSession.id, text, selectedSession.directory, activeModel)
+        await loadSelected(selectedSession.id, selectedSession.directory)
       }
-      await loadSelected(selectedSession.id, selectedSession.directory)
-      setOptimisticUserMessages((current) => current.filter((message) => message.info.id !== optimisticMessage.info.id))
       await refreshSessions()
     } catch (err) {
       completionShouldPlayRef.current = false

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -236,7 +236,7 @@ export const api = {
   },
 
   sendPrompt(config: ServerConfig, sessionID: string, text: string, directory?: string, model?: ModelSelection) {
-    return request<MessageEnvelope>(config, withDirectory(`/session/${sessionID}/message`, directory), {
+    return request<boolean>(config, withDirectory(`/session/${sessionID}/prompt_async`, directory), {
       method: "POST",
       body: { parts: [{ type: "text", text }], model: toModelBody(model), variant: model?.variant || undefined }
     })

--- a/web/src/model-regression.test.mjs
+++ b/web/src/model-regression.test.mjs
@@ -8,6 +8,8 @@ const styles = readFileSync(new URL('./styles.css', import.meta.url), 'utf8')
 
 assert.ok(api.includes('listModels(config: ServerConfig'), 'API should expose configured OpenCode models')
 assert.ok(api.includes('withDirectory("/config/providers"'), 'model list should use official /config/providers with directory scoping')
+assert.ok(api.includes('`/session/${sessionID}/prompt_async`'), 'chat prompts should use OpenCode async prompt endpoint')
+assert.ok(api.includes('return request<boolean>(config, withDirectory(`/session/${sessionID}/prompt_async`, directory)'), 'async prompt should return after 204 instead of waiting for assistant output')
 assert.ok(api.includes('model: toModelBody(model)'), 'prompt requests should send selected model object')
 assert.ok(api.includes('variant: model?.variant || undefined'), 'prompt requests should preserve selected model variant')
 assert.ok(api.includes('toCreateSessionModel'), 'new sessions should be creatable with the selected model')


### PR DESCRIPTION
## Summary
- Send normal chat prompts through OpenCode `/session/:id/prompt_async` instead of the blocking `/message` endpoint
- Keep the optimistic user bubble until the real user message appears, so async prompt dispatch does not flicker or lose the sent prompt
- Keep slash commands on the existing synchronous command endpoint
- Add regression coverage for async prompt wiring

## Verification
- `npm run test:ui`
- `npm run test:i18n`
- `npm run test:settings`
- `npm run test:model`
- `npm run build`
- `npx cap sync android`
- `JAVA_HOME=/home/giulio/.cache/hermes-jdks/jdk-21 ANDROID_HOME=$HOME/Android/Sdk ./gradlew assembleDebug --stacktrace --no-daemon`
- `aapt dump badging web/android/app/build/outputs/apk/debug/app-debug.apk`
- `apksigner verify --verbose --print-certs web/android/app/build/outputs/apk/debug/app-debug.apk`

## APK
`web/android/app/build/outputs/apk/debug/app-debug.apk`

SHA256: `0cd0fc1d41fa5e9eea9881dbd150d913f6fbf9f7c17aa5ea98d9788178b771e0`