### PR TITLE
Fix model picker spacing and new session directory handling

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,7 +3,7 @@ import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { api } from "./api"
 import { createTranslator, languageOptions, normalizeLanguage, type LanguageCode } from "./i18n"
-import type { CommandInfo, DiffFile, FileEntry, FileStatusEntry, MessageEnvelope, ModelOption, ModelSelection, ProjectDashboard, ServerConfig, Session, SessionView, TodoItem } from "./types"
+import type { CommandInfo, DiffFile, FileEntry, FileStatusEntry, MessageEnvelope, ModelOption, ModelSelection, PathInfo, ProjectDashboard, ServerConfig, Session, SessionView, TodoItem } from "./types"
 import {
   SettingsIcon,
   FolderIcon,
@@ -106,6 +106,10 @@ function modelSearchText(option: ModelOption): string {
 function normalizeDirectory(value: string): string | undefined {
   const trimmed = value.trim()
   return trimmed.length > 0 ? trimmed : undefined
+}
+
+function isProjectDirectory(pathInfo: PathInfo): boolean {
+  return pathInfo.worktree !== "/"
 }
 
 function toSessionView(session: Session): SessionView {
@@ -611,7 +615,14 @@ function App() {
     if (creatingSession) return
     setCreatingSession(true)
     setRuntimeError(null)
+    setPickerError(null)
     try {
+      if (directory) {
+        const pathInfo = await api.loadPath(config, directory)
+        if (!isProjectDirectory(pathInfo)) {
+          throw new Error(t('sessions.projectDirectoryInvalid', { directory }))
+        }
+      }
       const created = await api.createSession(config, "Mobile session", activeModel, directory)
       const createdView = toSessionView(created)
       if (directory) {
@@ -627,6 +638,7 @@ function App() {
       await loadSelected(created.id, created.directory)
       await refreshSessions()
     } catch (err) {
+      setPickerError((err as Error).message)
       setRuntimeError((err as Error).message)
     } finally {
       setCreatingSession(false)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,7 +3,7 @@ import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { api } from "./api"
 import { createTranslator, languageOptions, normalizeLanguage, type LanguageCode } from "./i18n"
-import type { CommandInfo, DiffFile, FileEntry, FileStatusEntry, MessageEnvelope, ModelOption, ModelSelection, ProjectDashboard, ServerConfig, SessionView, TodoItem } from "./types"
+import type { CommandInfo, DiffFile, FileEntry, FileStatusEntry, MessageEnvelope, ModelOption, ModelSelection, ProjectDashboard, ServerConfig, Session, SessionView, TodoItem } from "./types"
 import {
   SettingsIcon,
   FolderIcon,
@@ -106,6 +106,20 @@ function modelSearchText(option: ModelOption): string {
 function normalizeDirectory(value: string): string | undefined {
   const trimmed = value.trim()
   return trimmed.length > 0 ? trimmed : undefined
+}
+
+function toSessionView(session: Session): SessionView {
+  return {
+    id: session.id,
+    title: session.title,
+    directory: session.directory,
+    updated: session.time.updated,
+    status: "idle",
+    files: session.summary?.files ?? 0,
+    additions: session.summary?.additions ?? 0,
+    deletions: session.summary?.deletions ?? 0,
+    model: session.model ? { providerID: session.model.providerID, modelID: session.model.id, variant: session.model.variant } : undefined
+  }
 }
 
 function formatLimit(value?: number): string {
@@ -405,19 +419,13 @@ function App() {
     try {
       const [items, statuses] = await Promise.all([api.listSessions(config), api.listStatuses(config)])
       const mapped = items
-        .map((session) => ({
-          id: session.id,
-          title: session.title,
-          directory: session.directory,
-          updated: session.time.updated,
-          status: statuses[session.id]?.type ?? "idle",
-          files: session.summary?.files ?? 0,
-          additions: session.summary?.additions ?? 0,
-          deletions: session.summary?.deletions ?? 0,
-          model: session.model ? { providerID: session.model.providerID, modelID: session.model.id, variant: session.model.variant } : undefined
-        }))
+        .map((session) => ({ ...toSessionView(session), status: statuses[session.id]?.type ?? "idle" }))
         .sort((a, b) => b.updated - a.updated)
-      setSessions(mapped)
+      setSessions((current) => {
+        const selected = selectedID ? current.find((session) => session.id === selectedID) : null
+        if (!selected || mapped.some((session) => session.id === selected.id)) return mapped
+        return [selected, ...mapped].sort((a, b) => b.updated - a.updated)
+      })
       backgroundFailureCountRef.current = 0
       initialSessionLoadRef.current = false
       setConnectionState("connected")
@@ -605,14 +613,19 @@ function App() {
     setRuntimeError(null)
     try {
       const created = await api.createSession(config, "Mobile session", activeModel, directory)
+      const createdView = toSessionView(created)
       if (directory) {
         setNewSessionDirectory(directory)
       }
       setShowNewSessionPicker(false)
-      await refreshSessions()
+      setSessions((current) => {
+        if (current.some((session) => session.id === created.id)) return current
+        return [createdView, ...current].sort((a, b) => b.updated - a.updated)
+      })
       setSelectedID(created.id)
       setView("detail")
       await loadSelected(created.id, created.directory)
+      await refreshSessions()
     } catch (err) {
       setRuntimeError((err as Error).message)
     } finally {

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -65,6 +65,7 @@ type TranslationKey =
   | 'sessions.parentFolder'
   | 'sessions.folderPickerLoading'
   | 'sessions.folderPickerEmpty'
+  | 'sessions.projectDirectoryInvalid'
   | 'sessions.searchPlaceholder'
   | 'sessions.emptyTitle'
   | 'sessions.emptyHint'
@@ -196,6 +197,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'sessions.parentFolder': 'Parent folder',
     'sessions.folderPickerLoading': 'Loading folders...',
     'sessions.folderPickerEmpty': 'No folders here.',
+    'sessions.projectDirectoryInvalid': '{directory} is not an OpenCode project folder. Pick a project/worktree folder, or use the server default.',
     'sessions.searchPlaceholder': 'Search sessions by title or directory...',
     'sessions.emptyTitle': 'No sessions found',
     'sessions.emptyHint': 'Create a new session to get started',
@@ -329,7 +331,8 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'sessions.parentFolder': 'Cartella superiore',
     'sessions.folderPickerLoading': 'Caricamento cartelle...',
     'sessions.folderPickerEmpty': 'Nessuna cartella qui.',
-    'sessions.searchPlaceholder': 'Cerca sessioni per titolo o directory...',
+    'sessions.projectDirectoryInvalid': '{directory} non è una cartella progetto OpenCode. Scegli una cartella progetto/worktree oppure usa il default del server.',
+    'sessions.searchPlaceholder': 'Cerca sessioni per titolo o cartella...',
     'sessions.emptyTitle': 'Nessuna sessione trovata',
     'sessions.emptyHint': 'Crea una nuova sessione per iniziare',
     'sessions.loadingTitle': 'Connessione a OpenCode',
@@ -462,6 +465,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'sessions.parentFolder': '上一層資料夾',
     'sessions.folderPickerLoading': '正在載入資料夾...',
     'sessions.folderPickerEmpty': '這裡沒有資料夾。',
+    'sessions.projectDirectoryInvalid': '{directory} 不是 OpenCode 專案資料夾。請選擇專案/worktree 資料夾，或使用伺服器預設。',
     'sessions.searchPlaceholder': '依標題或目錄搜尋工作階段...',
     'sessions.emptyTitle': '找不到工作階段',
     'sessions.emptyHint': '建立新的工作階段以開始',

--- a/web/src/model-regression.test.mjs
+++ b/web/src/model-regression.test.mjs
@@ -29,5 +29,7 @@ assert.ok(i18n.includes("'detail.modelSearchPlaceholder'"), 'model search string
 assert.ok(/\.context-chip[\s\S]*?overflow/.test(styles), 'context chips should have compact mobile styling')
 assert.ok(/\.bottom-sheet[\s\S]*?max-height/.test(styles), 'model/details should use a mobile bottom sheet')
 assert.ok(/\.model-option-list[\s\S]*?overflow-y/.test(styles), 'searchable model results should scroll in the sheet')
+assert.ok(/\.model-option[\s\S]*?min-height:\s*64px/.test(styles), 'model options should be tall enough for two-line labels')
+assert.ok(/\.model-option span[\s\S]*?line-height:\s*1\.25/.test(styles), 'model option text should not look vertically squeezed')
 
 console.log('model picker regression tests passed')

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -686,9 +686,13 @@ p {
 
 .model-option {
   width: 100%;
+  min-height: 64px;
   justify-content: space-between;
+  align-items: center;
+  gap: var(--space-3);
   border-color: var(--border);
   background: var(--surface);
+  padding: 0.85rem 0.9rem;
   text-align: left;
 }
 
@@ -698,9 +702,11 @@ p {
 }
 
 .model-option span {
+  flex: 1 1 auto;
   min-width: 0;
   display: grid;
-  gap: 0.1rem;
+  gap: 0.2rem;
+  line-height: 1.25;
 }
 
 .model-option strong,
@@ -712,6 +718,7 @@ p {
 
 .model-option small {
   color: var(--muted);
+  line-height: 1.25;
 }
 
 .model-option em {

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -61,6 +61,8 @@ assert.ok(app.includes('api.loadPath(config, selectedNewSessionDirectory)'), 'fo
 assert.ok(api.includes('listFiles(config: ServerConfig, path: string, directory?: string)'), 'API should expose OpenCode /file for directory browsing')
 assert.ok(app.includes("t('sessions.projectDirectoryLabel')"), 'folder picker should be localized')
 assert.ok(app.includes('api.createSession(config, "Mobile session", activeModel, directory)'), 'new sessions should pass only the picked directory to OpenCode')
+assert.ok(app.includes("t('sessions.projectDirectoryInvalid'"), 'picked folders should be validated before creating unusable global sessions')
+assert.ok(app.includes('if (!isProjectDirectory(pathInfo))'), 'new session creation should reject folders that OpenCode resolves to the global project')
 assert.ok(app.includes('if (current.some((session) => session.id === created.id)) return current'), 'newly created sessions should remain selectable even when the default list refresh does not include the picked directory')
 assert.ok(api.includes('createSession(config: ServerConfig, title?: string, model?: ModelSelection, directory?: string)'), 'createSession API should accept a directory')
 assert.ok(api.includes('withDirectory("/session", directory)'), 'new session creation should append ?directory= when set')

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -61,6 +61,7 @@ assert.ok(app.includes('api.loadPath(config, selectedNewSessionDirectory)'), 'fo
 assert.ok(api.includes('listFiles(config: ServerConfig, path: string, directory?: string)'), 'API should expose OpenCode /file for directory browsing')
 assert.ok(app.includes("t('sessions.projectDirectoryLabel')"), 'folder picker should be localized')
 assert.ok(app.includes('api.createSession(config, "Mobile session", activeModel, directory)'), 'new sessions should pass only the picked directory to OpenCode')
+assert.ok(app.includes('if (current.some((session) => session.id === created.id)) return current'), 'newly created sessions should remain selectable even when the default list refresh does not include the picked directory')
 assert.ok(api.includes('createSession(config: ServerConfig, title?: string, model?: ModelSelection, directory?: string)'), 'createSession API should accept a directory')
 assert.ok(api.includes('withDirectory("/session", directory)'), 'new session creation should append ?directory= when set')
 assert.ok(api.includes('loadTodo(config: ServerConfig, sessionID: string, directory?: string)'), 'todo requests should be directory-aware')


### PR DESCRIPTION
## Summary
- Fix model picker option rows being too compressed after model search/provider list changes.
- Keep newly created sessions selected even when the default session refresh omits directory-scoped sessions.
- Validate picked new-session folders before creating OpenCode sessions, so invalid/global paths like `/home/ciulio` show an error instead of opening a ghost session.

## Verification
- `npm run test:ui`
- `npm run test:i18n`
- `npm run test:model`
- `npm run test:settings`
- `npm run build`
- `npx cap sync android`
- `./gradlew assembleDebug --stacktrace --no-daemon`

## APK smoke artifact
- Debug APK built locally: `versionName=1.3.11`, `versionCode=10311`
- SHA-256: `427cae8b040dfd7ea2bfc4b24231a7a268517b9523880ee2a2ada575e0e3192c`
