### PR TITLE
Fix the session header, and rebuild the rename affordance

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3025,35 +3025,44 @@ function App() {
                           className="rename-input"
                           autoComplete="off"
                         />
+                        {/* Two unlabelled 14px glyphs asked the user to guess which one commits.
+                            One labelled primary action, and cancel as the quieter icon. */}
                         <button
-                          className="btn-primary compact"
+                          className="btn-primary compact rename-save"
                           onClick={() => renameSession(selectedSession.id, renameValue, selectedSession.directory).catch(() => undefined)}
                           onMouseDown={(event) => event.preventDefault()}
-                          title={t('session.renameConfirm')}
+                          disabled={!renameValue.trim() || renameValue === selectedSession.title}
                         >
-                          <SaveIcon size={14} />
+                          <SaveIcon size={16} />
+                          {t('session.renameConfirm')}
                         </button>
                         <button
-                          className="btn-secondary compact"
+                          className="btn-icon btn-secondary compact"
                           onClick={() => cancelRename()}
+                          onMouseDown={(event) => event.preventDefault()}
                           title={t('session.cancel')}
+                          aria-label={t('session.cancel')}
                         >
-                          <CloseIcon size={14} />
+                          <CloseIcon size={18} />
                         </button>
                       </div>
                     ) : (
                       <>
-                        {selectedSession.title}
-                        {capabilities.sessionRename && (
+                        {/* A 14px glyph is a poor target and a poor hint. The title itself is the
+                            button; the pencil only says that it can be edited. */}
+                        {capabilities.sessionRename ? (
                           <button
-                            className="btn-icon btn-secondary compact"
+                            type="button"
+                            className="session-title-button"
                             onClick={() => startRename(selectedSession)}
                             title={t('session.renameTitle')}
                             aria-label={t('session.renameTitle')}
-                            style={{ marginLeft: 'var(--space-1)' }}
                           >
-                            <PencilIcon size={14} />
+                            <span className="session-title-text">{selectedSession.title}</span>
+                            <PencilIcon size={18} className="session-title-pencil" />
                           </button>
+                        ) : (
+                          <span className="session-title-text">{selectedSession.title}</span>
                         )}
                       </>
                     )}
@@ -3063,8 +3072,13 @@ function App() {
                 )}
               </h2>
               {selectedSession && (
-                <p className="subtle">
-                  {selectedSession.directory} • {t('sessions.updated', { time: formatTime(selectedSession.updated) })}
+                <p className="subtle detail-subline" title={selectedSession.directory}>
+                  <span className="detail-subline-path">{shortDirectory(selectedSession.directory)}</span>
+                  {/* Moved up from between the messages and the composer, where the sticky
+                      composer covered half of it. */}
+                  {selectedSession.external && (
+                    <span className="pill external-pill" title={t('detail.externalSession')}>{t('detail.externalShort')}</span>
+                  )}
                 </p>
                 )}
               </div>
