### PR TITLE
Beat on the bridge event stream so clients do not reconnect on a loop

### DIFF
--- a/bridge/src/server.js
+++ b/bridge/src/server.js
@@ -134,7 +134,15 @@ export function createBridgeServer({ config, acp }) {
         })
         response.write(": connected\n\n")
         const unsubscribe = omp.subscribe((event) => writeSSE(response, event.type, event))
-        request.on("close", unsubscribe)
+        // Clients treat a long silence as a dead connection, because a TCP stream can die
+        // without ever delivering an error. OpenCode beats every 10s; without matching it an
+        // idle OMP session looks broken and the client reconnects on a loop.
+        const heartbeat = setInterval(() => response.write(": ping\n\n"), config.heartbeatMs ?? 10_000)
+        heartbeat.unref?.()
+        request.on("close", () => {
+          clearInterval(heartbeat)
+          unsubscribe()
+        })
         return
       }
       if (request.method === "GET" && (url.pathname === "/v1/sessions" || url.pathname === "/session" || url.pathname === "/experimental/session")) {

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -446,6 +446,31 @@ test("matches session directories across path separator forms", async () => {
   }
 })
 
+test("beats on the event stream so an idle session is not mistaken for a dead one", async () => {
+  const bridge = await startServer({ heartbeatMs: 25 })
+  const controller = new AbortController()
+  try {
+    const response = await fetch(`${bridge.baseURL}/global/event`, {
+      headers: authHeaders(),
+      signal: controller.signal
+    })
+    assert.equal(response.headers.get("content-type"), "text/event-stream")
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    let received = ""
+    // No session activity at all: everything arriving here must be a heartbeat.
+    while (!received.includes(": ping")) {
+      const { value, done } = await reader.read()
+      if (done) break
+      received += decoder.decode(value, { stream: true })
+    }
+    assert.match(received, /: ping/, "an idle stream must still produce traffic")
+  } finally {
+    controller.abort()
+    await bridge.close()
+  }
+})
+
 test("allows only explicitly configured browser origins", async () => {
   const bridge = await startServer({ corsOrigins: ["http://192.168.1.64:5199"] })
   try {


### PR DESCRIPTION
Follow-up to #37, found while testing it against a real OMP install.

#37 added a stall watchdog to the SSE transport: if no bytes arrive for 30s, abort and reconnect, since a TCP stream can die without ever erroring. That is a good change and its premise holds for OpenCode, which beats every 10s. The bridge, however, only wrote when a session event occurred, so an idle OMP session looked like a dead connection.

Measured in the browser against the bridge, counting requests to `/global/event`:

| | requests in ~115s idle | started at |
|---|---|---|
| before | 4 | 0s, 0s, 31s, 62s |
| after | 1 | 0s |

The churn was not only wasteful: #37 skips the 3.5s polling fallback while live updates report connected, so each reconnect window left a gap where neither the stream nor polling was running.

The bridge now writes a comment frame every 10s, matching OpenCode. Covered by a test that reads the stream with no session activity at all and requires traffic to arrive anyway.