### PR TITLE
fix: warn when the hosted PWA cannot reach the configured server

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,29 @@ in `--cors`:
 npx -y opencode-ai serve --hostname 0.0.0.0 --port 4096 --cors https://giuliastro.github.io
 ```
 
+### The hosted PWA cannot reach a plain-http server on your LAN
+
+CORS is only the second obstacle. The first is that the hosted app is served over HTTPS, and an
+HTTPS page is not allowed to talk to an `http://` address unless that address is loopback:
+
+- `http://localhost:4096` and `http://127.0.0.1:4096` work — browsers treat loopback as
+  trustworthy. Good enough when the server runs on the same machine as the browser.
+- `http://192.168.1.64:4096` is refused as mixed content, *before the request is sent*. The
+  server never sees it, so no amount of `--cors` helps, and the app can only report
+  `Failed to fetch`. Settings shows a warning next to the host field when the address you typed
+  falls into this case.
+
+So the phone-to-PC setup — the reason this app exists — needs one of:
+
+- **the Android app** from [Releases](https://github.com/giuliastro/harness-remote/releases/latest),
+  which is not a web page and has no such restriction. This stays the recommended route.
+- **HTTPS on the server**, via a reverse proxy holding a certificate the phone trusts.
+- **a tunnel** (Tailscale Serve, Cloudflare Tunnel, ngrok) that gives the server its own HTTPS
+  origin — remember to add that origin to `--cors`.
+- **self-hosting this build over plain http** on your LAN, e.g. `npm run preview -- --host` in
+  `web/`. An `http://` page may talk to an `http://` server freely; you lose installability and
+  the service worker, both of which require a secure context.
+
 ## Technology Stack
 
 - frontend: React + TypeScript + Vite

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -20,6 +20,15 @@ self.addEventListener("activate", (event) => {
   )
 })
 
