### PR TITLE
Name the harness in the header, and name a failed model fetch

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1595,6 +1595,9 @@ function App() {
   const totalDiffAdditions = diffFiles.reduce((sum, file) => sum + file.additions, 0)
   const totalDiffDeletions = diffFiles.reduce((sum, file) => sum + file.deletions, 0)
   const showModelChip = modelOptions.length > 1 || Boolean(activeModelOption) || primaryAgentOptions.length > 0
+  /** Without this a failed model fetch is indistinguishable from one still in flight. */
+  const modelStatusLabel = activeModelOption?.modelName
+    ?? (modelLoadError ? t('detail.modelUnavailable') : t('detail.modelLoading'))
 
   async function openSession(sessionID: string, directory: string) {
     setSelectedID(sessionID)
@@ -2505,10 +2508,17 @@ function App() {
         <div className="brand-section">
           <div className="brand-title">
             <img src="/app-icon.png" alt="" className="app-icon" />
-            <div>
+            <div className="brand-text">
               <h1>{t('app.title')}</h1>
-              <p className="subtle">
-                {hasConfiguredServer ? `${config.host}:${config.port}` : t('settings.title')}
+              {/* The harness matters more than the address: the same host can serve a different
+                  one, and every backend-specific limitation follows from which it is. */}
+              <p className="brand-meta">
+                <span className={`harness-badge harness-${config.backend}`}>
+                  {backendDisplayName(config.backend)}
+                </span>
+                <span className="brand-server">
+                  {hasConfiguredServer ? `${config.host}:${config.port}` : t('settings.title')}
+                </span>
               </p>
             </div>
           </div>
@@ -2997,9 +3007,13 @@ function App() {
           {selectedSession && (
             <section className="session-context-strip" aria-label={t('detail.contextStripLabel')}>
               {showModelChip && (
-                <button type="button" className="context-chip" onClick={() => setActiveDetailSheet("ai")}>
+                <button
+                  type="button"
+                  className={`context-chip${modelLoadError && !activeModelOption ? " chip-warning" : ""}`}
+                  onClick={() => setActiveDetailSheet("ai")}
+                >
                   <span>{t('detail.aiChip')}</span>
-                  <strong>{capabilities.agents ? `${agentLabel(activeAgent ?? { id: activeAgentID, name: activeAgentID, mode: "primary" })} · ${activeModelOption?.modelName ?? t('detail.modelLoading')}` : activeModelOption?.modelName ?? t('detail.modelLoading')}</strong>
+                  <strong>{capabilities.agents ? `${agentLabel(activeAgent ?? { id: activeAgentID, name: activeAgentID, mode: "primary" })} · ${modelStatusLabel}` : modelStatusLabel}</strong>
                 </button>
               )}
 
@@ -3243,7 +3257,7 @@ function App() {
                 </div>
                 <div className="dashboard-card">
                   <span className="dashboard-label">{t('detail.modelTitle')}</span>
-                  <strong>{activeModelOption?.modelName ?? t('detail.modelLoading')}</strong>
+                  <strong>{modelStatusLabel}</strong>
                   <small>{activeModelOption?.providerName ?? "-"}</small>
                 </div>
               </div>

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -127,6 +127,7 @@ type TranslationKey =
   | 'detail.modelToolsNo'
   | 'detail.modelVariant'
   | 'detail.modelLoading'
+  | 'detail.modelUnavailable'
   | 'detail.modelLoadError'
   | 'detail.contextStripLabel'
   | 'detail.aiChip'
@@ -340,6 +341,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.modelToolsNo': 'No tools',
     'detail.modelVariant': 'Variant: {variant}',
     'detail.modelLoading': 'Loading configured models...',
+    'detail.modelUnavailable': 'Models unavailable — check the server',
     'detail.modelLoadError': 'Cannot load models: {message}',
     'detail.contextStripLabel': 'Session context shortcuts',
     'detail.aiChip': 'AI',
@@ -552,6 +554,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.modelToolsNo': 'Nessun tool',
     'detail.modelVariant': 'Variante: {variant}',
     'detail.modelLoading': 'Caricamento modelli configurati...',
+    'detail.modelUnavailable': 'Modelli non disponibili — controlla il server',
     'detail.modelLoadError': 'Impossibile caricare i modelli: {message}',
     'detail.contextStripLabel': 'Scorciatoie contesto sessione',
     'detail.aiChip': 'AI',
@@ -764,6 +767,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.modelToolsNo': '無工具',
     'detail.modelVariant': '變體：{variant}',
     'detail.modelLoading': '正在載入已設定模型...',
+    'detail.modelUnavailable': '無法取得模型 — 請檢查伺服器',
     'detail.modelLoadError': '無法載入模型：{message}',
     'detail.contextStripLabel': '工作階段情境捷徑',
     'detail.aiChip': 'AI',

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -20,6 +20,12 @@
   --nav-bg: rgba(255, 255, 255, 0.94);
   --bottom-nav-bg: rgba(255, 255, 255, 0.96);
   --primary-border: #c9ddff;
+  --harness-omp: #7c3aed;
+  --harness-omp-soft: #f1e9ff;
+  --harness-omp-border: #ddccff;
+  --harness-pi: #0f766e;
+  --harness-pi-soft: #e2f5f2;
+  --harness-pi-border: #bfe6e0;
   --danger-border: #f0c2be;
   --focus-ring: rgba(23, 105, 224, 0.2);
   --code-bg: #111827;
@@ -68,6 +74,12 @@
   --nav-bg: rgba(17, 24, 39, 0.94);
   --bottom-nav-bg: rgba(17, 24, 39, 0.96);
   --primary-border: rgba(96, 165, 250, 0.36);
+  --harness-omp: #c4b5fd;
+  --harness-omp-soft: rgba(124, 58, 237, 0.22);
+  --harness-omp-border: rgba(196, 181, 253, 0.38);
+  --harness-pi: #5eead4;
+  --harness-pi-soft: rgba(15, 118, 110, 0.26);
+  --harness-pi-border: rgba(94, 234, 212, 0.34);
   --danger-border: rgba(248, 113, 113, 0.42);
   --focus-ring: rgba(96, 165, 250, 0.28);
   --code-bg: #020617;
@@ -1851,4 +1863,76 @@ button.compact {
   font-size: 0.8125rem;
   line-height: 1.45;
   color: var(--text-muted, #8a93a6);
+}
+
+/* Which harness you are driving decides what the app can do, so it is named next to the
+   address rather than buried in Settings. The badge never shrinks; the address truncates. */
+.brand-text {
+  min-width: 0;
+}
+
+.brand-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  margin-top: 0.15rem;
+}
+
+.harness-badge {
+  flex: 0 0 auto;
+  border: 1px solid var(--primary-border);
+  border-radius: 999px;
+  background: var(--primary-soft);
+  /* --primary on --primary-soft lands at 4.43:1, just under AA for 10px bold text. */
+  color: var(--primary-strong);
+  padding: 0.1rem 0.45rem;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  line-height: 1.5;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.harness-badge.harness-omp {
+  border-color: var(--harness-omp-border);
+  background: var(--harness-omp-soft);
+  color: var(--harness-omp);
+}
+
+.harness-badge.harness-pi {
+  border-color: var(--harness-pi-border);
+  background: var(--harness-pi-soft);
+  color: var(--harness-pi);
+}
+
+.brand-server {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+/* A model list that failed to load is a different state from one still arriving. */
+.context-chip.chip-warning {
+  border-color: var(--warning);
+  background: var(--warning-soft);
+}
+
+.context-chip.chip-warning strong {
+  color: var(--warning);
+}
+
+@media (max-width: 430px) {
+  .harness-badge {
+    font-size: 0.66rem;
+    padding: 0.1rem 0.4rem;
+  }
+
+  .brand-server {
+    font-size: 0.76rem;
+  }
 }

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -159,4 +159,29 @@ assert.ok(
   'text-only replies must each keep their own bubble'
 )
 
+// A model list that never arrived used to render as "loading" forever, which reads as a slow
+// server rather than a failure — the reason a misconfigured server looked like a broken feature.
+assert.ok(
+  app.includes("?? (modelLoadError ? t('detail.modelUnavailable') : t('detail.modelLoading'))"),
+  'a failed model fetch must be named, not shown as still loading'
+)
+assert.ok(
+  app.includes('activeModelOption?.modelName') && app.includes('const modelStatusLabel'),
+  'a model already known must keep showing, even if a later refresh fails'
+)
+assert.equal(
+  app.includes("activeModelOption?.modelName ?? t('detail.modelLoading')"),
+  false,
+  'every model label should go through modelStatusLabel so the failure state cannot be missed'
+)
+assert.ok(app.includes('chip-warning'), 'the context chip should mark the failure visually')
+
+// The harness in use decides what the app can do, so it is named in the header.
+assert.ok(app.includes('className={`harness-badge harness-${config.backend}`}'), 'the header should badge the active harness')
+assert.ok(app.includes('{backendDisplayName(config.backend)}'), 'the badge should show the harness display name')
+for (const cls of ['.harness-badge', '.harness-omp', '.harness-pi', '.brand-server']) {
+  assert.ok(styles.includes(cls), `${cls} should be styled`)
+}
+assert.match(styles, /\.brand-server[\s\S]*?text-overflow: ellipsis/, 'a long address must truncate rather than push the badge off screen')
+
 console.log('ui regression tests passed')


### PR DESCRIPTION
Both changes come from the same confusion: an app pointed at the wrong server looked like an app with broken models.

## The header names the harness

It showed only `host:port`. Which harness you are driving decides what the app can do — every per-backend limitation follows from it — and the same host can serve a different one, so the address alone is not enough to tell where you are.

The badge carries a distinct accent per harness and is sized to match the pills already in the app, rather than introducing a new scale. Mobile-first in the way that matters: the badge never shrinks and the **address truncates instead**, verified with a 60-character hostname at 375px — badge fully visible, no horizontal overflow.

Contrast measured for all six harness/theme combinations against their own composited background:

| | light | dark |
|---|---|---|
| OpenCode | 5.99:1 | 7.55:1 |
| Oh My Pi | 4.84:1 | 8.06:1 |
| PI | 4.84:1 | 9.42:1 |

The OpenCode badge uses `--primary-strong` rather than `--primary`, because `--primary` on `--primary-soft` measures 4.43:1 — under AA for 10px bold text. No new colour was invented for it; the token already existed.

## A failed model fetch says so

`Loading configured models…` rendered indefinitely when the fetch had actually failed, which reads as a slow server rather than a failure. This is what made a misconfigured server look like a broken feature: pointing the app at a server that does not know your session id returns `400 {"error":"Harness session not found"}`, and the UI said "loading" forever.

The error was already held in `modelLoadError` and shown in the model panel — just not where anyone looks. Every model label now goes through one value that names the failure, and the context chip marks it.

A model already known keeps showing if a later refresh fails: verified by stopping the bridge with a session open, where the chip correctly kept the model rather than blanking it. Losing good information to report a transient error would be worse.

Web 6/6 with new assertions covering both changes, build clean.