### PR TITLE
feat: desktop mode

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -512,6 +512,51 @@ function Modal({
   )
 }
 
+/** Wraps children with `wrapper(children)` only when `condition` holds, otherwise renders children
+ *  as-is. Lets a panel's body be written once and reused unmodified in both its mobile inline form
+ *  and its desktop modal form. */
+function ConditionalWrapper({
+  condition,
+  wrapper,
+  children
+}: {
+  condition: boolean
+  wrapper: (children: ReactNode) => ReactNode
+  children: ReactNode
+}) {
+  return <>{condition ? wrapper(children) : children}</>
+}
+
+/** Desktop-only modal shell for panels (settings, help) that already render their own heading —
+ *  unlike Modal, it has no title bar of its own, just a close affordance, so the panel's existing
+ *  content isn't duplicated under a second title. */
+function DesktopModalOverlay({
+  onClose,
+  ariaLabel,
+  children
+}: {
+  onClose: () => void
+  ariaLabel: string
+  children: ReactNode
+}) {
+  return (
+    <div className="modal-backdrop" role="presentation" onClick={onClose}>
+      <section
+        className="modal-card desktop-panel-modal fade-in"
+        role="dialog"
+        aria-modal="true"
+        aria-label={ariaLabel}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <button type="button" className="btn-secondary desktop-modal-close" onClick={onClose} aria-label={ariaLabel}>
+          <CloseIcon size={16} />
+        </button>
+        {children}
+      </section>
+    </div>
+  )
+}
+
 function QuestionCard({
   config,
   directory,
@@ -1435,6 +1480,18 @@ function App() {
   const [view, setView] = useState<"settings" | "sessions" | "detail" | "help">(() => {
     return config.host && config.port > 0 ? "sessions" : "settings"
   })
+  // Desktop gets a persistent left sidebar instead of the mobile top bar/bottom nav; this mirrors
+  // the existing 780px CSS breakpoint so JS layout and stylesheet layout never disagree.
+  const [isDesktop, setIsDesktop] = useState(() => window.matchMedia("(min-width: 781px)").matches)
+  useEffect(() => {
+    const query = window.matchMedia("(min-width: 781px)")
+    const onChange = (event: MediaQueryListEvent) => setIsDesktop(event.matches)
+    query.addEventListener("change", onChange)
+    return () => query.removeEventListener("change", onChange)
+  }, [])
+  // On desktop the sidebar always shows sessions, so the main pane falls back to the chat view
+  // instead of duplicating the session list there.
+  const mainView = isDesktop && view === "sessions" ? "detail" : view
 
   const [sessions, setSessions] = useState<SessionView[]>([])
   const [selectedID, setSelectedID] = useState<string | null>(null)
@@ -2516,6 +2573,128 @@ function App() {
     wasRunningRef.current = ["busy", "retry"].includes(selectedSession.status)
   }, [selectedSession?.id, selectedSession?.status])
 
+  // Shared between the mobile sessions panel and the desktop sidebar so both list sessions
+  // identically instead of maintaining two copies of this markup.
+  const renderSessionCard = (session: SessionView) => (
+    <article
+      key={session.id}
+      className={`session-card ${session.status} ${selectedID === session.id ? "active" : ""} fade-in`}
+      onClick={() => openSession(session.id, session.directory).catch(() => undefined)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault()
+          openSession(session.id, session.directory).catch(() => undefined)
+        }
+      }}
+    >
+      <div className="session-card-main">
+        <div>
+          {renamingSessionID === session.id ? (
+            <div
+              className="rename-inline"
+              onClick={(event) => event.stopPropagation()}
+              onMouseDown={(event) => event.stopPropagation()}
+            >
+              <input
+                ref={renameInputRef}
+                value={renameValue}
+                onChange={(event) => setRenameValue(event.target.value)}
+                onKeyDown={(event) => {
+                  event.stopPropagation()
+                  if (event.key === "Enter") {
+                    event.preventDefault()
+                    renameSession(session.id, renameValue, session.directory).catch(() => undefined)
+                  } else if (event.key === "Escape") {
+                    cancelRename()
+                  }
+                }}
+                onBlur={() => {
+                  // Only cancel if not clicked on save button
+                  if (renameValue === session.title || !renameValue.trim()) {
+                    cancelRename()
+                  }
+                }}
+                placeholder={t('session.renamePlaceholder')}
+                enterKeyHint="done"
+                autoCorrect="off"
+                spellCheck={false}
+                className="rename-input"
+                autoComplete="off"
+              />
+              <button
+                className="btn-primary compact"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  renameSession(session.id, renameValue, session.directory).catch(() => undefined)
+                }}
+                onMouseDown={(event) => event.preventDefault()}
+                title={t('session.renameConfirm')}
+              >
+                <SaveIcon size={14} />
+              </button>
+              <button
+                className="btn-secondary compact"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  cancelRename()
+                }}
+                title={t('session.cancel')}
+              >
+                <CloseIcon size={14} />
+              </button>
+            </div>
+          ) : (
+            <h3 title={session.title}>{session.title}</h3>
+          )}
+          <p title={session.directory}>{shortDirectory(session.directory)}</p>
+        </div>
+      </div>
+      <div className="session-stats">
+        {/* "No file changes" is said by its absence: one line fewer on a phone. */}
+        {(session.files > 0 || session.additions > 0 || session.deletions > 0) && (
+          <span className="change-summary">
+            <strong>{session.files}</strong> files
+            <strong className="positive">+{session.additions}</strong>
+            <strong className="negative">-{session.deletions}</strong>
+          </span>
+        )}
+        <span className="subtle">{t('sessions.updated', { time: formatTime(session.updated) })}</span>
+        <span className={`pill ${session.status}`}>{session.status}</span>
+      </div>
+      <div className="inline-actions">
+        {capabilities.sessionRename && capabilities.sessionDelete && (
+          <>
+            <button
+              className="btn-secondary"
+              onClick={(event) => {
+                event.stopPropagation()
+                startRename(session)
+              }}
+              title={t('session.renameTitle')}
+              aria-label={t('session.renameTitle')}
+            >
+              <PencilIcon size={16} />
+              {t('session.renameConfirm')}
+            </button>
+            <button
+              className="btn-danger"
+              onClick={(event) => {
+                event.stopPropagation()
+                setSessionToDelete(session)
+              }}
+              title={t('sessions.delete')}
+            >
+              <TrashIcon size={16} />
+              {t('sessions.delete')}
+            </button>
+          </>
+        )}
+      </div>
+    </article>
+  )
+
   const navItems = [
     { view: "sessions" as const, label: t('nav.sessions'), icon: <FolderIcon size={19} />, disabled: !hasConfiguredServer },
     { view: "detail" as const, label: t('nav.detail'), icon: <ChatIcon size={19} />, disabled: !selectedSession },
@@ -2524,15 +2703,36 @@ function App() {
   ]
 
   return (
-    <div className="app-shell">
-      <header className="top-nav fade-in">
-        <div className="brand-section">
-          <div className="brand-title">
+    <div className={`app-shell${isDesktop ? " app-shell-desktop" : ""}`}>
+      {!isDesktop && (
+        <header className="top-nav fade-in">
+          <div className="brand-section">
+            <div className="brand-title">
+              <img src="/app-icon.png" alt="" className="app-icon" />
+              <div className="brand-text">
+                <h1>{t('app.title')}</h1>
+                {/* The harness matters more than the address: the same host can serve a different
+                    one, and every backend-specific limitation follows from which it is. */}
+                <p className="brand-meta">
+                  <span className={`harness-badge harness-${config.backend}`}>
+                    {backendDisplayName(config.backend)}
+                  </span>
+                  <span className="brand-server">
+                    {hasConfiguredServer ? `${config.host}:${config.port}` : t('settings.title')}
+                  </span>
+                </p>
+              </div>
+            </div>
+          </div>
+        </header>
+      )}
+
+      {isDesktop && (
+        <aside className="desktop-sidebar fade-in">
+          <div className="sidebar-brand">
             <img src="/app-icon.png" alt="" className="app-icon" />
             <div className="brand-text">
               <h1>{t('app.title')}</h1>
-              {/* The harness matters more than the address: the same host can serve a different
-                  one, and every backend-specific limitation follows from which it is. */}
               <p className="brand-meta">
                 <span className={`harness-badge harness-${config.backend}`}>
                   {backendDisplayName(config.backend)}
@@ -2543,25 +2743,67 @@ function App() {
               </p>
             </div>
           </div>
-        </div>
 
-        <nav className="desktop-nav tab-row" role="navigation" aria-label="Main navigation">
-          {navItems.map((item) => (
+          <div className="sidebar-toolbar">
+            <input
+              placeholder={t('sessions.searchPlaceholder')}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              className="search"
+            />
             <button
-              key={item.view}
-              className={view === item.view ? "active" : ""}
-              onClick={() => setView(item.view)}
-              disabled={item.disabled}
-              aria-label={item.label}
+              onClick={refreshSessionsWithIndicator}
+              className="btn-secondary"
+              disabled={refreshingSessions}
+              aria-label={t('sessions.refresh')}
+              title={t('sessions.refresh')}
             >
-              {item.icon}
-              <span>{item.label}</span>
+              {refreshingSessions ? <LoadingIcon size={16} /> : <RefreshIcon size={16} />}
             </button>
-          ))}
-        </nav>
-      </header>
+            <button
+              onClick={openNewSessionPicker}
+              className="btn-primary"
+              disabled={creatingSession || isOffline}
+              aria-label={t('sessions.new')}
+              title={isOffline ? t('sessions.offlineHint') : t('sessions.new')}
+            >
+              {creatingSession ? <LoadingIcon size={16} /> : <PlusIcon size={16} />}
+            </button>
+          </div>
 
-      {view === "settings" && (
+          <div className="sidebar-sessions">
+            {filteredSessions.length === 0 ? (
+              <p className="subtle sidebar-empty">
+                {isOffline ? t('sessions.offlineHint') : t('sessions.emptyTitle')}
+              </p>
+            ) : (
+              filteredSessions.map(renderSessionCard)
+            )}
+          </div>
+
+          <div className="sidebar-footer">
+            <button type="button" className="btn-secondary" onClick={() => setView("help")}>
+              <HelpIcon size={18} />
+              {t('nav.help')}
+            </button>
+            <button type="button" className="btn-secondary" onClick={() => setView("settings")}>
+              <SettingsIcon size={18} />
+              {t('nav.settings')}
+            </button>
+          </div>
+        </aside>
+      )}
+
+      <div className="main-content">
+      {mainView === "settings" && (
+        <ConditionalWrapper
+          condition={isDesktop}
+          wrapper={(children) => (
+            <DesktopModalOverlay onClose={() => setView("detail")} ariaLabel={t('settings.title')}>
+              {children}
+            </DesktopModalOverlay>
+          )}
+        >
         <section className="panel settings fade-in">
           <div className="section-heading">
             <div>
@@ -2710,9 +2952,10 @@ function App() {
             </div>
           )}
         </section>
+        </ConditionalWrapper>
       )}
 
-      {view === "sessions" && (
+      {mainView === "sessions" && (
         <section className="panel sessions fade-in">
           <div className="section-heading">
             <div>
@@ -2799,128 +3042,10 @@ function App() {
                 <p className="subtle">{t('sessions.emptyHint')}</p>
               </div>
             ) : (
-              filteredSessions.map((session) => (
-                <article 
-                  key={session.id} 
-                  className={`session-card ${selectedID === session.id ? "active" : ""} fade-in`}
-                  onClick={() => openSession(session.id, session.directory).catch(() => undefined)}
-                  role="button"
-                  tabIndex={0}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter" || event.key === " ") {
-                      event.preventDefault()
-                      openSession(session.id, session.directory).catch(() => undefined)
-                    }
-                  }}
-                >
-                  <div className="session-card-main">
-                    <div>
-                      {renamingSessionID === session.id ? (
-                        <div
-                          className="rename-inline"
-                          onClick={(event) => event.stopPropagation()}
-                          onMouseDown={(event) => event.stopPropagation()}
-                        >
-                          <input
-                            ref={renameInputRef}
-                            value={renameValue}
-                            onChange={(event) => setRenameValue(event.target.value)}
-                            onKeyDown={(event) => {
-                              event.stopPropagation()
-                              if (event.key === "Enter") {
-                                event.preventDefault()
-                                renameSession(session.id, renameValue, session.directory).catch(() => undefined)
-                              } else if (event.key === "Escape") {
-                                cancelRename()
-                              }
-                            }}
-                            onBlur={() => {
-                              // Only cancel if not clicked on save button
-                              if (renameValue === session.title || !renameValue.trim()) {
-                                cancelRename()
-                              }
-                            }}
-                            placeholder={t('session.renamePlaceholder')}
-                            enterKeyHint="done"
-                            autoCorrect="off"
-                            spellCheck={false}
-                            className="rename-input"
-                            autoComplete="off"
-                          />
-                          <button
-                            className="btn-primary compact"
-                            onClick={(event) => {
-                              event.stopPropagation()
-                              renameSession(session.id, renameValue, session.directory).catch(() => undefined)
-                            }}
-                            onMouseDown={(event) => event.preventDefault()}
-                            title={t('session.renameConfirm')}
-                          >
-                            <SaveIcon size={14} />
-                          </button>
-                          <button
-                            className="btn-secondary compact"
-                            onClick={(event) => {
-                              event.stopPropagation()
-                              cancelRename()
-                            }}
-                            title={t('session.cancel')}
-                          >
-                            <CloseIcon size={14} />
-                          </button>
-                        </div>
-                      ) : (
-                        <h3>{session.title}</h3>
-                      )}
-                      <p title={session.directory}>{shortDirectory(session.directory)}</p>
-                    </div>
-                  </div>
-                  <div className="session-stats">
-                    {/* "No file changes" is said by its absence: one line fewer on a phone. */}
-                    {(session.files > 0 || session.additions > 0 || session.deletions > 0) && (
-                      <span className="change-summary">
-                        <strong>{session.files}</strong> files
-                        <strong className="positive">+{session.additions}</strong>
-                        <strong className="negative">-{session.deletions}</strong>
-                      </span>
-                    )}
-                    <span className="subtle">{t('sessions.updated', { time: formatTime(session.updated) })}</span>
-                    <span className={`pill ${session.status}`}>{session.status}</span>
-                  </div>
-                  <div className="inline-actions">
-                    {capabilities.sessionRename && capabilities.sessionDelete && (
-                      <>
-                        <button
-                          className="btn-secondary"
-                          onClick={(event) => {
-                            event.stopPropagation()
-                            startRename(session)
-                          }}
-                          title={t('session.renameTitle')}
-                          aria-label={t('session.renameTitle')}
-                        >
-                          <PencilIcon size={16} />
-                          {t('session.renameConfirm')}
-                        </button>
-                        <button
-                          className="btn-danger"
-                          onClick={(event) => {
-                            event.stopPropagation()
-                            setSessionToDelete(session)
-                          }}
-                          title={t('sessions.delete')}
-                        >
-                          <TrashIcon size={16} />
-                          {t('sessions.delete')}
-                        </button>
-                      </>
-                    )}
-                  </div>
-                </article>
-              ))
+              filteredSessions.map(renderSessionCard)
             )}
           </div>
-          
+
           {/* The offline empty state already explains this and offers the two useful actions;
               repeating the raw transport error underneath is the second voice again. */}
           {runtimeError && !(isOffline && filteredSessions.length === 0) && (
@@ -2985,13 +3110,15 @@ function App() {
         </div>
       )}
 
-      {view === "detail" && (
+      {mainView === "detail" && (
         <main className="panel detail fade-in">
           <div className="detail-topbar">
-            <button className="btn-secondary" onClick={() => {
-              setView("sessions");
-              requestAnimationFrame(() => document.querySelector<HTMLElement>(".session-card.active")?.scrollIntoView({ block: "center" }));
-            }}>{t('detail.backToSessions')}</button>
+            {!isDesktop && (
+              <button className="btn-secondary" onClick={() => {
+                setView("sessions");
+                requestAnimationFrame(() => document.querySelector<HTMLElement>(".session-card.active")?.scrollIntoView({ block: "center" }));
+              }}>{t('detail.backToSessions')}</button>
+            )}
             {selectedSession && (
               <span className={`pill ${selectedSession.status}`}>{selectedSession.status}</span>
             )}
@@ -3377,7 +3504,15 @@ function App() {
         </div>
       )}
 
-      {view === "help" && (
+      {mainView === "help" && (
+        <ConditionalWrapper
+          condition={isDesktop}
+          wrapper={(children) => (
+            <DesktopModalOverlay onClose={() => setView("detail")} ariaLabel={t('help.title')}>
+              {children}
+            </DesktopModalOverlay>
+          )}
+        >
         <section className="panel help fade-in">
           <h2>
             <HelpIcon size={24} className="icon-inline-heading" />
@@ -3609,7 +3744,9 @@ http://YOUR_PC_IP:4096/global/health</pre>
           )}
           {runtimeError && <p className="error">{runtimeError}</p>}
         </section>
+        </ConditionalWrapper>
       )}
+      </div>
 
       <nav className="bottom-nav" role="navigation" aria-label="Mobile navigation">
         {navItems.map((item) => (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -157,6 +157,29 @@ function formatTime(epoch: number): string {
   return new Date(epoch).toLocaleString()
 }
 
+const RELATIVE_TIME_UNITS: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+  ["year", 60 * 60 * 24 * 365],
+  ["month", 60 * 60 * 24 * 30],
+  ["week", 60 * 60 * 24 * 7],
+  ["day", 60 * 60 * 24],
+  ["hour", 60 * 60],
+  ["minute", 60]
+]
+
+/** Compact, locale-translated "13 min ago" / "13 minuti fa" style string — falls back to
+ *  "just now" (via the 0-second `second` bucket) rather than "-1 minutes ago" for very recent times. */
+function formatRelativeTime(epoch: number, locale: LanguageCode): string {
+  if (!epoch) return "-"
+  const deltaSeconds = Math.round((epoch - Date.now()) / 1000)
+  const formatter = new Intl.RelativeTimeFormat(locale, { numeric: "auto", style: "short" })
+  for (const [unit, secondsInUnit] of RELATIVE_TIME_UNITS) {
+    if (Math.abs(deltaSeconds) >= secondsInUnit) {
+      return formatter.format(Math.round(deltaSeconds / secondsInUnit), unit)
+    }
+  }
+  return formatter.format(deltaSeconds, "second")
+}
+
 function extractText(msg: MessageEnvelope): string {
   return msg.parts
     .filter((part) => part.type === "text" && part.text)
@@ -2774,7 +2797,12 @@ function App() {
             <strong className="negative">-{session.deletions}</strong>
           </span>
         )}
-        <span className="subtle">{t('sessions.updated', { time: formatTime(session.updated) })}</span>
+        <span className="subtle session-meta-line">
+          <span className="session-directory-compact" title={session.directory}>{shortDirectory(session.directory)}</span>
+          <span title={formatTime(session.updated)}>
+            {t('sessions.updated', { time: formatRelativeTime(session.updated, language) })}
+          </span>
+        </span>
         <span className={`pill ${session.status}`}>{session.status}</span>
       </div>
       <div className="inline-actions">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1692,6 +1692,16 @@ function App() {
     return modelOptions.filter((option) => modelSearchText(option).includes(text))
   }, [modelOptions, modelQuery])
 
+  // On desktop there's always a sidebar listing sessions, so an empty main pane just says
+  // "select a session" for no reason — auto-open the first one instead. Only attempted once per
+  // server connection so it doesn't fight a session the user deliberately closed back out of.
+  const autoSelectAttemptedRef = useRef(false)
+  useEffect(() => {
+    if (!isDesktop || autoSelectAttemptedRef.current || selectedID || sessions.length === 0) return
+    autoSelectAttemptedRef.current = true
+    openSession(sessions[0].id, sessions[0].directory).catch(() => undefined)
+  }, [isDesktop, selectedID, sessions])
+
   const filteredSessions = useMemo(() => {
     const text = query.trim().toLowerCase()
     if (!text) return sessions
@@ -1799,6 +1809,7 @@ function App() {
     if (serverChanged) {
       loadSelectedRequestRef.current += 1
       loadModelsRequestRef.current += 1
+      autoSelectAttemptedRef.current = false
       setSessions([])
       setSelectedID(null)
       setMessages([])

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1626,6 +1626,7 @@ function App() {
   const [lastTestedConfigKey, setLastTestedConfigKey] = useState<string | null>(null)
   const [sessionToDelete, setSessionToDelete] = useState<SessionView | null>(null)
   const [renamingSessionID, setRenamingSessionID] = useState<string | null>(null)
+  const [renameSource, setRenameSource] = useState<"list" | "header" | null>(null)
   const [renameValue, setRenameValue] = useState("")
   const renameInputRef = useRef<HTMLInputElement | null>(null)
   const [activeDetailSheet, setActiveDetailSheet] = useState<null | "ai" | "details">(null)
@@ -2346,9 +2347,15 @@ function App() {
     }
   }
 
-  function startRename(session: SessionView) {
+  // The session list (mobile panel and desktop sidebar) and the detail header both offer a rename
+  // affordance for the same session — on desktop the sidebar always shows the open session, so
+  // without this, renaming from either place would flip both into edit mode at once (and fight
+  // over the single renameInputRef). Track which one is active so only that side switches to the
+  // input.
+  function startRename(session: SessionView, source: "list" | "header" = "list") {
     setRenameValue(session.title)
     setRenamingSessionID(session.id)
+    setRenameSource(source)
     // Focus the input after render
     setTimeout(() => {
       renameInputRef.current?.focus()
@@ -2358,6 +2365,7 @@ function App() {
 
   function cancelRename() {
     setRenamingSessionID(null)
+    setRenameSource(null)
     setRenameValue("")
   }
 
@@ -2684,7 +2692,7 @@ function App() {
   const renderSessionCard = (session: SessionView) => (
     <article
       key={session.id}
-      className={`session-card ${session.status} ${selectedID === session.id ? "active" : ""} fade-in`}
+      className={`session-card ${session.status} ${selectedID === session.id ? "active" : ""} ${renamingSessionID === session.id && renameSource === "list" ? "renaming" : ""} fade-in`}
       onClick={() => openSession(session.id, session.directory).catch(() => undefined)}
       role="button"
       tabIndex={0}
@@ -2697,7 +2705,7 @@ function App() {
     >
       <div className="session-card-main">
         <div>
-          {renamingSessionID === session.id ? (
+          {renamingSessionID === session.id && renameSource === "list" ? (
             <div
               className="rename-inline"
               onClick={(event) => event.stopPropagation()}
@@ -3233,17 +3241,13 @@ function App() {
                 requestAnimationFrame(() => document.querySelector<HTMLElement>(".session-card.active")?.scrollIntoView({ block: "center" }));
               }}>{t('detail.backToSessions')}</button>
             )}
-            {selectedSession && (
-              <span className={`pill ${selectedSession.status}`}>{selectedSession.status}</span>
-            )}
           </div>
           <div className="header-row detail-header">
               <div>
               <h2>
                 {selectedSession ? (
                   <div className="detail-title-row">
-                    <ChatIcon size={24} className="icon-inline-heading" />
-                    {renamingSessionID === selectedSession.id ? (
+                    {renamingSessionID === selectedSession.id && renameSource === "header" ? (
                       <div className="rename-inline">
                         <input
                           ref={renameInputRef}
@@ -3269,13 +3273,14 @@ function App() {
                         {/* Two unlabelled 14px glyphs asked the user to guess which one commits.
                             One labelled primary action, and cancel as the quieter icon. */}
                         <button
-                          className="btn-primary compact rename-save"
+                          className="btn-icon btn-primary compact rename-save"
                           onClick={() => renameSession(selectedSession.id, renameValue, selectedSession.directory).catch(() => undefined)}
                           onMouseDown={(event) => event.preventDefault()}
                           disabled={!renameValue.trim() || renameValue === selectedSession.title}
+                          title={t('session.renameConfirm')}
+                          aria-label={t('session.renameConfirm')}
                         >
                           <SaveIcon size={16} />
-                          {t('session.renameConfirm')}
                         </button>
                         <button
                           className="btn-icon btn-secondary compact"
@@ -3295,7 +3300,7 @@ function App() {
                           <button
                             type="button"
                             className="session-title-button"
-                            onClick={() => startRename(selectedSession)}
+                            onClick={() => startRename(selectedSession, "header")}
                             title={t('session.renameTitle')}
                             aria-label={t('session.renameTitle')}
                           >

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -41,9 +41,57 @@ const LANGUAGE_STORAGE_KEY = "opencode.remote.language"
 const MODEL_STORAGE_KEY = "opencode.remote.model"
 const AGENT_STORAGE_KEY = "opencode.remote.agent"
 const THEME_STORAGE_KEY = "opencode.remote.theme"
+const SIDEBAR_WIDTH_STORAGE_KEY = "opencode.remote.desktopSidebarWidth"
+const MAIN_WIDTH_STORAGE_KEY = "opencode.remote.desktopMainWidth"
 const NEW_SESSION_DIRECTORY_STORAGE_KEY = "opencode.remote.newSessionDirectory"
 
 type Translator = ReturnType<typeof createTranslator>
+
+const SIDEBAR_WIDTH_MIN = 220
+const SIDEBAR_WIDTH_MAX = 480
+const SIDEBAR_WIDTH_DEFAULT = 280
+const MAIN_WIDTH_MIN = 420
+const MAIN_WIDTH_MAX = 1400
+const MAIN_WIDTH_DEFAULT = 820
+// The app-shell's own horizontal padding plus the gap between the sidebar and main pane
+// (2 * --space-4 + --space-4, all 1rem) — how much of the viewport the two resizable panels
+// never get to claim, even before a scrollbar takes its own slice.
+const DESKTOP_LAYOUT_CHROME_WIDTH = 64
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+/** The most the sidebar and main pane may occupy together without overflowing the viewport. */
+function maxCombinedPanelWidth(): number {
+  return Math.max(SIDEBAR_WIDTH_MIN + MAIN_WIDTH_MIN, window.innerWidth - DESKTOP_LAYOUT_CHROME_WIDTH)
+}
+
+function readStoredWidth(key: string, fallback: number, min: number, max: number): number {
+  const raw = Number(localStorage.getItem(key))
+  return Number.isFinite(raw) && raw > 0 ? clamp(raw, min, max) : fallback
+}
+
+/** Drags a horizontal panel border: reports the pointer's horizontal movement since the previous
+ *  event (not since drag start), so callers can just add/subtract the delta from their own state
+ *  without tracking a separate drag-start snapshot. */
+function useHorizontalDrag(onDeltaX: (deltaX: number) => void): (event: React.PointerEvent) => void {
+  return useCallback((event: React.PointerEvent) => {
+    event.preventDefault()
+    let lastX = event.clientX
+    const onMove = (moveEvent: PointerEvent) => {
+      const deltaX = moveEvent.clientX - lastX
+      lastX = moveEvent.clientX
+      if (deltaX !== 0) onDeltaX(deltaX)
+    }
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove)
+      window.removeEventListener("pointerup", onUp)
+    }
+    window.addEventListener("pointermove", onMove)
+    window.addEventListener("pointerup", onUp)
+  }, [onDeltaX])
+}
 
 function isBridgeBackend(backend: ServerConfig["backend"]): boolean {
   return backend === "omp" || backend === "pi"
@@ -1493,6 +1541,53 @@ function App() {
   // instead of duplicating the session list there.
   const mainView = isDesktop && view === "sessions" ? "detail" : view
 
+  // Desktop panel widths: the sidebar (sessions) and main pane (chat) each get an explicit pixel
+  // width instead of the main pane simply filling whatever space is left, so both edges and the
+  // divider between them are independently draggable.
+  const [sidebarWidth, setSidebarWidth] = useState(() =>
+    readStoredWidth(SIDEBAR_WIDTH_STORAGE_KEY, SIDEBAR_WIDTH_DEFAULT, SIDEBAR_WIDTH_MIN, SIDEBAR_WIDTH_MAX)
+  )
+  const [mainWidth, setMainWidth] = useState(() =>
+    readStoredWidth(MAIN_WIDTH_STORAGE_KEY, MAIN_WIDTH_DEFAULT, MAIN_WIDTH_MIN, MAIN_WIDTH_MAX)
+  )
+  useEffect(() => {
+    localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(sidebarWidth))
+  }, [sidebarWidth])
+  useEffect(() => {
+    localStorage.setItem(MAIN_WIDTH_STORAGE_KEY, String(mainWidth))
+  }, [mainWidth])
+  const dragSidebarLeft = useHorizontalDrag((deltaX) => {
+    // Dragging the sidebar's left edge left (negative deltaX) grows it. Growing it can't push the
+    // combined width past the viewport, since the main pane doesn't move to make room.
+    setSidebarWidth((width) => clamp(width - deltaX, SIDEBAR_WIDTH_MIN, Math.min(SIDEBAR_WIDTH_MAX, maxCombinedPanelWidth() - mainWidth)))
+  })
+  const dragPanelDivider = useHorizontalDrag((deltaX) => {
+    // The divider trades width between the two panels, so their combined width never changes —
+    // no viewport cap needed here beyond each panel's own min/max.
+    setSidebarWidth((width) => clamp(width + deltaX, SIDEBAR_WIDTH_MIN, SIDEBAR_WIDTH_MAX))
+    setMainWidth((width) => clamp(width - deltaX, MAIN_WIDTH_MIN, MAIN_WIDTH_MAX))
+  })
+  const dragMainRight = useHorizontalDrag((deltaX) => {
+    setMainWidth((width) => clamp(width + deltaX, MAIN_WIDTH_MIN, Math.min(MAIN_WIDTH_MAX, maxCombinedPanelWidth() - sidebarWidth)))
+  })
+  // Restores/keeps the combined panel width within the viewport: on first mount (a stored width
+  // from a wider screen), and again whenever the window is resized narrower than the current
+  // total. Shrinks the main pane first since it has more room to give before hitting its floor.
+  useEffect(() => {
+    if (!isDesktop) return
+    const clampToViewport = () => {
+      const overflow = sidebarWidth + mainWidth - maxCombinedPanelWidth()
+      if (overflow <= 0) return
+      const mainShrink = Math.min(overflow, mainWidth - MAIN_WIDTH_MIN)
+      if (mainShrink > 0) setMainWidth((width) => clamp(width - mainShrink, MAIN_WIDTH_MIN, MAIN_WIDTH_MAX))
+      const sidebarShrink = overflow - mainShrink
+      if (sidebarShrink > 0) setSidebarWidth((width) => clamp(width - sidebarShrink, SIDEBAR_WIDTH_MIN, SIDEBAR_WIDTH_MAX))
+    }
+    clampToViewport()
+    window.addEventListener("resize", clampToViewport)
+    return () => window.removeEventListener("resize", clampToViewport)
+  }, [isDesktop, sidebarWidth, mainWidth])
+
   const [sessions, setSessions] = useState<SessionView[]>([])
   const [selectedID, setSelectedID] = useState<string | null>(null)
   const [newSessionDirectory, setNewSessionDirectory] = useState(() => localStorage.getItem(NEW_SESSION_DIRECTORY_STORAGE_KEY) ?? "")
@@ -2728,7 +2823,9 @@ function App() {
       )}
 
       {isDesktop && (
-        <aside className="desktop-sidebar fade-in">
+        <aside className="desktop-sidebar fade-in" style={{ width: sidebarWidth, flex: `0 0 ${sidebarWidth}px` }}>
+          <div className="resize-handle resize-handle--start" onPointerDown={dragSidebarLeft} role="separator" aria-orientation="vertical" aria-label="Resize sessions panel" />
+          <div className="resize-handle resize-handle--end" onPointerDown={dragPanelDivider} role="separator" aria-orientation="vertical" aria-label="Resize panels" />
           <div className="sidebar-brand">
             <img src="/app-icon.png" alt="" className="app-icon" />
             <div className="brand-text">
@@ -2794,7 +2891,13 @@ function App() {
         </aside>
       )}
 
-      <div className="main-content">
+      <div
+        className="main-content"
+        style={isDesktop ? { width: mainWidth, flex: `0 0 ${mainWidth}px`, position: "relative" } : undefined}
+      >
+      {isDesktop && (
+        <div className="resize-handle resize-handle--end" onPointerDown={dragMainRight} role="separator" aria-orientation="vertical" aria-label="Resize detail panel" />
+      )}
       {mainView === "settings" && (
         <ConditionalWrapper
           condition={isDesktop}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,6 +21,8 @@ import {
   SettingsIcon,
   FolderIcon,
   ChatIcon,
+  JumpToTopIcon,
+  JumpToBottomIcon,
   HelpIcon,
   PlusIcon,
   TrashIcon,
@@ -540,6 +542,130 @@ function PatchPartView({
 }
 
 const BOTTOM_STICK_THRESHOLD = 80
+
+/** How far from an end a list must be scrolled before its jump button appears, at most. */
+const JUMP_AFFORDANCE_MAX_THRESHOLD = 320
+/** Below this much total travel, jumping saves nobody a scroll and the buttons are pure clutter. */
+const JUMP_AFFORDANCE_MIN_RANGE = 240
+
+type JumpAffordances = { top: boolean; bottom: boolean }
+type ScrollMetrics = { fromTop: number; fromBottom: number }
+
+const NO_JUMP_AFFORDANCES: JumpAffordances = { top: false, bottom: false }
+
+/** Which jump buttons are worth showing at this scroll position.
+ *
+ *  The threshold has to scale with the total scroll range rather than being a flat 320px. Measured
+ *  absolutely, a list that only scrolls ~600px has no position where both ends are more than 320px
+ *  away, and its jump-to-top only appears in the last 320px of travel — which reads as "the buttons
+ *  only show up at the very bottom". Anything scrolling less than 320px got no buttons at all. */
+function jumpAffordancesFor({ fromTop, fromBottom }: ScrollMetrics): JumpAffordances {
+  const range = fromTop + fromBottom
+  if (range < JUMP_AFFORDANCE_MIN_RANGE) return NO_JUMP_AFFORDANCES
+  const threshold = Math.min(JUMP_AFFORDANCE_MAX_THRESHOLD, range * 0.25)
+  return { top: fromTop > threshold, bottom: fromBottom > threshold }
+}
+
+function windowScrollMetrics(): ScrollMetrics {
+  const doc = document.documentElement
+  return { fromTop: window.scrollY, fromBottom: doc.scrollHeight - window.scrollY - window.innerHeight }
+}
+
+function elementScrollMetrics(element: HTMLElement | null): ScrollMetrics {
+  if (!element) return { fromTop: 0, fromBottom: 0 }
+  return {
+    fromTop: element.scrollTop,
+    fromBottom: element.scrollHeight - element.scrollTop - element.clientHeight
+  }
+}
+
+/** True when the element is a real scroller rather than one that grows to fit its content. Geometry
+ *  alone is not enough: scrollHeight also exceeds clientHeight on an overflow: visible element whose
+ *  content spills, which is exactly what the mobile message list is, and treating that as a scroller
+ *  reads a scrollTop that is permanently 0. */
+function scrollsItself(element: HTMLElement | null): element is HTMLElement {
+  if (!element || element.scrollHeight <= element.clientHeight + 1) return false
+  const overflowY = window.getComputedStyle(element).overflowY
+  return overflowY === "auto" || overflowY === "scroll"
+}
+
+/** Watches how far a list sits from each end and reports which jump buttons are worth showing.
+ *  `getMetrics` is injected because the scroller varies: the chat scrolls its own pane in the
+ *  desktop layout, while every mobile list lets the page scroll instead. Returns a `refresh` to
+ *  call from an element's own onScroll and whenever content changes the distances without a
+ *  scroll event. */
+function useJumpAffordances(active: boolean, getMetrics: () => ScrollMetrics): [JumpAffordances, () => void] {
+  const [affordances, setAffordances] = useState<JumpAffordances>(NO_JUMP_AFFORDANCES)
+  const getMetricsRef = useRef(getMetrics)
+  getMetricsRef.current = getMetrics
+
+  const refresh = useCallback(() => {
+    const next = jumpAffordancesFor(getMetricsRef.current())
+    setAffordances((current) => (current.top === next.top && current.bottom === next.bottom ? current : next))
+  }, [])
+
+  useEffect(() => {
+    if (!active) {
+      setAffordances(NO_JUMP_AFFORDANCES)
+      return
+    }
+    window.addEventListener("scroll", refresh, { passive: true })
+    window.addEventListener("resize", refresh)
+    // Layout settles a frame after the view mounts, so the first read has to wait for it.
+    const frame = requestAnimationFrame(refresh)
+    return () => {
+      window.removeEventListener("scroll", refresh)
+      window.removeEventListener("resize", refresh)
+      cancelAnimationFrame(frame)
+    }
+  }, [active, refresh])
+
+  return [affordances, refresh]
+}
+
+/** Floating jump-to-top/bottom buttons for a long list. */
+function JumpControls({
+  affordances,
+  onJumpToTop,
+  onJumpToBottom,
+  variant = "chat",
+  t
+}: {
+  affordances: JumpAffordances
+  onJumpToTop: () => void
+  onJumpToBottom: () => void
+  /** "chat" clears the composer, "page" the bottom nav, "sidebar" the desktop sidebar footer. */
+  variant?: "chat" | "page" | "sidebar"
+  t: Translator
+}) {
+  if (!affordances.top && !affordances.bottom) return null
+  return (
+    <div className={`jump-controls jump-controls--${variant}`}>
+      {affordances.top && (
+        <button
+          type="button"
+          className="jump-button fade-in"
+          onClick={onJumpToTop}
+          title={t('app.jumpToTop')}
+          aria-label={t('app.jumpToTop')}
+        >
+          <JumpToTopIcon size={18} />
+        </button>
+      )}
+      {affordances.bottom && (
+        <button
+          type="button"
+          className="jump-button fade-in"
+          onClick={onJumpToBottom}
+          title={t('app.jumpToBottom')}
+          aria-label={t('app.jumpToBottom')}
+        >
+          <JumpToBottomIcon size={18} />
+        </button>
+      )}
+    </div>
+  )
+}
 
 let modalTitleSequence = 0
 
@@ -1445,7 +1571,10 @@ const MessagesPane = memo(function MessagesPane({
   messagesRef,
   messagesEndRef,
   onMessagesScroll,
-  onQuestionResolved
+  onQuestionResolved,
+  jumpAffordances,
+  onJumpToTop,
+  onJumpToBottom
 }: {
   loadingSessionID: string | null
   selectedID: string | null
@@ -1460,6 +1589,9 @@ const MessagesPane = memo(function MessagesPane({
   messagesEndRef: RefObject<HTMLDivElement>
   onMessagesScroll: () => void
   onQuestionResolved: (id: string) => void
+  jumpAffordances: { top: boolean; bottom: boolean }
+  onJumpToTop: () => void
+  onJumpToBottom: () => void
 }) {
   return (
     <div className="messages-wrap">
@@ -1516,6 +1648,7 @@ const MessagesPane = memo(function MessagesPane({
           </>
         )}
       </div>
+      <JumpControls affordances={jumpAffordances} onJumpToTop={onJumpToTop} onJumpToBottom={onJumpToBottom} t={t} />
     </div>
   )
 })
@@ -1657,6 +1790,22 @@ function App() {
   const stickToBottomRef = useRef(true)
   const messagesEndRef = useRef<HTMLDivElement | null>(null)
   const composerRef = useRef<HTMLDivElement | null>(null)
+  // Both gate on mainView, not view: on desktop, picking a session leaves view === "sessions" while
+  // the chat is what's actually rendered, so gating on view left the buttons permanently inactive.
+  const [jumpAffordances, refreshChatJumps] = useJumpAffordances(mainView === "detail", () =>
+    messagesScrollMetrics()
+  )
+  // mainView is never "sessions" on desktop — there the list is the sidebar below — so this is
+  // implicitly the mobile page-scrolled list.
+  const [sessionJumpAffordances, refreshSessionJumps] = useJumpAffordances(
+    mainView === "sessions",
+    windowScrollMetrics
+  )
+  // The desktop sidebar list scrolls itself, so it needs its own instance reading that element.
+  const sidebarSessionsRef = useRef<HTMLDivElement | null>(null)
+  const [sidebarJumpAffordances, refreshSidebarJumps] = useJumpAffordances(isDesktop, () =>
+    elementScrollMetrics(sidebarSessionsRef.current)
+  )
   const completionAudioRef = useRef<HTMLAudioElement | null>(null)
   const completionShouldPlayRef = useRef(false)
   const wasAwaitingAssistantReplyRef = useRef(false)
@@ -2095,7 +2244,17 @@ function App() {
     const composerStyles = window.getComputedStyle(composer)
     const composerBottom = Number.parseFloat(composerStyles.bottom) || 0
     const clearance = Math.ceil(composerRect.height + composerBottom + 16)
-    container.style.setProperty("--chat-bottom-clearance", `${clearance}px`)
+    // Scoped to the wrap rather than the list itself so the jump buttons, which are siblings of the
+    // list, can sit on top of the same clearance the list reserves for the composer.
+    const scope = container.parentElement ?? container
+    scope.style.setProperty("--chat-bottom-clearance", `${clearance}px`)
+  }
+
+  /** The chat is its own scroller in the desktop layout but lets the page scroll on mobile, so
+   *  anything reading scroll position has to look at whichever of the two actually scrolls. */
+  function messagesScrollMetrics(): ScrollMetrics {
+    const container = messagesRef.current
+    return scrollsItself(container) ? elementScrollMetrics(container) : windowScrollMetrics()
   }
 
   function isNearMessagesBottom(): boolean {
@@ -2112,6 +2271,7 @@ function App() {
 
   const handleMessagesScroll = useCallback(() => {
     stickToBottomRef.current = isNearMessagesBottom()
+    refreshChatJumps()
   }, [])
 
   const handleQuestionResolved = useCallback((id: string) => {
@@ -2138,6 +2298,43 @@ function App() {
       })
     })
   }
+
+  // Memoised so they don't defeat MessageList's memo on every render.
+  const handleJumpToTop = useCallback(() => {
+    // Jumping to the oldest message is an explicit "leave the live tail" gesture, so drop the pin;
+    // otherwise the next incoming message would yank the view straight back down.
+    stickToBottomRef.current = false
+    const container = messagesRef.current
+    if (scrollsItself(container)) {
+      container.scrollTo({ top: 0, behavior: "smooth" })
+      return
+    }
+    // The page is the scroller, so go to the actual top — scrolling the list into view instead
+    // would strand the header above the fold and leave this button showing with nowhere to go.
+    window.scrollTo({ top: 0, behavior: "smooth" })
+  }, [])
+
+  const handleJumpToBottom = useCallback(() => {
+    stickToBottomRef.current = true
+    scrollMessagesToBottom("smooth")
+  }, [])
+
+  const handleSessionsJumpToTop = useCallback(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" })
+  }, [])
+
+  const handleSessionsJumpToBottom = useCallback(() => {
+    window.scrollTo({ top: document.documentElement.scrollHeight, behavior: "smooth" })
+  }, [])
+
+  const handleSidebarJumpToTop = useCallback(() => {
+    sidebarSessionsRef.current?.scrollTo({ top: 0, behavior: "smooth" })
+  }, [])
+
+  const handleSidebarJumpToBottom = useCallback(() => {
+    const list = sidebarSessionsRef.current
+    list?.scrollTo({ top: list.scrollHeight, behavior: "smooth" })
+  }, [])
 
   async function browseNewSessionDirectory(path: string) {
     setPickerLoading(true)
@@ -2638,8 +2835,12 @@ function App() {
     }
   }, [hasConfiguredServer])
 
+  // useJumpAffordances watches window scroll for the jump buttons already; this listener is here for
+  // the auto-scroll pin, which must also break when the user scrolls the page rather than the list.
   useEffect(() => {
-    const onWindowScroll = () => handleMessagesScroll()
+    const onWindowScroll = () => {
+      stickToBottomRef.current = isNearMessagesBottom()
+    }
     window.addEventListener("scroll", onWindowScroll, { passive: true })
     return () => window.removeEventListener("scroll", onWindowScroll)
   }, [])
@@ -2649,6 +2850,29 @@ function App() {
     if (!stickToBottomRef.current) return
     scrollMessagesToBottom("auto")
   }, [view, messageScrollSignature, isWorking, showTypingBubble, pendingQuestions])
+
+  // Growing or swapping the transcript changes the distance to each end without any scroll event
+  // firing, so the jump buttons have to be re-evaluated off the content too.
+  useEffect(() => {
+    if (mainView !== "detail") return
+    const frame = requestAnimationFrame(refreshChatJumps)
+    return () => cancelAnimationFrame(frame)
+  }, [mainView, selectedID, messageScrollSignature, refreshChatJumps])
+
+  // Same for the sessions list: filtering or a refresh changes its length under a static scroll offset.
+  useEffect(() => {
+    if (mainView !== "sessions") return
+    const frame = requestAnimationFrame(refreshSessionJumps)
+    return () => cancelAnimationFrame(frame)
+  }, [mainView, query, filteredSessions.length, refreshSessionJumps])
+
+  // The desktop sidebar list is always on screen, so it only depends on its own length, and on the
+  // sidebar width, which reflows the rows.
+  useEffect(() => {
+    if (!isDesktop) return
+    const frame = requestAnimationFrame(refreshSidebarJumps)
+    return () => cancelAnimationFrame(frame)
+  }, [isDesktop, query, filteredSessions.length, sidebarWidth, refreshSidebarJumps])
 
   useEffect(() => {
     if (view !== "detail" || !selectedID) return
@@ -2915,7 +3139,7 @@ function App() {
             </button>
           </div>
 
-          <div className="sidebar-sessions">
+          <div className="sidebar-sessions" ref={sidebarSessionsRef} onScroll={refreshSidebarJumps}>
             {filteredSessions.length === 0 ? (
               <p className="subtle sidebar-empty">
                 {isOffline ? t('sessions.offlineHint') : t('sessions.emptyTitle')}
@@ -2924,6 +3148,14 @@ function App() {
               filteredSessions.map(renderSessionCard)
             )}
           </div>
+
+          <JumpControls
+            affordances={sidebarJumpAffordances}
+            onJumpToTop={handleSidebarJumpToTop}
+            onJumpToBottom={handleSidebarJumpToBottom}
+            variant="sidebar"
+            t={t}
+          />
 
           <div className="sidebar-footer">
             <button type="button" className="btn-secondary" onClick={() => setView("help")} title={t('nav.help')}>
@@ -3201,6 +3433,14 @@ function App() {
           {runtimeError && !(isOffline && filteredSessions.length === 0) && (
             <div className="error fade-in">✗ {runtimeError}</div>
           )}
+
+          <JumpControls
+            affordances={sessionJumpAffordances}
+            onJumpToTop={handleSessionsJumpToTop}
+            onJumpToBottom={handleSessionsJumpToBottom}
+            variant="page"
+            t={t}
+          />
         </section>
       )}
 
@@ -3420,6 +3660,9 @@ function App() {
             config={config}
             directory={selectedSession?.directory}
             t={t}
+            jumpAffordances={jumpAffordances}
+            onJumpToTop={handleJumpToTop}
+            onJumpToBottom={handleJumpToBottom}
             messagesRef={messagesRef}
             messagesEndRef={messagesEndRef}
             onMessagesScroll={handleMessagesScroll}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2746,7 +2746,7 @@ function App() {
                 onMouseDown={(event) => event.preventDefault()}
                 title={t('session.renameConfirm')}
               >
-                <SaveIcon size={14} />
+                <SaveIcon size={16} />
               </button>
               <button
                 className="btn-secondary compact"
@@ -2756,7 +2756,7 @@ function App() {
                 }}
                 title={t('session.cancel')}
               >
-                <CloseIcon size={14} />
+                <CloseIcon size={16} />
               </button>
             </div>
           ) : (
@@ -2898,13 +2898,13 @@ function App() {
           </div>
 
           <div className="sidebar-footer">
-            <button type="button" className="btn-secondary" onClick={() => setView("help")}>
+            <button type="button" className="btn-secondary" onClick={() => setView("help")} title={t('nav.help')}>
               <HelpIcon size={18} />
-              {t('nav.help')}
+              <span className="sidebar-footer-label">{t('nav.help')}</span>
             </button>
-            <button type="button" className="btn-secondary" onClick={() => setView("settings")}>
+            <button type="button" className="btn-secondary" onClick={() => setView("settings")} title={t('nav.settings')}>
               <SettingsIcon size={18} />
-              {t('nav.settings')}
+              <span className="sidebar-footer-label">{t('nav.settings')}</span>
             </button>
           </div>
         </aside>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -204,12 +204,6 @@ function toRenderedMessage(message: MessageEnvelope): MessageEnvelope & { text: 
   return wrapped
 }
 
-function assistantPayloadLength(items: MessageEnvelope[]): number {
-  return items
-    .filter((message) => message.info.role !== "user")
-    .reduce((sum, message) => sum + extractText(message).length, 0)
-}
-
 function messagesHaveSameContent(left: MessageEnvelope[], right: MessageEnvelope[]): boolean {
   return left.length === right.length && left.every((message, index) => {
     const candidate = right[index]
@@ -1333,9 +1327,12 @@ function createLocalAssistantMessage(sessionID: string, text: string): MessageEn
   }
 }
 
-/** Reasoning text should only ever grow while streaming — if an incoming snapshot is shorter than what's already shown, a reset/truncated event landed; keep the longer text instead of visibly erasing it. */
-function reconcileReasoningPart(previous: MessagePart | undefined, incoming: MessagePart): MessagePart {
-  if (incoming.type !== "reasoning" || !previous || previous.type !== "reasoning") return incoming
+/** Streamed text should only ever grow — if an incoming snapshot is shorter than what's already shown, a
+ *  reset/truncated event landed; keep the longer text instead of visibly erasing it. Applied per part rather
+ *  than by rejecting the whole snapshot, so a lean refetch can still deliver the messages that came with it. */
+function reconcileStreamedPart(previous: MessagePart | undefined, incoming: MessagePart): MessagePart {
+  if (!previous || previous.type !== incoming.type) return incoming
+  if (incoming.type !== "reasoning" && incoming.type !== "text") return incoming
   const previousText = previous.text ?? ""
   const incomingText = incoming.text ?? ""
   return incomingText.length >= previousText.length ? incoming : { ...incoming, text: previousText }
@@ -1356,7 +1353,7 @@ function mergeFetchedMessages(current: MessageEnvelope[], fetched: MessageEnvelo
     const previous = currentByID.get(message.info.id)
     if (!previous) return message
     const previousPartsByID = new Map(previous.parts.map((part) => [part.id, part]))
-    const parts = message.parts.map((part) => reconcileReasoningPart(previousPartsByID.get(part.id), part))
+    const parts = message.parts.map((part) => reconcileStreamedPart(previousPartsByID.get(part.id), part))
     const fetchedPartIDs = new Set(message.parts.map((part) => part.id))
     const missingReasoning = previous.parts.filter((part) => part.type === "reasoning" && !fetchedPartIDs.has(part.id))
     const mergedParts = missingReasoning.length === 0 ? parts : [...missingReasoning, ...parts]
@@ -1371,7 +1368,7 @@ function applyStreamedPartUpdate(messages: MessageEnvelope[], sessionID: string,
     changed = true
     const exists = message.parts.some((existing) => existing.id === part.id)
     const parts = exists
-      ? message.parts.map((existing) => (existing.id === part.id ? reconcileReasoningPart(existing, part) : existing))
+      ? message.parts.map((existing) => (existing.id === part.id ? reconcileStreamedPart(existing, part) : existing))
       : [...message.parts, part]
     return { ...message, parts }
   })
@@ -2205,11 +2202,13 @@ function App() {
     ])
     if (requestID !== loadSelectedRequestRef.current) return
     const current = loadedMessagesRef.current
-    const authoritativeExternalHistory = selectedSessionRef.current?.id === sessionID && selectedSessionRef.current.external
-    if (
-      !messagesHaveSameContent(current, msg) &&
-      (authoritativeExternalHistory || assistantPayloadLength(current) <= assistantPayloadLength(msg))
-    ) {
+    // A snapshot carrying less assistant text than is already on screen used to be rejected wholesale, to
+    // avoid erasing streamed content. But the optimistic user bubble below is cleared against this same
+    // snapshot either way, so rejecting it made a just-sent message vanish — and since the rejected
+    // snapshot never reached state, the comparison stayed true and swallowed every later message too,
+    // until the session was reopened. Shrinking text is now held back per part in mergeFetchedMessages
+    // instead, which keeps the streamed text without ever dropping the messages that came with it.
+    if (!messagesHaveSameContent(current, msg)) {
       shouldAutoScrollRef.current = messagesExtendContent(current, msg) && isNearMessagesBottom()
       loadedMessagesRef.current = msg
       setMessages((prev) => mergeFetchedMessages(prev, msg))

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3661,10 +3661,7 @@ function App() {
           )}
         >
         <section className="panel help fade-in">
-          <h2>
-            <HelpIcon size={24} className="icon-inline-heading" />
-            {t('help.title')}
-          </h2>
+          <h2>{t('help.title')}</h2>
           <div className="help-tabs" role="tablist">
             <button 
               className={helpPage === "overview" ? "active" : ""} 

--- a/web/src/Icons.tsx
+++ b/web/src/Icons.tsx
@@ -428,3 +428,43 @@ export const OfflineIcon = ({ className = "", size = 20 }: { className?: string;
     <path d="M12 20h.01" />
   </svg>
 )
+
+export const JumpToTopIcon = ({ className = "", size = 20 }: { className?: string; size?: number }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    role="img"
+    aria-label="Jump to top"
+  >
+    <path d="M5 4h14" />
+    <path d="M12 20V9" />
+    <path d="M6 15l6-6 6 6" />
+  </svg>
+)
+
+export const JumpToBottomIcon = ({ className = "", size = 20 }: { className?: string; size?: number }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    role="img"
+    aria-label="Jump to bottom"
+  >
+    <path d="M5 20h14" />
+    <path d="M12 4v11" />
+    <path d="M6 9l6 6 6-6" />
+  </svg>
+)

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -2,6 +2,8 @@ export type LanguageCode = 'en' | 'it' | 'zh-TW'
 
 type TranslationKey =
   | 'app.title'
+  | 'app.jumpToTop'
+  | 'app.jumpToBottom'
   | 'nav.settings'
   | 'nav.sessions'
   | 'nav.detail'
@@ -85,6 +87,7 @@ type TranslationKey =
   | 'detail.loading'
   | 'detail.emptyTitle'
   | 'detail.emptyHint'
+
   | 'detail.composerPlaceholder'
   | 'detail.externalSession'
   | 'detail.externalShort'
@@ -217,6 +220,8 @@ type TranslationKey =
 const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
   en: {
     'app.title': 'Harness Remote',
+    'app.jumpToTop': 'Jump to top',
+    'app.jumpToBottom': 'Jump to bottom',
     'nav.settings': 'Settings',
     'nav.sessions': 'Sessions',
     'nav.detail': 'Detail',
@@ -431,6 +436,8 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
   },
   it: {
     'app.title': 'Harness Remote',
+    'app.jumpToTop': 'Vai in alto',
+    'app.jumpToBottom': 'Vai in basso',
     'nav.settings': 'Impostazioni',
     'nav.sessions': 'Sessioni',
     'nav.detail': 'Dettaglio',
@@ -645,6 +652,8 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
   },
   'zh-TW': {
     'app.title': 'Harness Remote',
+    'app.jumpToTop': '跳到頂部',
+    'app.jumpToBottom': '跳到底部',
     'nav.settings': '設定',
     'nav.sessions': '工作階段',
     'nav.detail': '詳情',

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -877,6 +877,56 @@ p {
   scroll-padding-bottom: var(--chat-bottom-clearance, 140px);
 }
 
+/* Floating scroll affordances, stacked just above the composer. Absolute against .messages-wrap in
+   the desktop layout, where .messages is the scroller and the wrap itself stays put. */
+.jump-controls {
+  position: absolute;
+  right: var(--space-3);
+  z-index: var(--z-sticky);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  /* The column spans dead space between the two buttons; don't let it eat clicks on the chat. */
+  pointer-events: none;
+}
+
+/* The clearance is measured from the composer, which already folds in its own bottom offset. */
+.jump-controls--chat {
+  bottom: var(--chat-bottom-clearance, 140px);
+}
+
+/* No composer on a plain page list, so it only has to sit clear of the bottom nav. */
+.jump-controls--page {
+  bottom: var(--space-3);
+}
+
+/* Anchored to the sidebar (not to .sidebar-sessions, which is the scroller and would carry the
+   buttons away with the rows), so it has to clear the footer's buttons and padding. */
+.jump-controls--sidebar {
+  right: var(--space-2);
+  bottom: calc(44px + var(--space-3) * 2 + var(--space-5));
+}
+
+.jump-button {
+  pointer-events: auto;
+  width: 40px;
+  height: 40px;
+  min-height: 0;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--nav-bg);
+  color: var(--muted);
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(14px);
+}
+
+.jump-button:hover {
+  color: var(--text);
+}
+
 .messages-end {
   min-height: 1px;
   scroll-margin-bottom: var(--chat-bottom-clearance, 140px);
@@ -1689,6 +1739,11 @@ button.compact {
    mobile sessions panel uses — same markup (renderSessionCard), scoped override here. */
 .sidebar-sessions {
   gap: 2px;
+  /* Reserve a button stack's worth of room past the last row. Raising the floating jump buttons
+     alone only changes which row they cover — the overlay sits over the scroller either way,
+     swallowing that row's hover actions. Letting the list scroll further means no row has to sit
+     underneath them. Must stay after the base rule's `padding` shorthand, which would reset this. */
+  padding-bottom: calc(88px + var(--space-3));
 }
 
 .sidebar-sessions .session-card {
@@ -1960,6 +2015,48 @@ button.compact {
   max-width: 100%;
 }
 
+/* Bound the chat pane to the viewport the same way .desktop-sidebar bounds itself, so .messages is
+   the scroller rather than the page. Without this the pane grows to fit the whole transcript: the
+   page scrolls instead, .messages-wrap ends up as tall as the transcript, and the floating jump
+   buttons — absolute against that wrap — anchor to the bottom of the content instead of the pane,
+   landing at the very bottom of the page behind the composer. */
+.app-shell-desktop .detail {
+  height: calc(100dvh - var(--space-4) * 2);
+  min-height: 0;
+}
+
+/* The message list is the only part that may absorb the bound. Everything else in the pane — topbar,
+   header, context strip, todo box, composer — is fixed-size chrome that would otherwise shrink and
+   clip its own contents once the transcript got long. */
+.app-shell-desktop .detail > * {
+  flex: 0 0 auto;
+}
+
+/* min-height: 0 is what lets these flex children shrink below their content so the bound reaches
+   .messages and it actually overflows. */
+.app-shell-desktop .messages-wrap {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* The composer sits below the list in flow here rather than floating over it, so the list needs no
+   clearance reserved beneath it and the jump buttons only have to clear the list's own bottom edge.
+   Set explicitly rather than by overriding --chat-bottom-clearance: syncChatBottomClearance writes
+   that as an inline style on .messages-wrap, which would win over any rule here. */
+.app-shell-desktop .messages {
+  min-height: 0;
+  padding-bottom: var(--space-2);
+  scroll-padding-bottom: var(--space-2);
+}
+
+.app-shell-desktop .messages-end {
+  scroll-margin-bottom: 0;
+}
+
+.app-shell-desktop .jump-controls--chat {
+  bottom: var(--space-3);
+}
+
 .main-content {
   min-width: 0;
   flex: 1 1 auto;
@@ -2102,13 +2199,8 @@ button.compact {
     flex-direction: column;
   }
 
-  /* Bound the pane to the viewport (not just a floor) so .messages actually overflows and becomes
-     the scroller. Left unbounded, the flex chain grows to fit every message, .messages never
-     overflows, and its overscroll-behavior: contain leaves it a dead scroll container that
-     swallows swipes instead of passing them to the document. */
   .detail {
-    height: calc(100dvh - 158px);
-    min-height: 0;
+    min-height: calc(100dvh - 158px);
   }
 
   .detail-topbar {
@@ -2120,14 +2212,29 @@ button.compact {
     align-self: flex-start;
   }
 
-  /* min-height: 0 is what lets these flex children shrink below their content and overflow. */
-  .messages-wrap {
-    min-height: 0;
+  /* On mobile the whole page scrolls (the composer is pinned with fixed positioning), so the list
+     must not be a scroll container of its own: nothing bounds its height here, so it would never
+     overflow, and a scroll container with nothing to scroll swallows the swipe instead of letting
+     it reach the document. Keeping it a plain block also lets the header and topbar scroll away. */
+  .messages {
+    min-height: 240px;
+    overflow: visible;
+    padding: 0;
   }
 
-  .messages {
-    min-height: 0;
-    padding: 0;
+  /* The page is the scroller here, so the wrap scrolls away with it — pin to the viewport instead.
+     The clearance already folds in the composer's own bottom offset, so it clears the nav too. */
+  .jump-controls {
+    position: fixed;
+  }
+
+  .jump-controls--page {
+    bottom: calc(72px + var(--space-2) + env(safe-area-inset-bottom));
+  }
+
+  .jump-button {
+    width: 44px;
+    height: 44px;
   }
 
   .message {
@@ -2377,7 +2484,9 @@ button,
   -webkit-tap-highlight-color: transparent;
 }
 
-.messages,
+/* Deliberately excludes .messages: outside the desktop layout its height is unbounded, so it never
+   overflows, and containment on a scroll container with nothing to scroll blocks the swipe from
+   chaining to the page that does scroll. These others are all genuinely bounded scrollers. */
 .model-option-list,
 .folder-list,
 .bottom-sheet,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2220,6 +2220,11 @@ button.compact {
     min-height: 240px;
     overflow: visible;
     padding: 0;
+    /* The side padding goes away here, but the bottom clearance must not: the composer is sticky at
+       an offset above the page bottom, so without it the newest messages settle underneath it and
+       the page has no room left to scroll them clear. */
+    padding-bottom: var(--chat-bottom-clearance, 140px);
+    scroll-padding-bottom: var(--chat-bottom-clearance, 140px);
   }
 
   /* The page is the scroller here, so the wrap scrolls away with it — pin to the viewport instead.

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1692,6 +1692,7 @@ button.compact {
 }
 
 .sidebar-sessions .session-card {
+  position: relative;
   display: grid;
   grid-template-columns: 1fr auto;
   grid-template-areas:
@@ -1702,16 +1703,40 @@ button.compact {
   row-gap: 1px;
   padding: var(--space-2) var(--space-3);
   border: none;
-  border-left: 3px solid transparent;
   border-radius: var(--radius-md);
   background: transparent;
 }
 
 /* On desktop the pill is dropped in favor of a left-border flag: a session is assumed idle
-   unless it's actively busy/retrying, which is the only state worth calling out at a glance. */
-.sidebar-sessions .session-card.busy,
-.sidebar-sessions .session-card.retry {
-  border-left-color: var(--warning);
+   unless it's actively busy/retrying, which is the only state worth calling out at a glance. The
+   border uses the site's own accent color (rather than an off-palette warning yellow) and sweeps
+   like an indeterminate progress bar so a working session reads as "in motion" at a glance. */
+.sidebar-sessions .session-card.busy::before,
+.sidebar-sessions .session-card.retry::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: var(--space-1);
+  bottom: var(--space-1);
+  width: 3px;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(var(--primary-soft), var(--primary), var(--primary-soft));
+  background-size: 100% 24px;
+  background-repeat: repeat-y;
+  animation: session-busy-sweep 1s linear infinite;
+}
+
+/* A plain pixel-length shift (one full tile per loop) rather than a percentage-based one: with a
+   background taller than its element, percentage background-position isn't a simple fraction of
+   the tile size, so the loop never quite lined back up with itself and visibly hitched on every
+   repeat. */
+@keyframes session-busy-sweep {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: 0 24px;
+  }
 }
 
 .sidebar-sessions .session-card:hover,
@@ -1821,6 +1846,14 @@ button.compact {
   display: none;
 }
 
+/* The title area only spans the row's first column (the actions column sits to its right) — but
+   while renaming, actions is hidden and empty, so let the title area claim the full row width.
+   Otherwise the save/cancel buttons would end at the title column's edge instead of the row's,
+   misaligned with where the rename/delete icons themselves sit. */
+.sidebar-sessions .session-card.renaming .session-card-main {
+  grid-column: 1 / -1;
+}
+
 /* The rename input and its save/cancel buttons default to full-size (44px-tall buttons, a
    140px-min-width input) sized for the session detail header, not a ~40px-tall sidebar row —
    shrink everything to fit. */
@@ -1841,8 +1874,8 @@ button.compact {
 .sidebar-sessions .rename-inline button {
   flex: 0 0 auto;
   min-height: 0;
-  height: 20px;
-  width: 20px;
+  height: 22px;
+  width: 22px;
   padding: 0;
   font-size: 0;
   border: none;
@@ -1863,6 +1896,7 @@ button.compact {
 }
 
 .sidebar-footer {
+  container-type: inline-size;
   display: flex;
   gap: var(--space-2);
   padding: var(--space-3);
@@ -1871,7 +1905,20 @@ button.compact {
 
 .sidebar-footer button {
   flex: 1 1 0;
+  min-width: 0;
   justify-content: center;
+}
+
+.sidebar-footer button svg {
+  flex-shrink: 0;
+}
+
+/* Once the sidebar is narrow enough that "Help"/"Settings" would get cramped or truncated, drop
+   the labels entirely and fall back to icon-only buttons (the tooltip still carries the text). */
+@container (max-width: 260px) {
+  .sidebar-footer-label {
+    display: none;
+  }
 }
 
 .app-shell-desktop {
@@ -1950,7 +1997,10 @@ button.compact {
   position: absolute;
   top: var(--space-3);
   right: var(--space-3);
-  padding: var(--space-2);
+  width: 36px;
+  height: 36px;
+  min-height: 0;
+  padding: 0;
 }
 
 @media (max-width: 780px) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1636,7 +1636,6 @@ button.compact {
   background: var(--nav-bg);
   box-shadow: var(--shadow-sm);
   backdrop-filter: blur(14px);
-  overflow: hidden;
 }
 
 .sidebar-brand {
@@ -1798,7 +1797,11 @@ button.compact {
 .app-shell-desktop {
   flex-direction: row;
   align-items: flex-start;
-  width: min(100%, 1400px);
+  /* The sidebar and main pane both carry an explicit resizable width, so the shell should hug
+     their combined width (up to the viewport) rather than stretching to a fixed max — otherwise
+     dragging a panel's outer edge would leave dead space instead of visibly resizing anything. */
+  width: fit-content;
+  max-width: 100%;
 }
 
 .main-content {
@@ -1807,6 +1810,45 @@ button.compact {
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
+}
+
+/* Draggable borders for the desktop sidebar/main-pane layout: a thin invisible strip straddling
+   the panel edge, widened on hover/drag so it's easy to grab without adding visible chrome. */
+.resize-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 12px;
+  cursor: col-resize;
+  z-index: 5;
+  touch-action: none;
+}
+
+.resize-handle::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 2px;
+  transform: translateX(-50%);
+  border-radius: 1px;
+  background: transparent;
+}
+
+.resize-handle:hover::after,
+.resize-handle:active::after {
+  background: var(--primary);
+}
+
+.resize-handle--start {
+  left: 0;
+  transform: translateX(-50%);
+}
+
+.resize-handle--end {
+  right: 0;
+  transform: translateX(50%);
 }
 
 .desktop-panel-modal {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1773,6 +1773,16 @@ button.compact {
   display: none;
 }
 
+/* The full directory path lives in the now-hidden <p> above; the compact sidebar row surfaces a
+   shortened copy inline next to the relative timestamp instead. */
+.session-directory-compact {
+  display: none;
+}
+
+.sidebar-sessions .session-directory-compact {
+  display: inline;
+}
+
 /* .session-stats becomes a transparent box so its children (the "updated" timestamp and the
    status pill) can be placed directly into the row's grid areas, next to the title. */
 .sidebar-sessions .session-stats {
@@ -1790,6 +1800,25 @@ button.compact {
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 0.72rem;
+}
+
+/* The directory and relative-time spans live inside a single flex row (rather than each being a
+   grid item in its own right) so they sit side by side instead of stacking on top of each other
+   in the "meta" grid area. */
+.session-meta-line {
+  display: flex;
+  min-width: 0;
+  gap: var(--space-1);
+}
+
+.sidebar-sessions .session-directory-compact {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sidebar-sessions .session-directory-compact::after {
+  content: "\00b7";
+  margin-left: var(--space-1);
 }
 
 .sidebar-sessions .session-stats .pill {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -357,6 +357,19 @@ p {
   margin-top: var(--space-4);
 }
 
+/* Settings only ever puts one button (Test connection) in .actions, so it should span the row
+   instead of sitting in the first half of a two-column grid meant for pairs of buttons. */
+.settings .actions,
+.settings .connection-help {
+  grid-template-columns: 1fr;
+}
+
+/* Password is the seventh (odd) field in the two-column form-grid, so it lands alone in the
+   last row occupying only the first column — span the full row instead. */
+.settings .form-grid label[for="password"] {
+  grid-column: 1 / -1;
+}
+
 .form-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1604,6 +1617,218 @@ button.compact {
     opacity: 1;
     transform: translateY(-4px);
   }
+}
+
+/* Desktop-only left sidebar, replacing the top header bar above the 780px breakpoint. The
+   sidebar element only exists in the DOM when App.tsx's isDesktop check is true, so this rule
+   never touches layout on mobile. */
+.desktop-sidebar {
+  display: flex;
+  flex-direction: column;
+  width: 280px;
+  flex: 0 0 280px;
+  position: sticky;
+  top: var(--space-4);
+  align-self: flex-start;
+  max-height: calc(100dvh - var(--space-4) * 2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--nav-bg);
+  box-shadow: var(--shadow-sm);
+  backdrop-filter: blur(14px);
+  overflow: hidden;
+}
+
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--border);
+  min-width: 0;
+}
+
+.sidebar-brand .brand-text {
+  min-width: 0;
+}
+
+.sidebar-brand h1,
+.sidebar-brand .subtle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--border);
+}
+
+.sidebar-toolbar .search {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.sidebar-sessions {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: var(--space-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.sidebar-empty {
+  padding: var(--space-3);
+}
+
+/* Desktop sidebar sessions render as compact single-line rows rather than the card grid the
+   mobile sessions panel uses — same markup (renderSessionCard), scoped override here. */
+.sidebar-sessions {
+  gap: 2px;
+}
+
+.sidebar-sessions .session-card {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-areas:
+    "title  actions"
+    "meta   actions";
+  align-items: center;
+  column-gap: var(--space-2);
+  row-gap: 1px;
+  padding: var(--space-2) var(--space-3);
+  border: none;
+  border-left: 3px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+}
+
+/* On desktop the pill is dropped in favor of a left-border flag: a session is assumed idle
+   unless it's actively busy/retrying, which is the only state worth calling out at a glance. */
+.sidebar-sessions .session-card.busy,
+.sidebar-sessions .session-card.retry {
+  border-left-color: var(--warning);
+}
+
+.sidebar-sessions .session-card:hover,
+.sidebar-sessions .session-card:focus-visible {
+  background: var(--surface-subtle);
+  box-shadow: none;
+}
+
+.sidebar-sessions .session-card.active {
+  background: var(--primary-soft);
+}
+
+.sidebar-sessions .session-card-main {
+  grid-area: title;
+  display: block;
+  min-width: 0;
+}
+
+.sidebar-sessions .session-card-main > div {
+  min-width: 0;
+}
+
+.sidebar-sessions .session-card h3 {
+  margin: 0;
+  font-size: 0.86rem;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-sessions .session-card-main p,
+.sidebar-sessions .session-card > p {
+  display: none;
+}
+
+/* .session-stats becomes a transparent box so its children (the "updated" timestamp and the
+   status pill) can be placed directly into the row's grid areas, next to the title. */
+.sidebar-sessions .session-stats {
+  display: contents;
+}
+
+.sidebar-sessions .session-stats .change-summary {
+  display: none;
+}
+
+.sidebar-sessions .session-stats > .subtle {
+  grid-area: meta;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.72rem;
+}
+
+.sidebar-sessions .session-stats .pill {
+  display: none;
+}
+
+.sidebar-sessions .inline-actions {
+  grid-area: actions;
+  flex: 0 0 auto;
+  gap: 2px;
+}
+
+.sidebar-sessions .inline-actions button {
+  font-size: 0;
+  padding: var(--space-1);
+  gap: 0;
+}
+
+.sidebar-footer {
+  display: flex;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-top: 1px solid var(--border);
+}
+
+.sidebar-footer button {
+  flex: 1 1 0;
+  justify-content: center;
+}
+
+.app-shell-desktop {
+  flex-direction: row;
+  align-items: flex-start;
+  width: min(100%, 1400px);
+}
+
+.main-content {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.desktop-panel-modal {
+  position: relative;
+  width: min(92vw, 720px);
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.desktop-panel-modal > .panel {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.desktop-modal-close {
+  position: absolute;
+  top: var(--space-3);
+  right: var(--space-3);
+  padding: var(--space-2);
 }
 
 @media (max-width: 780px) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2102,8 +2102,13 @@ button.compact {
     flex-direction: column;
   }
 
+  /* Bound the pane to the viewport (not just a floor) so .messages actually overflows and becomes
+     the scroller. Left unbounded, the flex chain grows to fit every message, .messages never
+     overflows, and its overscroll-behavior: contain leaves it a dead scroll container that
+     swallows swipes instead of passing them to the document. */
   .detail {
-    min-height: calc(100dvh - 158px);
+    height: calc(100dvh - 158px);
+    min-height: 0;
   }
 
   .detail-topbar {
@@ -2115,8 +2120,13 @@ button.compact {
     align-self: flex-start;
   }
 
+  /* min-height: 0 is what lets these flex children shrink below their content and overflow. */
+  .messages-wrap {
+    min-height: 0;
+  }
+
   .messages {
-    min-height: 240px;
+    min-height: 0;
     padding: 0;
   }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1674,6 +1674,7 @@ button.compact {
 .sidebar-sessions {
   flex: 1 1 auto;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: var(--space-2);
   display: flex;
   flex-direction: column;
@@ -1773,13 +1774,92 @@ button.compact {
 .sidebar-sessions .inline-actions {
   grid-area: actions;
   flex: 0 0 auto;
+  flex-wrap: nowrap;
   gap: 2px;
+  width: 0;
+  overflow: hidden;
+  opacity: 0;
 }
 
+/* Collapsed to zero width so the title's grid column reclaims the space instead of just hiding
+   the (still layout-reserving) buttons behind invisible pixels. */
+.sidebar-sessions .session-card:hover .inline-actions,
+.sidebar-sessions .session-card:focus-within .inline-actions {
+  width: auto;
+  opacity: 1;
+}
+
+/* Bare icons, not bordered buttons — a desktop sidebar is mouse-driven, and the icon alone reads
+   fine at this size without the extra chrome a touch target needs. */
 .sidebar-sessions .inline-actions button {
   font-size: 0;
-  padding: var(--space-1);
+  min-height: 0;
+  height: 22px;
+  width: 22px;
+  padding: 0;
   gap: 0;
+  border: none;
+  background: transparent;
+  color: var(--muted-strong);
+  box-shadow: none;
+}
+
+.sidebar-sessions .inline-actions button:hover:not(:disabled) {
+  background: var(--surface-subtle);
+  border-color: transparent;
+  box-shadow: none;
+  color: var(--text);
+}
+
+.sidebar-sessions .inline-actions button.btn-danger:hover:not(:disabled) {
+  color: var(--danger);
+}
+
+/* While renaming, the rename/delete icons would just sit on top of (or squeeze) the rename
+   input — hide them until the rename is confirmed or cancelled. */
+.sidebar-sessions .session-card.renaming .inline-actions {
+  display: none;
+}
+
+/* The rename input and its save/cancel buttons default to full-size (44px-tall buttons, a
+   140px-min-width input) sized for the session detail header, not a ~40px-tall sidebar row —
+   shrink everything to fit. */
+.sidebar-sessions .rename-inline {
+  width: 100%;
+  gap: 4px;
+}
+
+.sidebar-sessions .rename-input {
+  min-width: 0;
+  min-height: 0;
+  width: 100%;
+  height: 20px;
+  padding: 0 var(--space-1);
+  font-size: 0.78rem;
+}
+
+.sidebar-sessions .rename-inline button {
+  flex: 0 0 auto;
+  min-height: 0;
+  height: 20px;
+  width: 20px;
+  padding: 0;
+  font-size: 0;
+  border: none;
+  background: transparent;
+  color: var(--muted-strong);
+  box-shadow: none;
+}
+
+.sidebar-sessions .rename-inline button:hover:not(:disabled) {
+  background: var(--surface-subtle);
+  border-color: transparent;
+  box-shadow: none;
+  color: var(--text);
+}
+
+.sidebar-sessions .rename-inline button.btn-primary {
+  color: var(--primary);
 }
 
 .sidebar-footer {
@@ -2264,7 +2344,7 @@ button.compact {
    unlabelled glyphs. The title carries the action now, so the target is the width of the title. */
 .session-title-button {
   display: inline-flex;
-  align-items: center;
+  align-items: flex-start;
   gap: var(--space-2);
   min-width: 0;
   min-height: 44px;
@@ -2286,13 +2366,13 @@ button.compact {
 
 .session-title-text {
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: break-word;
+  white-space: normal;
 }
 
 .session-title-pencil {
   flex: 0 0 auto;
+  margin-top: 0.2em;
   color: var(--muted);
 }
 

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -40,7 +40,15 @@ assert.ok(app.includes('completionShouldPlayRef.current = true'), 'completion so
 assert.ok(app.includes('wasAwaitingAssistantReplyRef.current && !awaitingAssistantReply && completionShouldPlayRef.current'), 'completion sound should play only when assistant waiting ends, not when the user bubble renders')
 assert.ok(app.includes('loadSelectedRequestRef'), 'session message refreshes should ignore stale overlapping polling responses')
 assert.ok(app.includes('if (requestID !== loadSelectedRequestRef.current) return'), 'older loadSelected requests must not overwrite newer assistant output')
-assert.ok(app.includes('assistantPayloadLength(current) <= assistantPayloadLength(msg)'), 'message refresh should not regress from assistant output back to user-only history')
+assert.ok(app.includes('reconcileStreamedPart'), 'message refresh should not regress streamed assistant output back to a leaner snapshot')
+assert.ok(
+  /function reconcileStreamedPart[\s\S]*?incomingText\.length >= previousText\.length \? incoming/.test(app),
+  'a snapshot with shorter text than what is already shown must keep the longer text'
+)
+assert.ok(
+  !/assistantPayloadLength\(current\) <= assistantPayloadLength\(msg\)/.test(app),
+  'a leaner snapshot must not be rejected wholesale: the optimistic user bubble is cleared against that same snapshot, so dropping it makes a just-sent message vanish and latches every later message out of the transcript until the session is reopened'
+)
 assert.ok(app.includes('SendIcon') && app.includes('<SendIcon size={18} />'), 'composer send button should use the clear paper-plane SendIcon')
 assert.ok(app.includes('StopCircleIcon') && app.includes('<StopCircleIcon size={18} />'), 'composer waiting button should use a clear stop-task icon')
 assert.match(icons, /export const StopCircleIcon/, 'StopCircleIcon should exist in the shared SVG icon set')
@@ -141,7 +149,10 @@ for (const capability of ['agents', 'models', 'todos', 'diff', 'questions', 'ses
 // A follow-up prompt can be queued while the agent is still working.
 assert.ok(app.includes('const showStopAction = isWorking && !composer.trim()'), 'stop should be offered only when there is nothing to send')
 assert.equal(app.includes('disabled={!selectedSession || isWorking}'), false, 'the composer must stay usable while the agent works')
-assert.ok(app.includes("authoritativeExternalHistory || assistantPayloadLength(current) <= assistantPayloadLength(msg)"), "external OMP history must replace stale cached ordering even when the corrected payload is shorter")
+// External OMP history must replace stale cached ordering even when the corrected payload is shorter.
+// This no longer needs its own escape hatch: every fetched snapshot is now applied, and only same-id
+// same-type text is held back from shrinking, so a corrected external history replaces the cache.
+assert.ok(app.includes("if (!messagesHaveSameContent(current, msg)) {"), "a fetched snapshot must be applied whenever it differs from what is on screen")
 // The marker moved from below the messages, where the sticky composer cut it in half, into the
 // header. What matters is that an external session is still marked and still explained, not where.
 assert.ok(app.includes("selectedSession.external && ("), "a session from another client must be marked as such")


### PR DESCRIPTION
## Summary

Adds a desktop layout to the web app, plus a handful of fixes that came out of using it.

- **Desktop mode**: two-pane layout (sessions list + session detail) when there's room for it, instead of the mobile single-view navigation
- **Resizable panels**: the split between the two panes can be dragged
- **Auto-select**: first session is selected automatically in desktop mode so the detail pane isn't empty on load
- **Graphical tweaks/effects** for the desktop layout
- **Jump-to-top / jump-to-bottom buttons** in the chat (translated in en / it / zh-TW)
- Fixes: chat scrolling on mobile, relative timestamps in the sessions list, removed the help icon from the header, and stopped a lean history snapshot from swallowing messages that had just been sent

Touches `web/src/App.tsx`, `Icons.tsx`, `i18n.ts`, `styles.css`, and the UI regression test.

## Note

This project can now use [Tauri V2](https://v2.tauri.app/) to start shipping windows and linux binaries as well.