### PR TITLE
ci: credit contributors in release notes instead of the merge

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Release notes are built from the tag's own annotation and the tag before it, and a
+          # depth-1 clone has neither.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -155,6 +159,40 @@ jobs:
           name: harness-remote-release-apk-v${{ steps.version.outputs.app_version }}
           path: ${{ steps.apk.outputs.path }}
 
+      # The release summary and its credits come from the annotated tag message, written by hand when
+      # the release is cut. generate_release_notes is deliberately off: it lists one line per pull
+      # request attributed to whoever merged it, which credits the maintainer for work contributors
+      # did. CI cannot tell those apart, so it does not try — it publishes the curated text and links
+      # the full changelog for anyone who wants the commit-level detail.
+      - name: Compose release notes
+        id: notes
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          SUMMARY=$(git tag -l --format='%(contents:body)' "$GITHUB_REF_NAME")
+          PREVIOUS_TAG=$(git describe --tags --abbrev=0 --exclude="$GITHUB_REF_NAME" 2>/dev/null || true)
+          {
+            echo 'body<<HARNESS_RELEASE_NOTES_EOF'
+            echo '## Release'
+            echo
+            echo "Stable Android release APK for Harness Remote \`${{ steps.version.outputs.app_version }}\`."
+            # A lightweight tag, or an annotation with only a subject line, leaves this empty. Better a
+            # terse release than a failed one, so it is skipped rather than treated as an error.
+            if [ -n "$SUMMARY" ]; then
+              echo
+              echo "$SUMMARY"
+            fi
+            echo
+            echo '## Notes'
+            echo
+            echo "- Built from \`$GITHUB_SHA\`"
+            echo "- Version code \`${{ steps.version.outputs.version_code }}\`"
+            if [ -n "$PREVIOUS_TAG" ]; then
+              echo
+              echo "**Full changelog**: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/$PREVIOUS_TAG...$GITHUB_REF_NAME"
+            fi
+            echo 'HARNESS_RELEASE_NOTES_EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Publish GitHub release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
@@ -162,11 +200,5 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: Harness Remote v${{ steps.version.outputs.app_version }}
           files: ${{ steps.apk.outputs.path }}
-          generate_release_notes: true
-          body: |
-            ## Release
-            Stable Android release APK for Harness Remote `${{ steps.version.outputs.app_version }}`.
-
-            ## Notes
-            - Built from `${{ github.sha }}`
-            - Version code `${{ steps.version.outputs.version_code }}`
+          generate_release_notes: false
+          body: ${{ steps.notes.outputs.body }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,6 +210,27 @@ npm run cap:sync:android
 A plain `npx cap sync android` does **not** copy those Java sources into the generated project, so
 your change is silently dropped and the app runs the previous version of the native plugin.
 
+## Cutting a release
+
+Bump `version` in `web/package.json`, commit it as `chore: release vX.Y.Z`, then tag that commit and
+push both. Everything else — the version code, the Android metadata, the signed APK, the GitHub
+release — is derived from that one field by CI.
+
+```bash
+git tag -a v2.4.0 -F release-notes.txt
+git push origin main && git push origin v2.4.0
+```
+
+**The tag annotation is the release notes.** CI publishes its body verbatim, so write it for someone
+deciding whether to update: what changed, then who to thank.
+
+**Credit contributors, not the merge.** GitHub's generated notes are switched off deliberately. They
+list one line per pull request attributed to whoever pressed merge, which on this repo means the
+maintainer collects credit for work other people did. So do not enumerate pull requests or say who
+did what task by task. Name the people whose work is in the release, say what they contributed, and
+give the largest contribution a `Special thanks`. Anyone who wants commit-level detail has the full
+changelog link that CI appends.
+
 ## The bridge is a network service
 
 Treat these three areas as security-sensitive and explain your reasoning in the PR when you change


### PR DESCRIPTION
\generate_release_notes\ listed one line per pull request, each ending in \y @<whoever merged it>\. On this repo that is almost always the maintainer, so v2.3.0 read as though the maintainer wrote the desktop layout — eight of its ten lines said \y @giuliastro\ — while the people who actually contributed appeared as two lines among the ten.

CI cannot tell a contribution from the merge that landed it, so it no longer tries. The annotated tag message becomes the release body: it is already written by hand at release time and already carried a credits line in both v2.2.0 and v2.3.0. Build notes and a full-changelog compare link are appended, so commit-level detail stays one click away.

- \generate_release_notes: false\, body composed from \git tag -l --format='%(contents:body)'\
- \etch-depth: 0\ on checkout — the tag annotation and the previous tag are both missing from a depth-1 clone
- a tag with no annotation body yields a terse release rather than a failed one
- CONTRIBUTING gains a **Cutting a release** section stating the convention, since crediting is now a judgement call rather than something the tooling does

The v2.3.0 notes have already been rewritten by hand to match.

## Verification

- Workflow YAML parses; \Compose release notes\ runs before \Publish GitHub release\, and the publish step reads \steps.notes.outputs.body\.
- Ran the composer script locally against the real \2.3.0\ tag: it reproduces the intended body, resolves the previous tag as \2.2.0\, and emits no per-PR attribution. The workflow path itself is only exercised on the next \*\ tag.