### PR TITLE
Keep consecutive text-only replies in separate bubbles

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1137,8 +1137,12 @@ function groupRenderedMessages(messages: (MessageEnvelope & { text: string })[])
   let buffer: (MessageEnvelope & { text: string })[] = []
   const flush = () => {
     if (buffer.length === 0) return
-    if (buffer.length === 1 && buffer[0].parts.every((part) => !ACTION_GROUP_TYPES.has(part.type))) {
-      groups.push({ kind: "message", message: buffer[0] })
+    // A run exists to merge action groups that a message boundary split apart. With nothing
+    // groupable there is nothing to merge, and folding the messages together would glue two
+    // separate replies into one bubble — which is what an OMP session looks like while a queued
+    // prompt is running, since it produces text parts only.
+    if (!buffer.some((message) => message.parts.some((part) => ACTION_GROUP_TYPES.has(part.type)))) {
+      for (const message of buffer) groups.push({ kind: "message", message })
     } else {
       const items = buildMessageTimeline(buffer.flatMap((message) => message.parts))
       const messagesByID = new Map(buffer.map((message) => [message.info.id, message]))

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -138,4 +138,17 @@ assert.ok(app.includes('const showStopAction = isWorking && !composer.trim()'), 
 assert.equal(app.includes('disabled={!selectedSession || isWorking}'), false, 'the composer must stay usable while the agent works')
 assert.ok(app.includes('onClick={showStopAction ? abortSession : send}'), 'the action button should send a queued follow-up instead of only stopping')
 
+// A run bubble merges action groups that a message boundary split apart. Consecutive replies with
+// nothing groupable in them must stay separate, or two answers to two queued prompts render as one.
+const groupRenderer = app.slice(app.indexOf('function groupRenderedMessages'), app.indexOf('function ConversationRunView'))
+assert.ok(groupRenderer, 'consecutive assistant messages should be grouped for rendering')
+assert.ok(
+  groupRenderer.includes('!buffer.some((message) => message.parts.some((part) => ACTION_GROUP_TYPES.has(part.type)))'),
+  'a run must only form when the buffered messages actually contain groupable parts'
+)
+assert.ok(
+  groupRenderer.includes('for (const message of buffer) groups.push({ kind: "message", message })'),
+  'text-only replies must each keep their own bubble'
+)
+
 console.log('ui regression tests passed')


### PR DESCRIPTION
Follow-up to #40, found while testing it against a real OMP install.

#40 groups consecutive assistant messages into one run so that an action group split across a message boundary renders as a single summary row. That part works well. The fallback, though, formed a run whenever the buffer held more than one message — including when nothing in it was groupable at all:

```js
if (buffer.length === 1 && buffer[0].parts.every((part) => !ACTION_GROUP_TYPES.has(part.type))) {
  // single message
} else {
  // run
}
```

`ACTION_GROUP_TYPES` is `reasoning`, `tool` and `patch`. OMP only ever produces `text` parts, so a run should never form for it — but two consecutive replies did form one, and merged into a single bubble.

Reproduced in the browser against OMP 17.1.3, sending a second prompt while the first was still running:

| | last bubbles |
|---|---|
| before | `user: LIVE_ONE`, `user: LIVE_TWO`, `assistant: LIVE_ONE \| LIVE_TWO` |
| after | `user: LIVEFIX_A`, `user: LIVEFIX_B`, `assistant: …`, `assistant: …` |

The queued-prompt flow is where this shows: the live order is user, user, assistant, assistant, so both answers shared a bubble with no way to tell which prompt each belonged to. Reopening the session split them again, because OMP's persisted history is strictly interleaved — so the same conversation rendered two different ways depending on whether you had just sent the prompts.

A run now forms only when the buffered messages actually contain a groupable part, which leaves #40's behaviour intact for the case it was written for.