### PR TITLE
Reconcile OMP sessions across clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If remote/mobile cannot connect, open TCP 4096 in your OS firewall and network f
 
 ### Oh My Pi Bridge Setup
 
-Harness Remote connects to OMP through the bridge included in this repository. The bridge starts `omp acp` on the same computer, translates its ACP stdio protocol to the app's HTTP/SSE API, and never reads or modifies OMP's internal databases.
+Harness Remote connects to OMP through the bridge included in this repository. The bridge starts `omp acp` on the same computer and translates its ACP stdio protocol to the app's HTTP/SSE API. To show sessions created by another OMP process without loading and interrupting them, it reads the append-only user/assistant transcript under OMP's session directory; it does not modify OMP state.
 
 #### Prerequisites
 
@@ -122,9 +122,10 @@ npx --yes ./bridge \
   --acp-arg @automatalabs/pi-acp@0.2.5
 ```
 
-The equivalent environment variables are `OMP_BRIDGE_ACP_COMMAND` and
-`OMP_BRIDGE_ACP_ARGS`, where the latter is a JSON array of strings. The
-PI setup below selects the adapter and the matching app backend automatically.
+The preferred environment variables are `HARNESS_REMOTE_ACP_COMMAND` and
+`HARNESS_REMOTE_ACP_ARGS`, where the latter is a JSON array of strings.
+Existing `OMP_BRIDGE_*` names remain aliases for one compatibility release.
+The PI setup below selects the adapter and the matching app backend automatically.
 
 The default bind address is `127.0.0.1`. Use `0.0.0.0` only for a trusted LAN or VPN. The bridge refuses a non-loopback bind without both username and password.
 
@@ -169,9 +170,11 @@ npx --yes ./bridge --port 4097 --username omp --password "…" --root "$HOME/Sof
 
 #### Live synchronization scope
 
-The bridge streams `busy`, assistant chunks, todos, and completion for work started through that same bridge. OMP ACP does not expose a global cross-client event feed or running-status API: a session driven by a separate desktop OMP or harness process can be listed and reopened, but the app cannot reliably show its live `busy` state, thinking bubble, or incremental output. A prompt sent from the app is recorded and handled by the bridge's ACP process; it does not inject a message into another already-running agent transport.
+The bridge streams `busy`, assistant chunks, todos, and completion for work started through that same bridge. Sessions created by desktop OMP or another client are listed with their persisted history and remain writable: the first prompt from the app loads that session into the bridge's ACP process and continues it there. This supports sequential hand-off between desktop and mobile, including sessions created days earlier.
 
-Use the bridge-created session for mobile-driven work. Reliable live observation and hand-off between independent OMP clients require a global session event/status API from OMP (or a relay integrated with the host harness); the bridge does not read OMP databases to simulate one.
+OMP ACP does not expose a global cross-client event feed, shared running-status API, or session lock. Concurrent desktop and app turns are accepted, and the bridge merges newly persisted OMP transcript branches into the app during polling so neither client's messages disappear. The two agent processes still run independently: response order and the context seen by each turn can branch. Sequential hand-off is deterministic; simultaneous use is supported for visibility but cannot provide server-level turn serialization.
+
+The bridge keeps its last successful message/todo snapshot under `~/.harness-remote/<backend>/`. This prevents an empty or partial ACP replay from erasing the app's conversation after navigation or a bridge restart. Use `--state-dir <path>` or `HARNESS_REMOTE_STATE_DIR` to relocate this state.
 
 Do not expose the bridge directly to the Internet. Use Tailscale, another VPN, or a TLS-terminating reverse proxy, and open port `4097` only to the network that needs it.
 

--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto"
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
 import path from "node:path"
 
 function toEpoch(value) {
@@ -15,8 +16,7 @@ export function sameDirectory(left, right) {
   }
   return normalize(left) === normalize(right)
 }
-
-function sessionView(session, status = "idle", title = session.title) {
+function sessionView(session, status = "idle", title = session.title, external = false) {
   return {
     id: session.sessionId,
     title: title || `Session ${session.sessionId.slice(0, 8)}`,
@@ -24,8 +24,74 @@ function sessionView(session, status = "idle", title = session.title) {
     time: { created: toEpoch(session.updatedAt), updated: toEpoch(session.updatedAt) },
     summary: { additions: 0, deletions: 0, files: 0 },
     model: undefined,
-    status
+    status,
+    ...(external ? { external: true } : {})
   }
+}
+
+function messageSignature(message) {
+  return `${message?.info?.role ?? ""}\u0000${(message?.parts ?? []).map((part) => part?.text ?? "").join("")}`
+}
+
+function mergeReplay(previous, replayed) {
+  if (previous.length === 0) return replayed
+  if (replayed.length === 0) return previous
+  const left = previous.map(messageSignature)
+  const right = replayed.map(messageSignature)
+  const common = Array.from({ length: left.length + 1 }, () => new Uint32Array(right.length + 1))
+  for (let leftIndex = left.length - 1; leftIndex >= 0; leftIndex -= 1) {
+    for (let rightIndex = right.length - 1; rightIndex >= 0; rightIndex -= 1) {
+      common[leftIndex][rightIndex] = left[leftIndex] === right[rightIndex]
+        ? common[leftIndex + 1][rightIndex + 1] + 1
+        : Math.max(common[leftIndex + 1][rightIndex], common[leftIndex][rightIndex + 1])
+    }
+  }
+  const merged = []
+
+  let leftIndex = 0
+  let rightIndex = 0
+  while (leftIndex < left.length && rightIndex < right.length) {
+    if (left[leftIndex] === right[rightIndex]) {
+      merged.push(previous[leftIndex])
+      leftIndex += 1
+      rightIndex += 1
+    } else if (common[leftIndex + 1][rightIndex] >= common[leftIndex][rightIndex + 1]) {
+      merged.push(previous[leftIndex])
+      leftIndex += 1
+    } else {
+      merged.push(replayed[rightIndex])
+      rightIndex += 1
+    }
+  }
+  return [...merged, ...previous.slice(leftIndex), ...replayed.slice(rightIndex)]
+}
+
+function mergeExternalHistory(persisted, cached) {
+  const persistedIDs = new Set(persisted.map((message) => message.info.id))
+  const persistedBySignature = new Map()
+  for (const message of persisted) {
+    const signature = messageSignature(message)
+    const times = persistedBySignature.get(signature) ?? []
+    times.push(message.info.time.created)
+    persistedBySignature.set(signature, times)
+  }
+  const cachedOnly = cached.filter((message) => {
+    if (persistedIDs.has(message.info.id)) return false
+    const duplicateTimes = persistedBySignature.get(messageSignature(message)) ?? []
+    return !duplicateTimes.some((created) => Math.abs(created - message.info.time.created) < 30_000)
+  })
+  return [...persisted, ...cachedOnly].sort((left, right) => left.info.time.created - right.info.time.created)
+}
+
+function mergeTodos(previous, replayed) {
+  if (previous.length === 0 || replayed.length === 0) return replayed.length > 0 ? replayed : previous
+  const priorByContent = new Map(previous.map((todo) => [todo.content, todo]))
+  if (replayed.some((todo) => !priorByContent.has(todo.content))) return replayed
+  const statusRank = { pending: 0, in_progress: 1, completed: 2 }
+  return replayed.map((todo) => {
+    const prior = priorByContent.get(todo.content)
+    return (statusRank[prior.status] ?? -1) > (statusRank[todo.status] ?? -1) ? { ...todo, status: prior.status } : todo
+  })
 }
 
 export class AcpService {
@@ -38,17 +104,28 @@ export class AcpService {
   #loads = new Map()
   #sessionListing
   #replaying = new Set()
+  #historyLoader
+  #ownedSessions = new Set()
   #promptAcknowledgements = new Map()
   #titles = new Map()
   #queues = new Map()
-  #streaming = new Map()
   #active = new Set()
   #listeners = new Set()
-
-  constructor(acp) {
+  #turnGenerations = new Map()
+  #cancelledSessions = new Set()
+  #promptedSessions = new Set()
+  #chunkMessageIDs = new Map()
+  #snapshotDirectory
+  #restoredSnapshots = new Set()
+  #dirtySnapshots = new Set()
+  #snapshotWrites = new Map()
+  constructor(acp, { snapshotDirectory, historyLoader } = {}) {
     this.#acp = acp
+    this.#snapshotDirectory = snapshotDirectory
+    this.#historyLoader = historyLoader
     acp.on("notification", (notification) => this.#handleNotification(notification))
   }
+
 
   subscribe(listener) {
     this.#listeners.add(listener)
@@ -57,9 +134,15 @@ export class AcpService {
 
   async listSessions(directory) {
     const sessions = await this.#refreshSessions()
+    await Promise.all(sessions.map((session) => this.#restoreSnapshot(session.sessionId)))
     return sessions
       .filter((session) => !directory || sameDirectory(session.cwd, directory))
-      .map((session) => sessionView(session, this.#isBusy(session.sessionId) ? "busy" : "idle", this.#titleFor(session.sessionId)))
+      .map((session) => sessionView(
+        session,
+        this.#isBusy(session.sessionId) ? "busy" : "idle",
+        this.#titleFor(session.sessionId),
+        Boolean(this.#historyLoader && !this.#ownedSessions.has(session.sessionId))
+      ))
   }
 
   async createSession({ directory, title, model }) {
@@ -77,19 +160,26 @@ export class AcpService {
     this.#messages.set(session.sessionId, [])
     this.#todos.set(session.sessionId, [])
     this.#loaded.add(session.sessionId)
+    this.#ownedSessions.add(session.sessionId)
     if (title) this.#titles.set(session.sessionId, title)
     if (model) await this.setModel(session.sessionId, model)
     this.#emit("session.created", session.sessionId)
+    this.#persistSnapshot(session.sessionId)
     return sessionView(session, "idle", this.#titleFor(session.sessionId))
   }
 
   async messages(sessionID, refresh = false) {
     await this.#refreshSessions()
-    await this.#load(sessionID, refresh)
+    await this.#restoreSnapshot(sessionID)
+    const externalHistory = Boolean(this.#historyLoader && !this.#ownedSessions.has(sessionID))
+    await this.#load(sessionID, refresh || externalHistory)
     return this.#messages.get(sessionID) ?? []
   }
 
   async todos(sessionID) {
+    await this.#refreshSessions()
+    await this.#restoreSnapshot(sessionID)
+    if (this.#historyLoader && !this.#ownedSessions.has(sessionID)) return []
     await this.#load(sessionID)
     return this.#todos.get(sessionID) ?? []
   }
@@ -104,7 +194,7 @@ export class AcpService {
     await this.#load(sessionID)
     const option = this.#configOptions.get(sessionID)?.find((item) => item.id === "model")
     if (!option?.options?.some((candidate) => candidate.value === model)) {
-      throw new Error(`Model is not available: ${model}`)
+      throw new Error(`Harness model is not available: ${model}`)
     }
     await this.#acp.request("session/set_config_option", { sessionId: sessionID, configId: "model", value: model })
     option.currentValue = model
@@ -116,7 +206,18 @@ export class AcpService {
    * is what makes it visible in the conversation while it waits.
    */
   async prompt(sessionID, text, model) {
-    await this.#load(sessionID)
+    if (this.#historyLoader && !this.#ownedSessions.has(sessionID)) {
+      this.#ownedSessions.add(sessionID)
+      this.#loaded.delete(sessionID)
+      try {
+        await this.#load(sessionID)
+      } catch (error) {
+        this.#ownedSessions.delete(sessionID)
+        throw error
+      }
+    } else {
+      await this.#load(sessionID)
+    }
     if (this.#active.has(sessionID)) {
       const messageID = this.#recordPrompt(sessionID, text)
       const queue = this.#queues.get(sessionID) ?? []
@@ -130,20 +231,27 @@ export class AcpService {
   }
 
   #startTurn(sessionID, text, recorded = false) {
+    const generation = (this.#turnGenerations.get(sessionID) ?? 0) + 1
+    this.#turnGenerations.set(sessionID, generation)
+    this.#cancelledSessions.delete(sessionID)
+    this.#promptedSessions.add(sessionID)
     if (!recorded) this.#recordPrompt(sessionID, text)
-    // Chunks with no messageId aggregate per turn, so each turn starts with none open.
-    this.#streaming.set(sessionID, {})
     this.#active.add(sessionID)
+    this.#chunkMessageIDs.delete(`${sessionID}:assistant`)
     this.#emit("session.updated", sessionID)
     void this.#acp.request("session/prompt", {
       sessionId: sessionID,
       prompt: [{ type: "text", text }]
     }, 300_000).catch((error) => {
-      this.#emit("session.error", sessionID, { message: error.message })
+      if (this.#turnGenerations.get(sessionID) === generation) {
+        this.#emit("session.error", sessionID, { message: error.message })
+      }
     }).finally(() => {
-      this.#streaming.delete(sessionID)
+      if (this.#turnGenerations.get(sessionID) !== generation) return
       this.#active.delete(sessionID)
+      this.#chunkMessageIDs.delete(`${sessionID}:assistant`)
       this.#emit("session.updated", sessionID)
+      this.#persistSnapshot(sessionID)
       void this.#runNextQueued(sessionID)
     })
   }
@@ -167,6 +275,9 @@ export class AcpService {
 
   /** Cancelling drops anything still queued, including the messages recorded for it. */
   abort(sessionID) {
+    if (this.#historyLoader && !this.#ownedSessions.has(sessionID)) {
+      throw new Error("This session is not active in the app")
+    }
     const queue = this.#queues.get(sessionID)
     if (queue?.length) {
       const discarded = new Set(queue.map((entry) => entry.messageID))
@@ -177,12 +288,68 @@ export class AcpService {
       }
       this.#emit("message.updated", sessionID)
     }
+    this.#turnGenerations.set(sessionID, (this.#turnGenerations.get(sessionID) ?? 0) + 1)
+    this.#cancelledSessions.add(sessionID)
+    this.#active.delete(sessionID)
+    this.#chunkMessageIDs.delete(`${sessionID}:assistant`)
     this.#acp.notify("session/cancel", { sessionId: sessionID })
     this.#emit("session.updated", sessionID)
+    this.#persistSnapshot(sessionID)
   }
 
   status(sessionID) {
     return { type: this.#isBusy(sessionID) ? "busy" : "idle" }
+  }
+
+  async flushSnapshots() {
+    while (this.#snapshotWrites.size > 0) {
+      await Promise.all(this.#snapshotWrites.values())
+    }
+  }
+
+  #snapshotPath(sessionID) {
+    const name = Buffer.from(sessionID).toString("base64url")
+    return path.join(this.#snapshotDirectory, `${name}.json`)
+  }
+
+  async #restoreSnapshot(sessionID) {
+    if (!this.#snapshotDirectory || this.#restoredSnapshots.has(sessionID)) return
+    this.#restoredSnapshots.add(sessionID)
+    try {
+      const snapshot = JSON.parse(await readFile(this.#snapshotPath(sessionID), "utf8"))
+      if (snapshot?.version !== 1) return
+      if (Array.isArray(snapshot.messages)) this.#messages.set(sessionID, snapshot.messages)
+      if (Array.isArray(snapshot.todos)) this.#todos.set(sessionID, snapshot.todos)
+      if (typeof snapshot.title === "string" && snapshot.title) this.#titles.set(sessionID, snapshot.title)
+    } catch (error) {
+      if (error?.code !== "ENOENT") this.#emit("session.error", sessionID, { message: "Stored session snapshot is unreadable" })
+    }
+  }
+
+  #persistSnapshot(sessionID) {
+    if (!this.#snapshotDirectory) return
+    this.#dirtySnapshots.add(sessionID)
+    if (this.#snapshotWrites.has(sessionID)) return
+    const writing = (async () => {
+      await mkdir(this.#snapshotDirectory, { recursive: true })
+      while (this.#dirtySnapshots.delete(sessionID)) {
+        const snapshot = JSON.stringify({
+          version: 1,
+          messages: this.#messages.get(sessionID) ?? [],
+          todos: this.#todos.get(sessionID) ?? [],
+          title: this.#titleFor(sessionID)
+        })
+        const target = this.#snapshotPath(sessionID)
+        const temporary = `${target}.${process.pid}.${randomUUID()}.tmp`
+        await writeFile(temporary, snapshot, { mode: 0o600 })
+        await rename(temporary, target)
+      }
+    })().catch(() => {
+      this.#emit("session.error", sessionID, { message: "Session snapshot could not be saved" })
+    }).finally(() => {
+      this.#snapshotWrites.delete(sessionID)
+    })
+    this.#snapshotWrites.set(sessionID, writing)
   }
 
   /** A queued prompt is still outstanding work, so the session must not read as idle between turns. */
@@ -193,7 +360,7 @@ export class AcpService {
   async #load(sessionID, force = false) {
     if (!this.#sessions.has(sessionID)) await this.listSessions()
     const session = this.#sessions.get(sessionID)
-    if (!session) throw new Error("Session not found")
+    if (!session) throw new Error("Harness session not found")
     if (!force && this.#loaded.has(sessionID)) return
     let loading = this.#loads.get(sessionID)
     if (!loading) {
@@ -209,14 +376,45 @@ export class AcpService {
 
   async #loadSession(sessionID) {
     const session = this.#sessions.get(sessionID)
-    if (!session) throw new Error("Session not found")
+    if (!session) throw new Error("Harness session not found")
+    await this.#restoreSnapshot(sessionID)
+    let previousMessages = this.#messages.get(sessionID) ?? []
+    const previousTodos = this.#todos.get(sessionID) ?? []
+    if (this.#historyLoader) {
+      try {
+        const persistedMessages = await this.#historyLoader(sessionID)
+        if (persistedMessages.length > 0) {
+          previousMessages = mergeExternalHistory(persistedMessages, previousMessages)
+          this.#messages.set(sessionID, previousMessages)
+          if (!this.#ownedSessions.has(sessionID)) {
+            this.#todos.set(sessionID, [])
+            this.#loaded.add(sessionID)
+            this.#persistSnapshot(sessionID)
+            return
+          }
+        }
+      } catch {
+        this.#emit("session.error", sessionID, { message: "Harness session history could not be read" })
+      }
+    }
     this.#replaying.add(sessionID)
     this.#messages.set(sessionID, [])
     this.#todos.set(sessionID, [])
+    this.#chunkMessageIDs.delete(`${sessionID}:user`)
+    this.#chunkMessageIDs.delete(`${sessionID}:assistant`)
     try {
       const result = await this.#acp.request("session/load", { sessionId: sessionID, cwd: session.cwd, mcpServers: [] }, 300_000)
       this.#rememberConfigOptions(sessionID, result.configOptions)
+      const replayedMessages = this.#messages.get(sessionID) ?? []
+      this.#messages.set(sessionID, mergeReplay(previousMessages, replayedMessages))
+      const replayedTodos = this.#todos.get(sessionID) ?? []
+      this.#todos.set(sessionID, mergeTodos(previousTodos, replayedTodos))
       this.#loaded.add(sessionID)
+      this.#persistSnapshot(sessionID)
+    } catch (error) {
+      this.#messages.set(sessionID, previousMessages)
+      this.#todos.set(sessionID, previousTodos)
+      throw error
     } finally {
       this.#replaying.delete(sessionID)
     }
@@ -248,6 +446,7 @@ export class AcpService {
     })
     this.#promptAcknowledgements.set(sessionID, { text, received: "" })
     this.#emit("message.updated", sessionID)
+    this.#persistSnapshot(sessionID)
     return messageID
   }
 
@@ -288,24 +487,29 @@ export class AcpService {
       }))
       this.#todos.set(sessionId, todos)
       if (!replaying) this.#emit("todo.updated", sessionId)
+      if (!replaying) this.#persistSnapshot(sessionId)
       return
     }
     if (update.sessionUpdate !== "user_message_chunk" && update.sessionUpdate !== "agent_message_chunk") return
     if (update.content?.type !== "text" || !update.content.text) return
     const role = update.sessionUpdate === "user_message_chunk" ? "user" : "assistant"
     // Acknowledgements only suppress a live echo of the prompt we just recorded;
-    // a history replay rebuilds from an empty list and must keep every message.
+    if (role === "assistant" && !replaying && this.#cancelledSessions.has(sessionId)) return
+    if (!update.messageId && role === "assistant" && !replaying && !this.#active.has(sessionId) && !this.#promptedSessions.has(sessionId)) return
     if (role === "user" && !replaying && this.#isAcknowledgedPromptChunk(sessionId, update.content.text)) return
+    const chunkKey = `${sessionId}:${role}`
+    let messageID = update.messageId
+    if (!messageID && replaying) {
+      // ACP has no message-boundary identifier. PI's adapter emits one full persisted
+      // text block per replay update, so keeping each update separate is safer than
+      // concatenating unrelated consecutive user or assistant messages.
+      messageID = randomUUID()
+    } else if (!messageID) {
+      messageID = this.#chunkMessageIDs.get(chunkKey) ?? randomUUID()
+      this.#chunkMessageIDs.set(chunkKey, messageID)
+    }
     const messages = this.#messages.get(sessionId) ?? []
     this.#messages.set(sessionId, messages)
-    // PI's adapter streams a turn as chunks carrying no messageId, so minting a fresh id per
-    // chunk split one reply into a bubble per token. Without an id, keep appending to the
-    // message this turn already opened for that role — scoped to the turn, so a later reply
-    // never lands on an earlier one. Replay is excluded: there the missing id means separate
-    // persisted messages rather than one live turn.
-    const openMessages = replaying ? undefined : this.#streaming.get(sessionId)
-    const messageID = update.messageId ?? openMessages?.[role] ?? randomUUID()
-    if (!update.messageId && openMessages) openMessages[role] = messageID
     let message = messages.find((item) => item.info.id === messageID)
     if (!message) {
       message = {

--- a/bridge/src/cli.js
+++ b/bridge/src/cli.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import path from "node:path"
 import { AcpClient } from "./acp-client.js"
 import { parseConfig, usage } from "./config.js"
 import { harnessProfile } from "./harness-profiles.js"
@@ -20,7 +21,14 @@ if (config?.help) {
 if (config) {
   const profile = harnessProfile(config.backend)
   const acp = new AcpClient({ command: config.acpCommand, args: config.acpArgs, permissionMode: profile.permissionMode })
-  const server = createBridgeServer({ config, acp })
+  const server = createBridgeServer({
+    config,
+    acp,
+    serviceOptions: {
+      snapshotDirectory: path.join(config.stateDirectory, profile.id),
+      historyLoader: profile.historyLoader
+    }
+  })
   let shuttingDown = false
 
   acp.on("stderr", (line) => process.stderr.write(`[${config.backend}] ${line}`))

--- a/bridge/src/config.js
+++ b/bridge/src/config.js
@@ -1,3 +1,5 @@
+import { homedir } from "node:os"
+import path from "node:path"
 import { harnessProfile } from "./harness-profiles.js"
 
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"])
@@ -57,7 +59,8 @@ export function parseConfig(args, environment = process.env) {
     acpArgs: parseArgumentList(acpArgs, profile.args),
     roots: root ? [root] : [],
     corsOrigins: cors ? [cors] : [],
-    logRequests: environmentValue(environment, "LOG_REQUESTS") === "1"
+    logRequests: environmentValue(environment, "LOG_REQUESTS") === "1",
+    stateDirectory: environmentValue(environment, "STATE_DIR") ?? path.join(homedir(), ".harness-remote")
   }
   let acpCommandOverridden = acpCommand !== undefined
   let acpArgsOverridden = acpArgs !== undefined
@@ -111,6 +114,10 @@ export function parseConfig(args, environment = process.env) {
       case "--log-requests":
         config.logRequests = true
         break
+      case "--state-dir":
+        config.stateDirectory = requireValue(args, index, option)
+        index += 1
+        break
       case "--help":
         config.help = true
         break
@@ -129,5 +136,5 @@ export function parseConfig(args, environment = process.env) {
 }
 
 export function usage() {
-  return `Usage: harness-remote-bridge [options]\n\nOptions:\n  --backend <name>       ACP backend: omp or pi (default: omp)\n  --host <host>          Bind host (default: 127.0.0.1)\n  --port <port>          Bind port (default: 4097)\n  --username <username>  Enable HTTP Basic Auth\n  --password <password>  Enable HTTP Basic Auth\n  --acp-command <path>   ACP adapter command (default depends on backend)\n  --acp-arg <arg>        ACP adapter argument; repeatable\n  --root <path>          Allowed worktree root; repeatable\n  --cors <origin>        Allow browser requests from this exact origin; repeatable\n  --log-requests         Log request method, path, and query\n  --help                 Show this help`
+  return `Usage: harness-remote-bridge [options]\n\nOptions:\n  --backend <name>       ACP backend: omp or pi (default: omp)\n  --host <host>          Bind host (default: 127.0.0.1)\n  --port <port>          Bind port (default: 4097)\n  --username <username>  Enable HTTP Basic Auth\n  --password <password>  Enable HTTP Basic Auth\n  --acp-command <path>   ACP adapter command (default depends on backend)\n  --acp-arg <arg>        ACP adapter argument; repeatable\n  --root <path>          Allowed worktree root; repeatable\n  --cors <origin>        Allow browser requests from this exact origin; repeatable\n  --state-dir <path>     Persist bridge session snapshots\n  --log-requests         Log request method, path, and query\n  --help                 Show this help`
 }

--- a/bridge/src/harness-profiles.js
+++ b/bridge/src/harness-profiles.js
@@ -1,3 +1,5 @@
+import { createOmpHistoryLoader } from "./omp-session-history.js"
+
 const COMMON_CAPABILITIES = {
   sessions: true,
   prompt: true,
@@ -18,6 +20,7 @@ export const HARNESS_PROFILES = {
     command: "omp",
     args: ["acp"],
     permissionMode: "allow",
+    historyLoader: createOmpHistoryLoader(),
     capabilities: {
       ...COMMON_CAPABILITIES,
       models: true,

--- a/bridge/src/omp-session-history.js
+++ b/bridge/src/omp-session-history.js
@@ -1,0 +1,68 @@
+import { createReadStream } from "node:fs"
+import { readdir } from "node:fs/promises"
+import { homedir } from "node:os"
+import path from "node:path"
+import { createInterface } from "node:readline"
+
+function messageText(content) {
+  if (typeof content === "string") return content
+  if (!Array.isArray(content)) return ""
+  return content
+    .filter((item) => item?.type === "text" && typeof item.text === "string")
+    .map((item) => item.text)
+    .join("")
+}
+
+export function createOmpHistoryLoader(sessionRoot = path.join(homedir(), ".omp", "agent", "sessions")) {
+  const sessionFiles = new Map()
+
+  async function locateSession(sessionID) {
+    const known = sessionFiles.get(sessionID)
+    if (known) return known
+    if (!/^[A-Za-z0-9_-]+$/.test(sessionID)) return undefined
+    try {
+      const suffix = `_${sessionID}.jsonl`
+      const entries = await readdir(sessionRoot, { recursive: true, withFileTypes: true })
+      const entry = entries.find((candidate) => candidate.isFile() && candidate.name.endsWith(suffix))
+      if (!entry) return undefined
+      const file = path.join(entry.parentPath ?? entry.path, entry.name)
+      sessionFiles.set(sessionID, file)
+      return file
+    } catch (error) {
+      if (error?.code === "ENOENT") return undefined
+      throw error
+    }
+  }
+
+  return async function loadOmpHistory(sessionID) {
+    const file = await locateSession(sessionID)
+    if (!file) return []
+    const messages = []
+    const lines = createInterface({ input: createReadStream(file), crlfDelay: Infinity })
+    for await (const line of lines) {
+      let record
+      try {
+        record = JSON.parse(line)
+      } catch {
+        continue
+      }
+      if (record?.type !== "message") continue
+      const role = record.message?.role
+      if (role !== "user" && role !== "assistant") continue
+      const text = messageText(record.message.content)
+      if (!text) continue
+      const messageID = record.id ?? `${sessionID}:${messages.length}`
+      const created = Date.parse(record.timestamp ?? "")
+      messages.push({
+        info: {
+          id: messageID,
+          role,
+          sessionID,
+          time: { created: Number.isFinite(created) ? created : Date.now() }
+        },
+        parts: [{ id: `${messageID}:text`, type: "text", text }]
+      })
+    }
+    return messages
+  }
+}

--- a/bridge/src/server.js
+++ b/bridge/src/server.js
@@ -85,10 +85,10 @@ function providersResponse(models) {
   return { providers: [...providers.values()], default: defaults }
 }
 
-export function createBridgeServer({ config, acp }) {
+export function createBridgeServer({ config, acp, serviceOptions }) {
   const backend = config.backend ?? "omp"
   const profile = harnessProfile(backend)
-  const service = new AcpService(acp)
+  const service = new AcpService(acp, serviceOptions)
   return http.createServer(async (request, response) => {
     applyCorsHeaders(request, response, config)
     // Browsers omit credentials on the preflight, so it must be answered before auth.

--- a/bridge/test/config.test.js
+++ b/bridge/test/config.test.js
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict"
+import { homedir } from "node:os"
+import path from "node:path"
 import test from "node:test"
 import { parseConfig } from "../src/config.js"
 
@@ -13,7 +15,8 @@ test("defaults to a loopback-only unauthenticated listener", () => {
     acpArgs: ["acp"],
     roots: [],
     corsOrigins: [],
-    logRequests: false
+    logRequests: false,
+    stateDirectory: path.join(homedir(), ".harness-remote")
   })
 })
 
@@ -69,6 +72,11 @@ test("prefers generic environment names while retaining OMP aliases", () => {
   assert.equal(legacy.backend, "pi")
   assert.equal(legacy.host, "localhost")
   assert.equal(legacy.port, 4902)
+})
+
+test("allows session snapshot storage to be relocated", () => {
+  assert.equal(parseConfig(["--state-dir", "/tmp/harness-state"], {}).stateDirectory, "/tmp/harness-state")
+  assert.equal(parseConfig([], { HARNESS_REMOTE_STATE_DIR: "/tmp/env-state" }).stateDirectory, "/tmp/env-state")
 })
 
 test("shares the bridge with browser origins only when asked", () => {

--- a/bridge/test/omp-session-history.test.js
+++ b/bridge/test/omp-session-history.test.js
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import test from "node:test"
+import { createOmpHistoryLoader } from "../src/omp-session-history.js"
+
+test("reads persisted user and assistant text from an OMP session transcript", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-history-"))
+  const nested = path.join(root, "workspace")
+  await mkdir(nested)
+  const sessionID = "session-1"
+  const records = [
+    { type: "message", id: "user-1", parentId: null, timestamp: "2026-07-26T10:00:00.000Z", message: { role: "user", content: "Question" } },
+    { type: "message", id: "abandoned-assistant", parentId: "user-1", timestamp: "2026-07-26T10:00:00.500Z", message: { role: "assistant", content: [{ type: "text", text: "Abandoned answer" }] } },
+    { type: "message", id: "assistant-1", parentId: "user-1", timestamp: "2026-07-26T10:00:01.000Z", message: { role: "assistant", content: [{ type: "thinking", thinking: "hidden" }, { type: "text", text: "Answer" }] } },
+    { type: "message", id: "tool-1", parentId: "assistant-1", message: { role: "toolResult", content: [{ type: "text", text: "hidden tool output" }] } }
+  ]
+  await writeFile(path.join(nested, `2026-07-26_${sessionID}.jsonl`), `${records.map((record) => JSON.stringify(record)).join("\n")}\n`)
+
+  try {
+    const loadHistory = createOmpHistoryLoader(root)
+    const messages = await loadHistory(sessionID)
+    assert.deepEqual(messages.map((message) => [message.info.role, message.parts[0].text]), [
+      ["user", "Question"],
+      ["assistant", "Abandoned answer"],
+      ["assistant", "Answer"]
+    ])
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict"
 import { EventEmitter } from "node:events"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
 import path from "node:path"
 import test from "node:test"
 import { createBridgeServer } from "../src/server.js"
@@ -725,4 +727,265 @@ test("keeps the persisted snapshot stable until an explicit history refresh", as
   } finally {
     await bridge.close()
   }
+})
+
+test("keeps the last snapshot when an ACP refresh replays no messages", async () => {
+  class EmptyRefreshAcp extends EventEmitter {
+    loads = 0
+
+    async start() {}
+
+    async listSessions() {
+      return [{ sessionId: "session-1", cwd: process.cwd(), updatedAt: "2026-07-26T00:00:00.000Z" }]
+    }
+
+    async request(method) {
+      if (method !== "session/load") return {}
+      this.loads += 1
+      if (this.loads === 1) {
+        this.emit("notification", {
+          method: "session/update",
+          params: {
+            sessionId: "session-1",
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              messageId: "persisted-assistant",
+              content: { type: "text", text: "Persisted response" }
+            }
+          }
+        })
+      }
+      return {}
+    }
+
+    notify() {}
+  }
+
+  const driver = new AcpService(new EmptyRefreshAcp())
+  assert.deepEqual((await driver.messages("session-1")).map((message) => message.parts[0].text), ["Persisted response"])
+  assert.deepEqual((await driver.messages("session-1", true)).map((message) => message.parts[0].text), ["Persisted response"])
+})
+
+test("restores messages from disk when ACP replay is empty or partial after restart", async () => {
+  class SnapshotReplayAcp extends EventEmitter {
+    constructor(replayMessages, todoContent, todoStatus = "in_progress") {
+      super()
+      this.replayMessages = replayMessages
+      this.todoContent = todoContent
+      this.todoStatus = todoStatus
+    }
+
+    async start() {}
+
+    async listSessions() {
+      return [{ sessionId: "session-1", cwd: process.cwd(), updatedAt: "2026-07-26T00:00:00.000Z" }]
+    }
+
+    async request(method) {
+      if (method !== "session/load") return {}
+      for (const text of this.replayMessages) {
+        this.emit("notification", {
+          method: "session/update",
+          params: {
+            sessionId: "session-1",
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              messageId: `persisted-${text}`,
+              content: { type: "text", text }
+            }
+          }
+        })
+      }
+      this.emit("notification", {
+        method: "session/update",
+        params: {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "plan",
+            entries: [{ content: this.todoContent, status: this.todoStatus, priority: "medium" }]
+          }
+        }
+      })
+      return {}
+    }
+
+    notify() {}
+  }
+
+  const snapshotDirectory = await mkdtemp(path.join(tmpdir(), "harness-remote-snapshots-"))
+  try {
+    const expectedMessages = ["First", "Second", "Third"]
+    const first = new AcpService(new SnapshotReplayAcp(expectedMessages, "Old todo"), { snapshotDirectory })
+    assert.deepEqual((await first.messages("session-1")).map((message) => message.parts[0].text), expectedMessages)
+    await first.flushSnapshots()
+
+    const emptyReplay = new AcpService(new SnapshotReplayAcp([], "Current todo"), { snapshotDirectory })
+    assert.deepEqual((await emptyReplay.messages("session-1")).map((message) => message.parts[0].text), expectedMessages)
+    assert.deepEqual((await emptyReplay.todos("session-1")).map((todo) => todo.content), ["Current todo"])
+    await emptyReplay.flushSnapshots()
+
+    const partialReplay = new AcpService(new SnapshotReplayAcp(["Second", "Third"], "Newest todo", "completed"), { snapshotDirectory })
+    assert.deepEqual((await partialReplay.messages("session-1")).map((message) => message.parts[0].text), expectedMessages)
+    assert.deepEqual((await partialReplay.todos("session-1")).map((todo) => todo.content), ["Newest todo"])
+    await partialReplay.flushSnapshots()
+
+    const stalePlanReplay = new AcpService(new SnapshotReplayAcp([], "Newest todo", "pending"), { snapshotDirectory })
+    assert.deepEqual((await stalePlanReplay.todos("session-1")).map((todo) => todo.status), ["completed"])
+    await stalePlanReplay.flushSnapshots()
+  } finally {
+    await rm(snapshotDirectory, { recursive: true, force: true })
+  }
+})
+
+test("reads external history without loading and interrupting the ACP session", async () => {
+  const message = (id, text) => ({
+    info: { id, role: "assistant", sessionID: "session-1", time: { created: Date.now() } },
+    parts: [{ id: `${id}:text`, type: "text", text }]
+  })
+  class MissingMiddleAcp extends EventEmitter {
+    loads = 0
+    async start() {}
+
+    async listSessions() {
+      return [{ sessionId: "session-1", cwd: process.cwd(), updatedAt: "2026-07-26T00:00:00.000Z" }]
+    }
+
+    async request(method) {
+      if (method === "session/load") this.loads += 1
+      return {}
+    }
+
+    notify() {}
+  }
+
+  let persistedHistory = [
+    message("native-first", "First"),
+    message("native-second", "Second"),
+    message("native-third", "Third")
+  ]
+  const historyLoader = async () => persistedHistory
+  const acp = new MissingMiddleAcp()
+  const driver = new AcpService(acp, { historyLoader })
+  assert.deepEqual((await driver.messages("session-1")).map((item) => item.parts[0].text), ["First", "Second", "Third"])
+  persistedHistory = [...persistedHistory, message("native-fourth", "Fourth")]
+  assert.deepEqual(
+    (await driver.messages("session-1")).map((item) => item.parts[0].text),
+    ["First", "Second", "Third", "Fourth"],
+    "external history must refresh and preserve native order without an explicit refresh flag"
+  )
+  assert.equal(acp.loads, 0)
+})
+
+test("merges bridge-only legacy prompts into native external history by timestamp", async () => {
+  class ExternalAcp extends EventEmitter {
+    async start() {}
+    async listSessions() {
+      return [{ sessionId: "external-1", cwd: process.cwd(), updatedAt: "2026-07-26T10:00:00.000Z" }]
+    }
+    async request() {
+      return {}
+    }
+    notify() {}
+  }
+  const envelope = (id, role, text, created) => ({
+    info: { id, role, sessionID: "external-1", time: { created } },
+    parts: [{ id: `${id}:text`, type: "text", text }]
+  })
+  const nativeHistory = [
+    envelope("native-first", "user", "First", 1_000),
+    envelope("native-last", "assistant", "Last", 3_000)
+  ]
+  const snapshotDirectory = await mkdtemp(path.join(tmpdir(), "harness-remote-external-"))
+  const snapshotPath = path.join(snapshotDirectory, `${Buffer.from("external-1").toString("base64url")}.json`)
+  await writeFile(snapshotPath, JSON.stringify({
+    version: 1,
+    messages: [
+      envelope("native-first", "user", "First", 1_000),
+      envelope("bridge-only", "user", "Bridge only", 2_000)
+    ],
+    todos: [{ id: "stale", content: "Stale external todo", status: "pending", priority: "medium" }],
+  }))
+  try {
+    const driver = new AcpService(new ExternalAcp(), {
+      snapshotDirectory,
+      historyLoader: async () => nativeHistory,
+    })
+    assert.deepEqual(
+      (await driver.messages("external-1")).map((item) => item.parts[0].text),
+      ["First", "Bridge only", "Last"]
+    )
+    assert.deepEqual(await driver.todos("external-1"), [])
+    await driver.flushSnapshots()
+  } finally {
+    await rm(snapshotDirectory, { recursive: true, force: true })
+  }
+})
+
+test("continues sessions created by another OMP client and reacquires them after restart", async () => {
+  class OwnershipAcp extends EventEmitter {
+    sessions = [{ sessionId: "desktop-session", cwd: process.cwd(), updatedAt: "2026-07-26T00:00:00.000Z" }]
+    prompts = []
+    loads = []
+    async start() {}
+
+    async listSessions() {
+      return this.sessions
+    }
+
+    async request(method, params) {
+      if (method === "session/new") {
+        const session = { sessionId: "mobile-session", cwd: params.cwd, updatedAt: "2026-07-26T00:00:00.000Z" }
+        this.sessions.push(session)
+        return { sessionId: session.sessionId, configOptions: [] }
+      }
+      if (method === "session/load") {
+        this.loads.push(params.sessionId)
+        return {}
+      }
+      if (method === "session/prompt") {
+        this.prompts.push(params.sessionId)
+        return {}
+      }
+      return {}
+    }
+
+    notify() {}
+  }
+
+  const persistedMessage = (sessionID, text = "Existing history", created = 1_000) => ({
+    info: { id: `${sessionID}-history-${created}`, role: "assistant", sessionID, time: { created } },
+    parts: [{ id: `${sessionID}-history-${created}:text`, type: "text", text }]
+  })
+  const snapshotDirectory = await mkdtemp(path.join(tmpdir(), "harness-remote-ownership-"))
+  const acp = new OwnershipAcp()
+  const nativeHistory = new Map()
+  const historyLoader = async (sessionID) => nativeHistory.get(sessionID) ?? [persistedMessage(sessionID)]
+  const driver = new AcpService(acp, { historyLoader, snapshotDirectory })
+
+  assert.equal((await driver.listSessions()).find((session) => session.id === "desktop-session")?.external, true)
+  await driver.prompt("desktop-session", "Continue from the app")
+  await new Promise((resolve) => setImmediate(resolve))
+  assert.deepEqual(acp.loads, ["desktop-session"])
+  assert.deepEqual(acp.prompts, ["desktop-session"])
+  assert.equal((await driver.listSessions()).find((session) => session.id === "desktop-session")?.external, undefined)
+
+  nativeHistory.set("desktop-session", [
+    persistedMessage("desktop-session"),
+    persistedMessage("desktop-session", "Concurrent desktop reply", 9_000_000_000_000)
+  ])
+  assert.deepEqual(
+    (await driver.messages("desktop-session", true)).map((message) => message.parts[0].text),
+    ["Existing history", "Continue from the app", "Concurrent desktop reply"]
+  )
+
+  await driver.createSession({ directory: process.cwd(), title: "Mobile", model: undefined })
+  await driver.flushSnapshots()
+  const restarted = new AcpService(acp, { historyLoader, snapshotDirectory })
+  assert.equal((await restarted.listSessions()).find((session) => session.id === "mobile-session")?.external, true)
+  await restarted.prompt("mobile-session", "Continue after restart")
+  await new Promise((resolve) => setImmediate(resolve))
+  assert.deepEqual(acp.loads, ["desktop-session", "desktop-session", "mobile-session"])
+  assert.deepEqual(acp.prompts, ["desktop-session", "mobile-session"])
+  await restarted.flushSnapshots()
+  await rm(snapshotDirectory, { recursive: true, force: true })
 })

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1029,7 +1029,8 @@ function toSessionView(session: Session, status?: SessionStatus, activityTime = 
     files: session.summary?.files ?? 0,
     additions: session.summary?.additions ?? 0,
     deletions: session.summary?.deletions ?? 0,
-    model: session.model ? { providerID: session.model.providerID, modelID: session.model.id, variant: session.model.variant } : undefined
+    model: session.model ? { providerID: session.model.providerID, modelID: session.model.id, variant: session.model.variant } : undefined,
+    external: session.external
   }
 }
 
@@ -1844,9 +1845,10 @@ function App() {
     ])
     if (requestID !== loadSelectedRequestRef.current) return
     const current = loadedMessagesRef.current
+    const authoritativeExternalHistory = selectedSessionRef.current?.id === sessionID && selectedSessionRef.current.external
     if (
       !messagesHaveSameContent(current, msg) &&
-      assistantPayloadLength(current) <= assistantPayloadLength(msg)
+      (authoritativeExternalHistory || assistantPayloadLength(current) <= assistantPayloadLength(msg))
     ) {
       shouldAutoScrollRef.current = messagesExtendContent(current, msg) && isNearMessagesBottom()
       loadedMessagesRef.current = msg
@@ -3056,6 +3058,10 @@ function App() {
             onQuestionResolved={handleQuestionResolved}
           />
 
+
+          {selectedSession?.external && (
+            <p className="field-hint">{t('detail.externalSession')}</p>
+          )}
 
           <div className="composer" ref={composerRef}>
             <textarea

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -86,6 +86,7 @@ type TranslationKey =
   | 'detail.emptyTitle'
   | 'detail.emptyHint'
   | 'detail.composerPlaceholder'
+  | 'detail.externalSession'
   | 'detail.waiting'
   | 'detail.send'
   | 'detail.jumpToLatest'
@@ -298,6 +299,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.emptyTitle': 'No messages yet',
     'detail.emptyHint': 'Start a conversation below',
     'detail.composerPlaceholder': 'Type a prompt or command (start with / for slash commands)...',
+    'detail.externalSession': 'From another client; sending continues it here',
     'detail.waiting': 'Waiting...',
     'detail.send': 'Send',
     'detail.jumpToLatest': 'Go to latest',
@@ -509,6 +511,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.emptyTitle': 'Ancora nessun messaggio',
     'detail.emptyHint': 'Inizia una conversazione qui sotto',
     'detail.composerPlaceholder': 'Scrivi un prompt o un comando (inizia con / per gli slash command)...',
+    'detail.externalSession': 'Da un altro client; inviando la continui qui',
     'detail.waiting': 'Attesa...',
     'detail.send': 'Invia',
     'detail.jumpToLatest': 'Vai alla fine',
@@ -720,6 +723,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.emptyTitle': '尚無訊息',
     'detail.emptyHint': '在下方開始對話',
     'detail.composerPlaceholder': '輸入提示或命令（以 / 開頭使用斜線命令）...',
+    'detail.externalSession': '來自其他用戶端；傳送後將在此繼續',
     'detail.waiting': '等待中...',
     'detail.send': '傳送',
     'detail.jumpToLatest': '前往最新',

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -78,6 +78,7 @@ export type Session = {
     name?: string
     worktree: string
   } | null
+  external?: boolean
 }
 
 export type SessionStatus = {
@@ -212,6 +213,7 @@ export type SessionView = {
   additions: number
   deletions: number
   model?: ModelSelection
+  external?: boolean
 }
 
 export type CommandInfo = {

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -141,6 +141,9 @@ for (const capability of ['agents', 'models', 'todos', 'diff', 'questions', 'ses
 // A follow-up prompt can be queued while the agent is still working.
 assert.ok(app.includes('const showStopAction = isWorking && !composer.trim()'), 'stop should be offered only when there is nothing to send')
 assert.equal(app.includes('disabled={!selectedSession || isWorking}'), false, 'the composer must stay usable while the agent works')
+assert.ok(app.includes("authoritativeExternalHistory || assistantPayloadLength(current) <= assistantPayloadLength(msg)"), "external OMP history must replace stale cached ordering even when the corrected payload is shorter")
+assert.ok(app.includes("selectedSession?.external"), "sessions from another client should explain that sending continues them here")
+assert.equal(app.includes("disabled={!selectedSession || selectedSession.external}"), false, "external sessions must remain writable")
 assert.ok(app.includes('onClick={showStopAction ? abortSession : send}'), 'the action button should send a queued follow-up instead of only stopping')
 
 // A run bubble merges action groups that a message boundary split apart. Consecutive replies with


### PR DESCRIPTION
Rebases #48 by @gervaso-assistant onto current `main`, unchanged in intent. The commit is theirs; the conflicts were mine, from #49 landing on `acp-service.js` after the PR was opened.

Merging this closes #48.

## What it does

- Reads persisted OMP history without spawning a second agent just to display a session.
- Keeps successful snapshots across navigation and bridge restarts, and reconciles a partial ACP replay instead of erasing newer cached messages or todos.
- Marks sessions this bridge process did not create as `external`, and lets them be continued from the app.
- Adds a turn-generation guard so a stale turn's completion cannot clobber a reacquired session.

## Conflict resolution

Their `#chunkMessageIDs` replaces the `#streaming` map I added in #49. Both solve the same problem — PI streams chunks with no `messageId`, and minting a fresh id per chunk split one reply into a message per token — but theirs is keyed by `sessionId:role` and handles replay explicitly, with the reasoning that a replay update is a whole persisted block rather than part of a live turn. I took theirs and removed mine; keeping both would have left a duplicate `messageID` declaration.

## Verification

Against real OMP 17.1.3, on a session created by an earlier bridge process:

```
external session: 019f9fb1-…  external=true
persisted history read: 2 messages, no second agent spawned
title derived after load: "Reply with exactly: OMP_INTEGRATED_OK"
continued with a new prompt -> assistant: CONTINUED_OK
history preserved: true
```

PI 0.82.1 re-checked as well: streamed reply as a single message, tool call granted with `allow_once` and the file written. Bridge 42/42 — including `continues sessions created by another OMP client and reacquires them after restart`, which failed with `ENOTEMPTY` in the original #43 and passes here. Web 6/6, build clean.