### PR TITLE
docs: document desktop mode, and fix the empty chat pane's endless spinner

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # Contributing to Harness Remote
 
 Thanks for wanting to work on this. Harness Remote is a companion app for driving coding-agent
-harnesses from a phone. It is deliberately harness-agnostic: OpenCode, Oh My Pi (OMP) and PI are
-supported today. Adding a harness should mean adding a profile entry and its setup section, never a
-special case threaded through the app.
+harnesses from a phone or a desktop browser. It is deliberately harness-agnostic: OpenCode, Oh My Pi
+(OMP) and PI are supported today. Adding a harness should mean adding a profile entry and its setup
+section, never a special case threaded through the app.
 
 This document is long on purpose. Read the section that matches what you are touching, or all of it
 if you are having an agent do the work.
@@ -116,6 +116,26 @@ Do not add a third pattern where an unimplemented endpoint surfaces an error to 
 When a feature is genuinely unavailable on a backend, say so in the README's harness section rather
 than leaving the user to discover a dead button.
 
+## The other rule: every UI change lives in two layouts
+
+Below 781px the app is a single view with bottom navigation; above it, a permanent sidebar sits next
+to the chat. `App.tsx` keeps an `isDesktop` flag from a `matchMedia` query on that exact breakpoint,
+so the JS layout and the stylesheet's `@media (max-width: 780px)` block never disagree. Change one
+and you have to change the other.
+
+Two things make this easy to get wrong:
+
+- **The scroller moves.** On mobile the page scrolls and `.messages` is a plain block; on desktop the
+  chat pane is height-bounded and `.messages` is the scroller. Anything reading or setting scroll
+  position has to ask which one is live rather than assuming — `scrollsItself()` and
+  `messagesScrollMetrics()` exist for that.
+- **The session list is rendered twice.** `renderSessionCard` is shared by the mobile panel and the
+  desktop sidebar, with the sidebar's compact row shape coming from CSS overrides under
+  `.sidebar-sessions`. Add a field to the card and check it in both, rather than forking the markup.
+
+Resize the browser window across 781px before opening a PR that touches layout. It is the cheapest
+check in this document and it catches most of these.
+
 ## How the tests work here, and how to change one
 
 The suites under `web/src/*-regression.test.mjs` are unusual: they assert against the **source text**
@@ -223,10 +243,10 @@ that needs changing afterwards goes in separate commits on top. Squashing is up 
 
 ## Where to start
 
