### PR TITLE
Add dark mode theme setting

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,6 +21,7 @@ import {
 const STORAGE_KEY = "opencode.remote.server"
 const LANGUAGE_STORAGE_KEY = "opencode.remote.language"
 const MODEL_STORAGE_KEY = "opencode.remote.model"
+const THEME_STORAGE_KEY = "opencode.remote.theme"
 const NEW_SESSION_DIRECTORY_STORAGE_KEY = "opencode.remote.newSessionDirectory"
 
 const defaultConfig: ServerConfig = {
@@ -174,6 +175,7 @@ function hasMatchingUserMessage(messages: MessageEnvelope[], optimistic: Message
 
 function App() {
   type NoticeType = "info" | "success" | "error"
+  type ThemePreference = "system" | "light" | "dark"
 
   const [config, setConfig] = useState<ServerConfig>(() => {
     const saved = localStorage.getItem(STORAGE_KEY)
@@ -186,6 +188,10 @@ function App() {
   })
   const [language, setLanguage] = useState<LanguageCode>(() => {
     return normalizeLanguage(localStorage.getItem(LANGUAGE_STORAGE_KEY) || navigator.language)
+  })
+  const [theme, setTheme] = useState<ThemePreference>(() => {
+    const saved = localStorage.getItem(THEME_STORAGE_KEY)
+    return saved === "light" || saved === "dark" || saved === "system" ? saved : "system"
   })
   const t = useMemo(() => createTranslator(language), [language])
 
@@ -692,6 +698,21 @@ function App() {
   }, [language])
 
   useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
+
+    function applyThemePreference() {
+      const resolvedTheme = theme === "system" && mediaQuery.matches ? "dark" : theme === "dark" ? "dark" : "light"
+      document.documentElement.dataset.theme = resolvedTheme
+      document.documentElement.style.colorScheme = resolvedTheme
+    }
+
+    localStorage.setItem(THEME_STORAGE_KEY, theme)
+    applyThemePreference()
+    mediaQuery.addEventListener("change", applyThemePreference)
+    return () => mediaQuery.removeEventListener("change", applyThemePreference)
+  }, [theme])
+
+  useEffect(() => {
     localStorage.setItem(NEW_SESSION_DIRECTORY_STORAGE_KEY, newSessionDirectory)
   }, [newSessionDirectory])
 
@@ -819,6 +840,19 @@ function App() {
               {languageOptions.map((option) => (
                 <option key={option.code} value={option.code}>{option.label}</option>
               ))}
+            </select>
+          </label>
+
+          <label htmlFor="theme">
+            {t('settings.theme')}
+            <select
+              id="theme"
+              value={theme}
+              onChange={(event) => setTheme(event.target.value as ThemePreference)}
+            >
+              <option value="system">{t('settings.themeSystem')}</option>
+              <option value="light">{t('settings.themeLight')}</option>
+              <option value="dark">{t('settings.themeDark')}</option>
             </select>
           </label>
           

--- a/web/src/i18n.test.mjs
+++ b/web/src/i18n.test.mjs
@@ -30,6 +30,9 @@ assert.equal(en('detail.fileStatusLabel'), 'Changed files')
 assert.equal(it('detail.fileStatusLabel'), 'File modificati')
 assert.equal(zh('detail.fileStatusLabel'), '已變更檔案')
 
+assert.equal(en('settings.theme'), 'Theme')
+assert.equal(it('settings.themeDark'), 'Scuro')
+assert.equal(zh('settings.themeSystem'), '跟隨系統')
 assert.equal(en('todo.title'), 'Todo Items')
 
 console.log('i18n tests passed')

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -28,6 +28,10 @@ type TranslationKey =
   | 'settings.connectionFailed'
   | 'settings.connectedTo'
   | 'settings.language'
+  | 'settings.theme'
+  | 'settings.themeSystem'
+  | 'settings.themeLight'
+  | 'settings.themeDark'
   | 'settings.draftHint'
   | 'settings.testedNotSaved'
   | 'settings.savedButton'
@@ -171,6 +175,10 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'settings.connectionFailed': 'Connection failed: {message}',
     'settings.connectedTo': 'Connected to OpenCode {version}',
     'settings.language': 'Language',
+    'settings.theme': 'Theme',
+    'settings.themeSystem': 'System',
+    'settings.themeLight': 'Light',
+    'settings.themeDark': 'Dark',
     'sessions.title': 'Sessions',
     'sessions.summary': '{total} total · {active} active · {changed} changed',
     'sessions.new': 'New Session',
@@ -298,6 +306,10 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'settings.connectionFailed': 'Connessione fallita: {message}',
     'settings.connectedTo': 'Connesso a OpenCode {version}',
     'settings.language': 'Lingua',
+    'settings.theme': 'Tema',
+    'settings.themeSystem': 'Sistema',
+    'settings.themeLight': 'Chiaro',
+    'settings.themeDark': 'Scuro',
     'sessions.title': 'Sessioni',
     'sessions.summary': '{total} totali · {active} attive · {changed} con modifiche',
     'sessions.new': 'Nuova sessione',
@@ -425,6 +437,10 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'settings.connectionFailed': '連線失敗：{message}',
     'settings.connectedTo': '已連線至 OpenCode {version}',
     'settings.language': '語言',
+    'settings.theme': '主題',
+    'settings.themeSystem': '跟隨系統',
+    'settings.themeLight': '淺色',
+    'settings.themeDark': '深色',
     'sessions.title': '工作階段',
     'sessions.summary': '{total} 總數 · {active} 進行中 · {changed} 有變更',
     'sessions.new': '新增工作階段',

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -17,6 +17,15 @@
   --danger-soft: #fae9e7;
   --warning: #9a6700;
   --warning-soft: #fff3cf;
+  --nav-bg: rgba(255, 255, 255, 0.94);
+  --bottom-nav-bg: rgba(255, 255, 255, 0.96);
+  --primary-border: #c9ddff;
+  --danger-border: #f0c2be;
+  --focus-ring: rgba(23, 105, 224, 0.2);
+  --code-bg: #111827;
+  --code-text: #f9fafb;
+  --modal-backdrop: rgba(20, 32, 51, 0.45);
+  --sheet-backdrop: rgba(20, 32, 51, 0.38);
   --font-family: Inter, "Segoe UI", Roboto, Arial, sans-serif;
   --font-mono: "Cascadia Code", "SF Mono", Consolas, monospace;
   --space-1: 0.25rem;
@@ -34,6 +43,39 @@
   --z-sticky: 20;
   --z-modal-backdrop: 40;
   --z-modal: 50;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --bg: #0b1120;
+  --surface: #111827;
+  --surface-subtle: #172033;
+  --surface-strong: #1f2937;
+  --border: #2d3a4f;
+  --border-strong: #435169;
+  --text: #e5edf7;
+  --muted: #9aa7ba;
+  --muted-strong: #c5cedb;
+  --primary: #60a5fa;
+  --primary-strong: #93c5fd;
+  --primary-soft: rgba(96, 165, 250, 0.16);
+  --success: #34d399;
+  --success-soft: rgba(18, 128, 92, 0.2);
+  --danger: #f87171;
+  --danger-soft: rgba(194, 65, 59, 0.2);
+  --warning: #fbbf24;
+  --warning-soft: rgba(154, 103, 0, 0.22);
+  --nav-bg: rgba(17, 24, 39, 0.94);
+  --bottom-nav-bg: rgba(17, 24, 39, 0.96);
+  --primary-border: rgba(96, 165, 250, 0.36);
+  --danger-border: rgba(248, 113, 113, 0.42);
+  --focus-ring: rgba(96, 165, 250, 0.28);
+  --code-bg: #020617;
+  --code-text: #e5edf7;
+  --modal-backdrop: rgba(2, 6, 23, 0.66);
+  --sheet-backdrop: rgba(2, 6, 23, 0.58);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.35);
+  --shadow-md: 0 12px 28px rgba(0, 0, 0, 0.38);
 }
 
 * {
@@ -113,7 +155,7 @@ input:focus,
 textarea:focus,
 select:focus,
 button:focus-visible {
-  outline: 3px solid rgba(23, 105, 224, 0.2);
+  outline: 3px solid var(--focus-ring);
   outline-offset: 2px;
   border-color: var(--primary);
 }
@@ -178,7 +220,7 @@ p {
   padding: var(--space-3);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  background: rgba(255, 255, 255, 0.94);
+  background: var(--nav-bg);
   box-shadow: var(--shadow-sm);
   backdrop-filter: blur(14px);
 }
@@ -231,7 +273,7 @@ p {
 .bottom-nav button.active {
   color: var(--primary);
   background: var(--primary-soft);
-  border-color: #c9ddff;
+  border-color: var(--primary-border);
 }
 
 .panel {
@@ -280,7 +322,7 @@ p {
 
 .btn-danger {
   background: var(--danger-soft);
-  border-color: #f0c2be;
+  border-color: var(--danger-border);
   color: var(--danger);
 }
 
@@ -427,7 +469,7 @@ p {
 
 .session-card.active {
   border-color: var(--primary);
-  background: #f8fbff;
+  background: var(--surface-subtle);
 }
 
 .session-card-main {
@@ -732,7 +774,7 @@ p {
 .message.user {
   align-self: flex-end;
   background: var(--primary-soft);
-  border-color: #c9ddff;
+  border-color: var(--primary-border);
 }
 
 .message.assistant {
@@ -811,7 +853,7 @@ p {
   padding: var(--space-3);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  background: rgba(255, 255, 255, 0.94);
+  background: var(--nav-bg);
   box-shadow: var(--shadow-md);
   backdrop-filter: blur(14px);
 }
@@ -906,7 +948,7 @@ p {
   align-items: center;
   justify-content: center;
   padding: var(--space-4);
-  background: rgba(20, 32, 51, 0.45);
+  background: var(--modal-backdrop);
 }
 
 .modal-card {
@@ -938,7 +980,7 @@ p {
   display: flex;
   align-items: flex-end;
   justify-content: center;
-  background: rgba(20, 32, 51, 0.38);
+  background: var(--sheet-backdrop);
 }
 
 .bottom-sheet {
@@ -1024,8 +1066,8 @@ button.compact {
   overflow-x: auto;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
-  background: #111827;
-  color: #f9fafb;
+  background: var(--code-bg);
+  color: var(--code-text);
   padding: var(--space-3);
   font-family: var(--font-mono);
   font-size: 0.84rem;
@@ -1221,7 +1263,7 @@ button.compact {
     gap: var(--space-1);
     border: 1px solid var(--border);
     border-radius: var(--radius-lg);
-    background: rgba(255, 255, 255, 0.96);
+    background: var(--bottom-nav-bg);
     box-shadow: var(--shadow-md);
     padding: var(--space-1);
     backdrop-filter: blur(14px);

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -67,6 +67,16 @@ assert.ok(api.includes('loadTodo(config: ServerConfig, sessionID: string, direct
 assert.ok(api.includes('loadDiff(config: ServerConfig, sessionID: string, directory?: string)'), 'diff requests should be directory-aware')
 assert.ok(api.includes('abort(config: ServerConfig, sessionID: string, directory?: string)'), 'abort requests should be directory-aware')
 
+assert.ok(app.includes('THEME_STORAGE_KEY'), 'theme preference should persist separately from server settings')
+assert.ok(app.includes('type ThemePreference = "system" | "light" | "dark"'), 'theme preference should support system, light, and dark')
+assert.ok(app.includes('window.matchMedia("(prefers-color-scheme: dark)"'), 'system theme should follow prefers-color-scheme')
+assert.ok(app.includes('document.documentElement.dataset.theme = resolvedTheme'), 'theme should be applied to the root element for CSS variables')
+assert.ok(app.includes("t('settings.theme')"), 'settings should expose a localized theme picker')
+assert.ok(styles.includes(':root[data-theme="dark"]'), 'dark mode should override design tokens through CSS variables')
+assert.ok(styles.includes('--nav-bg'), 'theme-sensitive navigation background should use a variable')
+assert.ok(styles.includes('--primary-border'), 'theme-sensitive active borders should use a variable')
+assert.ok(styles.includes('--focus-ring'), 'theme-sensitive focus ring should use a variable')
+
 assert.match(icons, /export const RefreshIcon/, 'RefreshIcon should exist for idle refresh UI')
 
 console.log('ui regression tests passed')


### PR DESCRIPTION
## Summary
- Add a dark mode theme setting to the app UI.
- Persist/apply the selected theme through the existing settings flow.
- Add localized strings for English, Italian, and zh-TW.

## Verification
- `npm run test:i18n` → passed
- `npm run test:ui` → passed
- `npm run build` → passed

## Manual testing
- Giulio tested the app with the new dark mode and confirmed it works well.