+/**
+ * A worker may be killed as soon as it has answered, so a cache write started inside the
+ * response chain is not guaranteed to finish: it has to be kept alive by the event itself.
+ */
+function storeInCache(event, key, response) {
+  const copy = response.clone()
+  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.put(key, copy)))
+}
+
 self.addEventListener("fetch", (event) => {
   const request = event.request
   if (request.method !== "GET") return
@@ -31,8 +40,7 @@ self.addEventListener("fetch", (event) => {
     event.respondWith(
       fetch(request)
         .then((response) => {
-          const copy = response.clone()
-          caches.open(CACHE_NAME).then((cache) => cache.put(scope, copy))
+          storeInCache(event, scope, response)
           return response
         })
         .catch(() => caches.match(scope))
@@ -44,10 +52,7 @@ self.addEventListener("fetch", (event) => {
     caches.match(request).then((cached) => {
       const network = fetch(request)
         .then((response) => {
-          if (response.ok) {
-            const copy = response.clone()
-            caches.open(CACHE_NAME).then((cache) => cache.put(request, copy))
-          }
+          if (response.ok) storeInCache(event, request, response)
           return response
         })
         .catch(() => cached)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,9 +1,9 @@
 import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from "react"
 import { App as CapacitorApp } from "@capacitor/app"
-import type { PluginListenerHandle } from "@capacitor/core"
+import { Capacitor, type PluginListenerHandle } from "@capacitor/core"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
-import { api, isValidServerConfig } from "./api"
+import { api, isMixedContentBlocked, isValidServerConfig } from "./api"
 import { ACTIVE_BACKEND_STORAGE_KEY, BACKEND_STORAGE_KEYS, LEGACY_STORAGE_KEY } from "./storageKeys"
 import {
   createFetchOpenCodeEventSubscription,
@@ -1950,6 +1950,12 @@ function App() {
 
   const hasConfiguredServer = isValidServerConfig(config)
   const draftConfigKey = configKey(draftConfig)
+  // The address is typed here but rejected by the browser, so the warning belongs next to the
+  // field rather than in the failure notice, where it would only appear after a pointless test.
+  // The native build goes through CapacitorHttp instead of the WebView and is never subject to
+  // this, whatever scheme `androidScheme` happens to serve the bundle under.
+  const draftBlockedByMixedContent = !Capacitor.isNativePlatform()
+    && isMixedContentBlocked(draftConfig, window.location.protocol)
   const canTestDraft = canTestConfig(draftConfig)
   const testAlreadyPassedForDraft = lastTestedConfigKey === draftConfigKey
   const connectionStatusText = connectionMessage || (connectionState === "connecting"
@@ -3282,7 +3288,7 @@ function App() {
             </select>
           </label>
 
-          <label htmlFor="host">
+          <label htmlFor="host" className={draftBlockedByMixedContent ? "field-row-span" : undefined}>
             {t('settings.host')}
             <input
               id="host"
@@ -3295,8 +3301,11 @@ function App() {
               spellCheck={false}
               autoComplete="off"
             />
+            {draftBlockedByMixedContent && (
+              <span className="field-warning">{t('settings.insecureHostWarning')}</span>
+            )}
           </label>
-          
+
           <label htmlFor="port">
             {t('settings.port')}
             <input

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,6 +1,6 @@
 import { Capacitor, CapacitorHttp } from "@capacitor/core"
 import { streamURL } from "./opencode-events"
-import { baseUrl, isValidServerConfig } from "./serverConfig"
+import { baseUrl, isMixedContentBlocked, isValidServerConfig } from "./serverConfig"
 import type {
   AgentOption,
   CommandInfo,
@@ -26,7 +26,7 @@ function authHeader(config: ServerConfig): string {
   return `Basic ${btoa(`${config.username}:${config.password}`)}`
 }
 
-export { baseUrl, isValidServerConfig }
+export { baseUrl, isMixedContentBlocked, isValidServerConfig }
 
 function withDirectory(path: string, directory?: string): string {
   if (!directory) return path

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -17,6 +17,7 @@ type TranslationKey =
   | 'settings.backend'
   | 'settings.host'
   | 'settings.hostPlaceholder'
+  | 'settings.insecureHostWarning'
   | 'settings.port'
   | 'settings.username'
   | 'settings.password'
@@ -234,6 +235,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'settings.backend': 'Backend',
     'settings.host': 'Host Address',
     'settings.hostPlaceholder': '192.168.1.100, localhost, or https://example.com',
+    'settings.insecureHostWarning': 'This app is served over HTTPS, so the browser will refuse a plain http:// server unless it runs on this same device. Serve the server over HTTPS, reach it through a tunnel, or use the installed Android app.',
     'settings.port': 'Port',
     'settings.username': 'Username',
     'settings.password': 'Password',
@@ -449,6 +451,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'settings.backend': 'Backend',
     'settings.host': 'Indirizzo host',
     'settings.hostPlaceholder': '192.168.1.100, localhost o https://example.com',
+    'settings.insecureHostWarning': 'Questa app è servita in HTTPS, quindi il browser rifiuta un server http:// che non sia su questo stesso dispositivo. Esponi il server in HTTPS, raggiungilo tramite un tunnel oppure usa l\'app Android installata.',
     'settings.port': 'Porta',
     'settings.username': 'Username',
     'settings.password': 'Password',
@@ -664,6 +667,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'settings.backend': '後端',
     'settings.host': '主機位址',
     'settings.hostPlaceholder': '192.168.1.100、localhost 或 https://example.com',
+    'settings.insecureHostWarning': '本應用透過 HTTPS 提供，因此除非伺服器就在這台裝置上，瀏覽器會拒絕連線至 http:// 伺服器。請改用 HTTPS 提供伺服器、透過通道連線，或使用已安裝的 Android 應用程式。',
     'settings.port': '連接埠',
     'settings.username': '使用者名稱',
     'settings.password': '密碼',

--- a/web/src/server-config.test.mjs
+++ b/web/src/server-config.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { streamURL } from './opencode-events.ts'
-import { baseUrl, isValidServerConfig } from './serverConfig.ts'
+import { baseUrl, isMixedContentBlocked, isValidServerConfig } from './serverConfig.ts'
 
 const config = (host, port = 4096) => ({ backend: 'opencode', host, port, username: 'opencode', password: 'secret' })
 
@@ -30,7 +30,34 @@ for (const host of ['Giulio-S7', 'http://192.168.1.64', 'https://example.com']) 
   assert.doesNotThrow(() => streamURL(baseUrl(config(host)), 'global'), `streamURL must not throw for ${host}`)
 }
 
+// Measured in a browser on an https page against one server bound to 0.0.0.0:4096: loopback
+// answered 200, the same server on 192.168.1.64 was refused. So the installed PWA reaches a
+// server on the same machine and nothing else, and the settings panel must say so — a blocked
+// request surfaces only as "Failed to fetch".
+for (const host of ['localhost', '127.0.0.1', '127.1.2.3', 'dev.localhost', '[::1]']) {
+  assert.equal(isMixedContentBlocked(config(host), 'https:'), false, `loopback host ${host} stays reachable from https`)
+}
+for (const host of ['192.168.1.64', 'Giulio-S7', 'http://192.168.1.64', 'http://example.com']) {
+  assert.equal(isMixedContentBlocked(config(host), 'https:'), true, `plain-http host ${host} is blocked from https`)
+}
+assert.equal(isMixedContentBlocked(config('https://example.com'), 'https:'), false, 'an https server is never mixed content')
+// The dev server and the Capacitor build are not https pages, so the warning must stay quiet there.
+for (const protocol of ['http:', 'capacitor:', 'file:']) {
+  assert.equal(isMixedContentBlocked(config('192.168.1.64'), protocol), false, `no warning on a ${protocol} page`)
+}
+assert.equal(isMixedContentBlocked(config('http://'), 'https:'), false, 'a half-typed host must not throw or warn')
+
 const app = readFileSync(new URL('./App.tsx', import.meta.url), 'utf8')
+assert.match(
+  app,
+  /isMixedContentBlocked\(draftConfig, window\.location\.protocol\)/,
+  'the settings panel must warn when the configured server cannot be reached from an https page'
+)
+assert.match(
+  app,
+  /!Capacitor\.isNativePlatform\(\)\s*\n?\s*&& isMixedContentBlocked/,
+  'the native build reaches the server through CapacitorHttp, so it must never show that warning'
+)
 assert.match(
   app,
   /if \(draftConfig\.host\.trim\(\) && !isValidServerConfig\(draftConfig\)\) return/,

--- a/web/src/serverConfig.ts
+++ b/web/src/serverConfig.ts
@@ -18,6 +18,35 @@ export function baseUrl(config: ServerConfig): string {
  * building any URL, because a throw on the render path blanks the whole app and a
  * persisted invalid host reproduces that crash on every launch.
  */
+/**
+ * Browsers treat loopback as trustworthy even over plain http, so these hosts stay reachable
+ * from an https page. Everything else does not.
+ */
+function isLoopbackHostname(hostname: string): boolean {
+  if (hostname === "localhost" || hostname.endsWith(".localhost")) return true
+  if (hostname === "[::1]" || hostname === "::1") return true
+  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname)
+}
+
+/**
+ * The installable web app is served over https, and an https page may not talk to a plain
+ * `http://` server unless that server is loopback: the browser refuses the request as mixed
+ * content before it leaves, and `fetch` reports it as a bare "Failed to fetch" that says nothing
+ * about the cause. That is exactly the phone-to-PC setup this app exists for, so the settings
+ * panel has to name the problem instead of letting the user retype the address.
+ *
+ * Irrelevant in the native Android build, which is not a page and has no scheme to be mixed with.
+ */
+export function isMixedContentBlocked(config: ServerConfig, pageProtocol: string): boolean {
+  if (pageProtocol !== "https:") return false
+  try {
+    const url = new URL(baseUrl(config))
+    return url.protocol === "http:" && !isLoopbackHostname(url.hostname)
+  } catch {
+    return false
+  }
+}
+
 export function isValidServerConfig(config: ServerConfig): boolean {
   if (!config.host.trim() || !Number.isInteger(config.port) || config.port <= 0 || config.port > 65535) return false
   try {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -370,6 +370,24 @@ p {
   grid-column: 1 / -1;
 }
 
+/* A field carrying an explanation needs the whole row: half of a two-column grid turns the
+   sentence into a narrow tower next to a two-line neighbour. */
+.settings .form-grid label.field-row-span {
+  grid-column: 1 / -1;
+}
+
+.field-warning {
+  display: block;
+  margin-top: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  background: var(--warning-soft);
+  color: var(--warning);
+  font-size: 0.8rem;
+  font-weight: 600;
+  line-height: 1.45;
+}
+
 .form-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -263,4 +263,22 @@ assert.ok(app.includes("t('sessions.retry')"), 'an offline state should offer a 
 assert.ok(app.includes('disabled={creatingSession || isOffline}'), 'an action that cannot succeed offline must not be offered')
 assert.ok(styles.includes('.empty-state-actions'), 'the offline actions should be styled')
 
+// The question tool's own parameter schema has no `custom` field at all, so a question always
+// arrives with it undefined and the documented default of `true` applies. Testing it for
+// truthiness therefore hid the free-text answer on every question ever asked.
+assert.ok(
+  app.includes('question.custom !== false'),
+  'the free-text answer must be offered unless a question opts out of it explicitly'
+)
+assert.equal(
+  /question\.custom &&/.test(app),
+  false,
+  'a missing `custom` flag means enabled, so it must never be read as a boolean'
+)
+assert.match(
+  app,
+  /if \(!multiple\) \{[\s\S]*?setCustomValues\(/,
+  'choosing an option in a single-answer question must clear the typed answer, so only one of the two is submitted'
+)
+
 console.log('ui regression tests passed')


### PR DESCRIPTION
Follow-up to #70 and #69, both merged. Neither is wrong; this fills the two gaps I found while verifying them.

## The hosted PWA cannot reach a plain-http server on the LAN

#70 serves the app from `https://giuliastro.github.io/harness-remote/`. An HTTPS page may not talk to an `http://` address unless that address is loopback — the browser refuses it as mixed content *before the request is sent*.

Measured in a browser on an HTTPS page, against a single server bound to `0.0.0.0:4096` and answering with `Access-Control-Allow-Origin: *`:

| server address | result |
| --- | --- |
| `http://127.0.0.1:4096` | 200 |
| `http://localhost:4096` | 200 |
| `http://192.168.1.64:4096` | refused |

Same server, same port, reachable from the OS on both addresses. So the hosted PWA works when the server runs on the same machine as the browser, and cannot work phone-to-PC — which is what the app is for. `--cors` is powerless here: the server never sees the request. All the user gets is `Failed to fetch`.

- `isMixedContentBlocked` in `serverConfig.ts` names the case; Settings shows it next to the host field, rather than after a connection test that cannot pass.
- Loopback in all its spellings (`localhost`, `*.localhost`, `127.0.0.0/8`, `[::1]`), an `https://` server, and a half-typed host stay quiet.
- The native build is excluded explicitly. It reaches the server through `CapacitorHttp` rather than the WebView, so the restriction never applies — today `androidScheme` is `http` and the check would fall through anyway, but that is a config away from being wrong.
- The README section now states the limitation and the four ways around it: the Android app (still the recommended route), HTTPS on the server, a tunnel, or self-hosting this build over plain http.

## Service worker

The revalidating `cache.put` was started inside the response chain, where the worker can be terminated before it lands. Both writes go through `event.waitUntil` now.

## Tests for #69

#69 shipped without any. Its central claim holds up against the tool it mirrors: the question tool's parameter schema has no `custom` field at all, so a question always arrives with it undefined and the documented default of `true` applies. Reading it for truthiness hid the free-text answer on *every* question ever asked. Pinned, along with the single-answer clearing and the arrays-of-labels answer shape the highlighting depends on.

## Verification

- web: clean build and typecheck, 6/6 suites
- bridge: 43/43
- PWA served from a `/harness-remote/` base: service worker registers at the right scope, manifest and icons resolve, app shell plus JS/CSS/audio cached on second load
- host field measured at 375x812 and 800: no horizontal overflow, the explanation takes the full grid row

## Not included

Enabling GitHub Pages in the repository settings, which #70 needs before its workflow can deploy. That is yours to flip.
