### PR TITLE
fix: rebuild the session detail header into one compact row

### DIFF
--- a/bridge/src/server.js
+++ b/bridge/src/server.js
@@ -30,7 +30,10 @@ function applyCorsHeaders(request, response, config) {
   response.setHeader("Access-Control-Allow-Origin", origin)
   response.setHeader("Access-Control-Allow-Credentials", "true")
   response.setHeader("Access-Control-Allow-Headers", "authorization, content-type")
-  response.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+  // Rename is a PATCH and deleting a session is a DELETE. Leaving them out of the preflight
+  // answer made both fail in a browser with a bare network error, while the preflight itself
+  // still returned 204.
+  response.setHeader("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
 }
 
 function matchesCredentials(request, config) {

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -495,6 +495,13 @@ test("allows only explicitly configured browser origins", async () => {
     })
     assert.equal(foreign.headers.get("access-control-allow-origin"), null, "unlisted origins must not be granted access")
     assert.equal(foreign.status, 200)
+
+    // Renaming a session is a PATCH and deleting one is a DELETE; a preflight that omits them
+    // lets the browser fail the real request with nothing but a network error.
+    const methods = preflight.headers.get("access-control-allow-methods") ?? ""
+    for (const method of ["GET", "POST", "PATCH", "DELETE", "OPTIONS"]) {
+      assert.ok(methods.includes(method), `${method} must be allowed for browser clients, got "${methods}"`)
+    }
   } finally {
     await bridge.close()
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,6 +31,7 @@ import {
   LoadingIcon,
   RefreshIcon,
   OfflineIcon,
+  ChevronLeftIcon,
   PencilIcon,
   CloseIcon
 } from "./Icons"
@@ -1502,6 +1503,7 @@ function App() {
     () => sessions.find((session) => session.id === selectedID) ?? null,
     [sessions, selectedID]
   )
+  const isRenamingSelected = Boolean(selectedSession && renamingSessionID === selectedSession.id)
   const projectPath = projectDashboard?.project
     ? pickString(projectDashboard.project.path) || pickString(projectDashboard.project.directory) || pickString(projectDashboard.project.root)
     : null
@@ -2987,67 +2989,73 @@ function App() {
 
       {view === "detail" && (
         <main className="panel detail fade-in">
-          <div className="detail-topbar">
-            <button className="btn-secondary" onClick={() => {
-              setView("sessions");
-              requestAnimationFrame(() => document.querySelector<HTMLElement>(".session-card.active")?.scrollIntoView({ block: "center" }));
-            }}>{t('detail.backToSessions')}</button>
-            {selectedSession && (
-              <span className={`pill ${selectedSession.status}`}>{selectedSession.status}</span>
-            )}
-          </div>
-          <div className="header-row detail-header">
-              <div>
-              <h2>
-                {selectedSession ? (
-                  <div className="detail-title-row">
-                    <ChatIcon size={24} className="icon-inline-heading" />
-                    {renamingSessionID === selectedSession.id ? (
-                      <div className="rename-inline">
-                        <input
-                          ref={renameInputRef}
-                          value={renameValue}
-                          onChange={(event) => setRenameValue(event.target.value)}
-                          onKeyDown={(event) => {
-                            if (event.key === "Enter") {
-                              event.preventDefault()
-                              renameSession(selectedSession.id, renameValue, selectedSession.directory).catch(() => undefined)
-                            } else if (event.key === "Escape") {
-                              cancelRename()
-                            }
-                          }}
-                          onBlur={() => {
-                            if (renameValue === selectedSession.title || !renameValue.trim()) {
-                              cancelRename()
-                            }
-                          }}
-                          placeholder={t('session.renamePlaceholder')}
-                          className="rename-input"
-                          autoComplete="off"
-                        />
-                        {/* Two unlabelled 14px glyphs asked the user to guess which one commits.
-                            One labelled primary action, and cancel as the quieter icon. */}
-                        <button
-                          className="btn-primary compact rename-save"
-                          onClick={() => renameSession(selectedSession.id, renameValue, selectedSession.directory).catch(() => undefined)}
-                          onMouseDown={(event) => event.preventDefault()}
-                          disabled={!renameValue.trim() || renameValue === selectedSession.title}
-                        >
-                          <SaveIcon size={16} />
-                          {t('session.renameConfirm')}
-                        </button>
-                        <button
-                          className="btn-icon btn-secondary compact"
-                          onClick={() => cancelRename()}
-                          onMouseDown={(event) => event.preventDefault()}
-                          title={t('session.cancel')}
-                          aria-label={t('session.cancel')}
-                        >
-                          <CloseIcon size={18} />
-                        </button>
-                      </div>
-                    ) : (
-                      <>
+          {/* Back, title and status used to be three stacked blocks costing 155px of chrome above
+              a 251px conversation. One row carries all three; the path keeps the second line. */}
+          <div className="detail-headline">
+            {selectedSession && isRenamingSelected ? (
+              /* Renaming takes over the row. Sharing it with the back button and the status pill
+                 left the field 214px wide and pushed its own buttons onto a second line. */
+              <div className="rename-inline">
+                <input
+                  ref={renameInputRef}
+                  value={renameValue}
+                  onChange={(event) => setRenameValue(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault()
+                      renameSession(selectedSession.id, renameValue, selectedSession.directory).catch(() => undefined)
+                    } else if (event.key === "Escape") {
+                      cancelRename()
+                    }
+                  }}
+                  onBlur={() => {
+                    if (renameValue === selectedSession.title || !renameValue.trim()) {
+                      cancelRename()
+                    }
+                  }}
+                  placeholder={t('session.renamePlaceholder')}
+                  className="rename-input"
+                  autoComplete="off"
+                />
+                {/* Two unlabelled 14px glyphs asked the user to guess which one commits.
+                    One labelled primary action, and cancel as the quieter icon. */}
+                <button
+                  className="btn-primary compact rename-save"
+                  onClick={() => renameSession(selectedSession.id, renameValue, selectedSession.directory).catch(() => undefined)}
+                  onMouseDown={(event) => event.preventDefault()}
+                  disabled={!renameValue.trim() || renameValue === selectedSession.title}
+                >
+                  <SaveIcon size={16} />
+                  {t('session.renameConfirm')}
+                </button>
+                <button
+                  className="btn-icon btn-secondary compact"
+                  onClick={() => cancelRename()}
+                  onMouseDown={(event) => event.preventDefault()}
+                  title={t('session.cancel')}
+                  aria-label={t('session.cancel')}
+                >
+                  <CloseIcon size={18} />
+                </button>
+              </div>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  className="btn-icon btn-secondary compact detail-back"
+                  title={t('detail.backToSessions')}
+                  aria-label={t('detail.backToSessions')}
+                  onClick={() => {
+                    setView("sessions");
+                    requestAnimationFrame(() => document.querySelector<HTMLElement>(".session-card.active")?.scrollIntoView({ block: "center" }));
+                  }}
+                >
+                  <ChevronLeftIcon size={20} />
+                </button>
+                <div className="detail-headline-main">
+                  <h2>
+                    {selectedSession ? (
+                      <div className="detail-title-row">
                         {/* A 14px glyph is a poor target and a poor hint. The title itself is the
                             button; the pencil only says that it can be edited. */}
                         {capabilities.sessionRename ? (
@@ -3064,26 +3072,23 @@ function App() {
                         ) : (
                           <span className="session-title-text">{selectedSession.title}</span>
                         )}
-                      </>
+                      </div>
+                    ) : (
+                      t('detail.selectSession')
                     )}
-                  </div>
-                ) : (
-                  t('detail.selectSession')
-                )}
-              </h2>
-              {selectedSession && (
-                <p className="subtle detail-subline" title={selectedSession.directory}>
-                  <span className="detail-subline-path">{shortDirectory(selectedSession.directory)}</span>
-                  {/* Moved up from between the messages and the composer, where the sticky
-                      composer covered half of it. Written out rather than tagged: a one-word
-                      label needed a tooltip to be understood, and touch has no tooltip. */}
-                  {selectedSession.external && (
-                    <span className="detail-subline-note">{t('detail.externalSession')}</span>
+                  </h2>
+                  {selectedSession && (
+                    <p className="subtle detail-subline" title={selectedSession.directory}>
+                      <span className="detail-subline-path">{shortDirectory(selectedSession.directory)}</span>
+                    </p>
                   )}
-                </p>
+                </div>
+                {selectedSession && (
+                  <span className={`pill ${selectedSession.status}`}>{selectedSession.status}</span>
                 )}
-              </div>
-            </div>
+              </>
+            )}
+          </div>
 
           {selectedSession && (
             <section className="session-context-strip" aria-label={t('detail.contextStripLabel')}>

--- a/web/src/Icons.tsx
+++ b/web/src/Icons.tsx
@@ -428,3 +428,21 @@ export const OfflineIcon = ({ className = "", size = 20 }: { className?: string;
     <path d="M12 20h.01" />
   </svg>
 )
+
+export const ChevronLeftIcon = ({ className = "", size = 20 }: { className?: string; size?: number }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    role="img"
+    aria-label="Back"
+  >
+    <path d="M15 18l-6-6 6-6" />
+  </svg>
+)

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -86,7 +86,6 @@ type TranslationKey =
   | 'detail.emptyTitle'
   | 'detail.emptyHint'
   | 'detail.composerPlaceholder'
-  | 'detail.externalSession'
   | 'detail.waiting'
   | 'detail.send'
   | 'detail.jumpToLatest'
@@ -300,7 +299,6 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.emptyTitle': 'No messages yet',
     'detail.emptyHint': 'Start a conversation below',
     'detail.composerPlaceholder': 'Prompt, or / for commands',
-    'detail.externalSession': 'Started by another client',
     'detail.waiting': 'Waiting...',
     'detail.send': 'Send',
     'detail.jumpToLatest': 'Go to latest',
@@ -513,7 +511,6 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.emptyTitle': 'Ancora nessun messaggio',
     'detail.emptyHint': 'Inizia una conversazione qui sotto',
     'detail.composerPlaceholder': 'Prompt, o / per i comandi',
-    'detail.externalSession': 'Avviata da un altro client',
     'detail.waiting': 'Attesa...',
     'detail.send': 'Invia',
     'detail.jumpToLatest': 'Vai alla fine',
@@ -726,7 +723,6 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.emptyTitle': '尚無訊息',
     'detail.emptyHint': '在下方開始對話',
     'detail.composerPlaceholder': '輸入提示，或以 / 下命令',
-    'detail.externalSession': '由其他用戶端啟動',
     'detail.waiting': '等待中...',
     'detail.send': '傳送',
     'detail.jumpToLatest': '前往最新',

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -581,23 +581,6 @@ p {
   flex-direction: column;
 }
 
-.detail-topbar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
-  margin-bottom: var(--space-3);
-}
-
-.detail-header {
-  margin-bottom: var(--space-3);
-}
-
-.detail-header h2 {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-}
 
 .icon-inline-heading {
   flex: 0 0 auto;
@@ -617,8 +600,7 @@ p {
   display: flex;
   gap: var(--space-2);
   overflow-x: auto;
-  padding: 0 0 var(--space-3);
-  margin-bottom: var(--space-2);
+  padding: 0 0 var(--space-2);
   scrollbar-width: none;
 }
 
@@ -629,7 +611,9 @@ p {
 .context-chip {
   flex: 1 1 0;
   min-width: 118px;
-  min-height: 58px;
+  /* 46px keeps the chip a comfortable tap target without spending a sixth of the
+     conversation's vertical space on two words. */
+  min-height: 46px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -639,7 +623,7 @@ p {
   border-radius: var(--radius-lg);
   background: var(--surface-subtle);
   color: var(--text);
-  padding: var(--space-2) var(--space-3);
+  padding: var(--space-1) var(--space-3);
   text-align: left;
 }
 
@@ -661,6 +645,14 @@ p {
 
 .context-chip.ghost {
   background: var(--surface);
+}
+
+/* Chips share the row when there are several, so their values truncate instead of
+   scrolling the strip. A lone chip has nothing to share with and reads as an empty
+   banner when stretched, so it takes only the width it needs. */
+.session-context-strip .context-chip:only-child {
+  flex: 0 1 auto;
+  max-width: 100%;
 }
 
 .project-dashboard {
@@ -1680,14 +1672,6 @@ button.compact {
     min-height: calc(100dvh - 158px);
   }
 
-  .detail-topbar {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .detail-topbar .pill {
-    align-self: flex-start;
-  }
 
   .messages {
     min-height: 240px;
@@ -1794,10 +1778,14 @@ button.compact {
   box-shadow: 0 0 0 2px var(--primary-soft);
 }
 
+/* A flex item defaults to min-width: auto, which refuses to shrink below its content — so a long
+   title pushed this row past its parent and out to the right instead of ellipsising. */
 .detail-title-row {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .detail-title-row .rename-input {
@@ -1987,19 +1975,6 @@ button.compact {
   font-size: 0.82rem;
 }
 
-/* A word needing a tooltip is not a label. The note stands on its own, and gives way to the
-   path when there is no room for both. */
-.detail-subline-note {
-  flex: 0 1 auto;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  border-left: 1px solid var(--border);
-  padding-left: var(--space-2);
-  color: var(--muted);
-  font-size: 0.78rem;
-}
-
 /* Rename was a 14px pencil in a 37x44 button placed with an inline style, and an editor with two
    unlabelled glyphs. The title carries the action now, so the target is the width of the title. */
 .session-title-button {
@@ -2044,12 +2019,16 @@ button.compact {
 
 .rename-inline {
   flex-wrap: wrap;
+  justify-content: flex-end;
   gap: var(--space-2);
   width: 100%;
 }
 
+/* A labelled Save plus Cancel plus a usable input do not fit 375px on one line. Rather than
+   let the wrap fall where it may — which stranded Cancel alone on a second line — the field
+   takes the first line and both buttons sit together on the second. */
 .rename-inline .rename-input {
-  flex: 1 1 10rem;
+  flex: 1 1 100%;
 }
 
 .rename-save {
@@ -2059,4 +2038,31 @@ button.compact {
 /* An icon-only button still needs a thumb-sized box, not just a thumb-sized height. */
 button.btn-icon.compact {
   min-width: 44px;
+}
+
+/* Back, title and status were three stacked blocks: 155px of chrome above a 251px conversation.
+   One row now carries all three, with the path on a second line under the title. */
+.detail-headline {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  margin-bottom: var(--space-3);
+}
+
+.detail-headline-main {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.detail-headline-main h2 {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  font-size: 1.05rem;
+}
+
+.detail-headline .pill,
+.detail-back {
+  flex: 0 0 auto;
 }

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -142,13 +142,9 @@ for (const capability of ['agents', 'models', 'todos', 'diff', 'questions', 'ses
 assert.ok(app.includes('const showStopAction = isWorking && !composer.trim()'), 'stop should be offered only when there is nothing to send')
 assert.equal(app.includes('disabled={!selectedSession || isWorking}'), false, 'the composer must stay usable while the agent works')
 assert.ok(app.includes("authoritativeExternalHistory || assistantPayloadLength(current) <= assistantPayloadLength(msg)"), "external OMP history must replace stale cached ordering even when the corrected payload is shorter")
-// The marker moved from below the messages, where the sticky composer cut it in half, into the
-// header. What matters is that an external session is still marked and still explained, not where.
-assert.ok(app.includes("selectedSession.external && ("), "a session from another client must be marked as such")
-assert.ok(
-  app.includes("t('detail.externalSession')") && !app.includes("externalShort"),
-  "the marker must read as a sentence, not a one-word tag that needs a tooltip touch cannot show"
-)
+// Whether a session was started here or by another client changes nothing the user can act on,
+// so it is no longer surfaced. The `external` flag still drives how history is loaded.
+assert.equal(app.includes("detail.externalSession"), false, 'an unactionable distinction should not be shown')
 assert.equal(app.includes("disabled={!selectedSession || selectedSession.external}"), false, "external sessions must remain writable")
 assert.ok(app.includes('onClick={showStopAction ? abortSession : send}'), 'the action button should send a queued follow-up instead of only stopping')
 
@@ -230,5 +226,30 @@ assert.ok(
 assert.ok(app.includes("t('sessions.retry')"), 'an offline state should offer a way out')
 assert.ok(app.includes('disabled={creatingSession || isOffline}'), 'an action that cannot succeed offline must not be offered')
 assert.ok(styles.includes('.empty-state-actions'), 'the offline actions should be styled')
+
+// The session screen opened with the status pill on one line, a decorative icon on the next and
+// the title on a third: 227px of chrome above 251px of conversation. Back, title and status
+// belong on one row.
+assert.equal(app.includes('detail-topbar'), false, 'back and status must not occupy a row of their own')
+assert.equal(styles.includes('.detail-topbar'), false, 'the stacked topbar rules should go with it')
+assert.equal(app.includes('<ChatIcon size={24} className="icon-inline-heading" />'), false, 'the session heading should not spend a line on decoration')
+const headlineBlock = app.slice(app.indexOf('className="detail-headline"'), app.indexOf('session-context-strip'))
+assert.ok(headlineBlock.includes('pill ${selectedSession.status}'), 'the status pill belongs on the headline row')
+assert.ok(headlineBlock.includes('session-title-button') && headlineBlock.includes('detail-back'), 'back and title belong on the headline row too')
+
+// Renaming nested inside the title left the field 214px wide and stranded Cancel alone on a
+// second line, so the form replaces the row rather than living inside it.
+assert.ok(headlineBlock.includes('isRenamingSelected ? ('), 'renaming should be a branch of the headline row')
+const headingBlock = headlineBlock.slice(headlineBlock.indexOf('<h2>'), headlineBlock.indexOf('</h2>'))
+assert.ok(headingBlock, 'the headline should still carry the session title')
+assert.equal(headingBlock.includes('rename-input'), false, 'the rename field must not be nested inside the title')
+assert.match(styles, /\.rename-inline \.rename-input \{[\s\S]*?flex: 1 1 100%/, 'the rename field should own its line so the buttons stay together')
+
+// A flex item will not shrink below its content unless told to, so a long title used to widen the
+// row past its parent and slide out to the right instead of ellipsising.
+assert.match(styles, /\.detail-title-row \{[\s\S]*?min-width: 0/, 'a long title must be allowed to truncate')
+
+// One chip stretched to full width reads as an empty banner; several must still share the row.
+assert.match(styles, /\.context-chip:only-child \{[\s\S]*?flex: 0 1 auto/, 'a lone context chip should take only the width it needs')
 
 console.log('ui regression tests passed')


### PR DESCRIPTION
## The problem

Opening a session, the top of the screen was three stacked blocks: the status pill on one line, the chat icon on the next, the title on the third. Measured at 375×812: **227px of chrome above 251px of conversation**.

```
y=101  h= 87  detail-topbar        ← Sessions | IDLE   (flex-direction: column on mobile)
y=200  h= 68  detail-header
y=280  h= 72  session-context-strip
y=360  h=251  messages-wrap
```

## What changes

- Back (a 44×44 chevron), title and status on **one row**; the shortened path on a second line.
- The decorative icon next to the title is gone: it cost a line, plus 24px of width taken from a title that already has to truncate.
- The context chip drops from 58px to 46px of minimum height, and a lone chip no longer stretches to full width — it read as an empty banner.
- Chrome **128px**, conversation **370px** (+47%).

```
y=101  h= 68  detail-headline      ‹ | model check ✎ | IDLE
y=181  h= 60  session-context-strip
y=241  h=370  messages-wrap
```

- Renaming used to happen inside that row, which left the field 214px wide and stranded Cancel alone on a second line. It now takes over the row while it is open: full-width field, Save and Cancel together on the right.
- A long title could widen the row past its parent and slide out to the right (844px inside a 317px parent): a flex item will not shrink below its content unless told to.

## Also: CORS

The preflight answered `Access-Control-Allow-Methods: GET, POST, OPTIONS`. Renaming (PATCH) and deleting (DELETE) a session failed in a browser with a bare `net::ERR_FAILED`, even though the preflight itself returned 204. Both are allowed now, with an assertion covering it.

## Verification

- web: clean build and typecheck, 3/3 regression suites
- bridge: 43/43
- measured at 375×812 and 1280: no horizontal overflow, long title truncates, Escape leaves the rename, back and pill return to their place