### PR TITLE
Run PI on Node, and let its tool calls through

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The app is backend-agnostic: you pick the harness in **Settings** and each one k
 |---|---|---|
 | [OpenCode](https://github.com/sst/opencode) | supported | directly to the OpenCode HTTP server |
 | Oh My Pi (OMP) | supported | through the local bridge included in this repository |
-| [PI](https://pi.dev/) | supported | through the local ACP bridge and [`pi-acp`](https://github.com/victor-software-house/pi-acp) adapter |
+| [PI](https://pi.dev/) | supported | through the local ACP bridge and the [`@automatalabs/pi-acp`](https://www.npmjs.com/package/@automatalabs/pi-acp) adapter |
 
 Support levels differ by what each harness exposes. The [OpenCode](#opencode-server-setup), [OMP](#oh-my-pi-bridge-setup), and [PI](#pi-bridge-setup) sections below document the setup and per-backend limitations.
 
@@ -119,7 +119,7 @@ The default ACP launch is `omp acp`. The bridge can launch another ACP adapter w
 npx --yes ./bridge \
   --acp-command npx \
   --acp-arg -y \
-  --acp-arg @victor-software-house/pi-acp
+  --acp-arg @automatalabs/pi-acp@0.2.5
 ```
 
 The equivalent environment variables are `OMP_BRIDGE_ACP_COMMAND` and
@@ -178,15 +178,18 @@ Do not expose the bridge directly to the Internet. Use Tailscale, another VPN, o
 ### PI Bridge Setup
 
 Harness Remote connects to PI through the same ACP bridge, using the community
-[`pi-acp`](https://github.com/victor-software-house/pi-acp) adapter. The bridge
-starts the adapter over stdio and translates ACP into the HTTP/SSE API used by
+[`@automatalabs/pi-acp`](https://www.npmjs.com/package/@automatalabs/pi-acp)
+adapter, which embeds PI through its published SDK and speaks ACP over stdio.
+The bridge starts the adapter and translates ACP into the HTTP/SSE API used by
 the app.
 
 #### Prerequisites
 
-- Node.js 24 or newer, as required by the current PI ACP adapter;
-- Bun available in `PATH`; the current `pi-acp` package entry launches its runtime through `bun`;
-- PI provider credentials configured for the adapter;
+- Node.js 22.19 or newer, as required by the adapter. Nothing here needs Bun: the other
+  widely referenced adapter, `@victor-software-house/pi-acp`, declares `engines.bun` and shells
+  out to `bun`, which is why this project does not use it;
+- a working `pi` command, with its provider credentials already configured — the bridge
+  authenticates with PI's stored credentials rather than reading an API key from the environment;
 - a checkout of this repository on the computer that runs the bridge.
 
 Start the bridge from the repository root:
@@ -201,9 +204,11 @@ npx --yes ./bridge \
   --root "$HOME/Software"
 ```
 
-The `pi` backend defaults to `npx -y @victor-software-house/pi-acp`. Use
-`--acp-command` and repeated `--acp-arg` options if the adapter is installed
-globally or launched from a local checkout.
+The `pi` backend defaults to `npx -y @automatalabs/pi-acp@0.2.5`. The version is pinned
+deliberately: an unpinned default failed with `notarget` when an upstream release appeared in
+the registry index before its tarball could be fetched. Use `--acp-command` and repeated
+`--acp-arg` options to track a newer adapter, or to launch one installed globally or from a
+local checkout. The first start downloads the adapter, which is why the handshake allows 90s.
 
 In the app, select **PI (ACP bridge)** and enter the same host, port, username,
 and password. A successful health check reports `backend: "pi"` and the
@@ -213,6 +218,12 @@ PI supports session listing, history replay, streaming prompts, cancellation,
 queued follow-up prompts, and model selection. Plan/todo updates, persistent
 session rename/delete, server slash commands, and VCS/diff are not currently
 exposed through this bridge.
+
+Unlike OMP, PI's adapter asks before each tool call. **The bridge grants those requests
+automatically**, choosing the broadest allow option the adapter offers, because there is no way
+to prompt you on the phone mid-turn and a refusal silently prevents PI from doing any work at
+all. The practical effect matches OMP, which approves its own tool calls without asking: an
+agent reached through this bridge edits files unattended.
 
 The bridge's `--root` restriction applies to directory browsing and new-session
 selection; it is not a sandbox for PI. The adapter still runs with the full

--- a/bridge/src/acp-client.js
+++ b/bridge/src/acp-client.js
@@ -77,8 +77,14 @@ export class AcpClient extends EventEmitter {
         clientInfo: { name: "harness-remote-bridge", version: "0.1.7" }
       }, START_TIMEOUT_MS)
       this.#agentInfo = initialized.agentInfo
+      // The bridge always runs beside a harness the user already configured, so prefer a method
+      // that uses those credentials. PI's adapter offers `anthropic-api-key` first and
+      // `pi-stored-credentials` last: picking the first would claim an API key from an
+      // environment variable that is usually unset, and fail later at inference rather than here.
       const authMethods = Array.isArray(initialized.authMethods) ? initialized.authMethods : []
-      const authMethod = authMethods.find((method) => method?.id === "agent") ?? authMethods.find((method) => method?.id)
+      const authMethod = authMethods.find((method) => method?.id === "agent")
+        ?? authMethods.find((method) => method?.id && method.type !== "env_var")
+        ?? authMethods.find((method) => method?.id)
       if (authMethod) await this.request("authenticate", { methodId: authMethod.id }, START_TIMEOUT_MS)
     } catch (error) {
       this.close()
@@ -154,7 +160,8 @@ export class AcpClient extends EventEmitter {
     // timeout, so always reply.
     if (message.id !== undefined && message.method) {
       this.emit("agent-request", message)
-      this.#respondUnsupported(message.id, message.method)
+      if (message.method === "session/request_permission") this.#grantPermission(message)
+      else this.#respondUnsupported(message.id, message.method)
       return
     }
     if (message.id !== undefined) {
@@ -167,6 +174,26 @@ export class AcpClient extends EventEmitter {
       return
     }
     if (message.method) this.emit("notification", message)
+  }
+
+  /**
+   * Tool calls stall without an answer. OMP approves its own and never asks, so granting the
+   * same for an agent that does ask keeps the backends consistent — and matches what the
+   * bridge already is: a local agent running with the user's privileges, as the README says.
+   * Refusing instead, which is what the generic unsupported reply did, silently prevented PI
+   * from touching a single file.
+   */
+  #grantPermission(message) {
+    if (!this.#child?.stdin.writable) return
+    const options = Array.isArray(message.params?.options) ? message.params.options : []
+    const allowed = options.find((option) => option?.kind === "allow_always")
+      ?? options.find((option) => option?.kind === "allow_once")
+      ?? options.find((option) => option?.optionId)
+    const outcome = allowed?.optionId
+      ? { outcome: "selected", optionId: allowed.optionId }
+      : { outcome: "cancelled" }
+    this.emit("permission", { method: message.method, optionId: allowed?.optionId })
+    this.#child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: message.id, result: { outcome } })}\n`)
   }
 
   #respondUnsupported(id, method) {

--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -41,6 +41,7 @@ export class AcpService {
   #promptAcknowledgements = new Map()
   #titles = new Map()
   #queues = new Map()
+  #streaming = new Map()
   #active = new Set()
   #listeners = new Set()
 
@@ -130,6 +131,8 @@ export class AcpService {
 
   #startTurn(sessionID, text, recorded = false) {
     if (!recorded) this.#recordPrompt(sessionID, text)
+    // Chunks with no messageId aggregate per turn, so each turn starts with none open.
+    this.#streaming.set(sessionID, {})
     this.#active.add(sessionID)
     this.#emit("session.updated", sessionID)
     void this.#acp.request("session/prompt", {
@@ -138,6 +141,7 @@ export class AcpService {
     }, 300_000).catch((error) => {
       this.#emit("session.error", sessionID, { message: error.message })
     }).finally(() => {
+      this.#streaming.delete(sessionID)
       this.#active.delete(sessionID)
       this.#emit("session.updated", sessionID)
       void this.#runNextQueued(sessionID)
@@ -292,9 +296,16 @@ export class AcpService {
     // Acknowledgements only suppress a live echo of the prompt we just recorded;
     // a history replay rebuilds from an empty list and must keep every message.
     if (role === "user" && !replaying && this.#isAcknowledgedPromptChunk(sessionId, update.content.text)) return
-    const messageID = update.messageId ?? randomUUID()
     const messages = this.#messages.get(sessionId) ?? []
     this.#messages.set(sessionId, messages)
+    // PI's adapter streams a turn as chunks carrying no messageId, so minting a fresh id per
+    // chunk split one reply into a bubble per token. Without an id, keep appending to the
+    // message this turn already opened for that role — scoped to the turn, so a later reply
+    // never lands on an earlier one. Replay is excluded: there the missing id means separate
+    // persisted messages rather than one live turn.
+    const openMessages = replaying ? undefined : this.#streaming.get(sessionId)
+    const messageID = update.messageId ?? openMessages?.[role] ?? randomUUID()
+    if (!update.messageId && openMessages) openMessages[role] = messageID
     let message = messages.find((item) => item.info.id === messageID)
     if (!message) {
       message = {

--- a/bridge/src/cli.js
+++ b/bridge/src/cli.js
@@ -22,6 +22,9 @@ if (config) {
   let shuttingDown = false
 
   acp.on("stderr", (line) => process.stderr.write(`[${config.backend}] ${line}`))
+  acp.on("permission", ({ optionId }) => {
+    process.stderr.write(`[${config.backend}] granted tool permission (${optionId ?? "none offered"})\n`)
+  })
   acp.on("agent-request", (message) => {
     process.stderr.write(`[${config.backend}] declined unsupported agent request: ${message.method}\n`)
   })

--- a/bridge/src/config.js
+++ b/bridge/src/config.js
@@ -37,8 +37,17 @@ function defaultAcpCommand(backend) {
   return backend === "pi" ? (process.platform === "win32" ? "npx.cmd" : "npx") : "omp"
 }
 
+// @automatalabs/pi-acp embeds PI through its published SDK and runs on Node. The other
+// widely referenced adapter, @victor-software-house/pi-acp, declares `engines.bun` and
+// shells out to `bun`, which this project deliberately does not depend on.
+//
+// The version is pinned rather than floating on `latest`: an unpinned default failed here
+// with `notarget` when an upstream release appeared in the registry index before its
+// tarball was fetchable. Override with --acp-arg to track a newer adapter.
+const PI_ADAPTER = "@automatalabs/pi-acp@0.2.5"
+
 function defaultAcpArgs(backend) {
-  return backend === "pi" ? ["-y", "@victor-software-house/pi-acp"] : ["acp"]
+  return backend === "pi" ? ["-y", PI_ADAPTER] : ["acp"]
 }
 
 

--- a/bridge/test/acp-client.test.js
+++ b/bridge/test/acp-client.test.js
@@ -127,11 +127,47 @@ test("forwards ACP notifications and request errors", async () => {
   client.close()
 })
 
-test("answers agent-initiated requests instead of leaving them unresolved", async () => {
+test("grants tool permission so a tool call is not silently blocked", async () => {
+  // Verified against PI's ACP adapter: it asks before every tool call, and the generic
+  // unsupported reply meant it never touched a file while reporting success.
   const child = new FakeChild((current, request) => {
     respondToHandshake(current, request)
     if (request.method === "session/prompt") {
-      current.respond({ jsonrpc: "2.0", id: 99, method: "session/request_permission", params: { sessionId: "session-1" } })
+      current.respond({
+        jsonrpc: "2.0",
+        id: 99,
+        method: "session/request_permission",
+        params: {
+          sessionId: "session-1",
+          options: [
+            { optionId: "reject", kind: "reject_once", name: "Reject" },
+            { optionId: "once", kind: "allow_once", name: "Allow once" },
+            { optionId: "always", kind: "allow_always", name: "Always allow" }
+          ]
+        }
+      })
+      current.respond({ jsonrpc: "2.0", id: request.id, result: { stopReason: "end_turn" } })
+    }
+  })
+  const client = new AcpClient({ spawnProcess: () => child })
+  const granted = []
+  client.on("permission", (event) => granted.push(event.optionId))
+  await client.start()
+
+  assert.deepEqual(await client.request("session/prompt", {}), { stopReason: "end_turn" })
+  const reply = child.writes.find((message) => message.id === 99)
+  assert.ok(reply, "a permission request must be answered")
+  assert.equal(reply.error, undefined, "answering with an error blocks the tool call")
+  assert.deepEqual(reply.result.outcome, { outcome: "selected", optionId: "always" })
+  assert.deepEqual(granted, ["always"])
+  client.close()
+})
+
+test("still declines agent-initiated requests it does not implement", async () => {
+  const child = new FakeChild((current, request) => {
+    respondToHandshake(current, request)
+    if (request.method === "session/prompt") {
+      current.respond({ jsonrpc: "2.0", id: 98, method: "fs/write_text_file", params: {} })
       current.respond({ jsonrpc: "2.0", id: request.id, result: { stopReason: "end_turn" } })
     }
   })
@@ -141,9 +177,9 @@ test("answers agent-initiated requests instead of leaving them unresolved", asyn
   await client.start()
 
   assert.deepEqual(await client.request("session/prompt", {}), { stopReason: "end_turn" })
-  assert.deepEqual(observed, ["session/request_permission"])
-  const reply = child.writes.find((message) => message.id === 99)
-  assert.ok(reply, "the bridge must reply to an agent-initiated request")
+  assert.deepEqual(observed, ["fs/write_text_file"])
+  const reply = child.writes.find((message) => message.id === 98)
+  assert.ok(reply, "the bridge must reply rather than let the agent wait")
   assert.equal(reply.error.code, -32601)
   client.close()
 })

--- a/bridge/test/config.test.js
+++ b/bridge/test/config.test.js
@@ -37,8 +37,12 @@ test("configures a non-OMP ACP adapter command and arguments", () => {
 test("selects PI defaults for the ACP backend", () => {
   assert.deepEqual(parseConfig(["--backend", "pi"], {}).backend, "pi")
   assert.equal(parseConfig(["--backend", "pi"], {}).acpCommand, process.platform === "win32" ? "npx.cmd" : "npx")
-  assert.deepEqual(parseConfig(["--backend", "pi"], {}).acpArgs, ["-y", "@victor-software-house/pi-acp"])
-  assert.deepEqual(parseConfig([], { OMP_BRIDGE_BACKEND: "pi" }).acpArgs, ["-y", "@victor-software-house/pi-acp"])
+  // The adapter must run on Node: @victor-software-house/pi-acp declares engines.bun and
+  // shells out to `bun`, which this project does not depend on. The version is pinned because
+  // an unpinned default failed with `notarget` when a release outran its own tarball.
+  assert.deepEqual(parseConfig(["--backend", "pi"], {}).acpArgs, ["-y", "@automatalabs/pi-acp@0.2.5"])
+  assert.deepEqual(parseConfig([], { OMP_BRIDGE_BACKEND: "pi" }).acpArgs, ["-y", "@automatalabs/pi-acp@0.2.5"])
+  assert.match(parseConfig(["--backend", "pi"], {}).acpArgs[1], /@\d+\.\d+\.\d+$/, "the adapter version must stay pinned")
 })
 
 test("shares the bridge with browser origins only when asked", () => {


### PR DESCRIPTION
PI support shipped in #42 against `@victor-software-house/pi-acp`, which declares `engines.bun` and shells out to `bun`. This project runs on Node everywhere, so that adapter is out.

PI itself was never the problem — it is an npm package that runs on Node. Only the adapter was. The default is now [`@automatalabs/pi-acp`](https://www.npmjs.com/package/@automatalabs/pi-acp), which embeds PI through its published SDK, speaks ACP over stdio, and requires only Node 22.19.

The version is pinned to `0.2.5`. An unpinned default failed live with `notarget`: `0.2.6` was in the registry index and tagged `latest` while its tarball was not yet fetchable, so a floating default breaks whenever an upstream publish goes wrong.

## Two defects only a real PI could show

Both are invisible with OMP, which is why the bridge had them.

**Tool calls never ran.** PI's adapter asks permission before each one, and the bridge answered every agent-initiated request with `-32601`. A prompt to write a file reported success and wrote nothing:

```
[pi] declined unsupported agent request: session/request_permission   × 4
file NOT created
```

Permission requests are now granted with the broadest allow option offered. That matches OMP, whose agent approves its own tool calls and never asks, and it is the only workable answer when there is no way to prompt the user mid-turn on a phone. After the change:

```
[pi] granted tool permission (allow_always)
FILE CREATED, content: 'HELLO'
```

This is documented plainly in the README rather than left implicit — an agent reached through this bridge edits files unattended.

**A reply arrived as one message per token.** PI streams chunks carrying no `messageId`, and minting a fresh id per chunk split one reply into four messages:

| | history after one prompt |
|---|---|
| before | `assistant: PI`, `assistant: _N`, `assistant: ODE`, `assistant: _OK` |
| after | `assistant: PI_NODE_OK` |

Chunks without an id now append to the message the same role opened during that turn, scoped to the turn so a later reply cannot land on an earlier one. Replay is excluded, because there a missing id means separate persisted messages rather than one live turn.

## Also

Authentication preferred the adapter's first offered method — an env-var Anthropic key that is usually unset — over `pi-stored-credentials`. Non-env-var methods now win, so the bridge uses the credentials the harness already has instead of failing later at inference.

## Credit

Both defects were found and fixed first in #43. This is the smaller change that unblocks PI on Node; that PR's profile and capability architecture stands on its own merits and is unaffected.

## Verification

Against PI 0.82.1 with adapter 0.2.5, through the bridge: session create, streamed prompt as a single message, a tool call that actually writes the file, model list from the adapter, session list, and abort. OMP 17.1.3 re-checked for regressions — health, prompt round-trip, single aggregated message. Bridge 32/32, web 6/6, build clean.