### PR TITLE
fix: don't close the app when pressing back from an open session

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.5.0",
       "dependencies": {
         "@capacitor/android": "^8.3.4",
+        "@capacitor/app": "^8.1.1",
         "@capacitor/cli": "^8.3.4",
         "@capacitor/core": "^8.3.4",
         "react": "18.3.1",
@@ -31,6 +32,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.3.0"
+      }
+    },
+    "node_modules/@capacitor/app": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.1.tgz",
+      "integrity": "sha512-xM2ZTX5jK60tFtmjsmJv+Cdj1Qsb6NcavkqmdEnCPQBeya9oKhamZJxYOnQNj1ZvcJM7sWfG6BEtSLx42pisbA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/cli": {

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@capacitor/android": "^8.3.4",
+    "@capacitor/app": "^8.1.1",
     "@capacitor/cli": "^8.3.4",
     "@capacitor/core": "^8.3.4",
     "react": "18.3.1",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react"
+import { App as CapacitorApp } from "@capacitor/app"
+import type { PluginListenerHandle } from "@capacitor/core"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { api } from "./api"
@@ -906,6 +908,24 @@ function App() {
   useEffect(() => {
     localStorage.setItem(LANGUAGE_STORAGE_KEY, language)
   }, [language])
+
+  useEffect(() => {
+    let listenerHandle: PluginListenerHandle | undefined
+    CapacitorApp.addListener("backButton", () => {
+      setView((current) => {
+        if (current === "sessions") {
+          CapacitorApp.exitApp()
+          return current
+        }
+        return "sessions"
+      })
+    }).then((handle) => {
+      listenerHandle = handle
+    })
+    return () => {
+      listenerHandle?.remove()
+    }
+  }, [])
 
   useEffect(() => {
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")


### PR DESCRIPTION
I kept closing this app by mistake so I made this fix out of spite.

If the user is in the "Sessions" tab, going back will close the app. In all other cases, the app will go back to the "Sessions" tab instead of closing.