### PR TITLE
feat: major UI overhaul

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.5.0",
       "dependencies": {
         "@capacitor/android": "^8.3.4",
+        "@capacitor/app": "^8.1.1",
         "@capacitor/cli": "^8.3.4",
         "@capacitor/core": "^8.3.4",
         "react": "18.3.1",
@@ -31,6 +32,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.3.0"
+      }
+    },
+    "node_modules/@capacitor/app": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.1.tgz",
+      "integrity": "sha512-xM2ZTX5jK60tFtmjsmJv+Cdj1Qsb6NcavkqmdEnCPQBeya9oKhamZJxYOnQNj1ZvcJM7sWfG6BEtSLx42pisbA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/cli": {

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@capacitor/android": "^8.3.4",
+    "@capacitor/app": "^8.1.1",
     "@capacitor/cli": "^8.3.4",
     "@capacitor/core": "^8.3.4",
     "react": "18.3.1",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react"
+import { App as CapacitorApp } from "@capacitor/app"
+import type { PluginListenerHandle } from "@capacitor/core"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { api } from "./api"
@@ -906,6 +908,24 @@ function App() {
   useEffect(() => {
     localStorage.setItem(LANGUAGE_STORAGE_KEY, language)
   }, [language])
+
+  useEffect(() => {
+    let listenerHandle: PluginListenerHandle | undefined
+    CapacitorApp.addListener("backButton", () => {
+      setView((current) => {
+        if (current === "sessions") {
+          CapacitorApp.exitApp()
+          return current
+        }
+        return "sessions"
+      })
+    }).then((handle) => {
+      listenerHandle = handle
+    })
+    return () => {
+      listenerHandle?.remove()
+    }
+  }, [])
 
   useEffect(() => {
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1647,19 +1647,17 @@ function App() {
               onKeyDown={(event) => {
                 if (event.key === "Enter" && !event.shiftKey) {
                   event.preventDefault()
-                  if (!isWorking) {
-                    send().catch(() => undefined)
-                  }
+                  send().catch(() => undefined)
                 }
               }}
-              disabled={!selectedSession || isWorking}
-            />
-            <button 
-              onClick={isWorking ? abortSession : send}
               disabled={!selectedSession}
-              className={isWorking ? "btn-danger" : "btn-primary"}
+            />
+            <button
+              onClick={isWorking && !composer.trim() ? abortSession : send}
+              disabled={!selectedSession}
+              className={isWorking && !composer.trim() ? "btn-danger" : "btn-primary"}
             >
-              {isWorking ? (
+              {isWorking && !composer.trim() ? (
                 <>
                   <StopCircleIcon size={18} />
                   {t('detail.waiting')}
@@ -1672,7 +1670,7 @@ function App() {
               )}
             </button>
           </div>
-          
+
           {runtimeError && <div className="error fade-in">✗ {runtimeError}</div>}
         </main>
       )}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -517,6 +517,19 @@ function createLocalAssistantMessage(sessionID: string, text: string): MessageEn
   }
 }
 
+/** GET /session/{id}/message doesn't return reasoning parts, only the live event stream does — keep any streamed-in reasoning the refetch would otherwise silently drop. */
+function mergeFetchedMessages(current: MessageEnvelope[], fetched: MessageEnvelope[]): MessageEnvelope[] {
+  const currentByID = new Map(current.map((message) => [message.info.id, message]))
+  return fetched.map((message) => {
+    const previous = currentByID.get(message.info.id)
+    if (!previous) return message
+    const fetchedPartIDs = new Set(message.parts.map((part) => part.id))
+    const missingReasoning = previous.parts.filter((part) => part.type === "reasoning" && !fetchedPartIDs.has(part.id))
+    if (missingReasoning.length === 0) return message
+    return { ...message, parts: [...missingReasoning, ...message.parts] }
+  })
+}
+
 function applyStreamedPartUpdate(messages: MessageEnvelope[], sessionID: string, part: MessagePart): MessageEnvelope[] {
   let changed = false
   const next = messages.map((message) => {
@@ -974,7 +987,7 @@ function App() {
     if (requestID !== loadSelectedRequestRef.current) return
     setMessages((current) => {
       if (assistantPayloadLength(current) > assistantPayloadLength(msg)) return current
-      return msg
+      return mergeFetchedMessages(current, msg)
     })
     setOptimisticUserMessages((current) => current.filter((message) => !hasMatchingUserMessage(msg, message)))
     setTodos(todo)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { api } from "./api"
 import {
   createFetchOpenCodeEventSubscription,
   createNativeOpenCodeEventSubscription,
+  eventPayload,
   eventType,
   isNativeEventTransport,
   type EventStreamStatus
@@ -246,6 +247,43 @@ function createLocalAssistantMessage(sessionID: string, text: string): MessageEn
       }
     ]
   }
+}
+
+function applyStreamedPartUpdate(messages: MessageEnvelope[], sessionID: string, part: MessagePart): MessageEnvelope[] {
+  let changed = false
+  const next = messages.map((message) => {
+    if (message.info.sessionID !== sessionID || message.info.id !== part.messageID) return message
+    changed = true
+    const exists = message.parts.some((existing) => existing.id === part.id)
+    const parts = exists
+      ? message.parts.map((existing) => (existing.id === part.id ? part : existing))
+      : [...message.parts, part]
+    return { ...message, parts }
+  })
+  return changed ? next : messages
+}
+
+function applyStreamedPartDelta(
+  messages: MessageEnvelope[],
+  sessionID: string,
+  messageID: string,
+  partID: string,
+  field: string,
+  delta: string
+): MessageEnvelope[] {
+  let changed = false
+  const next = messages.map((message) => {
+    if (message.info.sessionID !== sessionID || message.info.id !== messageID) return message
+    const parts = message.parts.map((existing) => {
+      if (existing.id !== partID) return existing
+      changed = true
+      const current = (existing as Record<string, unknown>)[field]
+      const nextValue = (typeof current === "string" ? current : "") + delta
+      return { ...existing, [field]: nextValue }
+    })
+    return changed ? { ...message, parts } : message
+  })
+  return changed ? next : messages
 }
 
 function hasMatchingUserMessage(messages: MessageEnvelope[], optimistic: MessageEnvelope): boolean {
@@ -1049,6 +1087,24 @@ function App() {
     }
     const onEvent = (event: { data: unknown; name: string }) => {
       const type = eventType(event.data) ?? event.name
+      const payload = eventPayload(event.data)
+      const body = (payload?.properties ?? payload?.data) as
+        | { sessionID?: string; part?: MessagePart; messageID?: string; partID?: string; field?: string; delta?: string }
+        | undefined
+      if (type === "message.part.updated" && body?.sessionID && body.part) {
+        setMessages((current) => applyStreamedPartUpdate(current, body.sessionID!, body.part!))
+      } else if (
+        type === "message.part.delta" &&
+        body?.sessionID &&
+        body.messageID &&
+        body.partID &&
+        body.field &&
+        typeof body.delta === "string"
+      ) {
+        setMessages((current) =>
+          applyStreamedPartDelta(current, body.sessionID!, body.messageID!, body.partID!, body.field!, body.delta!)
+        )
+      }
       if (type.startsWith("session.") || type.startsWith("message.") || type.startsWith("todo.")) {
         setLiveEventCount((count) => count + 1)
         scheduleRefresh()

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -179,6 +179,73 @@ function PatchPartView({ config, sessionID, messageID, files }: { config: Server
   )
 }
 
+const TEXT_PREVIEW_LINES = 6
+
+function truncatedText(text: string, limit: number): { shown: string; hiddenCount: number } {
+  const lines = text.split("\n")
+  if (lines.length <= limit) return { shown: text, hiddenCount: 0 }
+  return { shown: lines.slice(0, limit).join("\n"), hiddenCount: lines.length - limit }
+}
+
+function ExpandableOutput({ text, className, modalTitle }: { text: string; className: string; modalTitle: string }) {
+  const [expanded, setExpanded] = useState(false)
+  const { shown, hiddenCount } = truncatedText(text, TEXT_PREVIEW_LINES)
+  return (
+    <>
+      <button type="button" className="message-tool-preview" onClick={() => setExpanded(true)} aria-label={`Expand ${modalTitle}`}>
+        <pre className={className}>{shown}</pre>
+        {hiddenCount > 0 && <div className="diff-line-more">+{hiddenCount} more lines</div>}
+      </button>
+
+      {expanded && (
+        <div className="modal-backdrop" role="presentation" onClick={() => setExpanded(false)}>
+          <section
+            className="modal-card diff-modal fade-in"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="tool-modal-title"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="diff-modal-header">
+              <h2 id="tool-modal-title">{modalTitle}</h2>
+              <button type="button" className="btn-secondary" onClick={() => setExpanded(false)}>
+                Close
+              </button>
+            </div>
+            <div className="diff-modal-body">
+              <pre className={className}>{text}</pre>
+            </div>
+          </section>
+        </div>
+      )}
+    </>
+  )
+}
+
+function ToolPartView({ part }: { part: MessagePart }) {
+  const status = part.state?.status || "pending"
+  const command = toolCommandLabel(part)
+  return (
+    <div className={`message-tool message-tool-${status}`}>
+      <div className="message-tool-header">
+        <span className="message-tool-name">{part.tool}</span>
+        <span className="message-tool-status">{status}</span>
+      </div>
+      <ExpandableOutput text={command} className="message-tool-command" modalTitle={`${part.tool} — command`} />
+      {part.state?.output && (
+        <ExpandableOutput text={part.state.output} className="message-tool-output" modalTitle={`${part.tool} — output`} />
+      )}
+      {part.state?.error && (
+        <ExpandableOutput
+          text={part.state.error}
+          className="message-tool-output message-tool-error"
+          modalTitle={`${part.tool} — error`}
+        />
+      )}
+    </div>
+  )
+}
+
 function MessagePartView({ part, config, sessionID }: { part: MessagePart; config: ServerConfig; sessionID: string }) {
   if (part.type === "text") {
     if (!part.text) return null
@@ -200,18 +267,7 @@ function MessagePartView({ part, config, sessionID }: { part: MessagePart; confi
   }
 
   if (part.type === "tool") {
-    const status = part.state?.status || "pending"
-    return (
-      <div className={`message-tool message-tool-${status}`}>
-        <div className="message-tool-header">
-          <span className="message-tool-name">{part.tool}</span>
-          <span className="message-tool-status">{status}</span>
-        </div>
-        <pre className="message-tool-command">{toolCommandLabel(part)}</pre>
-        {part.state?.output && <pre className="message-tool-output">{part.state.output}</pre>}
-        {part.state?.error && <pre className="message-tool-output message-tool-error">{part.state.error}</pre>}
-      </div>
-    )
+    return <ToolPartView part={part} />
   }
 
   if (part.type === "patch") {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -517,16 +517,26 @@ function createLocalAssistantMessage(sessionID: string, text: string): MessageEn
   }
 }
 
+/** Reasoning text should only ever grow while streaming — if an incoming snapshot is shorter than what's already shown, a reset/truncated event landed; keep the longer text instead of visibly erasing it. */
+function reconcileReasoningPart(previous: MessagePart | undefined, incoming: MessagePart): MessagePart {
+  if (incoming.type !== "reasoning" || !previous || previous.type !== "reasoning") return incoming
+  const previousText = previous.text ?? ""
+  const incomingText = incoming.text ?? ""
+  return incomingText.length >= previousText.length ? incoming : { ...incoming, text: previousText }
+}
+
 /** GET /session/{id}/message doesn't return reasoning parts, only the live event stream does — keep any streamed-in reasoning the refetch would otherwise silently drop. */
 function mergeFetchedMessages(current: MessageEnvelope[], fetched: MessageEnvelope[]): MessageEnvelope[] {
   const currentByID = new Map(current.map((message) => [message.info.id, message]))
   return fetched.map((message) => {
     const previous = currentByID.get(message.info.id)
     if (!previous) return message
+    const previousPartsByID = new Map(previous.parts.map((part) => [part.id, part]))
+    const parts = message.parts.map((part) => reconcileReasoningPart(previousPartsByID.get(part.id), part))
     const fetchedPartIDs = new Set(message.parts.map((part) => part.id))
     const missingReasoning = previous.parts.filter((part) => part.type === "reasoning" && !fetchedPartIDs.has(part.id))
-    if (missingReasoning.length === 0) return message
-    return { ...message, parts: [...missingReasoning, ...message.parts] }
+    if (missingReasoning.length === 0) return { ...message, parts }
+    return { ...message, parts: [...missingReasoning, ...parts] }
   })
 }
 
@@ -537,7 +547,7 @@ function applyStreamedPartUpdate(messages: MessageEnvelope[], sessionID: string,
     changed = true
     const exists = message.parts.some((existing) => existing.id === part.id)
     const parts = exists
-      ? message.parts.map((existing) => (existing.id === part.id ? part : existing))
+      ? message.parts.map((existing) => (existing.id === part.id ? reconcileReasoningPart(existing, part) : existing))
       : [...message.parts, part]
     return { ...message, parts }
   })

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { Fragment, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import { App as CapacitorApp } from "@capacitor/app"
 import type { PluginListenerHandle } from "@capacitor/core"
 import ReactMarkdown from "react-markdown"
@@ -77,15 +77,124 @@ function toolCommandLabel(part: MessagePart): string {
   return `${part.tool}(${JSON.stringify(input)})`
 }
 
-const DIFF_PREVIEW_LINES = 6
+/** Counts changed lines between two strings using an LCS-based line diff. Skipped (returns null) for inputs large
+ *  enough that the O(n*m) table would be expensive — callers fall back to no diff stats in that case. */
+function diffLineStats(oldText: string, newText: string): { additions: number; deletions: number } | null {
+  const a = oldText.split("\n")
+  const b = newText.split("\n")
+  if (a.length * b.length > 250_000) return null
+  const dp: number[][] = Array.from({ length: a.length + 1 }, () => new Array(b.length + 1).fill(0))
+  for (let i = a.length - 1; i >= 0; i--) {
+    for (let j = b.length - 1; j >= 0; j--) {
+      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1])
+    }
+  }
+  const lcsLength = dp[0][0]
+  return { additions: b.length - lcsLength, deletions: a.length - lcsLength }
+}
 
-function DiffLines({ patch, limit }: { patch: string; limit?: number }) {
+/** Builds a simple unified-style diff (no hunk headers, every line shown) between two strings, for rendering
+ *  with DiffLines. Skipped (returns null) for the same size cutoff as diffLineStats. */
+function buildSimpleDiff(oldText: string, newText: string): string | null {
+  const a = oldText.split("\n")
+  const b = newText.split("\n")
+  if (a.length * b.length > 250_000) return null
+  const dp: number[][] = Array.from({ length: a.length + 1 }, () => new Array(b.length + 1).fill(0))
+  for (let i = a.length - 1; i >= 0; i--) {
+    for (let j = b.length - 1; j >= 0; j--) {
+      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1])
+    }
+  }
+  const lines: string[] = []
+  let i = 0
+  let j = 0
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      lines.push(` ${a[i]}`)
+      i++
+      j++
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      lines.push(`-${a[i]}`)
+      i++
+    } else {
+      lines.push(`+${b[j]}`)
+      j++
+    }
+  }
+  while (i < a.length) {
+    lines.push(`-${a[i]}`)
+    i++
+  }
+  while (j < b.length) {
+    lines.push(`+${b[j]}`)
+    j++
+  }
+  return lines.join("\n")
+}
+
+/** Shortens a tool's absolute file path to a path relative to the session's working directory, when the file
+ *  actually lives under it — long absolute paths otherwise get truncated in the single-line summary row. */
+function relativizePath(path: string, directory: string | undefined): string {
+  if (!directory) return path
+  const normalize = (value: string) => value.replace(/\\/g, "/").replace(/\/+$/, "")
+  const normalizedPath = normalize(path)
+  const normalizedDir = normalize(directory)
+  if (normalizedPath === normalizedDir) return "."
+  const prefix = `${normalizedDir}/`
+  if (normalizedPath.toLowerCase().startsWith(prefix.toLowerCase())) {
+    return normalizedPath.slice(prefix.length)
+  }
+  return path
+}
+
+/** Turns a raw tool call into a human-readable description of what the bot did, plus a +/- line-diff summary
+ *  when the tool is an edit with old/new content to compare. */
+function describeToolAction(
+  part: MessagePart,
+  directory: string | undefined
+): { label: string; diff: { additions: number; deletions: number } | null } {
+  const input = (part.state?.input ?? {}) as Record<string, unknown>
+  const tool = (part.tool || "").toLowerCase()
+  const filePath = typeof input.filePath === "string" ? relativizePath(input.filePath, directory) : undefined
+
+  switch (tool) {
+    case "read":
+      return { label: filePath ? `Read ${filePath}` : "Read file", diff: null }
+    case "write": {
+      const content = typeof input.content === "string" ? input.content : null
+      const diff = content !== null ? diffLineStats("", content) : null
+      return { label: filePath ? `Wrote ${filePath}` : "Wrote file", diff }
+    }
+    case "edit": {
+      const oldString = typeof input.oldString === "string" ? input.oldString : null
+      const newString = typeof input.newString === "string" ? input.newString : null
+      const diff = oldString !== null && newString !== null ? diffLineStats(oldString, newString) : null
+      return { label: filePath ? `Edited ${filePath}` : "Edited file", diff }
+    }
+    case "bash":
+      return { label: typeof input.command === "string" ? `Ran ${input.command}` : "Ran command", diff: null }
+    case "glob":
+      return { label: typeof input.pattern === "string" ? `Searched files for "${input.pattern}"` : "Searched files", diff: null }
+    case "grep":
+      return { label: typeof input.pattern === "string" ? `Searched for "${input.pattern}"` : "Searched code", diff: null }
+    case "webfetch":
+      return { label: typeof input.url === "string" ? `Fetched ${input.url}` : "Fetched a URL", diff: null }
+    case "todowrite":
+      return { label: "Updated the to-do list", diff: null }
+    case "task":
+      return { label: typeof input.description === "string" ? `Ran subagent: ${input.description}` : "Ran a subagent", diff: null }
+    case "skill":
+      return { label: typeof input.name === "string" ? `Used skill: ${input.name}` : "Used a skill", diff: null }
+    default:
+      return { label: toolCommandLabel(part), diff: null }
+  }
+}
+
+function DiffLines({ patch }: { patch: string }) {
   const lines = patch.split("\n")
-  const shown = limit ? lines.slice(0, limit) : lines
-  const hiddenCount = lines.length - shown.length
   return (
     <pre className="message-diff-patch">
-      {shown.map((line, index) => {
+      {lines.map((line, index) => {
         let className = "diff-line-context"
         if (line.startsWith("+++") || line.startsWith("---")) className = "diff-line-meta"
         else if (line.startsWith("+")) className = "diff-line-add"
@@ -97,12 +206,23 @@ function DiffLines({ patch, limit }: { patch: string; limit?: number }) {
           </div>
         )
       })}
-      {hiddenCount > 0 && <div className="diff-line-more">+{hiddenCount} more lines</div>}
     </pre>
   )
 }
 
-function PatchPartView({ config, sessionID, messageID, files }: { config: ServerConfig; sessionID: string; messageID: string; files: string[] }) {
+function PatchPartView({
+  config,
+  sessionID,
+  messageID,
+  files,
+  timestamp
+}: {
+  config: ServerConfig
+  sessionID: string
+  messageID: string
+  files: string[]
+  timestamp?: string
+}) {
   const [diffs, setDiffs] = useState<DiffFile[] | null>(null)
   const [expandedDiff, setExpandedDiff] = useState<DiffFile | null>(null)
 
@@ -133,92 +253,69 @@ function PatchPartView({ config, sessionID, messageID, files }: { config: Server
   return (
     <div className="message-patch">
       {diffs.map((diff) => (
-        <details key={diff.file} className="message-diff" open>
-          <summary>
-            <span className="message-diff-file">{diff.file}</span>
-            <span className="message-diff-stats">
-              <span className="diff-stat-add">+{diff.additions}</span>
-              <span className="diff-stat-del">-{diff.deletions}</span>
-            </span>
-          </summary>
-          {diff.patch && (
-            <button
-              type="button"
-              className="message-diff-preview"
-              onClick={() => setExpandedDiff(diff)}
-              aria-label={`Expand full diff for ${diff.file}`}
-            >
-              <DiffLines patch={diff.patch} limit={DIFF_PREVIEW_LINES} />
-            </button>
-          )}
-        </details>
+        <button
+          key={diff.file}
+          type="button"
+          className="message-diff-row"
+          onClick={() => setExpandedDiff(diff)}
+          aria-label={`Show diff for ${diff.file}`}
+        >
+          <span className="message-diff-file">{diff.file}</span>
+          <span className="message-diff-stats">
+            {diff.additions > 0 && <span className="diff-stat-add">+{diff.additions}</span>}
+            {diff.deletions > 0 && <span className="diff-stat-del">-{diff.deletions}</span>}
+          </span>
+        </button>
       ))}
 
       {expandedDiff && (
-        <div className="modal-backdrop" role="presentation" onClick={() => setExpandedDiff(null)}>
-          <section
-            className="modal-card diff-modal fade-in"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="diff-modal-title"
-            onClick={(event) => event.stopPropagation()}
-          >
-            <div className="diff-modal-header">
-              <h2 id="diff-modal-title">{expandedDiff.file}</h2>
-              <button type="button" className="btn-secondary" onClick={() => setExpandedDiff(null)}>
-                Close
-              </button>
-            </div>
-            <div className="diff-modal-body">
-              {expandedDiff.patch && <DiffLines patch={expandedDiff.patch} />}
-            </div>
-          </section>
-        </div>
+        <Modal title={expandedDiff.file} timestamp={timestamp} onClose={() => setExpandedDiff(null)}>
+          {expandedDiff.patch && <DiffLines patch={expandedDiff.patch} />}
+        </Modal>
       )}
     </div>
   )
 }
 
-const TEXT_PREVIEW_LINES = 6
+const BOTTOM_STICK_THRESHOLD = 80
 
-function truncatedText(text: string, limit: number): { shown: string; hiddenCount: number } {
-  const lines = text.split("\n")
-  if (lines.length <= limit) return { shown: text, hiddenCount: 0 }
-  return { shown: lines.slice(0, limit).join("\n"), hiddenCount: lines.length - limit }
-}
+let modalTitleSequence = 0
 
-function ExpandableOutput({ text, className, modalTitle }: { text: string; className: string; modalTitle: string }) {
-  const [expanded, setExpanded] = useState(false)
-  const { shown, hiddenCount } = truncatedText(text, TEXT_PREVIEW_LINES)
+/** Shared full-detail modal — everything that isn't the primary output text (thoughts, tool calls, edits) is
+ *  surfaced through this rather than inline collapsible/expandable regions. */
+function Modal({
+  title,
+  timestamp,
+  onClose,
+  children
+}: {
+  title: string
+  timestamp?: string
+  onClose: () => void
+  children: ReactNode
+}) {
+  const [titleID] = useState(() => `modal-title-${++modalTitleSequence}`)
   return (
-    <>
-      <button type="button" className="message-tool-preview" onClick={() => setExpanded(true)} aria-label={`Expand ${modalTitle}`}>
-        <pre className={className}>{shown}</pre>
-        {hiddenCount > 0 && <div className="diff-line-more">+{hiddenCount} more lines</div>}
-      </button>
-
-      {expanded && (
-        <div className="modal-backdrop" role="presentation" onClick={() => setExpanded(false)}>
-          <section
-            className="modal-card diff-modal fade-in"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="tool-modal-title"
-            onClick={(event) => event.stopPropagation()}
-          >
-            <div className="diff-modal-header">
-              <h2 id="tool-modal-title">{modalTitle}</h2>
-              <button type="button" className="btn-secondary" onClick={() => setExpanded(false)}>
-                Close
-              </button>
-            </div>
-            <div className="diff-modal-body">
-              <pre className={className}>{text}</pre>
-            </div>
-          </section>
+    <div className="modal-backdrop" role="presentation" onClick={onClose}>
+      <section
+        className="modal-card diff-modal fade-in"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleID}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="diff-modal-header">
+          <div className="diff-modal-heading">
+            <h2 id={titleID}>{title}</h2>
+            {timestamp && <small className="diff-modal-timestamp">{timestamp}</small>}
+          </div>
+          <button type="button" className="btn-secondary" onClick={onClose}>
+            Close
+          </button>
         </div>
-      )}
-    </>
+        <div className="diff-modal-body">{children}</div>
+      </section>
+    </div>
   )
 }
 
@@ -338,31 +435,97 @@ function QuestionCard({
   )
 }
 
-function ToolPartView({ part }: { part: MessagePart }) {
+function ToolPartView({
+  part,
+  directory,
+  timestamp
+}: {
+  part: MessagePart
+  directory: string | undefined
+  timestamp?: string
+}) {
+  const [open, setOpen] = useState(false)
   const status = part.state?.status || "pending"
   const command = toolCommandLabel(part)
+  const { label, diff } = describeToolAction(part, directory)
+  const tool = (part.tool || "").toLowerCase()
+  const input = (part.state?.input ?? {}) as Record<string, unknown>
+  let patch: string | null = null
+  if (tool === "edit" && typeof input.oldString === "string" && typeof input.newString === "string") {
+    patch = buildSimpleDiff(input.oldString, input.newString)
+  } else if (tool === "write" && typeof input.content === "string") {
+    patch = buildSimpleDiff("", input.content)
+  }
   return (
-    <div className={`message-tool message-tool-${status}`}>
-      <div className="message-tool-header">
-        <span className="message-tool-name">{part.tool}</span>
-        <span className="message-tool-status">{status}</span>
-      </div>
-      <ExpandableOutput text={command} className="message-tool-command" modalTitle={`${part.tool} — command`} />
-      {part.state?.output && (
-        <ExpandableOutput text={part.state.output} className="message-tool-output" modalTitle={`${part.tool} — output`} />
+    <>
+      <button type="button" className={`message-tool-summary message-tool-${status}`} onClick={() => setOpen(true)}>
+        <span className="message-tool-label">{label}</span>
+        <span className="message-tool-meta">
+          {diff && (diff.additions > 0 || diff.deletions > 0) && (
+            <span className="message-tool-diff-stats">
+              {diff.additions > 0 && <span className="diff-stat-add">+{diff.additions}</span>}
+              {diff.deletions > 0 && <span className="diff-stat-del">-{diff.deletions}</span>}
+            </span>
+          )}
+          {status === "error" && (
+            <span className="message-tool-status-error" title="Tool failed" aria-label="Tool failed">
+              ✕
+            </span>
+          )}
+          {(status === "pending" || status === "running") && (
+            <span className="message-tool-status-pending" title="Running…" aria-label="Running">
+              …
+            </span>
+          )}
+        </span>
+      </button>
+
+      {open && (
+        <Modal title={label} timestamp={timestamp} onClose={() => setOpen(false)}>
+          <pre className="message-tool-command">{command}</pre>
+          {patch ? (
+            <DiffLines patch={patch} />
+          ) : (
+            part.state?.output && <pre className="message-tool-output">{part.state.output}</pre>
+          )}
+          {part.state?.error && <pre className="message-tool-output message-tool-error">{part.state.error}</pre>}
+        </Modal>
       )}
-      {part.state?.error && (
-        <ExpandableOutput
-          text={part.state.error}
-          className="message-tool-output message-tool-error"
-          modalTitle={`${part.tool} — error`}
-        />
-      )}
-    </div>
+    </>
   )
 }
 
-function MessagePartView({ part, config, sessionID }: { part: MessagePart; config: ServerConfig; sessionID: string }) {
+function ReasoningPartView({ part, timestamp }: { part: MessagePart; timestamp?: string }) {
+  const [open, setOpen] = useState(false)
+  if (!part.text) return null
+  const label = reasoningLabel([part])
+  return (
+    <>
+      <button type="button" className="message-reasoning-summary" onClick={() => setOpen(true)}>
+        {label}
+      </button>
+      {open && (
+        <Modal title={label} timestamp={timestamp} onClose={() => setOpen(false)}>
+          <pre className="message-reasoning-text">{part.text}</pre>
+        </Modal>
+      )}
+    </>
+  )
+}
+
+function MessagePartView({
+  part,
+  config,
+  sessionID,
+  directory,
+  timestamp
+}: {
+  part: MessagePart
+  config: ServerConfig
+  sessionID: string
+  directory?: string
+  timestamp?: string
+}) {
   if (part.type === "text") {
     if (!part.text) return null
     return (
@@ -373,25 +536,185 @@ function MessagePartView({ part, config, sessionID }: { part: MessagePart; confi
   }
 
   if (part.type === "reasoning") {
-    if (!part.text) return null
-    return (
-      <details className="message-reasoning">
-        <summary>Thinking</summary>
-        <pre>{part.text}</pre>
-      </details>
-    )
+    return <ReasoningPartView part={part} timestamp={timestamp} />
   }
 
   if (part.type === "tool") {
-    return <ToolPartView part={part} />
+    return <ToolPartView part={part} directory={directory} timestamp={timestamp} />
   }
 
   if (part.type === "patch") {
     if (!part.files || part.files.length === 0 || !part.messageID) return null
-    return <PatchPartView config={config} sessionID={sessionID} messageID={part.messageID} files={part.files} />
+    return (
+      <PatchPartView
+        config={config}
+        sessionID={sessionID}
+        messageID={part.messageID}
+        files={part.files}
+        timestamp={timestamp}
+      />
+    )
   }
 
   return null
+}
+
+const ACTION_GROUP_TYPES = new Set(["reasoning", "tool", "patch"])
+
+type TimelineItem = { kind: "action-group"; parts: MessagePart[] } | { kind: "part"; part: MessagePart }
+
+/** Walks a message's parts in order and collapses each run of consecutive thinking/tool-call/edit parts into a
+ *  single action-group item, alternating with the output text parts as they actually occurred — so a turn that
+ *  thinks, calls a tool, replies, thinks again, calls another tool, and replies again renders as two separate
+ *  "thought for Xs, used N tools" rows interleaved with their two outputs, rather than one merged blob. A run of
+ *  just one action part skips the group wrapper entirely and renders as that part directly. */
+function buildMessageTimeline(parts: MessagePart[]): TimelineItem[] {
+  const items: TimelineItem[] = []
+  let buffer: MessagePart[] = []
+  const flush = () => {
+    if (buffer.length === 0) return
+    items.push(buffer.length === 1 ? { kind: "part", part: buffer[0] } : { kind: "action-group", parts: buffer })
+    buffer = []
+  }
+  for (const part of parts) {
+    if (part.type === "step-start" || part.type === "step-finish") continue
+    if (ACTION_GROUP_TYPES.has(part.type)) {
+      buffer.push(part)
+    } else {
+      flush()
+      items.push({ kind: "part", part })
+    }
+  }
+  flush()
+  return items
+}
+
+function formatActionDuration(ms: number): string {
+  const seconds = Math.max(1, Math.round(ms / 1000))
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.round(seconds / 60)
+  return `${minutes}m`
+}
+
+/** Groups tool calls by what kind of action they represent (reads, searches, commands, ...) so a run of tool
+ *  calls summarizes as "read 5 files, searched 1 time" instead of a meaningless "ran 6 tools". */
+function summarizeToolCounts(toolParts: MessagePart[]): string[] {
+  const counts = new Map<string, number>()
+  const bump = (key: string) => counts.set(key, (counts.get(key) ?? 0) + 1)
+  for (const part of toolParts) {
+    const tool = (part.tool || "").toLowerCase()
+    switch (tool) {
+      case "read":
+        bump("read")
+        break
+      case "write":
+        bump("write")
+        break
+      case "edit":
+        bump("edit")
+        break
+      case "bash":
+        bump("bash")
+        break
+      case "glob":
+      case "grep":
+        bump("search")
+        break
+      case "webfetch":
+        bump("webfetch")
+        break
+      case "task":
+        bump("task")
+        break
+      case "skill":
+        bump("skill")
+        break
+      default:
+        bump("other")
+        break
+    }
+  }
+
+  const pieces: string[] = []
+  const push = (key: string, one: string, many: string) => {
+    const count = counts.get(key)
+    if (count) pieces.push(count === 1 ? one : many.replace("{n}", String(count)))
+  }
+  push("read", "read 1 file", "read {n} files")
+  push("write", "wrote 1 file", "wrote {n} files")
+  push("edit", "edited 1 file", "edited {n} files")
+  push("search", "searched 1 time", "searched {n} times")
+  push("bash", "ran 1 command", "ran {n} commands")
+  push("webfetch", "fetched 1 URL", "fetched {n} URLs")
+  push("task", "ran 1 subagent", "ran {n} subagents")
+  push("skill", "used 1 skill", "used {n} skills")
+  push("other", "ran 1 tool", "ran {n} tools")
+  return pieces
+}
+
+/** "Thought for Xs"/"Thought for Xm" when the reasoning part(s) carry timing, else a plain "Thinking". */
+function reasoningLabel(reasoningParts: MessagePart[]): string {
+  let minStart: number | undefined
+  let maxEnd: number | undefined
+  for (const part of reasoningParts) {
+    const time = part.time
+    if (!time) continue
+    if (minStart === undefined || time.start < minStart) minStart = time.start
+    const end = time.end ?? Date.now()
+    if (maxEnd === undefined || end > maxEnd) maxEnd = end
+  }
+  return minStart !== undefined && maxEnd !== undefined ? `Thought for ${formatActionDuration(maxEnd - minStart)}` : "Thinking"
+}
+
+function summarizeActionGroup(parts: MessagePart[]): string {
+  const reasoningParts = parts.filter((part) => part.type === "reasoning")
+  const toolParts = parts.filter((part) => part.type === "tool")
+  const editCount = parts
+    .filter((part) => part.type === "patch")
+    .reduce((sum, part) => sum + (part.files?.length ?? 0), 0)
+
+  const pieces: string[] = []
+  if (reasoningParts.length > 0) pieces.push(reasoningLabel(reasoningParts))
+  pieces.push(...summarizeToolCounts(toolParts))
+  if (editCount > 0) pieces.push(`made ${editCount} edit${editCount === 1 ? "" : "s"}`)
+  if (pieces.length === 0) pieces.push("Actions")
+  return pieces.join(", ")
+}
+
+function ActionGroupView({
+  parts,
+  config,
+  sessionID,
+  directory,
+  timestamp
+}: {
+  parts: MessagePart[]
+  config: ServerConfig
+  sessionID: string
+  directory?: string
+  timestamp?: string
+}) {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <button type="button" className="message-action-summary" onClick={() => setOpen(true)}>
+        <span>{summarizeActionGroup(parts)}</span>
+      </button>
+
+      {open && (
+        <Modal title={summarizeActionGroup(parts)} timestamp={timestamp} onClose={() => setOpen(false)}>
+          <div className="message-action-details">
+            {parts.map((part, index) => (
+              <Fragment key={part.id}>
+                {index > 0 && <hr className="message-action-divider" />}
+                <MessagePartView part={part} config={config} sessionID={sessionID} directory={directory} timestamp={timestamp} />
+              </Fragment>
+            ))}
+          </div>
+        </Modal>
+      )}
+    </>
+  )
 }
 
 function toFileStatusList(input: FileStatusEntry[] | Record<string, FileStatusEntry>): FileStatusEntry[] {
@@ -668,6 +991,7 @@ function App() {
   const renameInputRef = useRef<HTMLInputElement | null>(null)
   const [activeDetailSheet, setActiveDetailSheet] = useState<null | "ai" | "details">(null)
   const messagesRef = useRef<HTMLDivElement | null>(null)
+  const stickToBottomRef = useRef(true)
   const messagesEndRef = useRef<HTMLDivElement | null>(null)
   const composerRef = useRef<HTMLDivElement | null>(null)
   const completionAudioRef = useRef<HTMLAudioElement | null>(null)
@@ -1030,6 +1354,22 @@ function App() {
     const composerBottom = Number.parseFloat(composerStyles.bottom) || 0
     const clearance = Math.ceil(composerRect.height + composerBottom + 16)
     container.style.setProperty("--chat-bottom-clearance", `${clearance}px`)
+  }
+
+  function isNearMessagesBottom(): boolean {
+    const container = messagesRef.current
+    if (!container) return true
+    const containerDistance = container.scrollHeight - container.scrollTop - container.clientHeight
+    if (containerDistance > BOTTOM_STICK_THRESHOLD) return false
+    // The page itself can also scroll (the composer is pinned via fixed positioning), so a user
+    // scrolling the outer window away from the bottom must also break the auto-scroll pin.
+    const doc = document.documentElement
+    const windowDistance = doc.scrollHeight - window.scrollY - window.innerHeight
+    return windowDistance <= BOTTOM_STICK_THRESHOLD
+  }
+
+  function handleMessagesScroll() {
+    stickToBottomRef.current = isNearMessagesBottom()
   }
 
   function scrollMessagesToBottom(behavior: ScrollBehavior = "smooth") {
@@ -1438,7 +1778,14 @@ function App() {
   }, [hasConfiguredServer])
 
   useEffect(() => {
+    const onWindowScroll = () => handleMessagesScroll()
+    window.addEventListener("scroll", onWindowScroll, { passive: true })
+    return () => window.removeEventListener("scroll", onWindowScroll)
+  }, [])
+
+  useEffect(() => {
     if (view !== "detail") return
+    if (!stickToBottomRef.current) return
     scrollMessagesToBottom("auto")
   }, [view, messageScrollSignature, isWorking, showTypingBubble, pendingQuestions])
 
@@ -1446,10 +1793,15 @@ function App() {
     if (view !== "detail" || !selectedID) return
     const container = messagesRef.current
     if (!container) return
+    // Opening a session should always land at the bottom, regardless of where a previous session left off.
+    stickToBottomRef.current = true
     scrollMessagesToBottom("auto")
     // Tool/diff parts fetch their content asynchronously and grow after the
-    // initial layout, so keep pinning to the bottom while that settles.
-    const observer = new ResizeObserver(() => scrollMessagesToBottom("auto"))
+    // initial layout, so keep pinning to the bottom while that settles — but only while the
+    // user hasn't scrolled away from it.
+    const observer = new ResizeObserver(() => {
+      if (stickToBottomRef.current) scrollMessagesToBottom("auto")
+    })
     observer.observe(container)
     const timeout = setTimeout(() => observer.disconnect(), 2000)
     return () => {
@@ -2030,7 +2382,7 @@ function App() {
           )}
 
           <div className="messages-wrap">
-            <div className="messages" ref={messagesRef}>
+            <div className="messages" ref={messagesRef} onScroll={handleMessagesScroll}>
             {loadingSessionID === selectedID ? (
               <div className="empty-state compact">
                 <LoadingIcon size={32} />
@@ -2046,15 +2398,27 @@ function App() {
               <>
                 {renderedMessages.map((message) => (
                   <article key={message.info.id} className={`message ${message.info.role} fade-in`}>
-                    <header>
-                      <strong>
-                        {message.info.role === "user" ? t('detail.you') : t('detail.opencode')}
-                      </strong>
-                      <small>{formatTime(message.info.time.created)}</small>
-                    </header>
-                    {message.parts.map((part) => (
-                      <MessagePartView key={part.id} part={part} config={config} sessionID={message.info.sessionID} />
-                    ))}
+                    {buildMessageTimeline(message.parts).map((item) =>
+                      item.kind === "action-group" ? (
+                        <ActionGroupView
+                          key={`group-${item.parts[0].id}`}
+                          parts={item.parts}
+                          config={config}
+                          sessionID={message.info.sessionID}
+                          directory={selectedSession?.directory}
+                          timestamp={formatTime(message.info.time.created)}
+                        />
+                      ) : (
+                        <MessagePartView
+                          key={item.part.id}
+                          part={item.part}
+                          config={config}
+                          sessionID={message.info.sessionID}
+                          directory={selectedSession?.directory}
+                          timestamp={formatTime(message.info.time.created)}
+                        />
+                      )
+                    )}
                   </article>
                 ))}
                 {selectedSession &&

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2164,17 +2164,21 @@ function App() {
               <p className="subtle">
                 {t('sessions.summary', { total: sessions.length, active: activeSessions, changed: changedSessions })}
               </p>
-              {connectionStatusText && (
-                <p className={`connection-status ${connectionState}`}>
-                  {['connecting', 'reconnecting'].includes(connectionState) && <LoadingIcon size={14} />}
-                  {connectionStatusText}
-                </p>
-              )}
-              {eventStreamText && (
-                <p className={`connection-status event-stream ${eventStreamState}`}>
-                  {['connecting', 'reconnecting'].includes(eventStreamState) && <LoadingIcon size={14} />}
-                  {eventStreamText}
-                </p>
+              {(connectionStatusText || eventStreamText) && (
+                <div className="connection-status-row">
+                  {connectionStatusText && (
+                    <p className={`connection-status ${connectionState}`}>
+                      {['connecting', 'reconnecting'].includes(connectionState) && <LoadingIcon size={14} />}
+                      {connectionStatusText}
+                    </p>
+                  )}
+                  {eventStreamText && (
+                    <p className={`connection-status event-stream ${eventStreamState}`}>
+                      {['connecting', 'reconnecting'].includes(eventStreamState) && <LoadingIcon size={14} />}
+                      {eventStreamText}
+                    </p>
+                  )}
+                </div>
               )}
             </div>
             <div className="inline-actions">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1300,6 +1300,22 @@ function App() {
   }, [view, messageScrollSignature, isWorking, showTypingBubble])
 
   useEffect(() => {
+    if (view !== "detail" || !selectedID) return
+    const container = messagesRef.current
+    if (!container) return
+    scrollMessagesToBottom("auto")
+    // Tool/diff parts fetch their content asynchronously and grow after the
+    // initial layout, so keep pinning to the bottom while that settles.
+    const observer = new ResizeObserver(() => scrollMessagesToBottom("auto"))
+    observer.observe(container)
+    const timeout = setTimeout(() => observer.disconnect(), 2000)
+    return () => {
+      observer.disconnect()
+      clearTimeout(timeout)
+    }
+  }, [view, selectedID])
+
+  useEffect(() => {
     if (!awaitingAssistantReply) return
     if (assistantResponseSignature && assistantResponseSignature !== awaitingAssistantBaselineRef.current) {
       setAwaitingAssistantReply(false)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -70,6 +70,13 @@ function normalizeMessageMarkdown(text: string): string {
   return text.includes("\n") ? text : text.replace(/\s-\s(?=\S)/g, "\n- ")
 }
 
+const MODAL_TITLE_MAX_LENGTH = 80
+
+function truncateForTitle(text: string, maxLength: number = MODAL_TITLE_MAX_LENGTH): string {
+  const singleLine = text.replace(/\s+/g, " ").trim()
+  return singleLine.length > maxLength ? `${singleLine.slice(0, maxLength - 1)}…` : singleLine
+}
+
 function toolCommandLabel(part: MessagePart): string {
   const input = part.state?.input
   if (!input) return part.tool || "tool"
@@ -577,7 +584,7 @@ function ToolPartView({
       </button>
 
       {open && (
-        <Modal title={label} timestamp={timestamp} onClose={() => setOpen(false)} t={t}>
+        <Modal title={truncateForTitle(label)} timestamp={timestamp} onClose={() => setOpen(false)} t={t}>
           {todos ? (
             <TodoListView items={todos} />
           ) : questions ? (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1452,9 +1452,23 @@ function App() {
         return [createdView, ...current].sort((a, b) => b.updated - a.updated)
       })
       setSelectedID(created.id)
+      setMessages([])
+      setOptimisticUserMessages([])
+      setTodos([])
+      setDiffFiles([])
+      setProjectDashboard(null)
+      setDashboardError(null)
+      setAwaitingAssistantReply(false)
       setView("detail")
-      await loadSelected(created.id, created.directory)
-      await refreshSessions(false, createdView)
+      setLoadingSessionID(created.id)
+      try {
+        await loadSelected(created.id, created.directory)
+        await Promise.all([loadAgents(), loadModels()])
+      } catch (err) {
+        setRuntimeError((err as Error).message)
+      } finally {
+        setLoadingSessionID((activeID) => (activeID === created.id ? null : activeID))
+      }
     } catch (err) {
       setPickerError((err as Error).message)
       setRuntimeError((err as Error).message)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -60,6 +60,20 @@ function extractText(msg: MessageEnvelope): string {
     .trim()
 }
 
+/** Wraps a message with its extracted text, reusing the previous wrapper when the underlying message object is
+ *  unchanged. applyStreamedPartUpdate/applyStreamedPartDelta already keep unrelated messages referentially
+ *  identical across streamed updates — without this cache, mapping over the whole array would create a brand
+ *  new wrapper object for every message on every token, defeating memoization of per-message rendering. */
+const renderedMessageCache = new WeakMap<MessageEnvelope, MessageEnvelope & { text: string }>()
+
+function toRenderedMessage(message: MessageEnvelope): MessageEnvelope & { text: string } {
+  const cached = renderedMessageCache.get(message)
+  if (cached) return cached
+  const wrapped = { ...message, text: extractText(message) }
+  renderedMessageCache.set(message, wrapped)
+  return wrapped
+}
+
 function assistantPayloadLength(items: MessageEnvelope[]): number {
   return items
     .filter((message) => message.info.role !== "user")
@@ -1039,6 +1053,49 @@ function hasMatchingUserMessage(messages: MessageEnvelope[], optimistic: Message
   ))
 }
 
+/** One message's parts. Memoized on the message object identity so that streaming a token into one message
+ *  (which necessarily re-renders MessagesPane) doesn't re-run timeline/diff formatting for every other message
+ *  in the conversation — toRenderedMessage keeps unrelated messages referentially stable across updates. */
+const MessageArticle = memo(function MessageArticle({
+  message,
+  config,
+  directory,
+  t
+}: {
+  message: MessageEnvelope & { text: string }
+  config: ServerConfig
+  directory: string | undefined
+  t: Translator
+}) {
+  return (
+    <article className={`message ${message.info.role} fade-in`}>
+      {buildMessageTimeline(message.parts).map((item) =>
+        item.kind === "action-group" ? (
+          <ActionGroupView
+            key={`group-${item.parts[0].id}`}
+            parts={item.parts}
+            config={config}
+            sessionID={message.info.sessionID}
+            directory={directory}
+            timestamp={formatTime(message.info.time.created)}
+            t={t}
+          />
+        ) : (
+          <MessagePartView
+            key={item.part.id}
+            part={item.part}
+            config={config}
+            sessionID={message.info.sessionID}
+            directory={directory}
+            timestamp={formatTime(message.info.time.created)}
+            t={t}
+          />
+        )
+      )}
+    </article>
+  )
+})
+
 /** Renders the message list, pending questions, and typing bubble. Memoized so that unrelated state changes in
  *  the parent (most importantly typing into the composer) don't re-run the per-message formatting/diffing work
  *  on every keystroke. */
@@ -1086,31 +1143,7 @@ const MessagesPane = memo(function MessagesPane({
         ) : (
           <>
             {renderedMessages.map((message) => (
-              <article key={message.info.id} className={`message ${message.info.role} fade-in`}>
-                {buildMessageTimeline(message.parts).map((item) =>
-                  item.kind === "action-group" ? (
-                    <ActionGroupView
-                      key={`group-${item.parts[0].id}`}
-                      parts={item.parts}
-                      config={config}
-                      sessionID={message.info.sessionID}
-                      directory={directory}
-                      timestamp={formatTime(message.info.time.created)}
-                      t={t}
-                    />
-                  ) : (
-                    <MessagePartView
-                      key={item.part.id}
-                      part={item.part}
-                      config={config}
-                      sessionID={message.info.sessionID}
-                      directory={directory}
-                      timestamp={formatTime(message.info.time.created)}
-                      t={t}
-                    />
-                  )
-                )}
-              </article>
+              <MessageArticle key={message.info.id} message={message} config={config} directory={directory} t={t} />
             ))}
             {directory !== undefined &&
               pendingQuestions.map((request) => (
@@ -1291,7 +1324,7 @@ function App() {
 
   const renderedMessages = useMemo(() => {
     return [...messages, ...optimisticUserMessages]
-      .map((message) => ({ ...message, text: extractText(message) }))
+      .map(toRenderedMessage)
       .filter((message) => message.text || message.parts.some((part) => part.type !== "step-start" && part.type !== "step-finish"))
   }, [messages, optimisticUserMessages])
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2175,15 +2175,15 @@ function App() {
                     >
                       <PencilIcon size={16} />
                     </button>
-                    <button 
-                      className="btn-danger" 
+                    <button
+                      className="btn-danger"
                       onClick={(event) => {
                         event.stopPropagation()
                         setSessionToDelete(session)
                       }}
+                      title={t('sessions.delete')}
                     >
                       <TrashIcon size={16} />
-                      {t('sessions.delete')}
                     </button>
                   </div>
                 </article>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,7 +13,7 @@ import {
   type EventStreamStatus
 } from "./opencode-events"
 import { createTranslator, languageOptions, normalizeLanguage, type LanguageCode } from "./i18n"
-import type { AgentOption, CommandInfo, DiffFile, FileEntry, FileStatusEntry, MessageEnvelope, MessagePart, ModelOption, ModelSelection, PathInfo, ProjectDashboard, QuestionRequest, ServerConfig, Session, SessionStatus, SessionView, TodoItem } from "./types"
+import type { AgentOption, CommandInfo, DiffFile, FileEntry, FileStatusEntry, MessageEnvelope, MessagePart, ModelOption, ModelSelection, PathInfo, ProjectDashboard, QuestionInfo, QuestionRequest, ServerConfig, Session, SessionStatus, SessionView, TodoItem } from "./types"
 import {
   SettingsIcon,
   FolderIcon,
@@ -148,6 +148,22 @@ function relativizePath(path: string, directory: string | undefined): string {
   return path
 }
 
+function parseTodos(value: unknown): TodoItem[] | null {
+  if (!Array.isArray(value)) return null
+  const items = value.filter(
+    (item): item is TodoItem => Boolean(item) && typeof item === "object" && typeof (item as TodoItem).content === "string"
+  )
+  return items.length > 0 ? items : null
+}
+
+function parseQuestions(value: unknown): QuestionInfo[] | null {
+  if (!Array.isArray(value)) return null
+  const items = value.filter(
+    (item): item is QuestionInfo => Boolean(item) && typeof item === "object" && typeof (item as QuestionInfo).question === "string"
+  )
+  return items.length > 0 ? items : null
+}
+
 /** Turns a raw tool call into a human-readable description of what the bot did, plus a +/- line-diff summary
  *  when the tool is an edit with old/new content to compare. */
 function describeToolAction(
@@ -190,8 +206,20 @@ function describeToolAction(
       }
     case "webfetch":
       return { label: typeof input.url === "string" ? t('action.fetchedUrlNamed', { url: input.url }) : t('action.fetchedUrl'), diff: null }
-    case "todowrite":
-      return { label: t('action.updatedTodos'), diff: null }
+    case "todowrite": {
+      const todos = parseTodos(input.todos)
+      if (!todos) return { label: t('action.updatedTodos'), diff: null }
+      const done = todos.filter((item) => item.status === "completed").length
+      return { label: t('action.todoSummary', { done, total: todos.length }), diff: null }
+    }
+    case "question": {
+      const questions = parseQuestions(input.questions)
+      if (!questions) return { label: t('action.askedQuestion'), diff: null }
+      return {
+        label: questions.length === 1 ? t('action.askedQuestionNamed', { question: questions[0].question }) : t('action.askedQuestions', { n: questions.length }),
+        diff: null
+      }
+    }
     case "task":
       return {
         label:
@@ -208,6 +236,44 @@ function describeToolAction(
     default:
       return { label: toolCommandLabel(part), diff: null }
   }
+}
+
+function TodoListView({ items }: { items: TodoItem[] }) {
+  return (
+    <div className="message-todo-list">
+      {items.map((item) => (
+        <div key={item.id} className="todo-item">
+          <span className={`todo-status ${item.status}`}>
+            {item.status === "completed" ? "✓" : item.status === "in_progress" ? "◐" : "○"}
+          </span>
+          <span>{item.content}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function QuestionListView({ questions }: { questions: QuestionInfo[] }) {
+  return (
+    <div className="question-options">
+      {questions.map((question, index) => (
+        <div key={index} className="question-block">
+          <div className="question-header">{question.header}</div>
+          <p className="question-text">{question.question}</p>
+          {question.options.length > 0 && (
+            <div className="question-options">
+              {question.options.map((option) => (
+                <div key={option.label} className="question-option static">
+                  <span className="question-option-label">{option.label}</span>
+                  {option.description && <span className="question-option-description">{option.description}</span>}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  )
 }
 
 function DiffLines({ patch }: { patch: string }) {
@@ -484,6 +550,8 @@ function ToolPartView({
   } else if (tool === "write" && typeof input.content === "string") {
     patch = buildSimpleDiff("", input.content)
   }
+  const todos = tool === "todowrite" ? parseTodos(input.todos) : null
+  const questions = tool === "question" ? parseQuestions(input.questions) : null
   return (
     <>
       <button type="button" className={`message-tool-summary message-tool-${status}`} onClick={() => setOpen(true)}>
@@ -510,11 +578,19 @@ function ToolPartView({
 
       {open && (
         <Modal title={label} timestamp={timestamp} onClose={() => setOpen(false)} t={t}>
-          <pre className="message-tool-command">{command}</pre>
-          {patch ? (
-            <DiffLines patch={patch} />
+          {todos ? (
+            <TodoListView items={todos} />
+          ) : questions ? (
+            <QuestionListView questions={questions} />
           ) : (
-            part.state?.output && <pre className="message-tool-output">{part.state.output}</pre>
+            <>
+              <pre className="message-tool-command">{command}</pre>
+              {patch ? (
+                <DiffLines patch={patch} />
+              ) : (
+                part.state?.output && <pre className="message-tool-output">{part.state.output}</pre>
+              )}
+            </>
           )}
           {part.state?.error && <pre className="message-tool-output message-tool-error">{part.state.error}</pre>}
         </Modal>
@@ -660,6 +736,12 @@ function summarizeToolCounts(toolParts: MessagePart[], t: Translator): string[] 
       case "skill":
         bump("skill")
         break
+      case "todowrite":
+        bump("todo")
+        break
+      case "question":
+        bump("question")
+        break
       default:
         bump("other")
         break
@@ -679,6 +761,8 @@ function summarizeToolCounts(toolParts: MessagePart[], t: Translator): string[] 
   push("webfetch", "action.countWebfetchOne", "action.countWebfetchMany")
   push("task", "action.countTaskOne", "action.countTaskMany")
   push("skill", "action.countSkillOne", "action.countSkillMany")
+  push("todo", "action.countTodoOne", "action.countTodoMany")
+  push("question", "action.countQuestionOne", "action.countQuestionMany")
   push("other", "action.countOtherOne", "action.countOtherMany")
   return pieces
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1278,6 +1278,7 @@ function App() {
   const initialSessionLoadRef = useRef(true)
   const latestMessageTimesRef = useRef(new Map<string, { sessionUpdated: number; activityTime: number }>())
   const selectedSessionRef = useRef<SessionView | null>(null)
+  const eventStreamStateRef = useRef<"idle" | "connecting" | "live" | "reconnecting" | "fallback">("idle")
 
   const selectedSession = useMemo(
     () => sessions.find((session) => session.id === selectedID) ?? null,
@@ -1973,6 +1974,10 @@ function App() {
   }, [selectedSession])
 
   useEffect(() => {
+    eventStreamStateRef.current = eventStreamState
+  }, [eventStreamState])
+
+  useEffect(() => {
     if (!config.host || config.port <= 0) {
       setConnectionState("idle")
       setConnectionMessage("")
@@ -1987,6 +1992,10 @@ function App() {
     loadAgents().catch(() => undefined)
     loadModels().catch(() => undefined)
     const timer = setInterval(() => {
+      // Live SSE events already keep sessions and the open session's messages/todos/diffs in sync
+      // (via applyStreamedPartUpdate/scheduleRefresh); this poll is only a fallback for when the
+      // stream isn't actually connected, so skip the redundant full refetch while it's live.
+      if (eventStreamStateRef.current === "live") return
       refreshSessions(true).catch(() => undefined)
       if (selectedSession) {
         loadSelected(selectedSession.id, selectedSession.directory).catch(() => undefined)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -38,6 +38,8 @@ const AGENT_STORAGE_KEY = "opencode.remote.agent"
 const THEME_STORAGE_KEY = "opencode.remote.theme"
 const NEW_SESSION_DIRECTORY_STORAGE_KEY = "opencode.remote.newSessionDirectory"
 
+type Translator = ReturnType<typeof createTranslator>
+
 const defaultConfig: ServerConfig = {
   host: "",
   port: 4096,
@@ -150,7 +152,8 @@ function relativizePath(path: string, directory: string | undefined): string {
  *  when the tool is an edit with old/new content to compare. */
 function describeToolAction(
   part: MessagePart,
-  directory: string | undefined
+  directory: string | undefined,
+  t: Translator
 ): { label: string; diff: { additions: number; deletions: number } | null } {
   const input = (part.state?.input ?? {}) as Record<string, unknown>
   const tool = (part.tool || "").toLowerCase()
@@ -158,32 +161,50 @@ function describeToolAction(
 
   switch (tool) {
     case "read":
-      return { label: filePath ? `Read ${filePath}` : "Read file", diff: null }
+      return { label: filePath ? t('action.readFileNamed', { file: filePath }) : t('action.readFile'), diff: null }
     case "write": {
       const content = typeof input.content === "string" ? input.content : null
       const diff = content !== null ? diffLineStats("", content) : null
-      return { label: filePath ? `Wrote ${filePath}` : "Wrote file", diff }
+      return { label: filePath ? t('action.wroteFileNamed', { file: filePath }) : t('action.wroteFile'), diff }
     }
     case "edit": {
       const oldString = typeof input.oldString === "string" ? input.oldString : null
       const newString = typeof input.newString === "string" ? input.newString : null
       const diff = oldString !== null && newString !== null ? diffLineStats(oldString, newString) : null
-      return { label: filePath ? `Edited ${filePath}` : "Edited file", diff }
+      return { label: filePath ? t('action.editedFileNamed', { file: filePath }) : t('action.editedFile'), diff }
     }
     case "bash":
-      return { label: typeof input.command === "string" ? `Ran ${input.command}` : "Ran command", diff: null }
+      return {
+        label: typeof input.command === "string" ? t('action.ranCommandNamed', { command: input.command }) : t('action.ranCommand'),
+        diff: null
+      }
     case "glob":
-      return { label: typeof input.pattern === "string" ? `Searched files for "${input.pattern}"` : "Searched files", diff: null }
+      return {
+        label: typeof input.pattern === "string" ? t('action.searchedFilesFor', { pattern: input.pattern }) : t('action.searchedFiles'),
+        diff: null
+      }
     case "grep":
-      return { label: typeof input.pattern === "string" ? `Searched for "${input.pattern}"` : "Searched code", diff: null }
+      return {
+        label: typeof input.pattern === "string" ? t('action.searchedCodeFor', { pattern: input.pattern }) : t('action.searchedCode'),
+        diff: null
+      }
     case "webfetch":
-      return { label: typeof input.url === "string" ? `Fetched ${input.url}` : "Fetched a URL", diff: null }
+      return { label: typeof input.url === "string" ? t('action.fetchedUrlNamed', { url: input.url }) : t('action.fetchedUrl'), diff: null }
     case "todowrite":
-      return { label: "Updated the to-do list", diff: null }
+      return { label: t('action.updatedTodos'), diff: null }
     case "task":
-      return { label: typeof input.description === "string" ? `Ran subagent: ${input.description}` : "Ran a subagent", diff: null }
+      return {
+        label:
+          typeof input.description === "string"
+            ? t('action.ranSubagentNamed', { description: input.description })
+            : t('action.ranSubagent'),
+        diff: null
+      }
     case "skill":
-      return { label: typeof input.name === "string" ? `Used skill: ${input.name}` : "Used a skill", diff: null }
+      return {
+        label: typeof input.name === "string" ? t('action.usedSkillNamed', { name: input.name }) : t('action.usedSkill'),
+        diff: null
+      }
     default:
       return { label: toolCommandLabel(part), diff: null }
   }
@@ -214,13 +235,15 @@ function PatchPartView({
   sessionID,
   messageID,
   files,
-  timestamp
+  timestamp,
+  t
 }: {
   config: ServerConfig
   sessionID: string
   messageID: string
   files: string[]
   timestamp?: string
+  t: Translator
 }) {
   const [diffs, setDiffs] = useState<DiffFile[] | null>(null)
   const [expandedDiff, setExpandedDiff] = useState<DiffFile | null>(null)
@@ -257,7 +280,7 @@ function PatchPartView({
           type="button"
           className="message-diff-row"
           onClick={() => setExpandedDiff(diff)}
-          aria-label={`Show diff for ${diff.file}`}
+          aria-label={t('action.showDiffFor', { file: diff.file })}
         >
           <span className="message-diff-file">{diff.file}</span>
           <span className="message-diff-stats">
@@ -268,7 +291,7 @@ function PatchPartView({
       ))}
 
       {expandedDiff && (
-        <Modal title={expandedDiff.file} timestamp={timestamp} onClose={() => setExpandedDiff(null)}>
+        <Modal title={expandedDiff.file} timestamp={timestamp} onClose={() => setExpandedDiff(null)} t={t}>
           {expandedDiff.patch && <DiffLines patch={expandedDiff.patch} />}
         </Modal>
       )}
@@ -286,12 +309,14 @@ function Modal({
   title,
   timestamp,
   onClose,
-  children
+  children,
+  t
 }: {
   title: string
   timestamp?: string
   onClose: () => void
   children: ReactNode
+  t: Translator
 }) {
   const [titleID] = useState(() => `modal-title-${++modalTitleSequence}`)
   return (
@@ -309,7 +334,7 @@ function Modal({
             {timestamp && <small className="diff-modal-timestamp">{timestamp}</small>}
           </div>
           <button type="button" className="btn-secondary" onClick={onClose}>
-            Close
+            {t('action.close')}
           </button>
         </div>
         <div className="diff-modal-body">{children}</div>
@@ -322,12 +347,14 @@ function QuestionCard({
   config,
   directory,
   request,
-  onResolved
+  onResolved,
+  t
 }: {
   config: ServerConfig
   directory: string
   request: QuestionRequest
   onResolved: (id: string) => void
+  t: Translator
 }) {
   const [selections, setSelections] = useState<string[][]>(() => request.questions.map(() => []))
   const [customValues, setCustomValues] = useState<string[]>(() => request.questions.map(() => ""))
@@ -390,7 +417,7 @@ function QuestionCard({
   }
 
   return (
-    <article className="message assistant question-card fade-in" aria-label="Question from OpenCode">
+    <article className="message assistant question-card fade-in" aria-label={t('question.ariaLabel')}>
       {request.questions.map((question, index) => (
         <div key={index} className="question-block">
           <div className="question-header">{question.header}</div>
@@ -413,7 +440,7 @@ function QuestionCard({
             <input
               type="text"
               className="question-custom-input"
-              placeholder="Other…"
+              placeholder={t('question.otherPlaceholder')}
               value={customValues[index]}
               onChange={(event) => setCustomValue(index, event.target.value)}
               disabled={submitting}
@@ -424,10 +451,10 @@ function QuestionCard({
       {error && <p className="question-error">{error}</p>}
       <div className="question-actions">
         <button type="button" className="btn-secondary" onClick={reject} disabled={submitting}>
-          Skip
+          {t('question.skip')}
         </button>
         <button type="button" className="btn-primary" onClick={submit} disabled={submitting || !canSubmit}>
-          Send answer
+          {t('question.sendAnswer')}
         </button>
       </div>
     </article>
@@ -437,16 +464,18 @@ function QuestionCard({
 function ToolPartView({
   part,
   directory,
-  timestamp
+  timestamp,
+  t
 }: {
   part: MessagePart
   directory: string | undefined
   timestamp?: string
+  t: Translator
 }) {
   const [open, setOpen] = useState(false)
   const status = part.state?.status || "pending"
   const command = toolCommandLabel(part)
-  const { label, diff } = describeToolAction(part, directory)
+  const { label, diff } = describeToolAction(part, directory, t)
   const tool = (part.tool || "").toLowerCase()
   const input = (part.state?.input ?? {}) as Record<string, unknown>
   let patch: string | null = null
@@ -467,12 +496,12 @@ function ToolPartView({
             </span>
           )}
           {status === "error" && (
-            <span className="message-tool-status-error" title="Tool failed" aria-label="Tool failed">
+            <span className="message-tool-status-error" title={t('action.toolFailed')} aria-label={t('action.toolFailed')}>
               ✕
             </span>
           )}
           {(status === "pending" || status === "running") && (
-            <span className="message-tool-status-pending" title="Running…" aria-label="Running">
+            <span className="message-tool-status-pending" title={t('action.running')} aria-label={t('action.running')}>
               …
             </span>
           )}
@@ -480,7 +509,7 @@ function ToolPartView({
       </button>
 
       {open && (
-        <Modal title={label} timestamp={timestamp} onClose={() => setOpen(false)}>
+        <Modal title={label} timestamp={timestamp} onClose={() => setOpen(false)} t={t}>
           <pre className="message-tool-command">{command}</pre>
           {patch ? (
             <DiffLines patch={patch} />
@@ -494,17 +523,17 @@ function ToolPartView({
   )
 }
 
-function ReasoningPartView({ part, timestamp }: { part: MessagePart; timestamp?: string }) {
+function ReasoningPartView({ part, timestamp, t }: { part: MessagePart; timestamp?: string; t: Translator }) {
   const [open, setOpen] = useState(false)
   if (!part.text) return null
-  const label = reasoningLabel([part])
+  const label = reasoningLabel([part], t)
   return (
     <>
       <button type="button" className="message-reasoning-summary" onClick={() => setOpen(true)}>
         {label}
       </button>
       {open && (
-        <Modal title={label} timestamp={timestamp} onClose={() => setOpen(false)}>
+        <Modal title={label} timestamp={timestamp} onClose={() => setOpen(false)} t={t}>
           <pre className="message-reasoning-text">{part.text}</pre>
         </Modal>
       )}
@@ -517,13 +546,15 @@ function MessagePartView({
   config,
   sessionID,
   directory,
-  timestamp
+  timestamp,
+  t
 }: {
   part: MessagePart
   config: ServerConfig
   sessionID: string
   directory?: string
   timestamp?: string
+  t: Translator
 }) {
   if (part.type === "text") {
     if (!part.text) return null
@@ -535,11 +566,11 @@ function MessagePartView({
   }
 
   if (part.type === "reasoning") {
-    return <ReasoningPartView part={part} timestamp={timestamp} />
+    return <ReasoningPartView part={part} timestamp={timestamp} t={t} />
   }
 
   if (part.type === "tool") {
-    return <ToolPartView part={part} directory={directory} timestamp={timestamp} />
+    return <ToolPartView part={part} directory={directory} timestamp={timestamp} t={t} />
   }
 
   if (part.type === "patch") {
@@ -551,6 +582,7 @@ function MessagePartView({
         messageID={part.messageID}
         files={part.files}
         timestamp={timestamp}
+        t={t}
       />
     )
   }
@@ -588,16 +620,16 @@ function buildMessageTimeline(parts: MessagePart[]): TimelineItem[] {
   return items
 }
 
-function formatActionDuration(ms: number): string {
+function formatActionDuration(ms: number, t: Translator): string {
   const seconds = Math.max(1, Math.round(ms / 1000))
-  if (seconds < 60) return `${seconds}s`
+  if (seconds < 60) return t('action.durationSeconds', { n: seconds })
   const minutes = Math.round(seconds / 60)
-  return `${minutes}m`
+  return t('action.durationMinutes', { n: minutes })
 }
 
 /** Groups tool calls by what kind of action they represent (reads, searches, commands, ...) so a run of tool
  *  calls summarizes as "read 5 files, searched 1 time" instead of a meaningless "ran 6 tools". */
-function summarizeToolCounts(toolParts: MessagePart[]): string[] {
+function summarizeToolCounts(toolParts: MessagePart[], t: Translator): string[] {
   const counts = new Map<string, number>()
   const bump = (key: string) => counts.set(key, (counts.get(key) ?? 0) + 1)
   for (const part of toolParts) {
@@ -635,24 +667,24 @@ function summarizeToolCounts(toolParts: MessagePart[]): string[] {
   }
 
   const pieces: string[] = []
-  const push = (key: string, one: string, many: string) => {
+  const push = (key: string, oneKey: string, manyKey: string) => {
     const count = counts.get(key)
-    if (count) pieces.push(count === 1 ? one : many.replace("{n}", String(count)))
+    if (count) pieces.push(count === 1 ? t(oneKey) : t(manyKey, { n: count }))
   }
-  push("read", "read 1 file", "read {n} files")
-  push("write", "wrote 1 file", "wrote {n} files")
-  push("edit", "edited 1 file", "edited {n} files")
-  push("search", "searched 1 time", "searched {n} times")
-  push("bash", "ran 1 command", "ran {n} commands")
-  push("webfetch", "fetched 1 URL", "fetched {n} URLs")
-  push("task", "ran 1 subagent", "ran {n} subagents")
-  push("skill", "used 1 skill", "used {n} skills")
-  push("other", "ran 1 tool", "ran {n} tools")
+  push("read", "action.countReadOne", "action.countReadMany")
+  push("write", "action.countWriteOne", "action.countWriteMany")
+  push("edit", "action.countEditOne", "action.countEditMany")
+  push("search", "action.countSearchOne", "action.countSearchMany")
+  push("bash", "action.countBashOne", "action.countBashMany")
+  push("webfetch", "action.countWebfetchOne", "action.countWebfetchMany")
+  push("task", "action.countTaskOne", "action.countTaskMany")
+  push("skill", "action.countSkillOne", "action.countSkillMany")
+  push("other", "action.countOtherOne", "action.countOtherMany")
   return pieces
 }
 
 /** "Thought for Xs"/"Thought for Xm" when the reasoning part(s) carry timing, else a plain "Thinking". */
-function reasoningLabel(reasoningParts: MessagePart[]): string {
+function reasoningLabel(reasoningParts: MessagePart[], t: Translator): string {
   let minStart: number | undefined
   let maxEnd: number | undefined
   for (const part of reasoningParts) {
@@ -662,10 +694,12 @@ function reasoningLabel(reasoningParts: MessagePart[]): string {
     const end = time.end ?? Date.now()
     if (maxEnd === undefined || end > maxEnd) maxEnd = end
   }
-  return minStart !== undefined && maxEnd !== undefined ? `Thought for ${formatActionDuration(maxEnd - minStart)}` : "Thinking"
+  return minStart !== undefined && maxEnd !== undefined
+    ? t('action.thoughtFor', { duration: formatActionDuration(maxEnd - minStart, t) })
+    : t('action.thinking')
 }
 
-function summarizeActionGroup(parts: MessagePart[]): string {
+function summarizeActionGroup(parts: MessagePart[], t: Translator): string {
   const reasoningParts = parts.filter((part) => part.type === "reasoning")
   const toolParts = parts.filter((part) => part.type === "tool")
   const editCount = parts
@@ -673,10 +707,10 @@ function summarizeActionGroup(parts: MessagePart[]): string {
     .reduce((sum, part) => sum + (part.files?.length ?? 0), 0)
 
   const pieces: string[] = []
-  if (reasoningParts.length > 0) pieces.push(reasoningLabel(reasoningParts))
-  pieces.push(...summarizeToolCounts(toolParts))
-  if (editCount > 0) pieces.push(`made ${editCount} edit${editCount === 1 ? "" : "s"}`)
-  if (pieces.length === 0) pieces.push("Actions")
+  if (reasoningParts.length > 0) pieces.push(reasoningLabel(reasoningParts, t))
+  pieces.push(...summarizeToolCounts(toolParts, t))
+  if (editCount > 0) pieces.push(editCount === 1 ? t('action.madeEditOne') : t('action.madeEditMany', { n: editCount }))
+  if (pieces.length === 0) pieces.push(t('action.actionsFallback'))
   return pieces.join(", ")
 }
 
@@ -685,28 +719,30 @@ function ActionGroupView({
   config,
   sessionID,
   directory,
-  timestamp
+  timestamp,
+  t
 }: {
   parts: MessagePart[]
   config: ServerConfig
   sessionID: string
   directory?: string
   timestamp?: string
+  t: Translator
 }) {
   const [open, setOpen] = useState(false)
   return (
     <>
       <button type="button" className="message-action-summary" onClick={() => setOpen(true)}>
-        <span>{summarizeActionGroup(parts)}</span>
+        <span>{summarizeActionGroup(parts, t)}</span>
       </button>
 
       {open && (
-        <Modal title={summarizeActionGroup(parts)} timestamp={timestamp} onClose={() => setOpen(false)}>
+        <Modal title={summarizeActionGroup(parts, t)} timestamp={timestamp} onClose={() => setOpen(false)} t={t}>
           <div className="message-action-details">
             {parts.map((part, index) => (
               <Fragment key={part.id}>
                 {index > 0 && <hr className="message-action-divider" />}
-                <MessagePartView part={part} config={config} sessionID={sessionID} directory={directory} timestamp={timestamp} />
+                <MessagePartView part={part} config={config} sessionID={sessionID} directory={directory} timestamp={timestamp} t={t} />
               </Fragment>
             ))}
           </div>
@@ -2411,6 +2447,7 @@ function App() {
                           sessionID={message.info.sessionID}
                           directory={selectedSession?.directory}
                           timestamp={formatTime(message.info.time.created)}
+                          t={t}
                         />
                       ) : (
                         <MessagePartView
@@ -2420,6 +2457,7 @@ function App() {
                           sessionID={message.info.sessionID}
                           directory={selectedSession?.directory}
                           timestamp={formatTime(message.info.time.created)}
+                          t={t}
                         />
                       )
                     )}
@@ -2433,6 +2471,7 @@ function App() {
                       directory={selectedSession.directory}
                       request={request}
                       onResolved={(id) => setPendingQuestions((current) => current.filter((item) => item.id !== id))}
+                      t={t}
                     />
                   ))}
                 {showTypingBubble && (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2308,6 +2308,7 @@ function App() {
                       title={t('sessions.delete')}
                     >
                       <TrashIcon size={16} />
+                      {t('sessions.delete')}
                     </button>
                   </div>
                 </article>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,7 +13,7 @@ import {
   type EventStreamStatus
 } from "./opencode-events"
 import { createTranslator, languageOptions, normalizeLanguage, type LanguageCode } from "./i18n"
-import type { AgentOption, CommandInfo, DiffFile, FileEntry, FileStatusEntry, MessageEnvelope, MessagePart, ModelOption, ModelSelection, PathInfo, ProjectDashboard, ServerConfig, Session, SessionStatus, SessionView, TodoItem } from "./types"
+import type { AgentOption, CommandInfo, DiffFile, FileEntry, FileStatusEntry, MessageEnvelope, MessagePart, ModelOption, ModelSelection, PathInfo, ProjectDashboard, QuestionRequest, ServerConfig, Session, SessionStatus, SessionView, TodoItem } from "./types"
 import {
   SettingsIcon,
   FolderIcon,
@@ -219,6 +219,122 @@ function ExpandableOutput({ text, className, modalTitle }: { text: string; class
         </div>
       )}
     </>
+  )
+}
+
+function QuestionCard({
+  config,
+  directory,
+  request,
+  onResolved
+}: {
+  config: ServerConfig
+  directory: string
+  request: QuestionRequest
+  onResolved: (id: string) => void
+}) {
+  const [selections, setSelections] = useState<string[][]>(() => request.questions.map(() => []))
+  const [customValues, setCustomValues] = useState<string[]>(() => request.questions.map(() => ""))
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  function toggleOption(questionIndex: number, label: string, multiple: boolean) {
+    setSelections((current) => {
+      const next = [...current]
+      const existing = next[questionIndex]
+      next[questionIndex] = multiple
+        ? existing.includes(label)
+          ? existing.filter((value) => value !== label)
+          : [...existing, label]
+        : existing.includes(label)
+          ? []
+          : [label]
+      return next
+    })
+  }
+
+  function setCustomValue(questionIndex: number, value: string) {
+    setCustomValues((current) => {
+      const next = [...current]
+      next[questionIndex] = value
+      return next
+    })
+  }
+
+  const canSubmit = request.questions.every((question, index) => {
+    return selections[index].length > 0 || (question.custom && customValues[index].trim().length > 0)
+  })
+
+  async function submit() {
+    setSubmitting(true)
+    setError(null)
+    try {
+      const answers = request.questions.map((_, index) => {
+        const customValue = customValues[index].trim()
+        return customValue ? [...selections[index], customValue] : selections[index]
+      })
+      await api.replyQuestion(config, request.id, answers, directory)
+      onResolved(request.id)
+    } catch (err) {
+      setError((err as Error).message)
+      setSubmitting(false)
+    }
+  }
+
+  async function reject() {
+    setSubmitting(true)
+    setError(null)
+    try {
+      await api.rejectQuestion(config, request.id, directory)
+      onResolved(request.id)
+    } catch (err) {
+      setError((err as Error).message)
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <article className="message assistant question-card fade-in" aria-label="Question from OpenCode">
+      {request.questions.map((question, index) => (
+        <div key={index} className="question-block">
+          <div className="question-header">{question.header}</div>
+          <p className="question-text">{question.question}</p>
+          <div className="question-options">
+            {question.options.map((option) => (
+              <button
+                key={option.label}
+                type="button"
+                className={`question-option ${selections[index].includes(option.label) ? "selected" : ""}`}
+                onClick={() => toggleOption(index, option.label, Boolean(question.multiple))}
+                disabled={submitting}
+              >
+                <span className="question-option-label">{option.label}</span>
+                {option.description && <span className="question-option-description">{option.description}</span>}
+              </button>
+            ))}
+          </div>
+          {question.custom && (
+            <input
+              type="text"
+              className="question-custom-input"
+              placeholder="Other…"
+              value={customValues[index]}
+              onChange={(event) => setCustomValue(index, event.target.value)}
+              disabled={submitting}
+            />
+          )}
+        </div>
+      ))}
+      {error && <p className="question-error">{error}</p>}
+      <div className="question-actions">
+        <button type="button" className="btn-secondary" onClick={reject} disabled={submitting}>
+          Skip
+        </button>
+        <button type="button" className="btn-primary" onClick={submit} disabled={submitting || !canSubmit}>
+          Send answer
+        </button>
+      </div>
+    </article>
   )
 }
 
@@ -499,6 +615,7 @@ function App() {
   const [optimisticUserMessages, setOptimisticUserMessages] = useState<MessageEnvelope[]>([])
   const [todos, setTodos] = useState<TodoItem[]>([])
   const [diffFiles, setDiffFiles] = useState<DiffFile[]>([])
+  const [pendingQuestions, setPendingQuestions] = useState<QuestionRequest[]>([])
 
   const [projectDashboard, setProjectDashboard] = useState<ProjectDashboard | null>(null)
 
@@ -653,6 +770,7 @@ function App() {
     setOptimisticUserMessages([])
     setTodos([])
     setDiffFiles([])
+    setPendingQuestions([])
     setProjectDashboard(null)
     setDashboardError(null)
     setAwaitingAssistantReply(false)
@@ -847,10 +965,11 @@ function App() {
 
   async function loadSelected(sessionID: string, directory: string) {
     const requestID = ++loadSelectedRequestRef.current
-    const [msg, todo, diff] = await Promise.all([
+    const [msg, todo, diff, questions] = await Promise.all([
       api.loadMessages(config, sessionID, directory),
       api.loadTodo(config, sessionID, directory),
-      api.loadDiff(config, sessionID, directory).catch(() => [])
+      api.loadDiff(config, sessionID, directory).catch(() => []),
+      api.loadQuestions(config, directory).catch(() => [])
     ])
     if (requestID !== loadSelectedRequestRef.current) return
     setMessages((current) => {
@@ -860,6 +979,7 @@ function App() {
     setOptimisticUserMessages((current) => current.filter((message) => !hasMatchingUserMessage(msg, message)))
     setTodos(todo)
     setDiffFiles(diff)
+    setPendingQuestions(questions.filter((question) => question.sessionID === sessionID))
     await loadProjectDashboard(directory)
   }
 
@@ -1257,7 +1377,7 @@ function App() {
           applyStreamedPartDelta(current, body.sessionID!, body.messageID!, body.partID!, body.field!, body.delta!)
         )
       }
-      if (type.startsWith("session.") || type.startsWith("message.") || type.startsWith("todo.")) {
+      if (type.startsWith("session.") || type.startsWith("message.") || type.startsWith("todo.") || type.startsWith("question.")) {
         setLiveEventCount((count) => count + 1)
         scheduleRefresh()
       }
@@ -1297,7 +1417,7 @@ function App() {
   useEffect(() => {
     if (view !== "detail") return
     scrollMessagesToBottom("auto")
-  }, [view, messageScrollSignature, isWorking, showTypingBubble])
+  }, [view, messageScrollSignature, isWorking, showTypingBubble, pendingQuestions])
 
   useEffect(() => {
     if (view !== "detail" || !selectedID) return
@@ -1893,7 +2013,7 @@ function App() {
                 <LoadingIcon size={32} />
                 <p>{t('detail.loading')}</p>
               </div>
-            ) : renderedMessages.length === 0 && !showTypingBubble ? (
+            ) : renderedMessages.length === 0 && !showTypingBubble && pendingQuestions.length === 0 ? (
               <div className="empty-state compact">
                 <ChatIcon size={40} className="icon-empty-state" />
                 <p>{t('detail.emptyTitle')}</p>
@@ -1914,6 +2034,16 @@ function App() {
                     ))}
                   </article>
                 ))}
+                {selectedSession &&
+                  pendingQuestions.map((request) => (
+                    <QuestionCard
+                      key={request.id}
+                      config={config}
+                      directory={selectedSession.directory}
+                      request={request}
+                      onResolved={(id) => setPendingQuestions((current) => current.filter((item) => item.id !== id))}
+                    />
+                  ))}
                 {showTypingBubble && (
                   <article className="message assistant typing-bubble fade-in" aria-label={t('detail.waiting')}>
                     <div className="typing-dots" aria-hidden="true">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -70,6 +70,10 @@ function normalizeMessageMarkdown(text: string): string {
   return text.includes("\n") ? text : text.replace(/\s-\s(?=\S)/g, "\n- ")
 }
 
+function capitalizeFirst(text: string): string {
+  return text.length > 0 ? text.charAt(0).toUpperCase() + text.slice(1) : text
+}
+
 const MODAL_TITLE_MAX_LENGTH = 80
 
 function truncateForTitle(text: string, maxLength: number = MODAL_TITLE_MAX_LENGTH): string {
@@ -802,7 +806,7 @@ function summarizeActionGroup(parts: MessagePart[], t: Translator): string {
   pieces.push(...summarizeToolCounts(toolParts, t))
   if (editCount > 0) pieces.push(editCount === 1 ? t('action.madeEditOne') : t('action.madeEditMany', { n: editCount }))
   if (pieces.length === 0) pieces.push(t('action.actionsFallback'))
-  return pieces.join(", ")
+  return capitalizeFirst(pieces.join(", "))
 }
 
 function ActionGroupView({

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,7 +20,6 @@ import {
   ChatIcon,
   HelpIcon,
   PlusIcon,
-  PlayIcon,
   TrashIcon,
   StopCircleIcon,
   SendIcon,
@@ -2156,16 +2155,6 @@ function App() {
                   </div>
                   <div className="inline-actions">
                     <button
-                      onClick={(event) => {
-                        event.stopPropagation()
-                        openSession(session.id, session.directory).catch(() => undefined)
-                      }}
-                      className="btn-primary"
-                    >
-                      <PlayIcon size={16} />
-                      {t('sessions.open')}
-                    </button>
-                    <button
                       className="btn-secondary"
                       onClick={(event) => {
                         event.stopPropagation()
@@ -2174,6 +2163,7 @@ function App() {
                       title={t('session.renameTitle')}
                     >
                       <PencilIcon size={16} />
+                      {t('session.renameConfirm')}
                     </button>
                     <button
                       className="btn-danger"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import {
   type EventStreamStatus
 } from "./opencode-events"
 import { createTranslator, languageOptions, normalizeLanguage, type LanguageCode } from "./i18n"
-import type { AgentOption, CommandInfo, DiffFile, FileEntry, FileStatusEntry, MessageEnvelope, ModelOption, ModelSelection, PathInfo, ProjectDashboard, ServerConfig, Session, SessionStatus, SessionView, TodoItem } from "./types"
+import type { AgentOption, CommandInfo, DiffFile, FileEntry, FileStatusEntry, MessageEnvelope, MessagePart, ModelOption, ModelSelection, PathInfo, ProjectDashboard, ServerConfig, Session, SessionStatus, SessionView, TodoItem } from "./types"
 import {
   SettingsIcon,
   FolderIcon,
@@ -66,6 +66,63 @@ function assistantPayloadLength(items: MessageEnvelope[]): number {
 
 function normalizeMessageMarkdown(text: string): string {
   return text.includes("\n") ? text : text.replace(/\s-\s(?=\S)/g, "\n- ")
+}
+
+function toolCommandLabel(part: MessagePart): string {
+  const input = part.state?.input
+  if (!input) return part.tool || "tool"
+  if (typeof input.command === "string") return input.command
+  if (typeof input.filePath === "string") return `${part.tool}: ${input.filePath}`
+  return `${part.tool}(${JSON.stringify(input)})`
+}
+
+function MessagePartView({ part }: { part: MessagePart }) {
+  if (part.type === "text") {
+    if (!part.text) return null
+    return (
+      <div className="message-content">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{normalizeMessageMarkdown(part.text)}</ReactMarkdown>
+      </div>
+    )
+  }
+
+  if (part.type === "reasoning") {
+    if (!part.text) return null
+    return (
+      <details className="message-reasoning">
+        <summary>Thinking</summary>
+        <pre>{part.text}</pre>
+      </details>
+    )
+  }
+
+  if (part.type === "tool") {
+    const status = part.state?.status || "pending"
+    return (
+      <div className={`message-tool message-tool-${status}`}>
+        <div className="message-tool-header">
+          <span className="message-tool-name">{part.tool}</span>
+          <span className="message-tool-status">{status}</span>
+        </div>
+        <pre className="message-tool-command">{toolCommandLabel(part)}</pre>
+        {part.state?.output && <pre className="message-tool-output">{part.state.output}</pre>}
+        {part.state?.error && <pre className="message-tool-output message-tool-error">{part.state.error}</pre>}
+      </div>
+    )
+  }
+
+  if (part.type === "patch") {
+    if (!part.files || part.files.length === 0) return null
+    return (
+      <div className="message-patch">
+        {part.files.map((file) => (
+          <div key={file} className="message-patch-file">{file}</div>
+        ))}
+      </div>
+    )
+  }
+
+  return null
 }
 
 function toFileStatusList(input: FileStatusEntry[] | Record<string, FileStatusEntry>): FileStatusEntry[] {
@@ -350,7 +407,7 @@ function App() {
   const renderedMessages = useMemo(() => {
     return [...messages, ...optimisticUserMessages]
       .map((message) => ({ ...message, text: extractText(message) }))
-      .filter((message) => message.text)
+      .filter((message) => message.text || message.parts.some((part) => part.type !== "step-start" && part.type !== "step-finish"))
   }, [messages, optimisticUserMessages])
 
   const messageScrollSignature = useMemo(() => {
@@ -1628,11 +1685,9 @@ function App() {
                       </strong>
                       <small>{formatTime(message.info.time.created)}</small>
                     </header>
-                    <div className="message-content">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                        {normalizeMessageMarkdown(message.text)}
-                      </ReactMarkdown>
-                    </div>
+                    {message.parts.map((part) => (
+                      <MessagePartView key={part.id} part={part} />
+                    ))}
                   </article>
                 ))}
                 {showTypingBubble && (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -77,7 +77,71 @@ function toolCommandLabel(part: MessagePart): string {
   return `${part.tool}(${JSON.stringify(input)})`
 }
 
-function MessagePartView({ part }: { part: MessagePart }) {
+function DiffLines({ patch }: { patch: string }) {
+  return (
+    <pre className="message-diff-patch">
+      {patch.split("\n").map((line, index) => {
+        let className = "diff-line-context"
+        if (line.startsWith("+++") || line.startsWith("---")) className = "diff-line-meta"
+        else if (line.startsWith("+")) className = "diff-line-add"
+        else if (line.startsWith("-")) className = "diff-line-del"
+        else if (line.startsWith("@@")) className = "diff-line-hunk"
+        return (
+          <div key={index} className={className}>
+            {line}
+          </div>
+        )
+      })}
+    </pre>
+  )
+}
+
+function PatchPartView({ config, sessionID, messageID, files }: { config: ServerConfig; sessionID: string; messageID: string; files: string[] }) {
+  const [diffs, setDiffs] = useState<DiffFile[] | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    api.loadMessageDiff(config, sessionID, messageID).then((result) => {
+      if (!cancelled) setDiffs(result)
+    }).catch(() => {
+      if (!cancelled) setDiffs([])
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [config.host, config.port, config.username, config.password, sessionID, messageID])
+
+  if (diffs === null) {
+    return (
+      <div className="message-patch">
+        {files.map((file) => (
+          <div key={file} className="message-patch-file">{file}</div>
+        ))}
+      </div>
+    )
+  }
+
+  if (diffs.length === 0) return null
+
+  return (
+    <div className="message-patch">
+      {diffs.map((diff) => (
+        <details key={diff.file} className="message-diff" open>
+          <summary>
+            <span className="message-diff-file">{diff.file}</span>
+            <span className="message-diff-stats">
+              <span className="diff-stat-add">+{diff.additions}</span>
+              <span className="diff-stat-del">-{diff.deletions}</span>
+            </span>
+          </summary>
+          {diff.patch && <DiffLines patch={diff.patch} />}
+        </details>
+      ))}
+    </div>
+  )
+}
+
+function MessagePartView({ part, config, sessionID }: { part: MessagePart; config: ServerConfig; sessionID: string }) {
   if (part.type === "text") {
     if (!part.text) return null
     return (
@@ -113,14 +177,8 @@ function MessagePartView({ part }: { part: MessagePart }) {
   }
 
   if (part.type === "patch") {
-    if (!part.files || part.files.length === 0) return null
-    return (
-      <div className="message-patch">
-        {part.files.map((file) => (
-          <div key={file} className="message-patch-file">{file}</div>
-        ))}
-      </div>
-    )
+    if (!part.files || part.files.length === 0 || !part.messageID) return null
+    return <PatchPartView config={config} sessionID={sessionID} messageID={part.messageID} files={part.files} />
   }
 
   return null
@@ -1742,7 +1800,7 @@ function App() {
                       <small>{formatTime(message.info.time.created)}</small>
                     </header>
                     {message.parts.map((part) => (
-                      <MessagePartView key={part.id} part={part} />
+                      <MessagePartView key={part.id} part={part} config={config} sessionID={message.info.sessionID} />
                     ))}
                   </article>
                 ))}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,6 +31,8 @@ import {
   CloseIcon
 } from "./Icons"
 
+const REMARK_PLUGINS = [remarkGfm]
+
 const STORAGE_KEY = "opencode.remote.server"
 const LANGUAGE_STORAGE_KEY = "opencode.remote.language"
 const MODEL_STORAGE_KEY = "opencode.remote.model"
@@ -661,7 +663,7 @@ function MessagePartView({
     if (!part.text) return null
     return (
       <div className="message-content">
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>{normalizeMessageMarkdown(part.text)}</ReactMarkdown>
+        <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{normalizeMessageMarkdown(part.text)}</ReactMarkdown>
       </div>
     )
   }
@@ -993,6 +995,14 @@ function reconcileReasoningPart(previous: MessagePart | undefined, incoming: Mes
 }
 
 /** GET /session/{id}/message doesn't return reasoning parts, only the live event stream does — keep any streamed-in reasoning the refetch would otherwise silently drop. */
+function partsEqual(a: MessagePart[], b: MessagePart[]): boolean {
+  return a === b || (a.length === b.length && JSON.stringify(a) === JSON.stringify(b))
+}
+
+/** Reuses the previous message object whenever the merged result is logically unchanged, instead of always
+ *  returning a fresh `{ ...message }` wrapper. The periodic 3.5s poll calls this for every message in the
+ *  conversation regardless of whether anything actually changed, and a fresh reference per message would defeat
+ *  the WeakMap/memo caching that keeps unrelated messages from re-rendering while one is actively streaming. */
 function mergeFetchedMessages(current: MessageEnvelope[], fetched: MessageEnvelope[]): MessageEnvelope[] {
   const currentByID = new Map(current.map((message) => [message.info.id, message]))
   return fetched.map((message) => {
@@ -1002,8 +1012,8 @@ function mergeFetchedMessages(current: MessageEnvelope[], fetched: MessageEnvelo
     const parts = message.parts.map((part) => reconcileReasoningPart(previousPartsByID.get(part.id), part))
     const fetchedPartIDs = new Set(message.parts.map((part) => part.id))
     const missingReasoning = previous.parts.filter((part) => part.type === "reasoning" && !fetchedPartIDs.has(part.id))
-    if (missingReasoning.length === 0) return { ...message, parts }
-    return { ...message, parts: [...missingReasoning, ...parts] }
+    const mergedParts = missingReasoning.length === 0 ? parts : [...missingReasoning, ...parts]
+    return partsEqual(previous.parts, mergedParts) ? previous : { ...message, parts: mergedParts }
   })
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
+import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from "react"
 import { App as CapacitorApp } from "@capacitor/app"
 import type { PluginListenerHandle } from "@capacitor/core"
 import ReactMarkdown from "react-markdown"
@@ -1039,6 +1039,107 @@ function hasMatchingUserMessage(messages: MessageEnvelope[], optimistic: Message
   ))
 }
 
+/** Renders the message list, pending questions, and typing bubble. Memoized so that unrelated state changes in
+ *  the parent (most importantly typing into the composer) don't re-run the per-message formatting/diffing work
+ *  on every keystroke. */
+const MessagesPane = memo(function MessagesPane({
+  loadingSessionID,
+  selectedID,
+  renderedMessages,
+  showTypingBubble,
+  pendingQuestions,
+  config,
+  directory,
+  t,
+  messagesRef,
+  messagesEndRef,
+  onMessagesScroll,
+  onQuestionResolved
+}: {
+  loadingSessionID: string | null
+  selectedID: string | null
+  renderedMessages: (MessageEnvelope & { text: string })[]
+  showTypingBubble: boolean
+  pendingQuestions: QuestionRequest[]
+  config: ServerConfig
+  directory: string | undefined
+  t: Translator
+  messagesRef: RefObject<HTMLDivElement>
+  messagesEndRef: RefObject<HTMLDivElement>
+  onMessagesScroll: () => void
+  onQuestionResolved: (id: string) => void
+}) {
+  return (
+    <div className="messages-wrap">
+      <div className="messages" ref={messagesRef} onScroll={onMessagesScroll}>
+        {loadingSessionID === selectedID ? (
+          <div className="empty-state compact">
+            <LoadingIcon size={32} />
+            <p>{t('detail.loading')}</p>
+          </div>
+        ) : renderedMessages.length === 0 && !showTypingBubble && pendingQuestions.length === 0 ? (
+          <div className="empty-state compact">
+            <ChatIcon size={40} className="icon-empty-state" />
+            <p>{t('detail.emptyTitle')}</p>
+            <p className="subtle">{t('detail.emptyHint')}</p>
+          </div>
+        ) : (
+          <>
+            {renderedMessages.map((message) => (
+              <article key={message.info.id} className={`message ${message.info.role} fade-in`}>
+                {buildMessageTimeline(message.parts).map((item) =>
+                  item.kind === "action-group" ? (
+                    <ActionGroupView
+                      key={`group-${item.parts[0].id}`}
+                      parts={item.parts}
+                      config={config}
+                      sessionID={message.info.sessionID}
+                      directory={directory}
+                      timestamp={formatTime(message.info.time.created)}
+                      t={t}
+                    />
+                  ) : (
+                    <MessagePartView
+                      key={item.part.id}
+                      part={item.part}
+                      config={config}
+                      sessionID={message.info.sessionID}
+                      directory={directory}
+                      timestamp={formatTime(message.info.time.created)}
+                      t={t}
+                    />
+                  )
+                )}
+              </article>
+            ))}
+            {directory !== undefined &&
+              pendingQuestions.map((request) => (
+                <QuestionCard
+                  key={request.id}
+                  config={config}
+                  directory={directory}
+                  request={request}
+                  onResolved={onQuestionResolved}
+                  t={t}
+                />
+              ))}
+            {showTypingBubble && (
+              <article className="message assistant typing-bubble fade-in" aria-label={t('detail.waiting')}>
+                <div className="typing-dots" aria-hidden="true">
+                  <span className="typing-dot" />
+                  <span className="typing-dot" />
+                  <span className="typing-dot" />
+                </div>
+              </article>
+            )}
+            <div ref={messagesEndRef} className="messages-end" aria-hidden="true" />
+          </>
+        )}
+      </div>
+    </div>
+  )
+})
+
 function App() {
   type NoticeType = "info" | "success" | "error"
   type ThemePreference = "system" | "light" | "dark"
@@ -1498,9 +1599,13 @@ function App() {
     return windowDistance <= BOTTOM_STICK_THRESHOLD
   }
 
-  function handleMessagesScroll() {
+  const handleMessagesScroll = useCallback(() => {
     stickToBottomRef.current = isNearMessagesBottom()
-  }
+  }, [])
+
+  const handleQuestionResolved = useCallback((id: string) => {
+    setPendingQuestions((current) => current.filter((item) => item.id !== id))
+  }, [])
 
   function scrollMessagesToBottom(behavior: ScrollBehavior = "smooth") {
     requestAnimationFrame(() => {
@@ -2521,73 +2626,20 @@ function App() {
             </div>
           )}
 
-          <div className="messages-wrap">
-            <div className="messages" ref={messagesRef} onScroll={handleMessagesScroll}>
-            {loadingSessionID === selectedID ? (
-              <div className="empty-state compact">
-                <LoadingIcon size={32} />
-                <p>{t('detail.loading')}</p>
-              </div>
-            ) : renderedMessages.length === 0 && !showTypingBubble && pendingQuestions.length === 0 ? (
-              <div className="empty-state compact">
-                <ChatIcon size={40} className="icon-empty-state" />
-                <p>{t('detail.emptyTitle')}</p>
-                <p className="subtle">{t('detail.emptyHint')}</p>
-              </div>
-            ) : (
-              <>
-                {renderedMessages.map((message) => (
-                  <article key={message.info.id} className={`message ${message.info.role} fade-in`}>
-                    {buildMessageTimeline(message.parts).map((item) =>
-                      item.kind === "action-group" ? (
-                        <ActionGroupView
-                          key={`group-${item.parts[0].id}`}
-                          parts={item.parts}
-                          config={config}
-                          sessionID={message.info.sessionID}
-                          directory={selectedSession?.directory}
-                          timestamp={formatTime(message.info.time.created)}
-                          t={t}
-                        />
-                      ) : (
-                        <MessagePartView
-                          key={item.part.id}
-                          part={item.part}
-                          config={config}
-                          sessionID={message.info.sessionID}
-                          directory={selectedSession?.directory}
-                          timestamp={formatTime(message.info.time.created)}
-                          t={t}
-                        />
-                      )
-                    )}
-                  </article>
-                ))}
-                {selectedSession &&
-                  pendingQuestions.map((request) => (
-                    <QuestionCard
-                      key={request.id}
-                      config={config}
-                      directory={selectedSession.directory}
-                      request={request}
-                      onResolved={(id) => setPendingQuestions((current) => current.filter((item) => item.id !== id))}
-                      t={t}
-                    />
-                  ))}
-                {showTypingBubble && (
-                  <article className="message assistant typing-bubble fade-in" aria-label={t('detail.waiting')}>
-                    <div className="typing-dots" aria-hidden="true">
-                      <span className="typing-dot" />
-                      <span className="typing-dot" />
-                      <span className="typing-dot" />
-                    </div>
-                  </article>
-                )}
-                <div ref={messagesEndRef} className="messages-end" aria-hidden="true" />
-              </>
-            )}
-            </div>
-          </div>
+          <MessagesPane
+            loadingSessionID={loadingSessionID}
+            selectedID={selectedID}
+            renderedMessages={renderedMessages}
+            showTypingBubble={showTypingBubble}
+            pendingQuestions={pendingQuestions}
+            config={config}
+            directory={selectedSession?.directory}
+            t={t}
+            messagesRef={messagesRef}
+            messagesEndRef={messagesEndRef}
+            onMessagesScroll={handleMessagesScroll}
+            onQuestionResolved={handleQuestionResolved}
+          />
 
           <div className="composer" ref={composerRef}>
             <textarea

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2140,7 +2140,6 @@ function App() {
                       )}
                       <p>{session.directory}</p>
                     </div>
-                    <span className={`pill ${session.status}`}>{session.status}</span>
                   </div>
                   <div className="session-stats">
                     {session.files > 0 || session.additions > 0 || session.deletions > 0 ? (
@@ -2153,6 +2152,7 @@ function App() {
                       <span className="subtle">{t('sessions.noFileChanges')}</span>
                     )}
                     <span className="subtle">{t('sessions.updated', { time: formatTime(session.updated) })}</span>
+                    <span className={`pill ${session.status}`}>{session.status}</span>
                   </div>
                   <div className="inline-actions">
                     <button

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2478,15 +2478,9 @@ function App() {
               className={isWorking && !composer.trim() ? "btn-danger" : "btn-primary"}
             >
               {isWorking && !composer.trim() ? (
-                <>
-                  <StopCircleIcon size={18} />
-                  {t('detail.waiting')}
-                </>
+                <StopCircleIcon size={18} />
               ) : (
-                <>
-                  <SendIcon size={18} />
-                  {t('detail.send')}
-                </>
+                <SendIcon size={18} />
               )}
             </button>
           </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -77,10 +77,15 @@ function toolCommandLabel(part: MessagePart): string {
   return `${part.tool}(${JSON.stringify(input)})`
 }
 
-function DiffLines({ patch }: { patch: string }) {
+const DIFF_PREVIEW_LINES = 6
+
+function DiffLines({ patch, limit }: { patch: string; limit?: number }) {
+  const lines = patch.split("\n")
+  const shown = limit ? lines.slice(0, limit) : lines
+  const hiddenCount = lines.length - shown.length
   return (
     <pre className="message-diff-patch">
-      {patch.split("\n").map((line, index) => {
+      {shown.map((line, index) => {
         let className = "diff-line-context"
         if (line.startsWith("+++") || line.startsWith("---")) className = "diff-line-meta"
         else if (line.startsWith("+")) className = "diff-line-add"
@@ -92,12 +97,14 @@ function DiffLines({ patch }: { patch: string }) {
           </div>
         )
       })}
+      {hiddenCount > 0 && <div className="diff-line-more">+{hiddenCount} more lines</div>}
     </pre>
   )
 }
 
 function PatchPartView({ config, sessionID, messageID, files }: { config: ServerConfig; sessionID: string; messageID: string; files: string[] }) {
   const [diffs, setDiffs] = useState<DiffFile[] | null>(null)
+  const [expandedDiff, setExpandedDiff] = useState<DiffFile | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -134,9 +141,40 @@ function PatchPartView({ config, sessionID, messageID, files }: { config: Server
               <span className="diff-stat-del">-{diff.deletions}</span>
             </span>
           </summary>
-          {diff.patch && <DiffLines patch={diff.patch} />}
+          {diff.patch && (
+            <button
+              type="button"
+              className="message-diff-preview"
+              onClick={() => setExpandedDiff(diff)}
+              aria-label={`Expand full diff for ${diff.file}`}
+            >
+              <DiffLines patch={diff.patch} limit={DIFF_PREVIEW_LINES} />
+            </button>
+          )}
         </details>
       ))}
+
+      {expandedDiff && (
+        <div className="modal-backdrop" role="presentation" onClick={() => setExpandedDiff(null)}>
+          <section
+            className="modal-card diff-modal fade-in"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="diff-modal-title"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="diff-modal-header">
+              <h2 id="diff-modal-title">{expandedDiff.file}</h2>
+              <button type="button" className="btn-secondary" onClick={() => setExpandedDiff(null)}>
+                Close
+              </button>
+            </div>
+            <div className="diff-modal-body">
+              {expandedDiff.patch && <DiffLines patch={expandedDiff.patch} />}
+            </div>
+          </section>
+        </div>
+      )}
     </div>
   )
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -306,6 +306,10 @@ export const api = {
     return request<DiffFile[]>(config, withDirectory(`/session/${sessionID}/diff`, directory))
   },
 
+  loadMessageDiff(config: ServerConfig, sessionID: string, messageID: string, directory?: string) {
+    return request<DiffFile[]>(config, withDirectory(`/session/${sessionID}/diff?messageID=${encodeURIComponent(messageID)}`, directory))
+  },
+
   loadProjectCurrent(config: ServerConfig, directory?: string) {
     return request<ProjectCurrent>(config, withDirectory("/project/current", directory))
   },

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -12,6 +12,7 @@ import type {
   ModelSelection,
   ProjectCurrent,
   PathInfo,
+  QuestionRequest,
   ServerConfig,
   Session,
   SessionStatus,
@@ -339,6 +340,24 @@ export const api = {
 
   abort(config: ServerConfig, sessionID: string, directory?: string) {
     return request<boolean>(config, withDirectory(`/session/${sessionID}/abort`, directory), {
+      method: "POST",
+      body: {}
+    })
+  },
+
+  loadQuestions(config: ServerConfig, directory?: string) {
+    return request<QuestionRequest[]>(config, withDirectory("/question", directory))
+  },
+
+  replyQuestion(config: ServerConfig, requestID: string, answers: string[][], directory?: string) {
+    return request<boolean>(config, withDirectory(`/question/${requestID}/reply`, directory), {
+      method: "POST",
+      body: { answers }
+    })
+  },
+
+  rejectQuestion(config: ServerConfig, requestID: string, directory?: string) {
+    return request<boolean>(config, withDirectory(`/question/${requestID}/reject`, directory), {
       method: "POST",
       body: {}
     })

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -168,6 +168,10 @@ type TranslationKey =
   | 'action.fetchedUrl'
   | 'action.fetchedUrlNamed'
   | 'action.updatedTodos'
+  | 'action.todoSummary'
+  | 'action.askedQuestion'
+  | 'action.askedQuestionNamed'
+  | 'action.askedQuestions'
   | 'action.ranSubagent'
   | 'action.ranSubagentNamed'
   | 'action.usedSkill'
@@ -194,6 +198,10 @@ type TranslationKey =
   | 'action.countSkillMany'
   | 'action.countOtherOne'
   | 'action.countOtherMany'
+  | 'action.countTodoOne'
+  | 'action.countTodoMany'
+  | 'action.countQuestionOne'
+  | 'action.countQuestionMany'
   | 'action.madeEditOne'
   | 'action.madeEditMany'
   | 'question.ariaLabel'
@@ -370,6 +378,10 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'action.fetchedUrl': 'Fetched a URL',
     'action.fetchedUrlNamed': 'Fetched {url}',
     'action.updatedTodos': 'Updated the to-do list',
+    'action.todoSummary': '{done}/{total} to-dos done',
+    'action.askedQuestion': 'Asked a question',
+    'action.askedQuestionNamed': 'Asked: {question}',
+    'action.askedQuestions': 'Asked {n} questions',
     'action.ranSubagent': 'Ran a subagent',
     'action.ranSubagentNamed': 'Ran subagent: {description}',
     'action.usedSkill': 'Used a skill',
@@ -396,6 +408,10 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'action.countSkillMany': 'used {n} skills',
     'action.countOtherOne': 'ran 1 tool',
     'action.countOtherMany': 'ran {n} tools',
+    'action.countTodoOne': 'updated the to-do list',
+    'action.countTodoMany': 'updated the to-do list {n} times',
+    'action.countQuestionOne': 'asked 1 question',
+    'action.countQuestionMany': 'asked {n} questions',
     'action.madeEditOne': 'made 1 edit',
     'action.madeEditMany': 'made {n} edits',
     'question.ariaLabel': 'Question from OpenCode',
@@ -571,6 +587,10 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'action.fetchedUrl': 'URL recuperato',
     'action.fetchedUrlNamed': 'Recuperato {url}',
     'action.updatedTodos': 'Elenco to-do aggiornato',
+    'action.todoSummary': '{done}/{total} to-do completati',
+    'action.askedQuestion': 'Posta una domanda',
+    'action.askedQuestionNamed': 'Chiesto: {question}',
+    'action.askedQuestions': 'Poste {n} domande',
     'action.ranSubagent': 'Subagente eseguito',
     'action.ranSubagentNamed': 'Eseguito subagente: {description}',
     'action.usedSkill': 'Skill usata',
@@ -597,6 +617,10 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'action.countSkillMany': 'usate {n} skill',
     'action.countOtherOne': 'eseguito 1 tool',
     'action.countOtherMany': 'eseguiti {n} tool',
+    'action.countTodoOne': 'aggiornato l\'elenco to-do',
+    'action.countTodoMany': 'aggiornato l\'elenco to-do {n} volte',
+    'action.countQuestionOne': 'posta 1 domanda',
+    'action.countQuestionMany': 'poste {n} domande',
     'action.madeEditOne': 'fatta 1 modifica',
     'action.madeEditMany': 'fatte {n} modifiche',
     'question.ariaLabel': 'Domanda da OpenCode',
@@ -772,6 +796,10 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'action.fetchedUrl': '已擷取網址',
     'action.fetchedUrlNamed': '已擷取 {url}',
     'action.updatedTodos': '已更新待辦事項清單',
+    'action.todoSummary': '已完成 {done}/{total} 個待辦事項',
+    'action.askedQuestion': '提出問題',
+    'action.askedQuestionNamed': '已提問：{question}',
+    'action.askedQuestions': '提出 {n} 個問題',
     'action.ranSubagent': '已執行子代理',
     'action.ranSubagentNamed': '已執行子代理：{description}',
     'action.usedSkill': '已使用技能',
@@ -798,6 +826,10 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'action.countSkillMany': '使用 {n} 個技能',
     'action.countOtherOne': '執行 1 個工具',
     'action.countOtherMany': '執行 {n} 個工具',
+    'action.countTodoOne': '更新待辦事項清單',
+    'action.countTodoMany': '更新待辦事項清單 {n} 次',
+    'action.countQuestionOne': '提出 1 個問題',
+    'action.countQuestionMany': '提出 {n} 個問題',
     'action.madeEditOne': '進行了 1 次編輯',
     'action.madeEditMany': '進行了 {n} 次編輯',
     'question.ariaLabel': '來自 OpenCode 的問題',

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -148,6 +148,58 @@ type TranslationKey =
   | 'help.network'
   | 'help.troubleshooting'
   | 'help.commands'
+  | 'action.close'
+  | 'action.thinking'
+  | 'action.thoughtFor'
+  | 'action.durationSeconds'
+  | 'action.durationMinutes'
+  | 'action.readFile'
+  | 'action.readFileNamed'
+  | 'action.wroteFile'
+  | 'action.wroteFileNamed'
+  | 'action.editedFile'
+  | 'action.editedFileNamed'
+  | 'action.ranCommand'
+  | 'action.ranCommandNamed'
+  | 'action.searchedFiles'
+  | 'action.searchedFilesFor'
+  | 'action.searchedCode'
+  | 'action.searchedCodeFor'
+  | 'action.fetchedUrl'
+  | 'action.fetchedUrlNamed'
+  | 'action.updatedTodos'
+  | 'action.ranSubagent'
+  | 'action.ranSubagentNamed'
+  | 'action.usedSkill'
+  | 'action.usedSkillNamed'
+  | 'action.toolFailed'
+  | 'action.running'
+  | 'action.showDiffFor'
+  | 'action.actionsFallback'
+  | 'action.countReadOne'
+  | 'action.countReadMany'
+  | 'action.countWriteOne'
+  | 'action.countWriteMany'
+  | 'action.countEditOne'
+  | 'action.countEditMany'
+  | 'action.countSearchOne'
+  | 'action.countSearchMany'
+  | 'action.countBashOne'
+  | 'action.countBashMany'
+  | 'action.countWebfetchOne'
+  | 'action.countWebfetchMany'
+  | 'action.countTaskOne'
+  | 'action.countTaskMany'
+  | 'action.countSkillOne'
+  | 'action.countSkillMany'
+  | 'action.countOtherOne'
+  | 'action.countOtherMany'
+  | 'action.madeEditOne'
+  | 'action.madeEditMany'
+  | 'question.ariaLabel'
+  | 'question.otherPlaceholder'
+  | 'question.skip'
+  | 'question.sendAnswer'
 
 const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
   en: {
@@ -297,7 +349,59 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'help.server': 'Server',
     'help.network': 'Network',
     'help.troubleshooting': 'Troubleshooting',
-    'help.commands': 'Commands'
+    'help.commands': 'Commands',
+    'action.close': 'Close',
+    'action.thinking': 'Thinking',
+    'action.thoughtFor': 'Thought for {duration}',
+    'action.durationSeconds': '{n}s',
+    'action.durationMinutes': '{n}m',
+    'action.readFile': 'Read file',
+    'action.readFileNamed': 'Read {file}',
+    'action.wroteFile': 'Wrote file',
+    'action.wroteFileNamed': 'Wrote {file}',
+    'action.editedFile': 'Edited file',
+    'action.editedFileNamed': 'Edited {file}',
+    'action.ranCommand': 'Ran command',
+    'action.ranCommandNamed': 'Ran {command}',
+    'action.searchedFiles': 'Searched files',
+    'action.searchedFilesFor': 'Searched files for "{pattern}"',
+    'action.searchedCode': 'Searched code',
+    'action.searchedCodeFor': 'Searched for "{pattern}"',
+    'action.fetchedUrl': 'Fetched a URL',
+    'action.fetchedUrlNamed': 'Fetched {url}',
+    'action.updatedTodos': 'Updated the to-do list',
+    'action.ranSubagent': 'Ran a subagent',
+    'action.ranSubagentNamed': 'Ran subagent: {description}',
+    'action.usedSkill': 'Used a skill',
+    'action.usedSkillNamed': 'Used skill: {name}',
+    'action.toolFailed': 'Tool failed',
+    'action.running': 'Running…',
+    'action.showDiffFor': 'Show diff for {file}',
+    'action.actionsFallback': 'Actions',
+    'action.countReadOne': 'read 1 file',
+    'action.countReadMany': 'read {n} files',
+    'action.countWriteOne': 'wrote 1 file',
+    'action.countWriteMany': 'wrote {n} files',
+    'action.countEditOne': 'edited 1 file',
+    'action.countEditMany': 'edited {n} files',
+    'action.countSearchOne': 'searched 1 time',
+    'action.countSearchMany': 'searched {n} times',
+    'action.countBashOne': 'ran 1 command',
+    'action.countBashMany': 'ran {n} commands',
+    'action.countWebfetchOne': 'fetched 1 URL',
+    'action.countWebfetchMany': 'fetched {n} URLs',
+    'action.countTaskOne': 'ran 1 subagent',
+    'action.countTaskMany': 'ran {n} subagents',
+    'action.countSkillOne': 'used 1 skill',
+    'action.countSkillMany': 'used {n} skills',
+    'action.countOtherOne': 'ran 1 tool',
+    'action.countOtherMany': 'ran {n} tools',
+    'action.madeEditOne': 'made 1 edit',
+    'action.madeEditMany': 'made {n} edits',
+    'question.ariaLabel': 'Question from OpenCode',
+    'question.otherPlaceholder': 'Other…',
+    'question.skip': 'Skip',
+    'question.sendAnswer': 'Send answer'
   },
   it: {
     'app.title': 'OpenCode Remote',
@@ -382,7 +486,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.loading': 'Caricamento sessione...',
     'detail.emptyTitle': 'Ancora nessun messaggio',
     'detail.emptyHint': 'Inizia una conversazione qui sotto',
-    'detail.composerPlaceholder': 'Scrivi un prompt o comando (inizia con / per gli slash command)...',
+    'detail.composerPlaceholder': 'Scrivi un prompt o un comando (inizia con / per gli slash command)...',
     'detail.waiting': 'Attesa...',
     'detail.send': 'Invia',
     'detail.jumpToLatest': 'Vai alla fine',
@@ -446,7 +550,59 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'help.server': 'Server',
     'help.network': 'Rete',
     'help.troubleshooting': 'Risoluzione problemi',
-    'help.commands': 'Comandi'
+    'help.commands': 'Comandi',
+    'action.close': 'Chiudi',
+    'action.thinking': 'Sto pensando',
+    'action.thoughtFor': 'Pensato per {duration}',
+    'action.durationSeconds': '{n}s',
+    'action.durationMinutes': '{n}m',
+    'action.readFile': 'File letto',
+    'action.readFileNamed': 'Letto {file}',
+    'action.wroteFile': 'File scritto',
+    'action.wroteFileNamed': 'Scritto {file}',
+    'action.editedFile': 'File modificato',
+    'action.editedFileNamed': 'Modificato {file}',
+    'action.ranCommand': 'Comando eseguito',
+    'action.ranCommandNamed': 'Eseguito {command}',
+    'action.searchedFiles': 'File cercati',
+    'action.searchedFilesFor': 'File cercati per "{pattern}"',
+    'action.searchedCode': 'Codice cercato',
+    'action.searchedCodeFor': 'Cercato "{pattern}"',
+    'action.fetchedUrl': 'URL recuperato',
+    'action.fetchedUrlNamed': 'Recuperato {url}',
+    'action.updatedTodos': 'Elenco to-do aggiornato',
+    'action.ranSubagent': 'Subagente eseguito',
+    'action.ranSubagentNamed': 'Eseguito subagente: {description}',
+    'action.usedSkill': 'Skill usata',
+    'action.usedSkillNamed': 'Usata skill: {name}',
+    'action.toolFailed': 'Tool fallito',
+    'action.running': 'In esecuzione…',
+    'action.showDiffFor': 'Mostra diff per {file}',
+    'action.actionsFallback': 'Azioni',
+    'action.countReadOne': 'letto 1 file',
+    'action.countReadMany': 'letti {n} file',
+    'action.countWriteOne': 'scritto 1 file',
+    'action.countWriteMany': 'scritti {n} file',
+    'action.countEditOne': 'modificato 1 file',
+    'action.countEditMany': 'modificati {n} file',
+    'action.countSearchOne': 'cercato 1 volta',
+    'action.countSearchMany': 'cercato {n} volte',
+    'action.countBashOne': 'eseguito 1 comando',
+    'action.countBashMany': 'eseguiti {n} comandi',
+    'action.countWebfetchOne': 'recuperato 1 URL',
+    'action.countWebfetchMany': 'recuperati {n} URL',
+    'action.countTaskOne': 'eseguito 1 subagente',
+    'action.countTaskMany': 'eseguiti {n} subagenti',
+    'action.countSkillOne': 'usata 1 skill',
+    'action.countSkillMany': 'usate {n} skill',
+    'action.countOtherOne': 'eseguito 1 tool',
+    'action.countOtherMany': 'eseguiti {n} tool',
+    'action.madeEditOne': 'fatta 1 modifica',
+    'action.madeEditMany': 'fatte {n} modifiche',
+    'question.ariaLabel': 'Domanda da OpenCode',
+    'question.otherPlaceholder': 'Altro…',
+    'question.skip': 'Salta',
+    'question.sendAnswer': 'Invia risposta'
   },
   'zh-TW': {
     'app.title': 'OpenCode 遠端',
@@ -595,7 +751,59 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'help.server': '伺服器',
     'help.network': '網路',
     'help.troubleshooting': '疑難排解',
-    'help.commands': '命令'
+    'help.commands': '命令',
+    'action.close': '關閉',
+    'action.thinking': '思考中',
+    'action.thoughtFor': '思考了 {duration}',
+    'action.durationSeconds': '{n} 秒',
+    'action.durationMinutes': '{n} 分',
+    'action.readFile': '已讀取檔案',
+    'action.readFileNamed': '已讀取 {file}',
+    'action.wroteFile': '已寫入檔案',
+    'action.wroteFileNamed': '已寫入 {file}',
+    'action.editedFile': '已編輯檔案',
+    'action.editedFileNamed': '已編輯 {file}',
+    'action.ranCommand': '已執行命令',
+    'action.ranCommandNamed': '已執行 {command}',
+    'action.searchedFiles': '已搜尋檔案',
+    'action.searchedFilesFor': '已搜尋檔案「{pattern}」',
+    'action.searchedCode': '已搜尋程式碼',
+    'action.searchedCodeFor': '已搜尋「{pattern}」',
+    'action.fetchedUrl': '已擷取網址',
+    'action.fetchedUrlNamed': '已擷取 {url}',
+    'action.updatedTodos': '已更新待辦事項清單',
+    'action.ranSubagent': '已執行子代理',
+    'action.ranSubagentNamed': '已執行子代理：{description}',
+    'action.usedSkill': '已使用技能',
+    'action.usedSkillNamed': '已使用技能：{name}',
+    'action.toolFailed': '工具失敗',
+    'action.running': '執行中…',
+    'action.showDiffFor': '顯示 {file} 的差異',
+    'action.actionsFallback': '動作',
+    'action.countReadOne': '讀取 1 個檔案',
+    'action.countReadMany': '讀取 {n} 個檔案',
+    'action.countWriteOne': '寫入 1 個檔案',
+    'action.countWriteMany': '寫入 {n} 個檔案',
+    'action.countEditOne': '編輯 1 個檔案',
+    'action.countEditMany': '編輯 {n} 個檔案',
+    'action.countSearchOne': '搜尋 1 次',
+    'action.countSearchMany': '搜尋 {n} 次',
+    'action.countBashOne': '執行 1 個命令',
+    'action.countBashMany': '執行 {n} 個命令',
+    'action.countWebfetchOne': '擷取 1 個網址',
+    'action.countWebfetchMany': '擷取 {n} 個網址',
+    'action.countTaskOne': '執行 1 個子代理',
+    'action.countTaskMany': '執行 {n} 個子代理',
+    'action.countSkillOne': '使用 1 個技能',
+    'action.countSkillMany': '使用 {n} 個技能',
+    'action.countOtherOne': '執行 1 個工具',
+    'action.countOtherMany': '執行 {n} 個工具',
+    'action.madeEditOne': '進行了 1 次編輯',
+    'action.madeEditMany': '進行了 {n} 次編輯',
+    'question.ariaLabel': '來自 OpenCode 的問題',
+    'question.otherPlaceholder': '其他…',
+    'question.skip': '略過',
+    'question.sendAnswer': '傳送回答'
   }
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1026,6 +1026,59 @@ p {
   color: #cf222e;
 }
 
+.message-diff-preview {
+  display: block;
+  width: 100%;
+  border: 0;
+  border-top: 1px solid var(--border);
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.message-diff-preview:hover .message-diff-patch {
+  background: var(--surface-strong);
+}
+
+.diff-line-more {
+  color: var(--muted);
+  font-style: italic;
+}
+
+.diff-modal {
+  width: min(92vw, 900px);
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+}
+
+.diff-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-bottom: 1px solid var(--border);
+}
+
+.diff-modal-header h2 {
+  font-size: 0.9rem;
+  font-family: var(--font-mono);
+  overflow-wrap: anywhere;
+}
+
+.diff-modal-body {
+  overflow: auto;
+  padding: 0 var(--space-2);
+}
+
+.diff-modal-body .message-diff-patch {
+  padding-bottom: var(--space-4);
+}
+
 .message-diff-patch {
   margin: 0;
   overflow-x: auto;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -912,6 +912,84 @@ p {
   color: inherit;
 }
 
+.message-reasoning {
+  margin-top: var(--space-2);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  color: var(--muted);
+}
+
+.message-reasoning summary {
+  cursor: pointer;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.message-reasoning pre {
+  margin-top: var(--space-2);
+  white-space: pre-wrap;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+}
+
+.message-tool {
+  margin-top: var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--code-bg);
+  color: var(--code-text);
+  padding: var(--space-3);
+}
+
+.message-tool-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+}
+
+.message-tool-name {
+  font-weight: 600;
+}
+
+.message-tool-status {
+  color: var(--muted);
+  text-transform: uppercase;
+  font-size: 0.7rem;
+}
+
+.message-tool-command,
+.message-tool-output {
+  margin-top: var(--space-2);
+  white-space: pre-wrap;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  overflow-x: auto;
+}
+
+.message-tool-error {
+  color: var(--danger, #d33);
+}
+
+.message-patch {
+  margin-top: var(--space-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.message-patch-file {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.2rem 0.5rem;
+  background: var(--surface-strong);
+}
+
 .message code,
 .help code,
 .command-name {
@@ -1315,9 +1393,7 @@ button.compact {
   }
 
   .message header {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: var(--space-1);
+    align-items: baseline;
   }
 
   .composer {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1083,6 +1083,24 @@ p {
   color: var(--muted);
 }
 
+.question-option.static {
+  cursor: default;
+}
+
+.message-todo-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.message-todo-list .todo-item {
+  margin-top: 0;
+  padding: var(--space-2) 0;
+}
+
+.message-todo-list .todo-item + .todo-item {
+  border-top: 1px solid var(--border);
+}
+
 .question-custom-input {
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
@@ -1287,8 +1305,16 @@ p {
 }
 
 .todo-status {
-  color: var(--success);
+  color: var(--muted);
   font-weight: 800;
+}
+
+.todo-status.completed {
+  color: var(--success);
+}
+
+.todo-status.in_progress {
+  color: var(--primary);
 }
 
 .notice,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -980,7 +980,7 @@ p {
 .message-tool-command,
 .message-tool-output {
   margin: 0;
-  white-space: pre-wrap;
+  white-space: pre;
   font-family: var(--font-mono);
   font-size: 0.82rem;
   overflow-x: auto;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -474,7 +474,7 @@ p {
 
 .session-card-main {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr);
   align-items: start;
   gap: var(--space-3);
 }
@@ -494,6 +494,10 @@ p {
   margin-top: var(--space-3);
   color: var(--muted);
   font-size: 0.86rem;
+}
+
+.session-stats .pill {
+  margin-left: auto;
 }
 
 .change-summary {
@@ -1707,10 +1711,6 @@ button.compact {
 
   .session-card-main {
     grid-template-columns: minmax(0, 1fr);
-  }
-
-  .session-card-main .pill {
-    justify-self: start;
   }
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -874,20 +874,6 @@ p {
   animation-delay: 320ms;
 }
 
-.message header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
-  margin-bottom: var(--space-2);
-}
-
-.message small {
-  color: var(--muted);
-  font-size: 0.76rem;
-  white-space: nowrap;
-}
-
 .message-content p {
   margin-top: var(--space-2);
   white-space: pre-wrap;
@@ -912,78 +898,98 @@ p {
   color: inherit;
 }
 
-.message-reasoning {
+.message-reasoning-summary,
+.message-action-summary,
+.message-tool-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  width: 100%;
   margin-top: var(--space-2);
   border: 1px dashed var(--border);
   border-radius: var(--radius-md);
+  background: transparent;
   padding: var(--space-2) var(--space-3);
   color: var(--muted);
-}
-
-.message-reasoning summary {
-  cursor: pointer;
   font-size: 0.82rem;
   font-weight: 600;
+  text-align: left;
+  cursor: pointer;
 }
 
-.message-reasoning pre {
-  margin-top: var(--space-2);
+.message-reasoning-summary:hover,
+.message-action-summary:hover,
+.message-tool-summary:hover {
+  background: var(--surface-strong);
+}
+
+.message-reasoning-text {
+  margin: 0;
   white-space: pre-wrap;
   font-family: var(--font-mono);
   font-size: 0.82rem;
 }
 
-.message-tool {
-  margin-top: var(--space-2);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: var(--code-bg);
-  color: var(--code-text);
-  padding: var(--space-3);
+.message-action-details > *:first-child {
+  margin-top: 0;
 }
 
-.message-tool-header {
+.message-action-divider {
+  border: 0;
+  margin: var(--space-3) 0;
+}
+
+.message-tool-summary {
+  min-width: 0;
+}
+
+.message-tool-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+}
+
+.message-tool-meta {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.message-tool-diff-stats {
+  display: flex;
   gap: var(--space-2);
   font-family: var(--font-mono);
-  font-size: 0.78rem;
 }
 
-.message-tool-name {
-  font-weight: 600;
+.message-tool-status-error {
+  color: var(--danger, #d33);
+  font-weight: 700;
+  font-size: 0.8rem;
+  line-height: 1;
 }
 
-.message-tool-status {
+.message-tool-status-pending {
   color: var(--muted);
-  text-transform: uppercase;
-  font-size: 0.7rem;
-}
-
-.message-tool-preview {
-  display: block;
-  width: 100%;
-  border: 0;
-  background: transparent;
-  padding: 0;
-  margin-top: var(--space-2);
-  text-align: left;
-  cursor: pointer;
-}
-
-.message-tool-preview:hover .message-tool-command,
-.message-tool-preview:hover .message-tool-output {
-  background: var(--surface-strong);
+  font-size: 0.8rem;
+  line-height: 1;
 }
 
 .message-tool-command,
 .message-tool-output {
   margin: 0;
+  margin-top: var(--space-2);
   white-space: pre;
   font-family: var(--font-mono);
   font-size: 0.82rem;
   overflow-x: auto;
+}
+
+.message-tool-command:first-child {
+  margin-top: 0;
 }
 
 .message-tool-error {
@@ -1087,22 +1093,25 @@ p {
   gap: var(--space-2);
 }
 
-.message-diff {
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  overflow: hidden;
-}
-
-.message-diff summary {
+.message-diff-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--space-2);
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
   cursor: pointer;
   padding: 0.35rem 0.6rem;
   background: var(--surface-strong);
+  color: inherit;
   font-family: var(--font-mono);
   font-size: 0.8rem;
+  text-align: left;
+}
+
+.message-diff-row:hover {
+  border-color: var(--primary-border);
 }
 
 .message-diff-file {
@@ -1123,27 +1132,6 @@ p {
   color: #cf222e;
 }
 
-.message-diff-preview {
-  display: block;
-  width: 100%;
-  border: 0;
-  border-top: 1px solid var(--border);
-  background: transparent;
-  padding: 0;
-  margin: 0;
-  text-align: left;
-  cursor: pointer;
-}
-
-.message-diff-preview:hover .message-diff-patch {
-  background: var(--surface-strong);
-}
-
-.diff-line-more {
-  color: var(--muted);
-  font-style: italic;
-}
-
 .diff-modal {
   width: min(92vw, 900px);
   max-height: 85vh;
@@ -1157,8 +1145,14 @@ p {
   align-items: center;
   justify-content: space-between;
   gap: var(--space-3);
-  padding: var(--space-4);
-  border-bottom: 1px solid var(--border);
+  padding: var(--space-3);
+}
+
+.diff-modal-heading {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
 }
 
 .diff-modal-header h2 {
@@ -1167,9 +1161,15 @@ p {
   overflow-wrap: anywhere;
 }
 
+.diff-modal-timestamp {
+  color: var(--muted);
+  font-size: 0.76rem;
+  white-space: nowrap;
+}
+
 .diff-modal-body {
   overflow: auto;
-  padding: 0 var(--space-2);
+  padding: var(--space-4) var(--space-2) 0;
 }
 
 .diff-modal-body .message-diff-patch {
@@ -1179,6 +1179,8 @@ p {
 .message-diff-patch {
   margin: 0;
   overflow-x: auto;
+  width: fit-content;
+  min-width: 100%;
   font-family: var(--font-mono);
   font-size: 0.78rem;
   line-height: 1.45;
@@ -1339,8 +1341,12 @@ p {
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   background: var(--surface);
-  padding: var(--space-5);
+  padding: var(--space-4);
   box-shadow: var(--shadow-md);
+}
+
+.modal-card h2 {
+  margin-bottom: var(--space-4);
 }
 
 .modal-card .subtle {
@@ -1612,10 +1618,6 @@ button.compact {
 
   .message {
     padding: var(--space-3);
-  }
-
-  .message header {
-    align-items: baseline;
   }
 
   .composer {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1635,7 +1635,6 @@ button.compact {
 
   .composer {
     bottom: calc(72px + env(safe-area-inset-bottom));
-    grid-template-columns: 1fr;
     margin-left: calc(var(--space-2) * -1);
     margin-right: calc(var(--space-2) * -1);
   }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -990,6 +990,78 @@ p {
   background: var(--surface-strong);
 }
 
+.message-diff {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.message-diff summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  cursor: pointer;
+  padding: 0.35rem 0.6rem;
+  background: var(--surface-strong);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+}
+
+.message-diff-file {
+  overflow-wrap: anywhere;
+}
+
+.message-diff-stats {
+  display: flex;
+  gap: var(--space-2);
+  white-space: nowrap;
+}
+
+.diff-stat-add {
+  color: #2da44e;
+}
+
+.diff-stat-del {
+  color: #cf222e;
+}
+
+.message-diff-patch {
+  margin: 0;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.message-diff-patch div {
+  padding: 0 0.6rem;
+  white-space: pre;
+}
+
+.diff-line-add {
+  background: rgba(45, 164, 78, 0.15);
+  color: #2da44e;
+}
+
+.diff-line-del {
+  background: rgba(207, 34, 46, 0.15);
+  color: #cf222e;
+}
+
+.diff-line-hunk {
+  color: var(--muted);
+  background: var(--surface-subtle);
+}
+
+.diff-line-meta {
+  color: var(--muted);
+}
+
+.diff-line-context {
+  color: var(--text);
+}
+
 .message code,
 .help code,
 .command-name {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -806,12 +806,14 @@ p {
   position: relative;
   flex: 1 1 auto;
   min-height: 220px;
+  min-width: 0;
   display: flex;
   flex-direction: column;
 }
 
 .messages {
   min-height: 220px;
+  min-width: 0;
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
@@ -829,6 +831,8 @@ p {
 
 .message {
   width: min(100%, 760px);
+  min-width: 0;
+  max-width: 100%;
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   padding: var(--space-4);
@@ -872,6 +876,11 @@ p {
 
 .typing-dot:nth-child(3) {
   animation-delay: 320ms;
+}
+
+.message-content {
+  overflow-wrap: anywhere;
+  min-width: 0;
 }
 
 .message-content p {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -210,9 +210,6 @@ p {
 }
 
 .top-nav {
-  position: sticky;
-  top: 0;
-  z-index: var(--z-sticky);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -1553,7 +1550,6 @@ button.compact {
   }
 
   .top-nav {
-    top: 0;
     border-radius: var(--radius-md);
   }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -367,6 +367,18 @@ p {
   padding: var(--space-2) var(--space-3);
 }
 
+.connection-status-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-top: var(--space-2);
+}
+
+.connection-status-row .connection-status {
+  margin-top: 0;
+}
+
 .connection-status {
   display: flex;
   align-items: center;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1578,10 +1578,6 @@ button.compact {
     grid-template-columns: 1fr 1fr;
   }
 
-  .session-card .inline-actions {
-    grid-template-columns: 1fr auto auto;
-  }
-
   .form-grid,
   .actions,
   .connection-help,
@@ -1706,7 +1702,7 @@ button.compact {
   }
 
   .session-card .inline-actions {
-    grid-template-columns: 1fr auto auto;
+    grid-template-columns: 1fr 1fr;
   }
 
   .session-card-main {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1006,6 +1006,87 @@ p {
   background: var(--surface-strong);
 }
 
+.question-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  border-color: var(--primary-border);
+}
+
+.question-block {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.question-header {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+.question-text {
+  font-weight: 600;
+}
+
+.question-options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.question-option {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  text-align: left;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+}
+
+.question-option:hover:not(:disabled) {
+  border-color: var(--primary-border);
+}
+
+.question-option.selected {
+  border-color: var(--primary);
+  background: var(--primary-soft);
+}
+
+.question-option-label {
+  font-weight: 600;
+}
+
+.question-option-description {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.question-custom-input {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  color: var(--text);
+  padding: var(--space-2) var(--space-3);
+  font: inherit;
+}
+
+.question-error {
+  color: var(--danger, #d33);
+  font-size: 0.85rem;
+}
+
+.question-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
 .message-diff {
   border: 1px solid var(--border);
   border-radius: var(--radius-md);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1574,6 +1574,10 @@ button.compact {
     grid-template-columns: 1fr 1fr;
   }
 
+  .session-card .inline-actions {
+    grid-template-columns: 1fr auto auto;
+  }
+
   .form-grid,
   .actions,
   .connection-help,
@@ -1695,6 +1699,10 @@ button.compact {
 
   .inline-actions {
     grid-template-columns: 1fr;
+  }
+
+  .session-card .inline-actions {
+    grid-template-columns: 1fr auto auto;
   }
 
   .session-card-main {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -961,9 +961,25 @@ p {
   font-size: 0.7rem;
 }
 
+.message-tool-preview {
+  display: block;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  margin-top: var(--space-2);
+  text-align: left;
+  cursor: pointer;
+}
+
+.message-tool-preview:hover .message-tool-command,
+.message-tool-preview:hover .message-tool-output {
+  background: var(--surface-strong);
+}
+
 .message-tool-command,
 .message-tool-output {
-  margin-top: var(--space-2);
+  margin: 0;
   white-space: pre-wrap;
   font-family: var(--font-mono);
   font-size: 0.82rem;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -67,6 +67,25 @@ export type SessionStatus = {
   next?: number
 }
 
+export type ToolState = {
+  status: string
+  input?: Record<string, unknown>
+  title?: string
+  output?: string
+  error?: string
+}
+
+export type MessagePart = {
+  id: string
+  type: string
+  text?: string
+  tool?: string
+  callID?: string
+  state?: ToolState
+  hash?: string
+  files?: string[]
+}
+
 export type MessageEnvelope = {
   info: {
     id: string
@@ -77,11 +96,7 @@ export type MessageEnvelope = {
       completed?: number
     }
   }
-  parts: Array<{
-    id: string
-    type: string
-    text?: string
-  }>
+  parts: MessagePart[]
 }
 
 export type TodoItem = {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -73,6 +73,7 @@ export type ToolState = {
   title?: string
   output?: string
   error?: string
+  time?: { start: number; end?: number }
 }
 
 export type MessagePart = {
@@ -85,6 +86,7 @@ export type MessagePart = {
   state?: ToolState
   hash?: string
   files?: string[]
+  time?: { start: number; end?: number }
 }
 
 export type MessageEnvelope = {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -77,6 +77,7 @@ export type ToolState = {
 
 export type MessagePart = {
   id: string
+  messageID?: string
   type: string
   text?: string
   tool?: string

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -107,6 +107,29 @@ export type TodoItem = {
   id: string
 }
 
+export type QuestionOption = {
+  label: string
+  description: string
+}
+
+export type QuestionInfo = {
+  question: string
+  header: string
+  options: QuestionOption[]
+  multiple?: boolean
+  custom?: boolean
+}
+
+export type QuestionRequest = {
+  id: string
+  sessionID: string
+  questions: QuestionInfo[]
+  tool?: {
+    messageID: string
+    callID: string
+  }
+}
+
 export type DiffFile = {
   file: string
   additions: number

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -111,6 +111,8 @@ export type DiffFile = {
   file: string
   additions: number
   deletions: number
+  patch?: string
+  status?: "added" | "deleted" | "modified"
 }
 
 export type ProjectCurrent = Record<string, unknown> & {


### PR DESCRIPTION
## Summary

Includes both #30 and #31 in order to avoid merge conflicts, so you might want to handle those before this one. Major refactor of the entire UI: streamed message rendering, grouped/formatted agent actions (tool calls, diffs, reasoning, to-dos, questions), interactive question answering, and several session-list and layout fixes.

It's a lot of commits so you might wanna squash and merge. These are substantial changes so I'm open to feedback and willing to make more changes in order to get it merged.

- Stream assistant replies token-by-token instead of waiting for the full message, and keep the message list correctly pinned to the bottom while it grows (without fighting a user who's scrolled away).
- Group each turn's thinking/tool-calls/edits into a single collapsible "action" row (e.g. *"Thought for 12s, read 3 files, edited 2 files"*) instead of showing every tool call inline, with a modal for full detail.
- Render tool calls, diffs, reasoning, to-do updates, and question prompts with purpose-built, readable formatting instead of raw JSON/command dumps — including colored unified diffs with a expandable full-diff modal.
- Let the user answer the assistant's interactive questions (`AskUserQuestion`) directly from the chat.
- Localize all of the newly added strings across English, Italian, and Traditional Chinese.
- Assorted layout/mobile fixes

## Changes

- **Streaming & rendering**: apply streamed `message.part` events for gradual token rendering; stop periodic refresh from wiping in-progress reasoning; never let a reasoning update shrink already-shown thinking text; keep pinned to the latest message while opening a session and while content is still loading.
- **Diffs**: render colored unified diffs for patch parts; truncate long diff/tool previews inline and expand to a full modal on tap; don't wrap long lines in tool call command/output.
- **Action grouping**: group a turn's reasoning/tool/patch parts into a single summarized row; give `question` and `todowrite` tool calls dedicated, readable summaries and detail views instead of raw JSON.
- **Questions**: let the user answer the assistant's `AskUserQuestion` prompts from the chat UI.
- **Queueing**: allow queuing prompts while a session is working (`queue` branch).
- **Session list**: keep rename/delete on one row on mobile; simplify session card actions to just Rename and Delete; move the session status pill onto the stats row; don't close the app on Android back-press from an open session (`main` branch); navigate to a newly created session immediately.
- **Layout**: top nav bar scrolls with the page instead of staying pinned; composer send button stays beside the composer on mobile and drops its redundant text label; modal spacing, stray divider, and chat horizontal overflow fixes; live-updates status text sits next to the connection status instead of on its own line.
- **i18n**: add and localize all strings introduced by the above (agent action labels/counts, question/todo formatting, modal close button) across `en`, `it`, and `zh-TW`.
- **Polish**: truncate long tool-call modal titles instead of dumping the full command into the title bar; capitalize the joined action-group summary regardless of which piece (reasoning vs. tool count) comes first.
- **Performance**: memoize the message list (`MessagesPane`) and each message (`MessageArticle`) so composer typing and unrelated state updates no longer re-render the whole conversation; keep unchanged messages referentially stable across streamed part updates and the periodic refetch (`mergeFetchedMessages`) instead of allocating a fresh object per message every time, so per-message rendering/diffing only reruns for messages that actually changed; hoist `remarkPlugins` to a stable reference; stop the 3.5s polling fallback from doing a redundant full refetch while the SSE event stream is already live.

## TODO

`App.tsx` needs to be split into multiple, independent component files. Let me know if it's in scope for this issue or if you want to handle it later.