### PR TITLE
ci: deploy the hosted web app from release tags, not from main

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,13 +1,14 @@
 name: Deploy web app to GitHub Pages
 
+# Tags only, to match how the APK is published: built on every push, released only on a `v*` tag.
+# Deploying from main would make the public app track the tip of the branch while the public APK
+# tracks releases — two channels telling users two different stories, and every merge live with no
+# step in between. `workflow_dispatch` stays for a manual redeploy.
 "on":
   workflow_dispatch: {}
   push:
-    branches:
-      - main
-    paths:
-      - "web/**"
-      - ".github/workflows/gh-pages.yml"
+    tags:
+      - "v*"
 
 permissions:
   contents: read
@@ -38,6 +39,18 @@ jobs:
 
       - name: Type-check
         run: npx tsc -b
+        working-directory: web
+
+      # This job now publishes to users, so it gates on the same suites as the APK release rather
+      # than on the type-check alone.
+      - name: Run web regression tests
+        run: |
+          npm run test:i18n
+          npm run test:config
+          npm run test:ui
+          npm run test:settings
+          npm run test:model
+          npm run test:events
         working-directory: web
 
       - name: Build web app

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ The web app is installable and is published straight from this repo via GitHub P
 https://giuliastro.github.io/harness-remote/. Open that URL over HTTPS and browsers will offer to
 add it to the home screen / app list, opening in its own standalone window.
 
+It is deployed from `v*` tags, the same tags that publish the APK, so the hosted app is always the
+current release rather than the tip of `main`.
+
 - A service worker caches the app shell (`index.html`, the manifest, and the icons) plus other
   same-origin static assets on a stale-while-revalidate basis, so the UI still loads offline or on
   a flaky connection after the first visit.


### PR DESCRIPTION
Follow-up to #70. The workflow it added deploys on `push` to `main` filtered by `paths: web/**`; the APK workflow next to it compiles on every push but publishes only when a `v*` tag is pushed (`if: startsWith(github.ref, 'refs/tags/v')`).

Left as it was, the two public channels would disagree: the hosted web app on the tip of `main`, the downloadable APK on the last release. And every merge would be live with no step in between.

## What changes

- Trigger is `push` on `v*` tags — the same tags that publish the APK. `workflow_dispatch` stays, for a redeploy without cutting a tag.
- The job runs the six web suites, not just the type-check. It publishes to users now, so it gates like the APK release does.
- README states that the hosted app is the current release rather than the tip of `main`.

## Verification

Workflow YAML re-parsed after the edit: triggers are `workflow_dispatch` and `push` on `v*`, and the build job keeps its step order with the suites ahead of the build. The six suites and the tag-gated publish both mirror `android-apk.yml`, so nothing new is being asserted about them.

## One thing to watch on the first deploy

Pages is still disabled on this repository, so the `github-pages` environment does not exist yet and I could not test a real deployment. When you enable it, GitHub creates that environment with a deployment branch policy — if it is limited to the default branch, a tag-triggered deploy is refused and `v*` has to be added to the environment's allowed deployment branches and tags (Settings → Environments → `github-pages`). Worth knowing before you read the first failure as a problem with this change.
