### PR TITLE
Say what an external session is instead of tagging it

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3075,9 +3075,10 @@ function App() {
                 <p className="subtle detail-subline" title={selectedSession.directory}>
                   <span className="detail-subline-path">{shortDirectory(selectedSession.directory)}</span>
                   {/* Moved up from between the messages and the composer, where the sticky
-                      composer covered half of it. */}
+                      composer covered half of it. Written out rather than tagged: a one-word
+                      label needed a tooltip to be understood, and touch has no tooltip. */}
                   {selectedSession.external && (
-                    <span className="pill external-pill" title={t('detail.externalSession')}>{t('detail.externalShort')}</span>
+                    <span className="detail-subline-note">{t('detail.externalSession')}</span>
                   )}
                 </p>
                 )}

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -87,7 +87,6 @@ type TranslationKey =
   | 'detail.emptyHint'
   | 'detail.composerPlaceholder'
   | 'detail.externalSession'
-  | 'detail.externalShort'
   | 'detail.waiting'
   | 'detail.send'
   | 'detail.jumpToLatest'
@@ -301,8 +300,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.emptyTitle': 'No messages yet',
     'detail.emptyHint': 'Start a conversation below',
     'detail.composerPlaceholder': 'Prompt, or / for commands',
-    'detail.externalSession': 'From another client; sending continues it here',
-    'detail.externalShort': 'external',
+    'detail.externalSession': 'Started by another client',
     'detail.waiting': 'Waiting...',
     'detail.send': 'Send',
     'detail.jumpToLatest': 'Go to latest',
@@ -515,8 +513,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.emptyTitle': 'Ancora nessun messaggio',
     'detail.emptyHint': 'Inizia una conversazione qui sotto',
     'detail.composerPlaceholder': 'Prompt, o / per i comandi',
-    'detail.externalSession': 'Da un altro client; inviando la continui qui',
-    'detail.externalShort': 'esterna',
+    'detail.externalSession': 'Avviata da un altro client',
     'detail.waiting': 'Attesa...',
     'detail.send': 'Invia',
     'detail.jumpToLatest': 'Vai alla fine',
@@ -729,8 +726,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.emptyTitle': '尚無訊息',
     'detail.emptyHint': '在下方開始對話',
     'detail.composerPlaceholder': '輸入提示，或以 / 下命令',
-    'detail.externalSession': '來自其他用戶端；傳送後將在此繼續',
-    'detail.externalShort': '外部',
+    'detail.externalSession': '由其他用戶端啟動',
     'detail.waiting': '等待中...',
     'detail.send': '傳送',
     'detail.jumpToLatest': '前往最新',

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1987,10 +1987,17 @@ button.compact {
   font-size: 0.82rem;
 }
 
-.external-pill {
-  flex: 0 0 auto;
-  color: var(--muted-strong);
-  background: var(--surface-strong);
+/* A word needing a tooltip is not a label. The note stands on its own, and gives way to the
+   path when there is no room for both. */
+.detail-subline-note {
+  flex: 0 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border-left: 1px solid var(--border);
+  padding-left: var(--space-2);
+  color: var(--muted);
+  font-size: 0.78rem;
 }
 
 /* Rename was a 14px pencil in a 37x44 button placed with an inline style, and an editor with two

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -146,8 +146,8 @@ assert.ok(app.includes("authoritativeExternalHistory || assistantPayloadLength(c
 // header. What matters is that an external session is still marked and still explained, not where.
 assert.ok(app.includes("selectedSession.external && ("), "a session from another client must be marked as such")
 assert.ok(
-  app.includes("title={t('detail.externalSession')}") && app.includes("t('detail.externalShort')"),
-  "the marker must still carry the explanation that sending continues the session here"
+  app.includes("t('detail.externalSession')") && !app.includes("externalShort"),
+  "the marker must read as a sentence, not a one-word tag that needs a tooltip touch cannot show"
 )
 assert.equal(app.includes("disabled={!selectedSession || selectedSession.external}"), false, "external sessions must remain writable")
 assert.ok(app.includes('onClick={showStopAction ? abortSession : send}'), 'the action button should send a queued follow-up instead of only stopping')


### PR DESCRIPTION
I had turned Gervaso's explanation into a one-word pill reading `esterna`, with the real sentence hidden in a `title` attribute — a tooltip a touch device never shows. A label that needs a tooltip has already failed, and this one did: it was unreadable on its own.

It is a sentence again, shortened to share the header line with the path: **"Avviata da un altro client"**. That is the fact worth knowing, because the bridge cannot show live status for a session another client is driving.

Measured after the change: header 48px, note not truncated, nothing cut by the composer, no horizontal overflow at 375px. The note gives way to the path when there is no room for both.

The assertion covering it asked for the tag and the tooltip. It now asks that the marker reads as a sentence and that the tag is gone.