### PR TITLE
Report models for a session this bridge process did not create

### DIFF
--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -185,13 +185,13 @@ export class AcpService {
   }
 
   async models(sessionID) {
-    await this.#load(sessionID)
+    await this.#loadForConfigOptions(sessionID)
     const option = this.#configOptions.get(sessionID)?.find((item) => item.id === "model")
     return option?.options?.map((candidate) => ({ ...candidate, currentValue: candidate.value === option.currentValue })) ?? []
   }
 
   async setModel(sessionID, model) {
-    await this.#load(sessionID)
+    await this.#loadForConfigOptions(sessionID)
     const option = this.#configOptions.get(sessionID)?.find((item) => item.id === "model")
     if (!option?.options?.some((candidate) => candidate.value === model)) {
       throw new Error(`Harness model is not available: ${model}`)
@@ -357,14 +357,26 @@ export class AcpService {
     return this.#active.has(sessionID) || Boolean(this.#queues.get(sessionID)?.length)
   }
 
-  async #load(sessionID, force = false) {
+  /**
+   * Displaying an external session deliberately skips the ACP load, but config options only
+   * arrive with it, so a session this process did not create reported no models at all — and
+   * model switching failed too, since it validates against that list. Pay for the load only
+   * when the options are genuinely missing, which keeps opening a session cheap.
+   */
+  async #loadForConfigOptions(sessionID) {
+    await this.#load(sessionID)
+    if (this.#configOptions.has(sessionID)) return
+    await this.#load(sessionID, true, true)
+  }
+
+  async #load(sessionID, force = false, requireConfigOptions = false) {
     if (!this.#sessions.has(sessionID)) await this.listSessions()
     const session = this.#sessions.get(sessionID)
     if (!session) throw new Error("Harness session not found")
     if (!force && this.#loaded.has(sessionID)) return
     let loading = this.#loads.get(sessionID)
     if (!loading) {
-      loading = this.#loadSession(sessionID)
+      loading = this.#loadSession(sessionID, requireConfigOptions)
       this.#loads.set(sessionID, loading)
     }
     try {
@@ -374,7 +386,7 @@ export class AcpService {
     }
   }
 
-  async #loadSession(sessionID) {
+  async #loadSession(sessionID, requireConfigOptions = false) {
     const session = this.#sessions.get(sessionID)
     if (!session) throw new Error("Harness session not found")
     await this.#restoreSnapshot(sessionID)
@@ -386,7 +398,7 @@ export class AcpService {
         if (persistedMessages.length > 0) {
           previousMessages = mergeExternalHistory(persistedMessages, previousMessages)
           this.#messages.set(sessionID, previousMessages)
-          if (!this.#ownedSessions.has(sessionID)) {
+          if (!this.#ownedSessions.has(sessionID) && !requireConfigOptions) {
             this.#todos.set(sessionID, [])
             this.#loaded.add(sessionID)
             this.#persistSnapshot(sessionID)

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -876,6 +876,63 @@ test("reads external history without loading and interrupting the ACP session", 
   assert.equal(acp.loads, 0)
 })
 
+test("reports models for an external session without losing its history", async () => {
+  // Displaying an external session skips the ACP load on purpose, but config options only
+  // arrive with that load — so every session survived a bridge restart reporting no models,
+  // and switching model failed because it validates against that same list.
+  const message = (id, text) => ({
+    info: { id, role: "assistant", sessionID: "session-1", time: { created: Date.now() } },
+    parts: [{ id: `${id}:text`, type: "text", text }]
+  })
+  class ConfigOptionAcp extends EventEmitter {
+    loads = 0
+    selected = []
+    async start() {}
+
+    async listSessions() {
+      return [{ sessionId: "session-1", cwd: process.cwd(), updatedAt: "2026-07-26T00:00:00.000Z" }]
+    }
+
+    async request(method, params) {
+      if (method === "session/set_config_option") {
+        this.selected.push(params.value)
+        return {}
+      }
+      if (method !== "session/load") return {}
+      this.loads += 1
+      return {
+        configOptions: [{
+          id: "model",
+          currentValue: "lm/one",
+          options: [{ value: "lm/one", name: "One" }, { value: "lm/two", name: "Two" }]
+        }]
+      }
+    }
+
+    notify() {}
+  }
+  const acp = new ConfigOptionAcp()
+  const driver = new AcpService(acp, { historyLoader: async () => [message("native-first", "First")] })
+
+  assert.deepEqual((await driver.messages("session-1")).map((item) => item.parts[0].text), ["First"])
+  assert.equal(acp.loads, 0, "displaying an external session must not load it")
+
+  assert.deepEqual((await driver.models("session-1")).map((option) => option.value), ["lm/one", "lm/two"])
+  assert.equal(acp.loads, 1, "the options are fetched once, only when asked for")
+
+  assert.deepEqual(
+    (await driver.messages("session-1")).map((item) => item.parts[0].text),
+    ["First"],
+    "fetching config options must not discard the external history"
+  )
+
+  await driver.setModel("session-1", "lm/two")
+  assert.deepEqual(acp.selected, ["lm/two"], "switching model must work on a session this process did not create")
+
+  await driver.models("session-1")
+  assert.equal(acp.loads, 1, "options already held must not trigger another load")
+})
+
 test("merges bridge-only legacy prompts into native external history by timestamp", async () => {
   class ExternalAcp extends EventEmitter {
     async start() {}


### PR DESCRIPTION
Found from a regression report on v2.2.0: the model box stayed on "loading" and model switching did nothing.

## The mechanism

#48 made displaying an *external* session — one this bridge process did not create — skip the ACP `session/load`, so that showing history does not start a second agent. Correct intent. But `session/load` is the only place config options arrive, and `#configOptions` is what `models()` returns and what `setModel()` validates against.

**After a bridge restart every session is external**, so this was not an edge case: the model list was empty for everything, and switching model failed with "model is not available".

Measured against real OMP 17.1.3, same bridge, same moment:

| Session | `/config/providers?sessionID=…` |
|---|---|
| created by this process (`external=false`) | 2 providers, 6 models |
| created by an earlier process (`external=true`) | **0 providers, 0 models** |

## The fix

The ACP load now happens only when the config options are genuinely missing, through `#loadForConfigOptions`. Opening a session stays as cheap as #48 made it; only the model picker pays for a load, once.

Verified that the extra load does not discard the merged external history — a four-message external session was byte-identical before and after fetching models, and switching model on it is accepted:

```
before: user:Reply with exactly: OMP_I | assistant:OMP_INTEGRATED_OK | user:Reply with exactly: CONTI | assistant:CONTINUED_OK
models loaded: 2 providers
after : user:Reply with exactly: OMP_I | assistant:OMP_INTEGRATED_OK | user:Reply with exactly: CONTI | assistant:CONTINUED_OK
preserved: true | count 4 -> 4
```

After the fix, the external session reports 2 providers and 65 models.

Covered by a test that asserts the whole shape: no load while displaying, one load when models are first asked for, history intact afterwards, `setModel` working, and no second load once the options are held. Bridge 43/43.