### PR TITLE
Repair what the PI merge dropped

### DIFF
--- a/bridge/src/server.js
+++ b/bridge/src/server.js
@@ -142,7 +142,15 @@ export function createBridgeServer({ config, acp }) {
         })
         response.write(": connected\n\n")
         const unsubscribe = service.subscribe((event) => writeSSE(response, event.type, event))
-        request.on("close", unsubscribe)
+        // Clients treat a long silence as a dead connection, because a TCP stream can die
+        // without ever delivering an error. OpenCode beats every 10s; without matching it an
+        // idle session looks broken and the client reconnects on a loop.
+        const heartbeat = setInterval(() => response.write(": ping\n\n"), config.heartbeatMs ?? 10_000)
+        heartbeat.unref?.()
+        request.on("close", () => {
+          clearInterval(heartbeat)
+          unsubscribe()
+        })
         return
       }
       if (request.method === "GET" && (url.pathname === "/v1/sessions" || url.pathname === "/session" || url.pathname === "/experimental/session")) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -40,6 +40,8 @@ const AGENT_STORAGE_KEY = "opencode.remote.agent"
 const THEME_STORAGE_KEY = "opencode.remote.theme"
 const NEW_SESSION_DIRECTORY_STORAGE_KEY = "opencode.remote.newSessionDirectory"
 
+type Translator = ReturnType<typeof createTranslator>
+
 function isBridgeBackend(backend: ServerConfig["backend"]): boolean {
   return backend === "omp" || backend === "pi"
 }
@@ -1558,7 +1560,6 @@ function App() {
   ).length
   const totalDiffAdditions = diffFiles.reduce((sum, file) => sum + file.additions, 0)
   const totalDiffDeletions = diffFiles.reduce((sum, file) => sum + file.deletions, 0)
-  const assistantDisplayName = backendDisplayName(config.backend)
   const showModelChip = modelOptions.length > 1 || Boolean(activeModelOption) || primaryAgentOptions.length > 0
 
   async function openSession(sessionID: string, directory: string) {
@@ -2769,16 +2770,6 @@ function App() {
                     <span className={`pill ${session.status}`}>{session.status}</span>
                   </div>
                   <div className="inline-actions">
-                    <button
-                      onClick={(event) => {
-                        event.stopPropagation()
-                        openSession(session.id, session.directory).catch(() => undefined)
-                      }}
-                      className="btn-primary"
-                    >
-                      <PlayIcon size={16} />
-                      {t('sessions.open')}
-                    </button>
                     {config.backend === "opencode" && (
                       <>
                         <button


### PR DESCRIPTION
Follow-up to #42. That branch merged `main` and resolved three conflicts by keeping its own side, which reverted work that had landed in between. None of it is a criticism of the PI implementation, which is sound — it is the ordinary cost of a branch that was open while `main` moved.

| Lost | Consequence | Restored |
|---|---|---|
| `type Translator` | web build failed with a dozen `TS2304` | declaration re-added |
| SSE heartbeat | 30s reconnect loop from #38 returns | interval re-added |
| Session card `Open` button | `PlayIcon` referenced with no import | button removed again, as in #40 |

Two things worth noting.

The web regression suites **passed the whole time the build was broken**, because they assert against source text and never compile. That is the known limit of that style, and `npm run build` is what actually catches it — which CI does run, so this would have failed there rather than shipping.

The `Open` button was removed deliberately in #40 as redundant with the card itself being clickable, so restoring the button rather than the import is the right resolution.

## Verification after the repair

- `npm run build` clean, web 6/6, bridge 30/30
- Real OMP 17.1.3: health reports the backend, a prompt round-trips, and an idle event stream emits `: ping` again
- `--backend pi` resolves to `npx.cmd` with `-y @victor-software-house/pi-acp` on Windows

The PI adapter itself is **not exercised here**: it is not installed on this machine and pulling it would mean fetching a third-party package. PI needs a real smoke test on a machine that has it before this is announced as working.