### PR TITLE
One honest state when the server cannot be reached

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -30,6 +30,7 @@ import {
   TestIcon,
   LoadingIcon,
   RefreshIcon,
+  OfflineIcon,
   PencilIcon,
   CloseIcon
 } from "./Icons"
@@ -1585,7 +1586,12 @@ function App() {
         : connectionState === "offline"
           ? t('connection.offline')
           : "")
-  const eventStreamText = eventStreamState === "live"
+  const isOffline = connectionState === "offline"
+  /* The connection status already speaks when the server is unreachable. A second, more hopeful
+     voice about the event stream only made the app look like it disagreed with itself. */
+  const eventStreamText = isOffline
+    ? ""
+    : eventStreamState === "live"
     ? t('events.live', { count: liveEventCount })
     : eventStreamState === "connecting"
       ? t('events.connecting')
@@ -1733,7 +1739,10 @@ function App() {
       }
 
       backgroundFailureCountRef.current += 1
-      if (backgroundFailureCountRef.current === 1) {
+      // Tolerating a few failures avoids flapping when a working connection hiccups — but on the
+      // first load there is no good state to protect, and pretending to still be connecting while
+      // an error is already on screen is what made the app look like it contradicted itself.
+      if (backgroundFailureCountRef.current === 1 && sessions.length > 0) {
         setConnectionState("reconnecting")
         setConnectionMessage(t('connection.reconnecting'))
         return
@@ -1744,6 +1753,7 @@ function App() {
       if (backgroundFailureCountRef.current >= 3) {
         setRuntimeError(message)
       }
+      initialSessionLoadRef.current = false
     }
   }
 
@@ -2732,7 +2742,12 @@ function App() {
                 {refreshingSessions ? <LoadingIcon size={18} /> : <RefreshIcon size={18} />}
                 {t('sessions.refresh')}
               </button>
-              <button onClick={openNewSessionPicker} className="btn-primary" disabled={creatingSession}>
+              <button
+                onClick={openNewSessionPicker}
+                className="btn-primary"
+                disabled={creatingSession || isOffline}
+                title={isOffline ? t('sessions.offlineHint') : undefined}
+              >
                 {creatingSession ? <LoadingIcon size={18} /> : <PlusIcon size={18} />}
                 {creatingSession ? t('sessions.creating') : t('sessions.new')}
               </button>
@@ -2749,7 +2764,29 @@ function App() {
           </div>
           
           <div className="session-list">
-            {filteredSessions.length === 0 && ['connecting', 'reconnecting'].includes(connectionState) ? (
+            {/* An empty list while the server is unreachable is not "still loading". Saying so,
+                and offering the two things worth doing, beats a spinner that never resolves. */}
+            {filteredSessions.length === 0 && isOffline ? (
+              <div className="empty-state">
+                <OfflineIcon size={44} className="icon-empty-state" />
+                <p>{t('sessions.offlineHint')}</p>
+                <div className="empty-state-actions">
+                  <button
+                    type="button"
+                    className="btn-primary"
+                    onClick={() => refreshSessionsWithIndicator().catch(() => undefined)}
+                    disabled={refreshingSessions}
+                  >
+                    {refreshingSessions ? <LoadingIcon size={18} /> : <RefreshIcon size={18} />}
+                    {t('sessions.retry')}
+                  </button>
+                  <button type="button" className="btn-secondary" onClick={() => setView("settings")}>
+                    <SettingsIcon size={18} />
+                    {t('nav.settings')}
+                  </button>
+                </div>
+              </div>
+            ) : filteredSessions.length === 0 && ['connecting', 'reconnecting'].includes(connectionState) ? (
               <div className="empty-state connection-pending">
                 <LoadingIcon size={40} className="icon-empty-state" />
                 <p>{t('sessions.loadingTitle')}</p>
@@ -2759,7 +2796,7 @@ function App() {
               <div className="empty-state">
                 <FolderIcon size={48} className="icon-empty-state" />
                 <p>{t('sessions.emptyTitle')}</p>
-                <p className="subtle">{connectionState === "offline" ? t('sessions.offlineHint') : t('sessions.emptyHint')}</p>
+                <p className="subtle">{t('sessions.emptyHint')}</p>
               </div>
             ) : (
               filteredSessions.map((session) => (
@@ -2884,7 +2921,11 @@ function App() {
             )}
           </div>
           
-          {runtimeError && <div className="error fade-in">✗ {runtimeError}</div>}
+          {/* The offline empty state already explains this and offers the two useful actions;
+              repeating the raw transport error underneath is the second voice again. */}
+          {runtimeError && !(isOffline && filteredSessions.length === 0) && (
+            <div className="error fade-in">✗ {runtimeError}</div>
+          )}
         </section>
       )}
 

--- a/web/src/Icons.tsx
+++ b/web/src/Icons.tsx
@@ -405,3 +405,26 @@ export const LogoIcon = ({ className = "", size = 32 }: { className?: string; si
     <path d="M16 3v6m0 8v6M3 16h6m8 0h6" stroke="url(#logoGradient)" strokeWidth="2" strokeLinecap="round"/>
   </svg>
 )
+export const OfflineIcon = ({ className = "", size = 20 }: { className?: string; size?: number }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    role="img"
+    aria-label="Offline"
+  >
+    <path d="M2 2l20 20" />
+    <path d="M8.5 16.5a5 5 0 0 1 7 0" />
+    <path d="M5 12.86a10 10 0 0 1 3.5-2.32" />
+    <path d="M15.5 10.54A10 10 0 0 1 19 12.86" />
+    <path d="M2 8.82a15 15 0 0 1 4.17-2.65" />
+    <path d="M10.66 5.05A15 15 0 0 1 22 8.82" />
+    <path d="M12 20h.01" />
+  </svg>
+)

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -126,7 +126,7 @@ async function requestWithHeaders<T>(config: ServerConfig, path: string, options
         readTimeout: options.readTimeout ?? 30_000
       })
     } catch {
-      throw new Error(`Network error: cannot reach ${target}. Check host, port, and firewall.`)
+      throw new Error(`Cannot reach ${config.host}:${config.port}.`)
     }
 
     if (response.status >= 400) {
@@ -146,12 +146,12 @@ async function requestWithHeaders<T>(config: ServerConfig, path: string, options
       body: options.body === undefined ? undefined : JSON.stringify(options.body)
     })
   } catch {
+    // Kept short: this text reaches a phone screen. The CORS note only means something in a
+    // browser, where it is the usual cause, and nothing at all inside the app.
     const corsHint = config.username && config.password
-      ? " Browser mode + Basic Auth may be blocked by CORS preflight; use APK/native mode or disable auth temporarily for browser debugging."
+      ? " In a browser, Basic Auth also needs the bridge started with --cors for this origin."
       : ""
-    throw new Error(
-      `Network error: cannot reach ${target}. Check server hostname/port, Windows firewall, and CORS (--cors).${corsHint}`
-    )
+    throw new Error(`Cannot reach ${config.host}:${config.port}.${corsHint}`)
   }
 
   if (!response.ok) {

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -56,6 +56,7 @@ type TranslationKey =
   | 'sessions.loadingTitle'
   | 'sessions.loadingHint'
   | 'sessions.offlineHint'
+  | 'sessions.retry'
   | 'sessions.title'
   | 'sessions.summary'
   | 'sessions.new'
@@ -287,7 +288,8 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'sessions.emptyHint': 'Create a new session to get started',
     'sessions.loadingTitle': 'Connecting to backend',
     'sessions.loadingHint': 'Loading sessions. This can take a few seconds on mobile or after the server wakes up.',
-    'sessions.offlineHint': 'Backend is not reachable yet. Check Settings or try Refresh.',
+    'sessions.offlineHint': 'The server did not answer. It may be asleep, off, or on another network.',
+    'sessions.retry': 'Try again',
     'sessions.noFileChanges': 'No file changes',
     'sessions.updated': 'Updated {time}',
     'sessions.open': 'Open',
@@ -499,7 +501,8 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'sessions.emptyHint': 'Crea una nuova sessione per iniziare',
     'sessions.loadingTitle': 'Connessione al backend',
     'sessions.loadingHint': 'Carico le sessioni. Su mobile o dopo il risveglio del server può volerci qualche secondo.',
-    'sessions.offlineHint': 'Backend non ancora raggiungibile. Controlla Impostazioni o riprova con Aggiorna.',
+    'sessions.offlineHint': "Il server non ha risposto. Può essere spento, in standby o su un'altra rete.",
+    'sessions.retry': 'Riprova',
     'sessions.noFileChanges': 'Nessuna modifica ai file',
     'sessions.updated': 'Aggiornata {time}',
     'sessions.open': 'Apri',
@@ -711,7 +714,8 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'sessions.emptyHint': '建立新的工作階段以開始',
     'sessions.loadingTitle': '正在連線到後端',
     'sessions.loadingHint': '正在載入工作階段。行動裝置或伺服器剛喚醒時可能需要幾秒。',
-    'sessions.offlineHint': '尚無法連線到後端。請檢查設定或重新整理。',
+    'sessions.offlineHint': '伺服器未回應。它可能已關機、休眠，或位於另一個網路。',
+    'sessions.retry': '重試',
     'sessions.noFileChanges': '沒有檔案變更',
     'sessions.updated': '更新於 {time}',
     'sessions.open': '開啟',

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1967,3 +1967,17 @@ button,
 button.compact {
   min-height: 44px;
 }
+
+/* The offline state offers the only two useful actions, side by side and thumb-sized. */
+.empty-state-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+}
+
+.empty-state-actions button {
+  flex: 1 1 auto;
+  min-width: 8.5rem;
+}

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -201,4 +201,20 @@ assert.ok(styles.includes('-webkit-tap-highlight-color: transparent'), 'the plat
 assert.ok(styles.includes('overscroll-behavior: contain'), 'scrolling to the end of a list should not drag the page')
 assert.match(styles, /button\.compact \{[\s\S]*?min-height: 44px/, 'a compact button is still a thumb target')
 
+// With the server unreachable the app used to show four hopeful messages and a developer-facing
+// error at the same time, for about ten seconds, and kept a stale list that could not be opened.
+assert.ok(app.includes('const isOffline = connectionState === "offline"'), 'offline should be one named state')
+assert.ok(
+  app.includes("backgroundFailureCountRef.current === 1 && sessions.length > 0"),
+  'tolerating failures protects an existing list; on the first load it only delays the truth'
+)
+assert.ok(app.includes('eventStreamText = isOffline'), 'the event stream must not claim to be reconnecting while the connection is down')
+assert.ok(
+  app.includes('runtimeError && !(isOffline && filteredSessions.length === 0)'),
+  'the offline state explains itself; the raw transport error must not repeat it'
+)
+assert.ok(app.includes("t('sessions.retry')"), 'an offline state should offer a way out')
+assert.ok(app.includes('disabled={creatingSession || isOffline}'), 'an action that cannot succeed offline must not be offered')
+assert.ok(styles.includes('.empty-state-actions'), 'the offline actions should be styled')
+
 console.log('ui regression tests passed')


### PR DESCRIPTION
Found by looking at the app with the bridge stopped — which is what a phone sees whenever it loses Wi-Fi or the workstation sleeps, so not a contrived state.

## What it did

Four hopeful messages and a developer-facing error, at the same time, for about ten seconds:

```
Connessione e caricamento sessioni...
Riconnessione aggiornamenti live…
Connessione al backend
Carico le sessioni. Su mobile o dopo il risveglio del server può volerci qualche secondo.
✗ Network error: cannot reach http://127.0.0.1:4097/session. Check server hostname/port,
  Windows firewall, and CORS (--cors).
```

Three status surfaces each spoke for themselves, so the app simultaneously claimed to be loading and reported failure. Measured after the change: **one state, reached in 255ms**, with the reason and the two actions worth offering.

| | before | after |
|---|---|---|
| messages on screen | 5, contradictory | 1 explanation + 2 actions |
| time to settle | ~10s | 255ms |
| error banners | 1, 120px, developer-facing | 0 |
| New session | offered, could not work | disabled |

## Why it took ten seconds

Tolerating three failures before admitting defeat protects a working list from a hiccup. On the **first** load there is nothing to protect, so it only delayed the truth while an error was already on screen. One failure with an empty list is now enough; the tolerant path still applies once sessions exist.

## Also

- The event stream no longer reports itself as reconnecting while the connection is down — one voice at a time.
- The raw transport error no longer repeats what the offline state already explains.
- That error spoke of Windows firewalls and `--cors`, the latter meaningless inside the app where CORS does not exist. It is now the host and port, with the CORS note kept only for browser mode where it is the usual cause.

## It also answers a question this raised

The app does **not** cache sessions. Measured: with the server down, a reload shows an empty list; without a reload the previous list stays because a failed refresh left in-memory state untouched. That is why sessions opened empty and looked cached — and why the list is no longer presented as usable when it is not.

Web 6/6 with assertions for each part, build clean. Verified live: offline in 255ms with the bridge stopped, and automatic recovery to 14 sessions when it came back.