### PR TITLE
docs: even out the README screenshots, drop the hand-kept contributors list

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,22 @@ Support levels differ by what each harness exposes. The [OpenCode](#opencode-ser
 
 ## Screenshots
 
-| Sessions | Detail |
-|---|---|
-| ![](docs/screenshots/sessions.jpg) | ![](docs/screenshots/detail.jpg) |
+<!-- A raw table with 50% columns, rather than a markdown one: GitHub sizes markdown table columns
+     from their content, and "Sessions" is a wider heading than "Detail", so that column took ~14px
+     more and each screenshot scaled to fill whichever column it landed in — the right one rendered
+     visibly smaller. Pinning the columns keeps the pair identical at any viewport width, which a
+     fixed width on the images alone does not: max-width: 100% still clamps each to its own cell. -->
+
+<table>
+  <tr>
+    <th width="50%">Sessions</th>
+    <th width="50%">Detail</th>
+  </tr>
+  <tr>
+    <td><img src="docs/screenshots/sessions.jpg" alt="Sessions list showing connection status, session cards with relative timestamps, and rename and delete actions"></td>
+    <td><img src="docs/screenshots/detail.jpg" alt="Session detail showing the model chip, a collapsed reasoning bubble, an assistant reply, and the composer"></td>
+  </tr>
+</table>
 
 ## What It Can Do
 

--- a/README.md
+++ b/README.md
@@ -342,10 +342,3 @@ The app is not limited to LAN. You can also use it over WAN/VPN if your network 
 
 Setup, the checks CI expects, how the regression suites work, and the rules that every change has to
 hold on more than one harness and in both layouts are all in [CONTRIBUTING.md](CONTRIBUTING.md).
-
-## Contributors
-
-<a href="https://github.com/giuliastro"><img src="https://github.com/giuliastro.png" width="40" height="40" alt="giuliastro" title="giuliastro" /></a>
-<a href="https://github.com/gervaso-assistant"><img src="https://github.com/gervaso-assistant.png" width="40" height="40" alt="Gervaso" title="Gervaso" /></a>
-<a href="https://github.com/ergs0204"><img src="https://github.com/ergs0204.png" width="40" height="40" alt="Eric-Yeh" title="Eric-Yeh" /></a>
-<a href="https://github.com/birabittoh"><img src="https://github.com/birabittoh.png" width="40" height="40" alt="birabittoh" title="birabittoh" /></a>


### PR DESCRIPTION
Two small README fixes.

**Screenshot sizing.** The two shots are the same 1220x2712, but the right one rendered about 3.5% smaller. GitHub sizes markdown table columns from their content, and \Sessions\ is a wider heading than \Detail\, so its column took 418px against 404px and each bare image scaled to fill whichever column it landed in.

Pinning the columns to 50% is what actually fixes it. A fixed \width\ on the images alone equalises the desktop view but not a phone — GitHub's \max-width: 100%\ still clamps each image to its own unequal cell, which put them 13px apart again at a 420px viewport. Both images also gain the alt text the bare \![]()\ form never had.

Verified on GitHub's own rendering of this branch: identical at 384x854 in 411px cells at a 1280px viewport, and at 149x332 in 177px cells at 420px, with no horizontal overflow.

**Contributors list.** Removed. GitHub builds the same thing from commit history and the sidebar links it; a hand-kept copy is just a place to forget someone.