### PR TITLE
feat: allow local ACP tool permissions once

### DIFF
--- a/bridge/src/acp-client.js
+++ b/bridge/src/acp-client.js
@@ -8,6 +8,7 @@ export class AcpClient extends EventEmitter {
   #command
   #args
   #spawn
+  #permissionMode
   #child
   #buffer = ""
   #nextID = 1
@@ -15,10 +16,11 @@ export class AcpClient extends EventEmitter {
   #starting
   #agentInfo
 
-  constructor({ command = "omp", args = ["acp"], spawnProcess = spawn } = {}) {
+  constructor({ command = "omp", args = ["acp"], permissionMode = "deny", spawnProcess = spawn } = {}) {
     super()
     this.#command = command
     this.#args = args
+    this.#permissionMode = permissionMode
     this.#spawn = spawnProcess
   }
 
@@ -143,7 +145,8 @@ export class AcpClient extends EventEmitter {
     // timeout, so always reply.
     if (message.id !== undefined && message.method) {
       this.emit("agent-request", message)
-      this.#respondUnsupported(message.id, message.method)
+      if (message.method === "session/request_permission") this.#respondPermission(message.id, message.params)
+      else this.#respondUnsupported(message.id, message.method)
       return
     }
     if (message.id !== undefined) {
@@ -156,6 +159,20 @@ export class AcpClient extends EventEmitter {
       return
     }
     if (message.method) this.emit("notification", message)
+  }
+
+  #respondPermission(id, params) {
+    if (!this.#child?.stdin.writable) return
+    const options = Array.isArray(params?.options) ? params.options : []
+    const allowed = this.#permissionMode === "allow"
+      ? options.find((option) => option.kind === "allow_once")
+        ?? options.find((option) => option.kind === "allow_always")
+        ?? options.find((option) => typeof option.kind === "string" && option.kind.startsWith("allow"))
+      : undefined
+    const outcome = allowed?.optionId
+      ? { outcome: "selected", optionId: allowed.optionId }
+      : { outcome: "cancelled" }
+    this.#child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, result: { outcome } })}\n`)
   }
 
   #respondUnsupported(id, method) {

--- a/bridge/src/cli.js
+++ b/bridge/src/cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { AcpClient } from "./acp-client.js"
 import { parseConfig, usage } from "./config.js"
+import { harnessProfile } from "./harness-profiles.js"
 import { createBridgeServer } from "./server.js"
 
 let config
@@ -17,13 +18,14 @@ if (config?.help) {
 }
 
 if (config) {
-  const acp = new AcpClient({ command: config.acpCommand, args: config.acpArgs })
+  const profile = harnessProfile(config.backend)
+  const acp = new AcpClient({ command: config.acpCommand, args: config.acpArgs, permissionMode: profile.permissionMode })
   const server = createBridgeServer({ config, acp })
   let shuttingDown = false
 
   acp.on("stderr", (line) => process.stderr.write(`[${config.backend}] ${line}`))
   acp.on("agent-request", (message) => {
-    process.stderr.write(`[${config.backend}] declined unsupported agent request: ${message.method}\n`)
+    process.stderr.write(`[${config.backend}] handled agent request: ${message.method}\n`)
   })
   acp.on("exit", (error) => {
     if (!shuttingDown) process.stderr.write(`[${config.backend}] ${error.message}\n`)

--- a/bridge/src/harness-profiles.js
+++ b/bridge/src/harness-profiles.js
@@ -17,6 +17,7 @@ export const HARNESS_PROFILES = {
     label: "Oh My Pi",
     command: "omp",
     args: ["acp"],
+    permissionMode: "allow",
     capabilities: {
       ...COMMON_CAPABILITIES,
       models: true,
@@ -29,6 +30,7 @@ export const HARNESS_PROFILES = {
     label: "PI",
     command: process.platform === "win32" ? "npx.cmd" : "npx",
     args: ["-y", "@victor-software-house/pi-acp"],
+    permissionMode: "allow",
     capabilities: {
       ...COMMON_CAPABILITIES,
       models: true,

--- a/bridge/test/acp-client.test.js
+++ b/bridge/test/acp-client.test.js
@@ -127,15 +127,27 @@ test("forwards ACP notifications and request errors", async () => {
   client.close()
 })
 
-test("answers agent-initiated requests instead of leaving them unresolved", async () => {
+test("selects allow-once for agent permission requests", async () => {
   const child = new FakeChild((current, request) => {
     respondToHandshake(current, request)
     if (request.method === "session/prompt") {
-      current.respond({ jsonrpc: "2.0", id: 99, method: "session/request_permission", params: { sessionId: "session-1" } })
+      current.respond({
+        jsonrpc: "2.0",
+        id: 99,
+        method: "session/request_permission",
+        params: {
+          sessionId: "session-1",
+          options: [
+            { optionId: "reject", kind: "reject_once" },
+            { optionId: "always", kind: "allow_always" },
+            { optionId: "allow", kind: "allow_once" }
+          ]
+        }
+      })
       current.respond({ jsonrpc: "2.0", id: request.id, result: { stopReason: "end_turn" } })
     }
   })
-  const client = new AcpClient({ spawnProcess: () => child })
+  const client = new AcpClient({ permissionMode: "allow", spawnProcess: () => child })
   const observed = []
   client.on("agent-request", (message) => observed.push(message.method))
   await client.start()
@@ -143,8 +155,7 @@ test("answers agent-initiated requests instead of leaving them unresolved", asyn
   assert.deepEqual(await client.request("session/prompt", {}), { stopReason: "end_turn" })
   assert.deepEqual(observed, ["session/request_permission"])
   const reply = child.writes.find((message) => message.id === 99)
-  assert.ok(reply, "the bridge must reply to an agent-initiated request")
-  assert.equal(reply.error.code, -32601)
+  assert.deepEqual(reply?.result, { outcome: { outcome: "selected", optionId: "allow" } })
   client.close()
 })
 


### PR DESCRIPTION
## Summary

Second focused slice requested in #43, stacked on #46.

- handles `session/request_permission` as an ACP request instead of returning `-32601`
- prefers `allow_once`, then `allow_always`, and otherwise cancels cleanly
- keeps the default policy deny-safe inside `AcpClient`; local OMP/PI profiles opt into allow
- keeps unknown agent-initiated methods answered as unsupported so they cannot stall the agent

## Validation

- `cd bridge && npm test` — 32/32
- unit regression verifies `allow_once` wins even when `allow_always` is offered first
- real PI adapter `0.17.1`: session created, prompt completed, exact concatenated response `PI permission works`, final status `idle`

## Dependency

Stacked on #46 using the temporary `review/profiles-capabilities-base` base branch so this diff contains only the four permission-policy files. Retarget to `main` after #46 merges.

Relates to #36.