### PR TITLE
Mobile polish: keyboard, session cards, touch affordances

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- interactive-widget: without it Chrome on Android leaves the layout at full height when the
+         on-screen keyboard opens, so the sticky composer ends up behind the keyboard. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content" />
     <title>Harness Remote</title>
   </head>
   <body>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -48,6 +48,17 @@ function isBridgeBackend(backend: ServerConfig["backend"]): boolean {
   return backend === "omp" || backend === "pi"
 }
 
+/**
+ * A session card showed the whole absolute path, which on a phone wrapped to three lines and
+ * took a third of the card. The last segments are what identifies a project; the full path stays
+ * in the title attribute and in the session detail.
+ */
+function shortDirectory(directory: string): string {
+  const segments = directory.split(/[\\/]+/).filter(Boolean)
+  if (segments.length <= 2) return directory
+  return `…/${segments.slice(-2).join("/")}`
+}
+
 function backendDisplayName(backend: ServerConfig["backend"]): string {
   if (backend === "omp") return "Oh My Pi"
   if (backend === "pi") return "PI"
@@ -2600,6 +2611,11 @@ function App() {
               value={draftConfig.host}
               onChange={(event) => setDraftConfig({ ...draftConfig, host: event.target.value })}
               placeholder={t('settings.hostPlaceholder')}
+              inputMode="url"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+              autoComplete="off"
             />
           </label>
           
@@ -2611,6 +2627,8 @@ function App() {
               value={draftConfig.port}
               onChange={(event) => setDraftConfig({ ...draftConfig, port: Number(event.target.value || 0) })}
               placeholder="4096"
+              inputMode="numeric"
+              autoComplete="off"
             />
           </label>
           
@@ -2621,6 +2639,10 @@ function App() {
               value={draftConfig.username}
               onChange={(event) => setDraftConfig({ ...draftConfig, username: event.target.value })}
               placeholder="opencode"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+              autoComplete="username"
             />
           </label>
           
@@ -2632,6 +2654,7 @@ function App() {
               value={draftConfig.password}
               onChange={(event) => setDraftConfig({ ...draftConfig, password: event.target.value })}
               placeholder={t('settings.passwordPlaceholder')}
+              autoComplete="current-password"
             />
           </label>
           </div>
@@ -2781,6 +2804,9 @@ function App() {
                               }
                             }}
                             placeholder={t('session.renamePlaceholder')}
+                            enterKeyHint="done"
+                            autoCorrect="off"
+                            spellCheck={false}
                             className="rename-input"
                             autoComplete="off"
                           />
@@ -2809,18 +2835,17 @@ function App() {
                       ) : (
                         <h3>{session.title}</h3>
                       )}
-                      <p>{session.directory}</p>
+                      <p title={session.directory}>{shortDirectory(session.directory)}</p>
                     </div>
                   </div>
                   <div className="session-stats">
-                    {session.files > 0 || session.additions > 0 || session.deletions > 0 ? (
+                    {/* "No file changes" is said by its absence: one line fewer on a phone. */}
+                    {(session.files > 0 || session.additions > 0 || session.deletions > 0) && (
                       <span className="change-summary">
                         <strong>{session.files}</strong> files
                         <strong className="positive">+{session.additions}</strong>
                         <strong className="negative">-{session.deletions}</strong>
                       </span>
-                    ) : (
-                      <span className="subtle">{t('sessions.noFileChanges')}</span>
                     )}
                     <span className="subtle">{t('sessions.updated', { time: formatTime(session.updated) })}</span>
                     <span className={`pill ${session.status}`}>{session.status}</span>
@@ -3082,6 +3107,9 @@ function App() {
               value={composer}
               onChange={(event) => setComposer(event.target.value)}
               placeholder={t('detail.composerPlaceholder')}
+              enterKeyHint="send"
+              autoCapitalize="sentences"
+              autoCorrect="on"
               onFocus={() => {
                 syncChatBottomClearance()
                 setTimeout(() => scrollMessagesToBottom("smooth"), 400)
@@ -3181,6 +3209,10 @@ function App() {
                         value={modelQuery}
                         onChange={(event) => setModelQuery(event.target.value)}
                         placeholder={t('detail.modelSearchPlaceholder')}
+                        inputMode="search"
+                        enterKeyHint="search"
+                        autoCapitalize="none"
+                        spellCheck={false}
                         disabled={isWorking}
                         autoComplete="off"
                       />

--- a/web/src/i18n.test.mjs
+++ b/web/src/i18n.test.mjs
@@ -35,11 +35,4 @@ assert.equal(it('settings.themeDark'), 'Scuro')
 assert.equal(zh('settings.themeSystem'), '跟隨系統')
 assert.equal(en('todo.title'), 'Todo Items')
 
-// A bare Windows computer name does not resolve from a phone, so the host field must say so.
-for (const translate of [en, it, zh]) {
-  const hint = translate('settings.hostHint')
-  assert.notEqual(hint, 'settings.hostHint', 'every language must translate the host hint')
-  assert.ok(hint.includes('http://'), 'the hint must state that the scheme is optional')
-}
-
 console.log('i18n tests passed')

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -15,7 +15,6 @@ type TranslationKey =
   | 'settings.backend'
   | 'settings.host'
   | 'settings.hostPlaceholder'
-  | 'settings.hostHint'
   | 'settings.port'
   | 'settings.username'
   | 'settings.password'
@@ -229,7 +228,6 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'settings.backend': 'Backend',
     'settings.host': 'Host Address',
     'settings.hostPlaceholder': '192.168.1.100, localhost, or https://example.com',
-    'settings.hostHint': "Use the computer's IP address. http:// is optional and only needed as https:// for a TLS server. A Windows computer name such as MY-PC usually cannot be resolved from a phone.",
     'settings.port': 'Port',
     'settings.username': 'Username',
     'settings.password': 'Password',
@@ -299,7 +297,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.loading': 'Loading session...',
     'detail.emptyTitle': 'No messages yet',
     'detail.emptyHint': 'Start a conversation below',
-    'detail.composerPlaceholder': 'Type a prompt or command (start with / for slash commands)...',
+    'detail.composerPlaceholder': 'Prompt, or / for commands',
     'detail.externalSession': 'From another client; sending continues it here',
     'detail.waiting': 'Waiting...',
     'detail.send': 'Send',
@@ -442,7 +440,6 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'settings.backend': 'Backend',
     'settings.host': 'Indirizzo host',
     'settings.hostPlaceholder': '192.168.1.100, localhost o https://example.com',
-    'settings.hostHint': "Usa l'indirizzo IP del computer. http:// è facoltativo e serve solo come https:// per un server TLS. Un nome di computer Windows come MIO-PC di solito non è risolvibile dal telefono.",
     'settings.port': 'Porta',
     'settings.username': 'Username',
     'settings.password': 'Password',
@@ -512,7 +509,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.loading': 'Caricamento sessione...',
     'detail.emptyTitle': 'Ancora nessun messaggio',
     'detail.emptyHint': 'Inizia una conversazione qui sotto',
-    'detail.composerPlaceholder': 'Scrivi un prompt o un comando (inizia con / per gli slash command)...',
+    'detail.composerPlaceholder': 'Prompt, o / per i comandi',
     'detail.externalSession': 'Da un altro client; inviando la continui qui',
     'detail.waiting': 'Attesa...',
     'detail.send': 'Invia',
@@ -655,7 +652,6 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'settings.backend': '後端',
     'settings.host': '主機位址',
     'settings.hostPlaceholder': '192.168.1.100、localhost 或 https://example.com',
-    'settings.hostHint': '請使用電腦的 IP 位址。http:// 可省略，僅在使用 TLS 伺服器時需寫成 https://。像 MY-PC 這樣的 Windows 電腦名稱通常無法從手機解析。',
     'settings.port': '連接埠',
     'settings.username': '使用者名稱',
     'settings.password': '密碼',
@@ -725,7 +721,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.loading': '載入工作階段...',
     'detail.emptyTitle': '尚無訊息',
     'detail.emptyHint': '在下方開始對話',
-    'detail.composerPlaceholder': '輸入提示或命令（以 / 開頭使用斜線命令）...',
+    'detail.composerPlaceholder': '輸入提示，或以 / 下命令',
     'detail.externalSession': '來自其他用戶端；傳送後將在此繼續',
     'detail.waiting': '等待中...',
     'detail.send': '傳送',

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1815,14 +1815,20 @@ button.compact {
   line-height: 1;
 }
 
+/* Full opacity is the default: dimming it is a hover affordance, and a finger never hovers. */
 .detail-title-row .btn-icon {
-  opacity: 0.6;
   transition: opacity 0.15s;
 }
 
-.detail-title-row:hover .btn-icon,
-.detail-title-row .btn-icon:focus-visible {
-  opacity: 1;
+@media (hover: hover) {
+  .detail-title-row .btn-icon {
+    opacity: 0.6;
+  }
+
+  .detail-title-row:hover .btn-icon,
+  .detail-title-row .btn-icon:focus-visible {
+    opacity: 1;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -1935,4 +1941,29 @@ button.compact {
   .brand-server {
     font-size: 0.76rem;
   }
+}
+
+/* Touch tuning. Android paints its own blue flash over a tap, which fights the pressed state
+   the buttons already have, and a scroll that reaches the end of a list should not start
+   dragging the page underneath it. */
+button,
+.session-card,
+.context-chip,
+.model-option,
+.folder-row,
+.message-diff-row {
+  -webkit-tap-highlight-color: transparent;
+}
+
+.messages,
+.model-option-list,
+.folder-list,
+.bottom-sheet,
+.diff-modal-body {
+  overscroll-behavior: contain;
+}
+
+/* A sheet is dismissed from a small button, so it has to be reachable by thumb. */
+button.compact {
+  min-height: 44px;
 }

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -184,4 +184,21 @@ for (const cls of ['.harness-badge', '.harness-omp', '.harness-pi', '.brand-serv
 }
 assert.match(styles, /\.brand-server[\s\S]*?text-overflow: ellipsis/, 'a long address must truncate rather than push the badge off screen')
 
+// Mobile keyboard: an address is not a sentence, a port is a number, and Enter sends.
+assert.ok(app.includes('inputMode="url"') && app.includes('autoCapitalize="none"'), 'the host field must not be autocapitalised or autocorrected')
+assert.ok(app.includes('inputMode="numeric"'), 'the port field should raise a numeric keypad')
+assert.ok(app.includes('autoComplete="username"') && app.includes('autoComplete="current-password"'), 'credentials should be offerable by a password manager')
+assert.ok(app.includes('enterKeyHint="send"'), "the composer's action key should say send")
+
+// A session card showed a full absolute path over three lines, a third of its height.
+assert.ok(app.includes('function shortDirectory'), 'the card should shorten the directory it shows')
+assert.ok(app.includes('<p title={session.directory}>{shortDirectory(session.directory)}</p>'), 'the full path should stay available as a title')
+assert.equal(app.includes("t('sessions.noFileChanges')"), false, 'absence of changes needs no line of its own on a phone')
+
+// Hover is not a state a finger can produce.
+assert.match(styles, /@media \(hover: hover\)[\s\S]*?\.detail-title-row \.btn-icon/, 'a hover-only affordance must not leave a control dimmed on touch')
+assert.ok(styles.includes('-webkit-tap-highlight-color: transparent'), 'the platform tap flash should not fight the pressed state')
+assert.ok(styles.includes('overscroll-behavior: contain'), 'scrolling to the end of a list should not drag the page')
+assert.match(styles, /button\.compact \{[\s\S]*?min-height: 44px/, 'a compact button is still a thumb target')
+
 console.log('ui regression tests passed')


### PR DESCRIPTION
The first group from the mobile pass at 375x812. Seven independent fixes, each measured in the browser before and after.

## The keyboard had no help at all

The viewport meta now carries `interactive-widget=resizes-content`. Without it Chrome on Android keeps the layout at full height when the on-screen keyboard opens, so the sticky composer ends up **behind** the keyboard.

None of the seven fields declared a keyboard — measured, all null:

| Field | Now |
|---|---|
| host | `inputMode="url"`, no autocapitalise, no autocorrect, no spellcheck |
| port | `inputMode="numeric"` |
| username / password | `autoComplete="username"` / `"current-password"`, so a password manager can fill them |
| composer | `enterKeyHint="send"` — Enter already sends, the key now says so |
| model search | `inputMode="search"`, `enterKeyHint="search"` |
| rename | `enterKeyHint="done"` |

Typing `192.168.1.64` into a field that autocapitalises and autocorrects is a small fight the app was picking with its own user.

## Session cards were two thirds waste

| | before | after |
|---|---|---|
| card height | 193px | **123px** |
| path | 114 chars, 62px, 3 lines | `…/scratchpad/ompproj`, 21px, 1 line |
| status row | 57px, 3 lines | 28px, 1 line |
| list height | 3274px | 2295px |

The full path stays in the `title` attribute. "No file changes" is now said by its absence rather than spending a line to report nothing.

## The composer placeholder could not be read

69 characters in a box 217px wide. Now 25, fitting one line at 182px with room to spare — verified by measuring the rendered text, not by counting characters.

## Hover is not a state a finger can produce

```css
.detail-title-row .btn-icon { opacity: 0.6 }
.detail-title-row:hover .btn-icon { opacity: 1 }
```

The rename pencil sat permanently at 60% on touch — always in its "off" state. Dimming now lives inside `@media (hover: hover)`.

## Touch tuning

Android painted its own blue flash over taps, fighting the pressed state the buttons already have; scrolling to the end of a list dragged the page underneath it. Both addressed, and the sheet close button — the only control under 44px, at 37px — is now thumb-sized.

## Cleanup

`settings.hostHint` is removed in all three languages along with the assertion covering it: the hint it belonged to was deliberately dropped, so the strings were dead and the test was defending them.

## Verification

Sweep at 375px across settings, sessions and detail: no horizontal overflow anywhere, no control under 44px. Web 6/6 with new assertions for each change, bridge 43/43, build clean.

Not included, from the same pass: making the message list the scroll container with `visualViewport` handling, and the vertical-budget questions. Those need their own change.