### PR TITLE
fix: contain a long session title without truncating it

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -529,11 +529,18 @@ p {
   min-width: 0;
 }
 
+/* A long title must not widen the card: that is what overflowed the whole mobile layout, together
+   with the min-width above. Breaking it is enough to contain it, and keeps the wrapped two-line
+   titles the cards have always shown — `white-space: nowrap` with an ellipsis contains it just as
+   well, but collapses every one of them to a single truncated line, which costs real information on
+   a phone where session titles are long and the card has the room. break-word also covers the one
+   case plain wrapping cannot: a title that is a single unbroken token.
+   The desktop sidebar overrides this back to one ellipsised line on purpose — a compact row is the
+   point there, and the full title is in the tooltip. */
 .session-card h3 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: break-word;
 }
+
 .session-card-main p,
 .session-card > p {
   margin-top: var(--space-1);

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -11,7 +11,18 @@ assert.ok(refreshButton, 'sessions refresh button should call refreshSessionsWit
 assert.ok(refreshButton[0].includes('RefreshIcon'), 'idle sessions refresh button should render a non-spinning RefreshIcon')
 assert.ok(refreshButton[0].includes('refreshingSessions ? <LoadingIcon'), 'refresh button should spin only during an active manual refresh')
 assert.match(styles, /\.session-card-main\s*\{[\s\S]*?min-width:\s*0;/, 'session card content should be allowed to shrink inside narrow layouts')
-assert.match(styles, /\.session-card h3\s*\{[\s\S]*?overflow:\s*hidden;[\s\S]*?text-overflow:\s*ellipsis;[\s\S]*?white-space:\s*nowrap;/, 'long session titles should stay within their card and show an ellipsis')
+// The invariant is that a long title cannot widen its card, not how that is achieved. Asserting the
+// nowrap/ellipsis spelling instead pinned a truncation the mobile cards never had: their titles wrap,
+// and the README screenshots show it. Breaking the word contains the overflow and keeps the wrapping.
+// Anchored to line start, and each match kept inside one rule block with [^}]: an unanchored
+// `.session-card h3` also matches the tail of `.sidebar-sessions .session-card h3`, which made the
+// negative assertion below fire on the sidebar's deliberate nowrap.
+assert.match(styles, /^\.session-card h3\s*\{[^}]*overflow-wrap:\s*(break-word|anywhere);/m, 'a long session title must break rather than widen its card')
+assert.ok(
+  !/^\.session-card h3\s*\{[^}]*white-space:\s*nowrap/m.test(styles),
+  'the mobile session card title must stay free to wrap; only the compact desktop sidebar row truncates it'
+)
+assert.match(styles, /^\.sidebar-sessions \.session-card h3\s*\{[^}]*white-space:\s*nowrap;/m, 'the desktop sidebar row keeps its single-line ellipsised title')
 
 assert.ok(app.includes('messageScrollSignature'), 'conversation auto-scroll should react to message content changes, not only message count')
 assert.ok(


### PR DESCRIPTION
Follow-up on top of #67, which is already merged.

#67's `min-width: 0` is the fix for the overflow: a grid child cannot shrink below its content without it. The `white-space: nowrap` next to it goes further than the overflow required — it collapses every multi-line card title to one ellipsised line. The mobile cards have always wrapped, and the README screenshots show two-line titles, so the app stopped matching its own documentation.

Breaking the word contains the title just as well and keeps the wrapping, while also covering the case plain wrapping cannot: a title that is a single unbroken token.

## Measured

Against the real stylesheet at a 390px viewport, with two titles — one long with spaces, one a 128-character unbroken token:

| | `nowrap` (as merged) | `overflow-wrap: break-word` |
|---|---|---|
| long spaced title | 1 line, truncated | 4 lines, wrapped |
| unbroken token | 1 line, truncated | 4 lines, wrapped |
| overflows card / viewport | no | no |

The desktop sidebar is unchanged and still shows one ellipsised line — verified at 1280px. That row sets its own `white-space: nowrap`, a compact row is the point there, and the full title stays in the tooltip.

## On the test

The guard now asserts the invariant — a long title must break rather than widen its card — instead of the `nowrap`/`ellipsis` spelling, which pinned the truncation itself. Per CONTRIBUTING's rule about asserting the guarantee rather than the shape of the code.

Its selectors are also anchored and scoped to a single rule block. A bare `.session-card h3` matches the tail of `.sidebar-sessions .session-card h3` too, which made my first attempt read the sidebar's deliberate `nowrap` as the mobile regression and fail. Confirmed the guards do fail if the truncation is reintroduced.

Build, all six web suites and the bridge's 43 tests pass.