-- [#36](https://github.com/giuliastro/harness-remote/issues/36) — **PI support**, the next planned
-  harness, with the groundwork mapped out including the two hard-coded assumptions in the bridge
-  that need generalising.
-- Issues labelled [`help wanted`](https://github.com/giuliastro/harness-remote/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
+- [Open issues](https://github.com/giuliastro/harness-remote/issues), especially any labelled
+  [`help wanted`](https://github.com/giuliastro/harness-remote/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
+  A fourth harness is the obvious next step: the profile mechanism in `bridge/src/harness-profiles.js`
+  is what PI was added through, so it is a well-worn path rather than new ground.
 - Bug reports from real use are genuinely valuable here, for the reason in
   [Test against a real agent](#test-against-a-real-agent).
 - Translations, if the UI does not speak your language.

--- a/README.md
+++ b/README.md
@@ -33,9 +33,44 @@ Support levels differ by what each harness exposes. The [OpenCode](#opencode-ser
 - open a session and read messages, todo items, and progress
 - send prompts (and `/commands`) directly from the chat input
 - stop running work when necessary
-- use Android-friendly bottom navigation for quick access to Sessions, Detail, Settings, and Help
+- adapt to the screen: Android-friendly bottom navigation on a phone, a two-pane sidebar layout on a
+  wide screen (see [Desktop Mode](#desktop-mode))
+- jump to the top or the bottom of a long transcript or session list without dragging through it
 - play completion feedback sound when a running session finishes
 - switch UI language between English, Italian, and Traditional Chinese
+
+## Desktop Mode
+
+The app is one build with two layouts. There is no switch to flip and no separate desktop
+download: open it in a window at least 781px wide and it rearranges itself into a two-pane
+desktop layout. Narrow the window below that and it goes back to the phone layout, live.
+
+| | Phone layout | Desktop layout |
+|---|---|---|
+| Navigation | bottom nav, one view at a time | permanent left sidebar next to the chat |
+| Sessions | full-screen list, tap to open | compact rows in the sidebar, always visible |
+| Settings / Help | own full-screen views | modal over the chat, so the session stays put |
+| Session status | `idle` / `busy` / `retry` pill | animated accent bar on the row, only while busy or retrying |
+
+### Using it
+
+1. Serve the web app — `npm run dev` in `web/` during development, or any static host for a
+   `npm run build` bundle. The Android APK uses the same code and switches layout on a tablet or
+   a large foldable.
+2. Open it in a desktop browser. Above 781px the sidebar appears and the first session opens by
+   itself, so you land in a conversation rather than on an empty pane.
+3. Pick sessions from the sidebar. Hovering a row reveals its rename and delete icons; the
+   session you are reading stays highlighted while you browse the rest.
+4. Drag any of the three vertical borders to resize: the sidebar's outer edge, the divider between
+   the two panes, and the chat's outer edge. The sidebar accepts 220–480px and the chat 420–1400px.
+   Both widths are remembered per browser and are clamped back inside the window if you later open
+   the app on a smaller screen.
+5. Use the floating arrow buttons at the bottom right of a long transcript or session list to jump
+   to either end. They only appear when there is enough scrolling left to be worth it, and jumping
+   to the top also releases the chat's auto-follow so incoming output stops yanking the view down.
+
+Everything else — prompts, slash commands, stopping a run, model and agent selection, todos,
+diffs — behaves exactly as it does on a phone. The backend setup below is identical either way.
 
 ## Technology Stack
 
@@ -244,7 +279,8 @@ cd web
 npm install
 npm run dev
 ```
-Open the shown URL from your browser (or your phone on the same LAN).
+Open the shown URL from your browser (or your phone on the same LAN). A desktop browser window
+gets the two-pane layout described in [Desktop Mode](#desktop-mode); a phone gets the mobile one.
 
 ## Android APK Build (Cloud, no local SDK required)
 
@@ -291,9 +327,8 @@ The app is not limited to LAN. You can also use it over WAN/VPN if your network 
 
 ## Contributing
 
-Setup, the checks CI expects, how the regression suites work, and the rule that every change has to
-hold on more than one harness are all in [CONTRIBUTING.md](CONTRIBUTING.md).
-[#36](https://github.com/giuliastro/harness-remote/issues/36) (PI support) is open and unassigned.
+Setup, the checks CI expects, how the regression suites work, and the rules that every change has to
+hold on more than one harness and in both layouts are all in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Contributors
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1595,7 +1595,15 @@ const MessagesPane = memo(function MessagesPane({
   return (
     <div className="messages-wrap">
       <div className="messages" ref={messagesRef} onScroll={onMessagesScroll}>
-        {loadingSessionID === selectedID || (selectedID !== null && loadedSessionID !== selectedID) ? (
+        {/* Nothing selected is its own state, not a load in progress. Both of the tests below compare
+            against selectedID, so a null one used to satisfy them and left the desktop layout — which
+            renders this pane with no session, unlike mobile — spinning "loading" forever. */}
+        {selectedID === null ? (
+          <div className="empty-state compact">
+            <ChatIcon size={40} className="icon-empty-state" />
+            <p>{t('detail.selectSession')}</p>
+          </div>
+        ) : loadingSessionID === selectedID || loadedSessionID !== selectedID ? (
           <div className="empty-state compact">
             <LoadingIcon size={32} />
             <p>{t('detail.loading')}</p>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -49,6 +49,11 @@ const NEW_SESSION_DIRECTORY_STORAGE_KEY = "opencode.remote.newSessionDirectory"
 
 type Translator = ReturnType<typeof createTranslator>
 
+/** One pixel past the stylesheet's `@media (max-width: 780px)` block, so the JS layout switches on
+ *  exactly the width the CSS does. Named because the Help page quotes the number back to the user. */
+const DESKTOP_MIN_WIDTH = 781
+const DESKTOP_MEDIA_QUERY = `(min-width: ${DESKTOP_MIN_WIDTH}px)`
+
 const SIDEBAR_WIDTH_MIN = 220
 const SIDEBAR_WIDTH_MAX = 480
 const SIDEBAR_WIDTH_DEFAULT = 280
@@ -1693,9 +1698,9 @@ function App() {
   })
   // Desktop gets a persistent left sidebar instead of the mobile top bar/bottom nav; this mirrors
   // the existing 780px CSS breakpoint so JS layout and stylesheet layout never disagree.
-  const [isDesktop, setIsDesktop] = useState(() => window.matchMedia("(min-width: 781px)").matches)
+  const [isDesktop, setIsDesktop] = useState(() => window.matchMedia(DESKTOP_MEDIA_QUERY).matches)
   useEffect(() => {
-    const query = window.matchMedia("(min-width: 781px)")
+    const query = window.matchMedia(DESKTOP_MEDIA_QUERY)
     const onChange = (event: MediaQueryListEvent) => setIsDesktop(event.matches)
     query.addEventListener("change", onChange)
     return () => query.removeEventListener("change", onChange)
@@ -3970,12 +3975,34 @@ function App() {
                 <li><strong>Configure Server:</strong> Use Settings to enter host, port, username and password</li>
                 <li><strong>Test Connection:</strong> Press Test to validate server connectivity</li>
                 <li><strong>Configuration:</strong> Changes are saved automatically and applied after you pause typing.</li>
-                <li><strong>Browse Sessions:</strong> View and manage sessions from the Sessions tab</li>
-                <li><strong>Interact:</strong> Open a session and chat in the Detail view</li>
+                {/* Told in terms of what is actually on screen: the same two steps are a tab and a
+                    view on a phone, and two panes side by side on a desktop. */}
+                <li><strong>Browse Sessions:</strong> {isDesktop
+                  ? "Pick a session from the sidebar on the left"
+                  : "View and manage sessions from the Sessions tab"}</li>
+                <li><strong>Interact:</strong> {isDesktop
+                  ? "Read and reply in the conversation beside it"
+                  : "Open a session and chat in the Detail view"}</li>
                 <li><strong>Quick Input:</strong> Press Enter to send, Shift+Enter for new lines</li>
                 <li><strong>Slash Commands:</strong> Text starting with <code>/</code> is sent as a command</li>
               </ul>
-              
+
+              {/* Window width alone picks the layout, so the one thing worth stating is where the
+                  boundary is: otherwise a resized window looks like the app lost its sidebar. */}
+              <h3>Desktop Layout</h3>
+              <p>
+                A window at least {DESKTOP_MIN_WIDTH}px wide shows the sessions sidebar and the
+                conversation side by side.{isDesktop
+                  ? " Narrow it below that and the single-view mobile layout comes back."
+                  : " This window is narrower than that, which is why you are seeing one view at a time."}
+              </p>
+              <ul>
+                <li><strong>Resize:</strong> Drag the sidebar's outer edge, the divider between the panes, or the conversation's outer edge. Both widths are remembered.</li>
+                <li><strong>Rename or delete:</strong> Hover a sidebar row to reveal its icons.</li>
+                <li><strong>Working sessions:</strong> A moving accent bar down the left of a row replaces the status pill.</li>
+                <li><strong>Settings and Help:</strong> Open over the conversation, so it stays where you left it.</li>
+              </ul>
+
               <h3>Key Features</h3>
               <ul>
                 <li>🔄 Real-time session monitoring</li>
@@ -3983,6 +4010,7 @@ function App() {
                 <li>📋 Todo tracking display</li>
                 <li>⚡ Instant session control</li>
                 <li>🔔 Completion notifications</li>
+                <li>↕️ Jump to either end of a long conversation</li>
               </ul>
             </div>
           )}

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -43,6 +43,12 @@ assert.ok(app.includes('if (requestID !== loadSelectedRequestRef.current) return
 assert.ok(app.includes('loadedSessionID'), 'the message pane should track whether the selected session history has loaded')
 assert.ok(app.includes('loadedSessionID !== selectedID'), 'an unloaded selected session must render the loading state instead of an empty transcript')
 assert.ok(app.includes('setLoadedSessionID(sessionID)'), 'a successful selected-session snapshot should unlock the empty transcript state')
+// The desktop layout renders the chat pane with no session selected, which mobile never does: both
+// load checks compare against selectedID, so a null one satisfied them and spun "loading" forever.
+assert.ok(
+  /selectedID === null \?[\s\S]*?t\('detail\.selectSession'\)[\s\S]*?loadingSessionID === selectedID/.test(app),
+  'no selected session must render its own empty state, ahead of and separate from the loading state'
+)
 assert.ok(app.includes('reconcileStreamedPart'), 'message refresh should not regress streamed assistant output back to a leaner snapshot')
 assert.ok(
   /function reconcileStreamedPart[\s\S]*?incomingText\.length >= previousText\.length \? incoming/.test(app),


### PR DESCRIPTION
## Summary

Desktop mode shipped in #60 and nothing documented it. This adds that documentation, and fixes one
desktop-only bug found while checking the docs against the running app.

- **README** gets a Desktop Mode section: the 781px boundary, a table of what changes across it, and
  the five things needed to drive it (serving it, auto-select, the sidebar rows, the three draggable
  borders with their 220–480 / 420–1400px ranges and persisted widths, the jump buttons).
- **Help → Overview** describes whichever layout is on screen rather than assuming a phone, and names
  the boundary so a resized window reads as a layout change instead of a lost sidebar. The breakpoint
  becomes a constant now that the UI quotes it.
- **CONTRIBUTING** gains the layout counterpart to the two-backends rule, covering the two traps
  already load-bearing in the code: the scroller changes identity across the breakpoint, and the
  session card is rendered twice from one function. Its "where to start" also stopped pointing at
  #36, which shipped as PI support in v2.2.0.
- **Fix:** with no session selected, the conversation pane sat on "Loading session…" forever. Both of
  its load checks compare against `selectedID`, so a null one satisfied `loadingSessionID === selectedID`
  and there was nothing for the spinner to wait for. Mobile never showed it — the Detail tab is
  disabled until a session is picked — but the desktop layout renders the pane unconditionally, so
  connecting to a server with no sessions, or closing Settings before picking one, met a spinner that
  would not stop. Nothing selected is now its own branch ahead of the load checks.

## Verification

- `npm run build`, all six web suites, and `npm test` in `bridge/` — green, and green on each commit
  individually.
- Drove the real app at 1280px and at 400px: the sidebar and the Settings/Help modals appear and
  disappear at the breakpoint live, both Help variants render the right wording, and the empty pane
  now says "Select a session" with no spinner.
