### PR TITLE
fix: preserve loading and reconnect states

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1557,6 +1557,7 @@ const MessageArticle = memo(function MessageArticle({
  *  on every keystroke. */
 const MessagesPane = memo(function MessagesPane({
   loadingSessionID,
+  loadedSessionID,
   selectedID,
   renderedMessages,
   timelineGroups,
@@ -1574,6 +1575,7 @@ const MessagesPane = memo(function MessagesPane({
   onJumpToBottom
 }: {
   loadingSessionID: string | null
+  loadedSessionID: string | null
   selectedID: string | null
   renderedMessages: (MessageEnvelope & { text: string })[]
   timelineGroups: RenderGroup[]
@@ -1593,7 +1595,7 @@ const MessagesPane = memo(function MessagesPane({
   return (
     <div className="messages-wrap">
       <div className="messages" ref={messagesRef} onScroll={onMessagesScroll}>
-        {loadingSessionID === selectedID ? (
+        {loadingSessionID === selectedID || (selectedID !== null && loadedSessionID !== selectedID) ? (
           <div className="empty-state compact">
             <LoadingIcon size={32} />
             <p>{t('detail.loading')}</p>
@@ -1763,6 +1765,8 @@ function App() {
   const [composer, setComposer] = useState("")
   const [busySending, setBusySending] = useState(false)
   const [loadingSessionID, setLoadingSessionID] = useState<string | null>(null)
+  /** The empty transcript state is only meaningful after this session's first history snapshot succeeds. */
+  const [loadedSessionID, setLoadedSessionID] = useState<string | null>(null)
   const [testingConnection, setTestingConnection] = useState(false)
   const [creatingSession, setCreatingSession] = useState(false)
   const [refreshingSessions, setRefreshingSessions] = useState(false)
@@ -1955,6 +1959,7 @@ function App() {
     setModelOptions([])
     setMessages([])
     loadedMessagesRef.current = []
+    setLoadedSessionID(null)
     setOptimisticUserMessages([])
     setTodos([])
     setDiffFiles([])
@@ -1983,6 +1988,7 @@ function App() {
       setSessions([])
       setSelectedID(null)
       setMessages([])
+      setLoadedSessionID(null)
       loadedMessagesRef.current = []
       setOptimisticUserMessages([])
       setTodos([])
@@ -2072,20 +2078,18 @@ function App() {
       }
 
       backgroundFailureCountRef.current += 1
-      // Tolerating a few failures avoids flapping when a working connection hiccups — but on the
-      // first load there is no good state to protect, and pretending to still be connecting while
-      // an error is already on screen is what made the app look like it contradicted itself.
-      if (backgroundFailureCountRef.current === 1 && sessions.length > 0) {
-        setConnectionState("reconnecting")
-        setConnectionMessage(t('connection.reconnecting'))
+      // A device returning from standby commonly loses one or two polling rounds while Wi-Fi and
+      // the server wake up. Keep the last known state and retry quietly before calling it offline.
+      if (backgroundFailureCountRef.current < 3) {
+        const isInitialLoad = initialSessionLoadRef.current && sessions.length === 0
+        setConnectionState(isInitialLoad ? "connecting" : "reconnecting")
+        setConnectionMessage(isInitialLoad ? t('connection.loadingSessions') : t('connection.reconnecting'))
         return
       }
 
       setConnectionState("offline")
       setConnectionMessage(t('connection.offline'))
-      if (backgroundFailureCountRef.current >= 3) {
-        setRuntimeError(message)
-      }
+      setRuntimeError(message)
       initialSessionLoadRef.current = false
     }
   }
@@ -2201,6 +2205,7 @@ function App() {
       capabilities.questions ? api.loadQuestions(config, directory).catch(() => []) : Promise.resolve([])
     ])
     if (requestID !== loadSelectedRequestRef.current) return
+    setLoadedSessionID(sessionID)
     const current = loadedMessagesRef.current
     // A snapshot carrying less assistant text than is already on screen used to be rejected wholesale, to
     // avoid erasing streamed content. But the optimistic user bubble below is cleared against this same
@@ -2396,6 +2401,7 @@ function App() {
       })
       setSelectedID(created.id)
       setMessages([])
+      setLoadedSessionID(null)
       setOptimisticUserMessages([])
       setTodos([])
       setDiffFiles([])
@@ -3652,6 +3658,7 @@ function App() {
 
           <MessagesPane
             loadingSessionID={loadingSessionID}
+            loadedSessionID={loadedSessionID}
             selectedID={selectedID}
             renderedMessages={renderedMessages}
             timelineGroups={timelineGroups}

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -40,6 +40,9 @@ assert.ok(app.includes('completionShouldPlayRef.current = true'), 'completion so
 assert.ok(app.includes('wasAwaitingAssistantReplyRef.current && !awaitingAssistantReply && completionShouldPlayRef.current'), 'completion sound should play only when assistant waiting ends, not when the user bubble renders')
 assert.ok(app.includes('loadSelectedRequestRef'), 'session message refreshes should ignore stale overlapping polling responses')
 assert.ok(app.includes('if (requestID !== loadSelectedRequestRef.current) return'), 'older loadSelected requests must not overwrite newer assistant output')
+assert.ok(app.includes('loadedSessionID'), 'the message pane should track whether the selected session history has loaded')
+assert.ok(app.includes('loadedSessionID !== selectedID'), 'an unloaded selected session must render the loading state instead of an empty transcript')
+assert.ok(app.includes('setLoadedSessionID(sessionID)'), 'a successful selected-session snapshot should unlock the empty transcript state')
 assert.ok(app.includes('reconcileStreamedPart'), 'message refresh should not regress streamed assistant output back to a leaner snapshot')
 assert.ok(
   /function reconcileStreamedPart[\s\S]*?incomingText\.length >= previousText\.length \? incoming/.test(app),
@@ -65,7 +68,6 @@ assert.ok(/\.project-dashboard[\s\S]*?grid-template-columns:\s*repeat\(3/.test(s
 assert.ok(/@media \(max-width: 780px\)[\s\S]*?\.project-dashboard[\s\S]*?grid-template-columns:\s*1fr/.test(styles), 'project dashboard should stack on mobile')
 assert.ok(app.includes('connectionState'), 'sessions view should track connection state separately from one-off runtime errors')
 assert.ok(app.includes('backgroundFailureCountRef.current += 1'), 'background refresh should count failures before showing persistent offline errors')
-assert.ok(app.includes('backgroundFailureCountRef.current >= 3'), 'transient 1-2 refresh failures should not immediately show the red runtime error')
 assert.ok(app.includes('connection-pending'), 'initial slow connection should show an explicit loading state instead of an empty sessions list')
 assert.ok(app.includes("t('connection.reconnecting')"), 'slow reconnecting state should be translated and shown quietly')
 assert.ok(styles.includes('.connection-status'), 'connection status should have a dedicated non-error visual treatment')
@@ -226,12 +228,12 @@ assert.ok(styles.includes('-webkit-tap-highlight-color: transparent'), 'the plat
 assert.ok(styles.includes('overscroll-behavior: contain'), 'scrolling to the end of a list should not drag the page')
 assert.match(styles, /button\.compact \{[\s\S]*?min-height: 44px/, 'a compact button is still a thumb target')
 
-// With the server unreachable the app used to show four hopeful messages and a developer-facing
-// error at the same time, for about ten seconds, and kept a stale list that could not be opened.
+// A phone returning from standby can miss a couple of polls while Wi-Fi and the server wake up.
+// Keep the last valid UI and show a quiet reconnect state before presenting the offline screen.
 assert.ok(app.includes('const isOffline = connectionState === "offline"'), 'offline should be one named state')
 assert.ok(
-  app.includes("backgroundFailureCountRef.current === 1 && sessions.length > 0"),
-  'tolerating failures protects an existing list; on the first load it only delays the truth'
+  app.includes('if (backgroundFailureCountRef.current < 3)'),
+  'background refreshes should retry twice before declaring the server offline'
 )
 assert.ok(app.includes('eventStreamText = isOffline'), 'the event stream must not claim to be reconnecting while the connection is down')
 assert.ok(


### PR DESCRIPTION
## Summary
- keep the session loading indicator visible until the selected session has received its first history snapshot
- avoid presenting an unloaded transcript as an empty conversation
- retry two missed background refreshes in the quiet reconnecting state before showing the backend as offline

## Verification
- `npm run test:ui`
- `npm run build`