@@ -3139,9 +3153,6 @@ function App() {
           />
 
 
-          {selectedSession?.external && (
-            <p className="field-hint">{t('detail.externalSession')}</p>
-          )}
 
           <div className="composer" ref={composerRef}>
             <textarea

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -87,6 +87,7 @@ type TranslationKey =
   | 'detail.emptyHint'
   | 'detail.composerPlaceholder'
   | 'detail.externalSession'
+  | 'detail.externalShort'
   | 'detail.waiting'
   | 'detail.send'
   | 'detail.jumpToLatest'
@@ -301,6 +302,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.emptyHint': 'Start a conversation below',
     'detail.composerPlaceholder': 'Prompt, or / for commands',
     'detail.externalSession': 'From another client; sending continues it here',
+    'detail.externalShort': 'external',
     'detail.waiting': 'Waiting...',
     'detail.send': 'Send',
     'detail.jumpToLatest': 'Go to latest',
@@ -514,6 +516,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.emptyHint': 'Inizia una conversazione qui sotto',
     'detail.composerPlaceholder': 'Prompt, o / per i comandi',
     'detail.externalSession': 'Da un altro client; inviando la continui qui',
+    'detail.externalShort': 'esterna',
     'detail.waiting': 'Attesa...',
     'detail.send': 'Invia',
     'detail.jumpToLatest': 'Vai alla fine',
@@ -727,6 +730,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.emptyHint': '在下方開始對話',
     'detail.composerPlaceholder': '輸入提示，或以 / 下命令',
     'detail.externalSession': '來自其他用戶端；傳送後將在此繼續',
+    'detail.externalShort': '外部',
     'detail.waiting': '等待中...',
     'detail.send': '傳送',
     'detail.jumpToLatest': '前往最新',

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1815,21 +1815,7 @@ button.compact {
   line-height: 1;
 }
 
-/* Full opacity is the default: dimming it is a hover affordance, and a finger never hovers. */
-.detail-title-row .btn-icon {
-  transition: opacity 0.15s;
-}
 
-@media (hover: hover) {
-  .detail-title-row .btn-icon {
-    opacity: 0.6;
-  }
-
-  .detail-title-row:hover .btn-icon,
-  .detail-title-row .btn-icon:focus-visible {
-    opacity: 1;
-  }
-}
 
 @media (prefers-reduced-motion: reduce) {
   *,
@@ -1980,4 +1966,90 @@ button.compact {
 .empty-state-actions button {
   flex: 1 1 auto;
   min-width: 8.5rem;
+}
+
+/* The detail subline carried a full absolute path and a timestamp with seconds, wrapping to
+   three lines. The path is shortened, the whole line truncates, and the external marker moved
+   here from below the messages where the sticky composer cut it in half. */
+.detail-subline {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  margin-top: var(--space-1);
+}
+
+.detail-subline-path {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.82rem;
+}
+
+.external-pill {
+  flex: 0 0 auto;
+  color: var(--muted-strong);
+  background: var(--surface-strong);
+}
+
+/* Rename was a 14px pencil in a 37x44 button placed with an inline style, and an editor with two
+   unlabelled glyphs. The title carries the action now, so the target is the width of the title. */
+.session-title-button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  min-height: 44px;
+  max-width: 100%;
+  padding: 0 var(--space-2) 0 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+}
+
+.session-title-button:hover:not(:disabled),
+.session-title-button:active:not(:disabled) {
+  border-color: transparent;
+  box-shadow: none;
+  transform: none;
+}
+
+.session-title-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-title-pencil {
+  flex: 0 0 auto;
+  color: var(--muted);
+}
+
+@media (hover: hover) {
+  .session-title-button:hover .session-title-pencil {
+    color: var(--primary);
+  }
+}
+
+.rename-inline {
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  width: 100%;
+}
+
+.rename-inline .rename-input {
+  flex: 1 1 10rem;
+}
+
+.rename-save {
+  flex: 0 0 auto;
+}
+
+/* An icon-only button still needs a thumb-sized box, not just a thumb-sized height. */
+button.btn-icon.compact {
+  min-width: 44px;
 }

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -142,7 +142,13 @@ for (const capability of ['agents', 'models', 'todos', 'diff', 'questions', 'ses
 assert.ok(app.includes('const showStopAction = isWorking && !composer.trim()'), 'stop should be offered only when there is nothing to send')
 assert.equal(app.includes('disabled={!selectedSession || isWorking}'), false, 'the composer must stay usable while the agent works')
 assert.ok(app.includes("authoritativeExternalHistory || assistantPayloadLength(current) <= assistantPayloadLength(msg)"), "external OMP history must replace stale cached ordering even when the corrected payload is shorter")
-assert.ok(app.includes("selectedSession?.external"), "sessions from another client should explain that sending continues them here")
+// The marker moved from below the messages, where the sticky composer cut it in half, into the
+// header. What matters is that an external session is still marked and still explained, not where.
+assert.ok(app.includes("selectedSession.external && ("), "a session from another client must be marked as such")
+assert.ok(
+  app.includes("title={t('detail.externalSession')}") && app.includes("t('detail.externalShort')"),
+  "the marker must still carry the explanation that sending continues the session here"
+)
 assert.equal(app.includes("disabled={!selectedSession || selectedSession.external}"), false, "external sessions must remain writable")
 assert.ok(app.includes('onClick={showStopAction ? abortSession : send}'), 'the action button should send a queued follow-up instead of only stopping')
 
@@ -196,7 +202,15 @@ assert.ok(app.includes('<p title={session.directory}>{shortDirectory(session.dir
 assert.equal(app.includes("t('sessions.noFileChanges')"), false, 'absence of changes needs no line of its own on a phone')
 
 // Hover is not a state a finger can produce.
-assert.match(styles, /@media \(hover: hover\)[\s\S]*?\.detail-title-row \.btn-icon/, 'a hover-only affordance must not leave a control dimmed on touch')
+// The defect was a control left at 60% opacity until hovered, a state a finger cannot produce.
+// What must hold is that hover-dependent styling is behind a hover query, and that nothing
+// interactive is dimmed by default. Disabled controls and the typing animation are not that.
+assert.ok(styles.includes('@media (hover: hover)'), 'hover-dependent styling must be behind a hover query')
+const dimmedOutsideHover = styles
+  .split('@media (hover: hover)')[0]
+  .match(/opacity: 0\.\d+/g)
+  ?.filter((rule) => rule !== 'opacity: 0.45' && rule !== 'opacity: 0.35') ?? []
+assert.deepEqual(dimmedOutsideHover, [], 'no interactive control should start dimmed on a touch device')
 assert.ok(styles.includes('-webkit-tap-highlight-color: transparent'), 'the platform tap flash should not fight the pressed state')
 assert.ok(styles.includes('overscroll-behavior: contain'), 'scrolling to the end of a list should not drag the page')
 assert.match(styles, /button\.compact \{[\s\S]*?min-height: 44px/, 'a compact button is still a thumb target')


### PR DESCRIPTION
Prompted by a fair correction: I had been measuring the sessions list and not the view actually on screen. Two defects in the session detail, plus the rename affordance.

## The header repeated the mistake I had just fixed

It still carried the full absolute path and a timestamp with seconds.

| | before | after |
|---|---|---|
| header height | 107px | **56px** |
| path | 114 chars, three lines | `…/scratchpad/ompproj`, one line, full value in `title` |

## Half a sentence behind the composer

The note explaining that a session came from another client sat below the messages at y=631–649, while the sticky composer starts at y=642. **Eight of its nineteen pixels were behind the composer**, so it read as half a sentence — exactly as reported.

It is now a pill in the header, with the full explanation as its `title`. Verified: nothing crosses under the composer any more.

## Rename was a 14px glyph in a lopsided button

Measured: **37×44**, not square, at 60% opacity, positioned with an inline `style` inside an `<h2>`, holding a 14px icon.

| | before | after |
|---|---|---|
| rename target | 37×44 (the pencil) | **142×44** (the title itself) |
| icon | 14px, as the target | 18px, as the hint |
| placement | inline style in an `<h2>` | a real button with its own class |

Tapping the title is both the larger target and the more discoverable one; the pencil now only says the title can be edited, and tints on hover where hovering exists.

**The editor** asked which of two unlabelled 14px glyphs commits. Save is labelled and **disabled until the name actually changes**, so a no-op rename is not offered; cancel is a square icon button with an accessible name. The input already focused and selected its text, which is kept.

Also: an icon-only button had a 44px height but a 41px width. It is square now.

## Two assertions rewritten rather than satisfied

Both pinned the shape of the code instead of what it guarantees — the trap `CONTRIBUTING.md` warns about, and it caught me:

- one required `selectedSession?.external` verbatim; what matters is that an external session stays marked and explained, wherever the marker lives;
- one required a hover block that no longer exists; it now asserts that no interactive control starts dimmed on a touch device, which was the actual defect.

Web 6/6, bridge 43/43, build clean. All measurements taken at 375×812.

## Still open, with numbers

On OpenCode each session card carries two always-visible buttons, Rename and Delete, 142×47 each — 46px per card, and a destructive action permanently one tap from the target that opens the session. I would move both behind a single overflow control opening the sheet pattern the app already has. That is a new interaction rather than a tidy-up, so it is not in here.