### PR TITLE
fix: prevent long session titles from breaking layout

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -526,8 +526,14 @@ p {
   grid-template-columns: minmax(0, 1fr);
   align-items: start;
   gap: var(--space-3);
+  min-width: 0;
 }
 
+.session-card h3 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .session-card-main p,
 .session-card > p {
   margin-top: var(--space-1);

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -10,6 +10,8 @@ const refreshButton = app.match(/<button onClick=\{refreshSessionsWithIndicator\
 assert.ok(refreshButton, 'sessions refresh button should call refreshSessionsWithIndicator')
 assert.ok(refreshButton[0].includes('RefreshIcon'), 'idle sessions refresh button should render a non-spinning RefreshIcon')
 assert.ok(refreshButton[0].includes('refreshingSessions ? <LoadingIcon'), 'refresh button should spin only during an active manual refresh')
+assert.match(styles, /\.session-card-main\s*\{[\s\S]*?min-width:\s*0;/, 'session card content should be allowed to shrink inside narrow layouts')
+assert.match(styles, /\.session-card h3\s*\{[\s\S]*?overflow:\s*hidden;[\s\S]*?text-overflow:\s*ellipsis;[\s\S]*?white-space:\s*nowrap;/, 'long session titles should stay within their card and show an ellipsis')
 
 assert.ok(app.includes('messageScrollSignature'), 'conversation auto-scroll should react to message content changes, not only message count')
 assert.ok(


### PR DESCRIPTION
## Why
Returning from a session to the sessions tab could leave a very long session title wider than its card, causing the mobile layout to overflow and break the UI.

## What changed
- Constrain session card content so it can shrink in narrow layouts.
- Render long session titles as a single-line ellipsis while preserving the full title in the existing title attribute.
- Add a regression guard for the CSS invariant.

## Verification
- Reproduced the overflow at 390px with a 240-character title before the fix.
- Confirmed ellipsis containment at 390px and 900px in the running Vite app.
- npm run build
- npm run test:i18n
- npm run test:config
- npm run test:ui
- npm run test:settings
- npm run test:model
- npm run test:events
- bridge: npm test (43 passing)

Not tested against a real harness; this is a UI-only change.