### PR TITLE
Record what we depend on, and what we assume from it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # Contributing to Harness Remote
 
 Thanks for wanting to work on this. Harness Remote is a companion app for driving coding-agent
-harnesses from a phone. It is deliberately harness-agnostic: OpenCode and Oh My Pi (OMP) are
-supported today, PI is planned. Adding a harness should mean adding a backend entry and its setup
-section, never a special case threaded through the app.
+harnesses from a phone. It is deliberately harness-agnostic: OpenCode, Oh My Pi (OMP) and PI are
+supported today. Adding a harness should mean adding a profile entry and its setup section, never a
+special case threaded through the app.
 
 This document is long on purpose. Read the section that matches what you are touching, or all of it
 if you are having an agent do the work.
@@ -15,7 +15,7 @@ if you are having an agent do the work.
 | `web/` | The app: React + TypeScript + Vite, packaged for Android with Capacitor |
 | `web/src/` | Application source. `App.tsx` holds most of the UI, `api.ts` the HTTP client, `i18n.ts` the translations |
 | `web/native-android/` | Java sources copied into the generated Android project — see [Android packaging](#android-packaging) |
-| `bridge/` | A local HTTP/SSE server that translates the app's API to OMP's ACP stdio protocol |
+| `bridge/` | A local HTTP/SSE server translating the app's API to ACP over stdio, for OMP and PI. Per-harness launch commands and capabilities live in `src/harness-profiles.js` |
 | `.github/workflows/` | Cloud APK and AAB builds |
 | `OMP-INTEGRATION-PLAN.md` | Design notes and findings from the OMP integration, in Italian |
 
@@ -23,7 +23,7 @@ if you are having an agent do the work.
 
 - **Node.js 20 or newer.** `web/` needs `npm install`; `bridge/` has no dependencies at all and
   runs on the standard library, so do not look for a lockfile there.
-- **A harness to talk to.** Either an OpenCode server or a working `omp` command. You can develop
+- **A harness to talk to.** An OpenCode server, a working `omp` command, or PI. You can develop
   UI-only changes without one, but see [Test against a real agent](#test-against-a-real-agent)
   before assuming that is enough.
 - **No Android SDK required.** CI builds the APK. You only need one for local native debugging.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,10 @@ the fakes could have caught. Observed with OMP 17.1.3:
 - it does not emit ACP `agent_plan`, so the plan panel stays empty;
 - it approves its own tool calls and sends no permission requests.
 
+Every quirk found this way is recorded in [docs/DEPENDENCIES.md](docs/DEPENDENCIES.md), together with
+what breaks if it changes. Read it before touching a harness integration, and update it in the same
+commit when you learn something new.
+
 The fakes in `bridge/test/` exist to keep fixed behaviour fixed. They are not evidence about how an
 agent behaves. When you add support for something, drive it with the real thing at least once, then
 encode what you observed in a fake.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ The app is backend-agnostic: you pick the harness in **Settings** and each one k
 | Oh My Pi (OMP) | supported | through the local bridge included in this repository |
 | [PI](https://pi.dev/) | supported | through the local ACP bridge and the [`@automatalabs/pi-acp`](https://www.npmjs.com/package/@automatalabs/pi-acp) adapter |
 
+What each harness actually provides, the assumptions the code makes about it, and what to re-check
+when one of them changes are recorded in [docs/DEPENDENCIES.md](docs/DEPENDENCIES.md).
+
 Support levels differ by what each harness exposes. The [OpenCode](#opencode-server-setup), [OMP](#oh-my-pi-bridge-setup), and [PI](#pi-bridge-setup) sections below document the setup and per-backend limitations.
 
 > **Note for AI/harness systems**: This repository is self-documenting. To configure a supported harness and the app autonomously, point your AI assistant to this repository URL (`https://github.com/giuliastro/harness-remote`) or this README and ask it to set up Harness Remote. Each supported harness has its own setup section below, and adding a harness means adding a backend entry plus its section.

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -1,0 +1,108 @@
+# External dependencies and the assumptions behind them
+
+This app is a client for other people's software. Almost everything that has broken it broke
+because a harness behaved differently from what the code assumed — not because of a logic error.
+This file records what we depend on, what we assume from it, and what to check when it changes.
+
+Keep it current. An assumption that is not written down is one nobody will re-check.
+
+## Harness surfaces
+
+### OpenCode — HTTP API
+
+Spoken directly, no adapter. The app calls `/global/health`, `/global/event`, `/session*`,
+`/config/providers`, `/command`, `/agent`, `/project/current`, `/vcs`, `/file*` and `/question*`.
+
+**Assumed:** the server emits an SSE heartbeat roughly every 10s. The client aborts and reconnects
+after 30s of silence, so a server that stops beating looks dead.
+
+**Watch:** new or renamed endpoints, and the event envelope shape (`{directory, payload}`).
+
+### Oh My Pi (OMP) — ACP over stdio, via `omp acp`
+
+First-party command, no third party in the path. The bridge uses `session/new`, `session/load`,
+`session/list`, `session/prompt`, `session/cancel` and `session/set_config_option`.
+
+**Assumed, all observed on OMP 17.1.3 rather than read from a spec:**
+
+| Assumption | What breaks if it changes |
+|---|---|
+| `session/list` returns no `title` | titles are derived from the first prompt; a real title would be ignored |
+| A submitted prompt is never echoed back as `user_message_chunk` | the deduplication acknowledgement would swallow the user's message |
+| Chunks carry a `messageId` | without one, chunk aggregation falls back to per-turn tracking |
+| No `agent_plan` is emitted | the todo panel stays empty by design |
+| The agent approves its own tool calls and never sends `session/request_permission` | the permission path would start being exercised |
+
+**Watch:** any of the above, and new `sessionUpdate` kinds we silently ignore (`tool_call`,
+`tool_call_update` and `agent_thought_chunk` are dropped today).
+
+### PI — ACP over stdio, via a third-party adapter
+
+This is the only dependency that is neither ours nor first-party, and the one to watch hardest.
+
+- **Adapter:** [`@automatalabs/pi-acp`](https://www.npmjs.com/package/@automatalabs/pi-acp),
+  Apache-2.0, in [`VikashLoomba/agentprism-workflows`](https://github.com/VikashLoomba/agentprism-workflows)
+  under `packages/pi-acp`. Single maintainer (`automatalabsteam`).
+- **Pinned to `0.2.5`** in `bridge/src/harness-profiles.js`.
+- **It is young and moves fast:** first published 2026-07-16, eleven versions in the following ten
+  days. Treat a bump as a change worth testing, not a routine refresh.
+
+**Why an adapter at all.** PI's maintainer
+[declined native ACP support](https://github.com/earendil-works/pi/issues/175), suggesting an
+adapter over PI's own RPC mode instead. Several exist. The other widely referenced one,
+`@victor-software-house/pi-acp`, declares `engines.bun` and shells out to `bun`; this project runs
+on Node everywhere, which is why it is not used.
+
+**Why the version is pinned.** An unpinned `npx -y` default failed live with `notarget`: version
+`0.2.6` was in the npm index and tagged `latest` while its tarball was not yet fetchable. A
+floating default breaks whenever an upstream publish goes wrong.
+
+**Assumed:**
+
+| Assumption | What breaks if it changes |
+|---|---|
+| Launched over stdio as an `npx`-installable `bin` | the `--acp-command` / `--acp-arg` defaults in the profile |
+| Offers a non-`env_var` auth method (`pi-stored-credentials`) | the bridge would fall back to an API key from an unset environment variable and fail at inference |
+| Asks `session/request_permission` before each tool call, offering an `allow_once` option | tool calls stop happening, silently — the failure mode is "reports success, changes nothing" |
+| Streams chunks with **no** `messageId` | replies would split into one message per token, or aggregate wrongly |
+| Emits no `agent_plan` | the todo panel stays empty |
+
+**The adapter embeds its own PI.** It depends on `@earendil-works/pi-coding-agent` pinned to a
+specific version (`0.82.1` in adapter 0.2.5), so the PI that actually runs is the one bundled with
+the adapter, not the `pi` on your PATH. Your local install still matters for configuration and
+credentials, which it reads from disk. Two consequences:
+
+- updating `pi` locally does not change what the bridge runs;
+- the adapter can lag PI releases, so a PI feature can exist locally and be unavailable here.
+
+**Exit route.** If the adapter becomes unmaintained or unreliable, PI's own RPC mode
+(`packages/coding-agent/docs/rpc.md` in the PI repo) is the first-party alternative. It means
+writing a transport in the bridge rather than reusing the ACP client, but it removes the third
+party entirely.
+
+## App and packaging
+
+- **Capacitor** (`@capacitor/core`, `/android`, `/cli`, `/app`) — Android packaging and the back
+  button. A major Capacitor version changes the generated Android project, and
+  `web/native-android/*.java` is copied into it by `npm run cap:sync:android`; a plain
+  `npx cap sync android` drops those files silently.
+- **React 18, Vite, `react-markdown`, `remark-gfm`** — ordinary frontend dependencies.
+- The **bridge has no dependencies at all** and runs on the Node standard library. Keep it that
+  way: it is the piece that has to start reliably on someone else's machine.
+
+## When a harness changes
+
+Unit tests will not catch this. Every quirk in the tables above was found by running a real agent,
+and the fakes in `bridge/test/` only lock in what was already learned.
+
+1. Run the harness for real: create a session, send a prompt, watch the reply stream, run a prompt
+   that uses a **tool**, and stop a run.
+2. Check whether a tool call actually did something. "Reported success and changed nothing" is the
+   signature failure here.
+3. Reopen a session and confirm the history is intact and in order.
+4. Compare what you see against this file's tables, and update them in the same commit as the fix.
+5. Update the capability matrix in `bridge/src/harness-profiles.js` if the harness gained or lost
+   something.
+
+For a version bump of the PI adapter specifically, the pin in `harness-profiles.js` is deliberate:
+change it consciously, run the checks above, then commit the new pin.


### PR DESCRIPTION
Prompted by a fair question: what actually is the PI ACP adapter, and how do we notice when a harness moves under us?

Almost everything that has broken this app broke because a harness behaved differently from what the code assumed — not because of a logic error. Those assumptions existed only in commit messages and PR comments, which is to say nowhere anybody re-reads them.

`docs/DEPENDENCIES.md` records, per harness surface, what we assume and **what breaks if it changes**. The entries are the ones a real agent taught us, not spec readings:

- OMP sends no session title in listings, never echoes a submitted prompt, emits no `agent_plan`, and approves its own tool calls without ever asking.
- PI's adapter sends no `messageId` on chunks, and asks permission before every tool call — where the failure mode is "reports success, changes nothing".
- OpenCode is assumed to beat on its event stream about every 10s, because the client treats 30s of silence as a dead connection.

It also records that only three `sessionUpdate` kinds are handled at all; `tool_call`, `tool_call_update` and `agent_thought_chunk` are dropped today.

## On the PI adapter specifically

It is the one dependency that is neither ours nor first-party, so its provenance is written down rather than left to be rediscovered:

- [`@automatalabs/pi-acp`](https://www.npmjs.com/package/@automatalabs/pi-acp), Apache-2.0, in [`VikashLoomba/agentprism-workflows`](https://github.com/VikashLoomba/agentprism-workflows), single maintainer;
- **first published 2026-07-16 — ten days ago — with eleven versions in those ten days**, `0.2.7` released the same day we pinned `0.2.5`. A bump is a change to test, not a routine refresh;
- it **embeds its own PI** via `@earendil-works/pi-coding-agent` pinned inside the adapter, so the PI that runs is the adapter's, not the `pi` on your PATH. Updating `pi` locally does not change what the bridge runs, and the adapter can lag PI releases;
- PI's native RPC mode is the exit route if it stops being maintained, at the cost of writing a transport instead of reusing the ACP client.

## Also

A "when a harness changes" checklist, ending on the check that matters most — whether a tool call actually did anything — and a note that the bridge deliberately has zero dependencies, which is worth keeping.

Linked from the README harness table and from CONTRIBUTING, whose intro still described PI as planned.

Every claim about our own code was verified against the tree: the pin, the empty bridge dependency set, the `cap:sync:android` script, the 30s watchdog default, and which `sessionUpdate` kinds the handler accepts.