### PR TITLE
Keep the back button in the app, and queue a follow-up prompt instead of blocking the composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ Expected response:
 
 OMP sessions expose their configured model when ACP provides it, and model changes apply to subsequent prompts. Agent selection, persistent session rename/delete, server slash commands, and VCS/diff are intentionally unavailable.
 
+A prompt sent while the agent is still working is queued rather than refused: it appears in the conversation
+straight away and runs when the current turn ends. Stopping the session discards anything still queued.
+
 Session titles come from the title you give a session in the app, otherwise from its first prompt; sessions created outside the app are listed as `OMP session <id>`, because OMP session listings carry no title.
 
 #### What `--root` does and does not restrict

--- a/bridge/src/omp-service.js
+++ b/bridge/src/omp-service.js
@@ -40,6 +40,7 @@ export class OmpService {
   #replaying = new Set()
   #promptAcknowledgements = new Map()
   #titles = new Map()
+  #queues = new Map()
   #active = new Set()
   #listeners = new Set()
 
@@ -57,7 +58,7 @@ export class OmpService {
     const sessions = await this.#refreshSessions()
     return sessions
       .filter((session) => !directory || sameDirectory(session.cwd, directory))
-      .map((session) => sessionView(session, this.#active.has(session.sessionId) ? "busy" : "idle", this.#titleFor(session.sessionId)))
+      .map((session) => sessionView(session, this.#isBusy(session.sessionId) ? "busy" : "idle", this.#titleFor(session.sessionId)))
   }
 
   async createSession({ directory, title, model }) {
@@ -108,11 +109,27 @@ export class OmpService {
     option.currentValue = model
   }
 
+  /**
+   * ACP accepts one turn per session at a time, so a prompt sent while the agent is
+   * still working is queued rather than rejected. It is recorded straight away, which
+   * is what makes it visible in the conversation while it waits.
+   */
   async prompt(sessionID, text, model) {
     await this.#load(sessionID)
+    if (this.#active.has(sessionID)) {
+      const messageID = this.#recordPrompt(sessionID, text)
+      const queue = this.#queues.get(sessionID) ?? []
+      queue.push({ text, model, messageID })
+      this.#queues.set(sessionID, queue)
+      this.#emit("session.updated", sessionID)
+      return
+    }
     if (model) await this.setModel(sessionID, model)
-    if (this.#active.has(sessionID)) throw new Error("The OMP session is already running")
-    this.#recordPrompt(sessionID, text)
+    this.#startTurn(sessionID, text)
+  }
+
+  #startTurn(sessionID, text, recorded = false) {
+    if (!recorded) this.#recordPrompt(sessionID, text)
     this.#active.add(sessionID)
     this.#emit("session.updated", sessionID)
     void this.#acp.request("session/prompt", {
@@ -123,16 +140,50 @@ export class OmpService {
     }).finally(() => {
       this.#active.delete(sessionID)
       this.#emit("session.updated", sessionID)
+      void this.#runNextQueued(sessionID)
     })
   }
 
+  async #runNextQueued(sessionID) {
+    const queue = this.#queues.get(sessionID)
+    if (!queue?.length) return
+    const next = queue.shift()
+    if (!queue.length) this.#queues.delete(sessionID)
+    // The model is applied on dequeue: doing it on enqueue would switch the model
+    // underneath the turn that was still running.
+    if (next.model) {
+      try {
+        await this.setModel(sessionID, next.model)
+      } catch (error) {
+        this.#emit("session.error", sessionID, { message: error.message })
+      }
+    }
+    this.#startTurn(sessionID, next.text, true)
+  }
+
+  /** Cancelling drops anything still queued, including the messages recorded for it. */
   abort(sessionID) {
+    const queue = this.#queues.get(sessionID)
+    if (queue?.length) {
+      const discarded = new Set(queue.map((entry) => entry.messageID))
+      this.#queues.delete(sessionID)
+      const messages = this.#messages.get(sessionID)
+      if (messages) {
+        this.#messages.set(sessionID, messages.filter((message) => !discarded.has(message.info.id)))
+      }
+      this.#emit("message.updated", sessionID)
+    }
     this.#acp.notify("session/cancel", { sessionId: sessionID })
     this.#emit("session.updated", sessionID)
   }
 
   status(sessionID) {
-    return { type: this.#active.has(sessionID) ? "busy" : "idle" }
+    return { type: this.#isBusy(sessionID) ? "busy" : "idle" }
+  }
+
+  /** A queued prompt is still outstanding work, so the session must not read as idle between turns. */
+  #isBusy(sessionID) {
+    return this.#active.has(sessionID) || Boolean(this.#queues.get(sessionID)?.length)
   }
 
   async #load(sessionID, force = false) {
@@ -193,6 +244,7 @@ export class OmpService {
     })
     this.#promptAcknowledgements.set(sessionID, { text, received: "" })
     this.#emit("message.updated", sessionID)
+    return messageID
   }
 
   /** OMP session listings carry no title, so keep the creation title or derive one from the first prompt. */

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -200,6 +200,64 @@ class RealisticOmpAcp extends EventEmitter {
   notify() {}
 }
 
+/** Holds each turn open so a second prompt arrives while the first is still running. */
+class HeldTurnOmpAcp extends EventEmitter {
+  agentInfo = { version: "17.1.3" }
+  prompts = []
+  models = []
+  #releases = []
+  #started = []
+
+  async start() {}
+
+  async listSessions() {
+    return [{ sessionId: "session-1", cwd: process.cwd(), updatedAt: "2026-07-25T00:00:00.000Z" }]
+  }
+
+  async request(method, params) {
+    if (method === "session/prompt") {
+      this.prompts.push(params.prompt[0].text)
+      this.#started.shift()?.()
+      await new Promise((resolve) => this.#releases.push(resolve))
+      this.emit("notification", {
+        method: "session/update",
+        params: {
+          sessionId: params.sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            messageId: `a${this.prompts.length}`,
+            content: { type: "text", text: `reply to ${params.prompt[0].text}` }
+          }
+        }
+      })
+      return { stopReason: "end_turn" }
+    }
+    if (method === "session/set_config_option") {
+      this.models.push(params.value)
+      return {}
+    }
+    if (method === "session/load") {
+      return {
+        configOptions: [{
+          id: "model",
+          currentValue: "omp/first",
+          options: [{ value: "omp/first", name: "First" }, { value: "omp/second", name: "Second" }]
+        }]
+      }
+    }
+    return {}
+  }
+
+  /** Resolves once the next turn has actually reached the agent. */
+  turnStarted() {
+    return new Promise((resolve) => this.#started.push(resolve))
+  }
+
+  releaseTurn() {
+    this.#releases.shift()?.()
+  }
+}
+
 async function startServer({ acp = new FakeAcp(), ...options } = {}) {
   const server = createBridgeServer({
     acp,
@@ -246,6 +304,83 @@ async function waitForIdle(baseURL, sessionID) {
   }
   throw new Error("the session never returned to idle")
 }
+
+test("queues a prompt sent while the agent is still working", async () => {
+  const acp = new HeldTurnOmpAcp()
+  const bridge = await startServer({ acp })
+  const sendPrompt = (text, model) => fetch(`${bridge.baseURL}/session/session-1/prompt_async`, {
+    method: "POST",
+    headers: jsonHeaders(),
+    body: JSON.stringify({ parts: [{ type: "text", text }], model })
+  })
+  try {
+    const firstStarted = acp.turnStarted()
+    assert.equal((await sendPrompt("first")).status, 200)
+    await firstStarted
+
+    // Previously this returned 400 "The OMP session is already running".
+    assert.equal((await sendPrompt("second", { providerID: "omp", modelID: "second" })).status, 200)
+    assert.deepEqual(acp.prompts, ["first"], "the queued prompt must not reach the agent yet")
+    assert.deepEqual(acp.models, [], "a queued model change must not affect the running turn")
+
+    assert.deepEqual(conversation(await readJSON(bridge.baseURL, "/session/session-1/message")), [
+      "user: first",
+      "user: second"
+    ], "a queued prompt is visible while it waits")
+    const statuses = await readJSON(bridge.baseURL, "/session/status")
+    assert.equal(statuses["session-1"].type, "busy")
+
+    const secondStarted = acp.turnStarted()
+    acp.releaseTurn()
+    await secondStarted
+    assert.deepEqual(acp.prompts, ["first", "second"], "the queued prompt runs once the turn ends")
+    assert.deepEqual(acp.models, ["omp/second"], "its model is applied on dequeue")
+
+    acp.releaseTurn()
+    await waitForIdle(bridge.baseURL, "session-1")
+    // Showing a queued prompt the moment it is sent means both user messages precede the
+    // first reply, the way any chat looks when two messages are fired off in a row.
+    // Reopening the session replays OMP's own history, which is strictly interleaved.
+    assert.deepEqual(conversation(await readJSON(bridge.baseURL, "/session/session-1/message")), [
+      "user: first",
+      "user: second",
+      "assistant: reply to first",
+      "assistant: reply to second"
+    ])
+  } finally {
+    acp.releaseTurn()
+    acp.releaseTurn()
+    await bridge.close()
+  }
+})
+
+test("discards queued prompts when the session is aborted", async () => {
+  const acp = new HeldTurnOmpAcp()
+  const bridge = await startServer({ acp })
+  const sendPrompt = (text) => fetch(`${bridge.baseURL}/session/session-1/prompt_async`, {
+    method: "POST",
+    headers: jsonHeaders(),
+    body: JSON.stringify({ parts: [{ type: "text", text }] })
+  })
+  try {
+    const started = acp.turnStarted()
+    await sendPrompt("running")
+    await started
+    await sendPrompt("queued")
+
+    await fetch(`${bridge.baseURL}/session/session-1/abort`, { method: "POST", headers: authHeaders() })
+    assert.deepEqual(conversation(await readJSON(bridge.baseURL, "/session/session-1/message")), [
+      "user: running"
+    ], "a cancelled queue must not leave a message that was never sent")
+
+    acp.releaseTurn()
+    await waitForIdle(bridge.baseURL, "session-1")
+    assert.deepEqual(acp.prompts, ["running"], "a cancelled prompt must never reach the agent")
+  } finally {
+    acp.releaseTurn()
+    await bridge.close()
+  }
+})
 
 test("keeps the submitted prompt in history when the session is reopened", async () => {
   const bridge = await startServer({ acp: new RealisticOmpAcp() })

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "harness-remote-web",
-  "version": "1.5.2",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "harness-remote-web",
-      "version": "1.5.2",
+      "version": "2.0.0",
       "dependencies": {
         "@capacitor/android": "^8.3.4",
+        "@capacitor/app": "^8.1.1",
         "@capacitor/cli": "^8.3.4",
         "@capacitor/core": "^8.3.4",
         "react": "18.3.1",
@@ -31,6 +32,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.3.0"
+      }
+    },
+    "node_modules/@capacitor/app": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.1.tgz",
+      "integrity": "sha512-xM2ZTX5jK60tFtmjsmJv+Cdj1Qsb6NcavkqmdEnCPQBeya9oKhamZJxYOnQNj1ZvcJM7sWfG6BEtSLx42pisbA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/cli": {

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@capacitor/android": "^8.3.4",
+    "@capacitor/app": "^8.1.1",
     "@capacitor/cli": "^8.3.4",
     "@capacitor/core": "^8.3.4",
     "react": "18.3.1",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -426,6 +426,7 @@ function App() {
   const isSessionRunning = Boolean(selectedSession && ["busy", "retry"].includes(selectedSession.status))
   const isWaitingForOpenCodeReply = awaitingAssistantReply || busySending || isSessionRunning
   const isWorking = isWaitingForOpenCodeReply
+  const showStopAction = isWorking && !composer.trim()
   const showTypingBubble = Boolean(selectedSession) && isWaitingForOpenCodeReply
   const activeSessions = sessions.filter((session) => ["busy", "retry"].includes(session.status)).length
   const changedSessions = sessions.filter(
@@ -1815,19 +1816,19 @@ function App() {
               onKeyDown={(event) => {
                 if (event.key === "Enter" && !event.shiftKey) {
                   event.preventDefault()
-                  if (!isWorking) {
-                    send().catch(() => undefined)
-                  }
+                  send().catch(() => undefined)
                 }
               }}
-              disabled={!selectedSession || isWorking}
-            />
-            <button 
-              onClick={isWorking ? abortSession : send}
               disabled={!selectedSession}
-              className={isWorking ? "btn-danger" : "btn-primary"}
+            />
+            {/* While the agent works the same button stops it, but starts sending again as
+                soon as there is something to send, so a follow-up can be queued. */}
+            <button
+              onClick={showStopAction ? abortSession : send}
+              disabled={!selectedSession}
+              className={showStopAction ? "btn-danger" : "btn-primary"}
             >
-              {isWorking ? (
+              {showStopAction ? (
                 <>
                   <StopCircleIcon size={18} />
                   {t('detail.waiting')}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react"
+import { App as CapacitorApp } from "@capacitor/app"
+import type { PluginListenerHandle } from "@capacitor/core"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { api, isValidServerConfig } from "./api"
@@ -983,6 +985,45 @@ function App() {
   useEffect(() => {
     localStorage.setItem(LANGUAGE_STORAGE_KEY, language)
   }, [language])
+
+  // Android back: dismiss whatever is on top, then fall back to the session list,
+  // and only leave the app from there. Reads state through a ref because the
+  // handler is registered once and must not capture a stale view.
+  const backStateRef = useRef({ view, activeDetailSheet, sessionToDelete, renamingSessionID })
+  backStateRef.current = { view, activeDetailSheet, sessionToDelete, renamingSessionID }
+
+  useEffect(() => {
+    let handle: PluginListenerHandle | undefined
+    let removed = false
+    void CapacitorApp.addListener("backButton", () => {
+      const state = backStateRef.current
+      if (state.sessionToDelete) {
+        setSessionToDelete(null)
+        return
+      }
+      if (state.renamingSessionID) {
+        setRenamingSessionID(null)
+        return
+      }
+      if (state.activeDetailSheet) {
+        setActiveDetailSheet(null)
+        return
+      }
+      if (state.view !== "sessions") {
+        setView("sessions")
+        return
+      }
+      CapacitorApp.exitApp()
+    }).then((registered) => {
+      // The effect can be torn down before registration resolves.
+      if (removed) void registered.remove()
+      else handle = registered
+    })
+    return () => {
+      removed = true
+      void handle?.remove()
+    }
+  }, [])
 
   useEffect(() => {
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -129,4 +129,9 @@ assert.ok(
   'the app should only exit from the session list'
 )
 
+// A follow-up prompt can be queued while the agent is still working.
+assert.ok(app.includes('const showStopAction = isWorking && !composer.trim()'), 'stop should be offered only when there is nothing to send')
+assert.equal(app.includes('disabled={!selectedSession || isWorking}'), false, 'the composer must stay usable while the agent works')
+assert.ok(app.includes('onClick={showStopAction ? abortSession : send}'), 'the action button should send a queued follow-up instead of only stopping')
+
 console.log('ui regression tests passed')

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -110,4 +110,23 @@ assert.ok(/\.message-content pre[\s\S]*?overflow-x:\s*auto/.test(styles), 'fence
 
 assert.match(icons, /export const RefreshIcon/, 'RefreshIcon should exist for idle refresh UI')
 
+// Android back button: dismiss the topmost layer, then fall back to the session list.
+const backStart = app.indexOf('CapacitorApp.addListener("backButton"')
+assert.notEqual(backStart, -1, 'the Android back button should be handled')
+const backHandler = app.slice(backStart, app.indexOf('}, [])', backStart))
+assert.equal(
+  /setView\(\(current\)/.test(backHandler),
+  false,
+  'exitApp must not run inside a state updater, which React may invoke more than once'
+)
+assert.ok(backHandler.includes('backStateRef.current'), 'the handler is registered once, so it must read state through a ref')
+assert.ok(backHandler.includes('if (removed) void registered.remove()'), 'a listener registered after teardown must still be removed')
+for (const layer of ['sessionToDelete', 'renamingSessionID', 'activeDetailSheet']) {
+  assert.ok(backHandler.includes(layer), `back should dismiss ${layer} before leaving the view`)
+}
+assert.ok(
+  backHandler.indexOf('exitApp') > backHandler.indexOf('setView("sessions")'),
+  'the app should only exit from the session list'
+)
+
 console.log('ui regression tests passed')


### PR DESCRIPTION
Adopts the two small PRs from @birabittoh — #30 and #31 — reworked so they hold up on both harnesses.

## Back button (from #30)

Back from any view other than the session list closed the app, and it dismissed nothing when a sheet or dialog was open. Three changes to the original:

- `exitApp()` no longer runs inside a `setView` updater. Updaters must be pure, and React can invoke them more than once — under StrictMode that meant a double `exitApp`.
- A listener that finished registering after teardown was leaked, because the cleanup ran before the `addListener` promise resolved. It is now removed either way.
- Back closes the delete dialog, an inline rename, or an open detail sheet before it changes view.

## Prompt queue (from #31)

The composer was disabled while the agent worked, so a follow-up meant waiting or hitting stop.

Taken as-is, #31 would have broken OMP: the bridge rejected a second prompt with `The OMP session is already running`, so the user would have got a red error where they expected a queued message. ACP allows one turn per session, so the bridge now queues instead:

- the prompt is recorded immediately, which is what makes it visible while it waits;
- the session keeps reporting `busy` between turns, so no spurious idle flicker or completion sound;
- a queued model change is applied on dequeue, not under the turn that is still running;
- stopping the session discards the queue **and** the messages recorded for it, so nothing is left in the history that was never sent.

Both user messages appear before the first reply, the way any chat looks when two messages are fired off in a row. Reopening the session replays OMP's own history, which is strictly interleaved.

## Verification

- Bridge: 24/24, including a fake that holds a turn open to exercise the queue and the abort path
- Web: 6/6 suites, with regression cover for the back-button handler shape and the composer behaviour
- Against real OMP 17.1.3: a prompt sent mid-turn returns 200 (previously 400), status stays `busy`, both messages show immediately, and the queued prompt is answered once the first turn ends
- Each commit builds and passes independently

Not included: #32, which needs a rebase onto the current `main`.