### PR TITLE
Survive a cold adapter start, and say why an adapter died

### DIFF
--- a/bridge/src/acp-client.js
+++ b/bridge/src/acp-client.js
@@ -1,8 +1,12 @@
 import { spawn } from "node:child_process"
 import { EventEmitter } from "node:events"
 
-const START_TIMEOUT_MS = 10_000
+// An adapter launched through `npx` downloads itself on first use, which takes far longer
+// than a warm start. Ten seconds failed on a cold PI adapter while npm was still fetching.
+const START_TIMEOUT_MS = 90_000
 const REQUEST_TIMEOUT_MS = 30_000
+/** Kept so a failed handshake can report why the adapter died instead of just its exit code. */
+const STDERR_KEPT_CHARS = 600
 
 export class AcpClient extends EventEmitter {
   #command
@@ -14,6 +18,7 @@ export class AcpClient extends EventEmitter {
   #pending = new Map()
   #starting
   #agentInfo
+  #stderr = ""
 
   constructor({ command = "omp", args = ["acp"], spawnProcess = spawn } = {}) {
     super()
@@ -53,10 +58,16 @@ export class AcpClient extends EventEmitter {
     child.stdout.setEncoding("utf8")
     child.stderr.setEncoding("utf8")
     child.stdout.on("data", (chunk) => this.#consume(chunk))
-    child.stderr.on("data", (chunk) => this.emit("stderr", chunk))
+    child.stderr.on("data", (chunk) => {
+      this.#stderr = `${this.#stderr}${chunk}`.slice(-STDERR_KEPT_CHARS)
+      this.emit("stderr", chunk)
+    })
     child.on("error", (error) => this.#handleExit(error))
     child.on("exit", (code, signal) => {
-      this.#handleExit(new Error(`ACP adapter exited (${code ?? "unknown"}${signal ? `, ${signal}` : ""})`))
+      const reason = this.#stderrSummary()
+      this.#handleExit(new Error(
+        `ACP adapter exited (${code ?? "unknown"}${signal ? `, ${signal}` : ""})${reason ? `: ${reason}` : ""}`
+      ))
     })
 
     try {
@@ -162,6 +173,16 @@ export class AcpClient extends EventEmitter {
     if (!this.#child?.stdin.writable) return
     const error = { code: -32_601, message: `Harness Remote bridge does not implement ${method}` }
     this.#child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, error })}\n`)
+  }
+
+  /**
+   * The adapter explains a missing prerequisite on stderr; without this the caller only sees an
+   * exit code. Several lines are kept because a Windows shell error wraps the useful part —
+   * "'bun' is not recognized…" arrives split from the sentence that follows it.
+   */
+  #stderrSummary() {
+    const lines = this.#stderr.split(/\r?\n/).map((line) => line.trim()).filter(Boolean)
+    return lines.slice(-3).join(" ")
   }
 
   #handleExit(error) {

--- a/bridge/test/acp-client.test.js
+++ b/bridge/test/acp-client.test.js
@@ -148,6 +148,25 @@ test("answers agent-initiated requests instead of leaving them unresolved", asyn
   client.close()
 })
 
+test("reports why the adapter died instead of only its exit code", async () => {
+  // The PI ACP adapter requires Bun, and when it is missing the shell explains that on
+  // stderr while the exit code alone says nothing. Windows wraps the message over two
+  // lines, so a single trailing line would drop the part that names the missing command.
+  const child = new FakeChild((current, request) => {
+    if (request.method !== "initialize") return
+    current.stderr.emit("data", '"bun" is not recognized as an internal or external command,\n')
+    current.stderr.emit("data", "operable program or batch file.\n")
+    current.emit("exit", 1, null)
+  })
+  const client = new AcpClient({ spawnProcess: () => child })
+
+  await assert.rejects(client.start(), (error) => {
+    assert.match(error.message, /ACP adapter exited \(1\)/)
+    assert.match(error.message, /"bun" is not recognized/, "the failing prerequisite must reach the caller")
+    return true
+  })
+})
+
 test("rejects an in-flight request when ACP exits", async () => {
   const child = new FakeChild((current, request) => {
     respondToHandshake(current, request)


### PR DESCRIPTION
Both of these were found on the first real attempt to reach PI through the `pi-acp` adapter, with PI 0.82.1 installed.

## A cold `npx` adapter never connected

The PI backend defaults to `npx -y @victor-software-house/pi-acp`, which downloads the package on first use. The ACP handshake allowed 10s, and npm was still fetching when it expired:

```
first attempt:  {"error":"ACP adapter request timed out: initialize"}
                [pi] npm warn deprecated node-domexception@1.0.0: …
second attempt: fails in 1.4s, package now cached
```

Every user selecting PI would have met that on their first connection and had no way to know it was just a download. The handshake now allows 90s. A warm start is unaffected, since the timeout only bounds the failure case.

## An adapter that died said nothing about why

With the package cached the adapter exited immediately and the app was told:

```
{"error":"ACP adapter exited (1)"}
```

while the actual reason was on stderr — the adapter requires Bun, which is not installed here:

```
[pi] "bun" is not recognized as an internal or external command,
```

The exit error now carries a short stderr tail, so the same request answers:

```
{"error":"ACP adapter exited (1): … \"bun\" is not recognized as an internal or external command, …"}
```

Several lines are kept rather than one, because a Windows shell error wraps the part that names the missing command away from the sentence that follows it — with a single trailing line the message was `"operable program or batch file."`, which says nothing.

Covered by a test that emits the two-line shell error and requires the failing prerequisite to reach the caller.

## Still not verified

PI itself remains un-smoke-tested: the adapter needs Bun ≥1.3 (`"engines": {"bun": ">=1.3"}` in `pi-acp@0.17.1`) and this machine does not have it. The prerequisite is correctly documented in the README by #42. Bridge suite is 31/31.