### PR TITLE
Fix global session listing and activity time

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,7 +3,7 @@ import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { api } from "./api"
 import { createTranslator, languageOptions, normalizeLanguage, type LanguageCode } from "./i18n"
-import type { CommandInfo, DiffFile, FileEntry, FileStatusEntry, MessageEnvelope, ModelOption, ModelSelection, PathInfo, ProjectDashboard, ServerConfig, Session, SessionView, TodoItem } from "./types"
+import type { CommandInfo, DiffFile, FileEntry, FileStatusEntry, MessageEnvelope, ModelOption, ModelSelection, PathInfo, ProjectDashboard, ServerConfig, Session, SessionStatus, SessionView, TodoItem } from "./types"
 import {
   SettingsIcon,
   FolderIcon,
@@ -112,13 +112,17 @@ function isProjectDirectory(pathInfo: PathInfo): boolean {
   return pathInfo.worktree !== "/"
 }
 
-function toSessionView(session: Session): SessionView {
+function messageActivityTime(message: MessageEnvelope): number {
+  return Math.max(message.info.time.created, message.info.time.completed ?? 0)
+}
+
+function toSessionView(session: Session, status?: SessionStatus, activityTime = session.time.updated): SessionView {
   return {
     id: session.id,
     title: session.title,
     directory: session.directory,
-    updated: session.time.updated,
-    status: "idle",
+    updated: activityTime,
+    status: status?.type ?? "idle",
     files: session.summary?.files ?? 0,
     additions: session.summary?.additions ?? 0,
     deletions: session.summary?.deletions ?? 0,
@@ -263,6 +267,7 @@ function App() {
   const loadSelectedRequestRef = useRef(0)
   const backgroundFailureCountRef = useRef(0)
   const initialSessionLoadRef = useRef(true)
+  const latestMessageTimesRef = useRef(new Map<string, { sessionUpdated: number; activityTime: number }>())
 
   const selectedSession = useMemo(
     () => sessions.find((session) => session.id === selectedID) ?? null,
@@ -421,9 +426,18 @@ function App() {
       setConnectionMessage(t('connection.loadingSessions'))
     }
     try {
-      const [items, statuses] = await Promise.all([api.listSessions(config), api.listStatuses(config)])
-      const mapped = items
-        .map((session) => ({ ...toSessionView(session), status: statuses[session.id]?.type ?? "idle" }))
+      const items = await api.listGlobalSessions(config).catch(() => api.listSessions(config))
+      const directories = [...new Set(items.map((session) => session.directory).filter(Boolean))]
+      const [sessionLists, statusMaps] = await Promise.all([
+        Promise.all(directories.map((directory) => api.listSessions(config, directory).catch(() => [] as Session[]))),
+        Promise.all(directories.map((directory) => api.listStatuses(config, directory).catch(() => ({} as Record<string, SessionStatus>))))
+      ])
+      const scopedSessions = new Map(sessionLists.flat().map((session) => [session.id, session]))
+      const statuses = Object.assign({}, ...statusMaps)
+      const hydratedItems = items.map((session) => ({ ...session, ...scopedSessions.get(session.id), project: session.project }))
+      const activityTimes = await loadSessionActivityTimes(hydratedItems)
+      const mapped = hydratedItems
+        .map((session) => toSessionView(session, statuses[session.id], activityTimes.get(session.id)))
         .sort((a, b) => b.updated - a.updated)
       setSessions((current) => {
         const selected = selectedID ? current.find((session) => session.id === selectedID) : null
@@ -498,6 +512,20 @@ function App() {
     } catch (err) {
       setModelLoadError((err as Error).message)
     }
+  }
+
+  async function loadSessionActivityTimes(items: Session[]): Promise<Map<string, number>> {
+    const results = await Promise.all(items.map(async (session) => {
+      const cached = latestMessageTimesRef.current.get(session.id)
+      if (cached?.sessionUpdated === session.time.updated) return [session.id, cached.activityTime] as const
+
+      const latest = await api.loadLatestMessage(config, session.id, session.directory).catch(() => null)
+      if (latest === null) return [session.id, session.time.updated] as const
+      const activityTime = latest.length > 0 ? Math.max(...latest.map(messageActivityTime)) : session.time.updated
+      latestMessageTimesRef.current.set(session.id, { sessionUpdated: session.time.updated, activityTime })
+      return [session.id, activityTime] as const
+    }))
+    return new Map(results)
   }
 
   function changeModel(nextKey: string) {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -37,6 +37,11 @@ type RequestOptions = {
   readTimeout?: number
 }
 
+type ResponseWithHeaders<T> = {
+  data: T
+  headers: Record<string, string>
+}
+
 function responseDetail(body: unknown): string | null {
   if (!body) return null
   if (typeof body === "string") {
@@ -51,6 +56,13 @@ function responseDetail(body: unknown): string | null {
     return value.data?.message ?? value.message ?? JSON.stringify(body)
   }
   return String(body)
+}
+
+function normalizeHeaders(headers: Record<string, unknown> | undefined): Record<string, string> {
+  if (!headers) return {}
+  return Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), Array.isArray(value) ? value.join(", ") : String(value)])
+  )
 }
 
 type ConfigProvidersResponse = {
@@ -76,7 +88,7 @@ type ConfigProvidersResponse = {
   default?: Record<string, string>
 }
 
-async function request<T>(config: ServerConfig, path: string, options: RequestOptions = {}): Promise<T> {
+async function requestWithHeaders<T>(config: ServerConfig, path: string, options: RequestOptions = {}): Promise<ResponseWithHeaders<T>> {
   const target = `${baseUrl(config)}${path}`
 
   const headers: Record<string, string> = {
@@ -110,8 +122,9 @@ async function request<T>(config: ServerConfig, path: string, options: RequestOp
       throw new Error(responseDetail(response.data) || `HTTP ${response.status}`)
     }
 
-    if (response.status === 204) return true as T
-    return response.data as T
+    const responseHeaders = normalizeHeaders(response.headers)
+    if (response.status === 204) return { data: true as T, headers: responseHeaders }
+    return { data: response.data as T, headers: responseHeaders }
   }
 
   let response: Response
@@ -142,8 +155,13 @@ async function request<T>(config: ServerConfig, path: string, options: RequestOp
     throw new Error(detail)
   }
 
-  if (response.status === 204) return true as T
-  return (await response.json()) as T
+  const responseHeaders = normalizeHeaders(Object.fromEntries(response.headers.entries()))
+  if (response.status === 204) return { data: true as T, headers: responseHeaders }
+  return { data: (await response.json()) as T, headers: responseHeaders }
+}
+
+async function request<T>(config: ServerConfig, path: string, options: RequestOptions = {}): Promise<T> {
+  return (await requestWithHeaders<T>(config, path, options)).data
 }
 
 function toModelBody(model?: ModelSelection) {
@@ -168,6 +186,18 @@ export const api = {
 
   listSessions(config: ServerConfig, directory?: string) {
     return request<Session[]>(config, withDirectory("/session", directory))
+  },
+
+  async listGlobalSessions(config: ServerConfig) {
+    const sessions: Session[] = []
+    let cursor: string | undefined
+    do {
+      const path = cursor ? `/experimental/session?cursor=${encodeURIComponent(cursor)}` : "/experimental/session"
+      const response = await requestWithHeaders<Session[]>(config, path)
+      sessions.push(...response.data)
+      cursor = response.headers["x-next-cursor"]
+    } while (cursor)
+    return sessions
   },
 
   listStatuses(config: ServerConfig, directory?: string) {
@@ -226,6 +256,10 @@ export const api = {
 
   loadMessages(config: ServerConfig, sessionID: string, directory?: string) {
     return request<MessageEnvelope[]>(config, withDirectory(`/session/${sessionID}/message?limit=100`, directory))
+  },
+
+  loadLatestMessage(config: ServerConfig, sessionID: string, directory?: string) {
+    return request<MessageEnvelope[]>(config, withDirectory(`/session/${sessionID}/message?limit=1`, directory))
   },
 
   loadTodo(config: ServerConfig, sessionID: string, directory?: string) {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -45,6 +45,11 @@ export type Session = {
     providerID: string
     variant?: string
   }
+  project?: {
+    id: string
+    name?: string
+    worktree: string
+  } | null
 }
 
 export type SessionStatus = {

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -69,6 +69,13 @@ assert.ok(api.includes('withDirectory("/session", directory)'), 'new session cre
 assert.ok(api.includes('loadTodo(config: ServerConfig, sessionID: string, directory?: string)'), 'todo requests should be directory-aware')
 assert.ok(api.includes('loadDiff(config: ServerConfig, sessionID: string, directory?: string)'), 'diff requests should be directory-aware')
 assert.ok(api.includes('abort(config: ServerConfig, sessionID: string, directory?: string)'), 'abort requests should be directory-aware')
+assert.ok(api.includes('listGlobalSessions(config: ServerConfig)'), 'sessions view should use global session discovery when available')
+assert.ok(api.includes('x-next-cursor'), 'global session discovery should page through all experimental session results')
+assert.ok(app.includes('api.listSessions(config, directory).catch(() => [] as Session[])'), 'global sessions should be hydrated from scoped session lists for fresh timestamps and summaries')
+assert.ok(api.includes('loadLatestMessage(config: ServerConfig, sessionID: string, directory?: string)'), 'API should expose a cheap latest-message request')
+assert.ok(app.includes('function messageActivityTime'), 'sessions should display latest message activity instead of mutable session row timestamps')
+assert.ok(app.includes('latestMessageTimesRef'), 'latest message activity lookups should be cached between refreshes')
+assert.ok(app.includes('catch(() => null)'), 'failed latest-message lookups should not be cached as session row timestamps')
 
 assert.ok(app.includes('THEME_STORAGE_KEY'), 'theme preference should persist separately from server settings')
 assert.ok(app.includes('type ThemePreference = "system" | "light" | "dark"'), 'theme preference should support system, light, and dark')


### PR DESCRIPTION
## Summary

This fixes session list behavior when `opencode serve` is launched from a broad/default directory such as `~` and sessions exist in other project folders.

The previous remote UI only listed `/session` from the server's default workspace. That could hide sessions created in selected folders, or switch to the detail view after creation without a usable selected session in app state.

This PR changes the session list flow to:

- discover sessions across projects with `/experimental/session` when available
- fall back to `/session` for older OpenCode servers
- hydrate discovered sessions from scoped `/session?directory=...` lists so card metadata such as summaries comes from the project-scoped endpoint
- query statuses per session directory with `/session/status?directory=...`
- keep a newly created session in local state if refresh does not immediately return it

It also fixes the displayed/sorted "Updated" timestamp. The app previously used `session.time.updated`, but OpenCode can bump that row timestamp for non-chat session metadata/maintenance. That made old sessions, for example an unused `/home/opc/kesto` session, appear as updated today. The session list now uses the latest message timestamp when available, falling back to the session row timestamp only when no message exists or the lookup fails.

## Details

- Added `api.listGlobalSessions()` for `/experimental/session`.
- Added `api.loadLatestMessage()` for a cheap `/session/:id/message?limit=1` activity lookup.
- Added global session hydration from per-directory scoped session lists.
- Added a small in-memory latest-message timestamp cache keyed by session id and server `session.time.updated`.
- Extended the `Session` type for optional global-session `project` metadata.
- Added regression assertions covering global discovery, scoped hydration, and latest-message activity timestamps.

## Verification

Local verification passed:

- `npm run test:ui`
- `npm run test:model`
- `npm run test:settings`
- `npm run build`

GitHub Actions signed APK build passed:

- https://github.com/ergs0204/opencode-remote-android/actions/runs/27855606991

Tested manually on Android after the signed APK build.
