### PR TITLE
ci: keep the curated release notes, and fail loudly when they are missing

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -28,6 +28,14 @@ jobs:
           # depth-1 clone has neither.
           fetch-depth: 0
 
+      # checkout writes the tag ref pointing at the commit rather than at the tag object, so the
+      # annotation is not in the clone even with fetch-depth: 0. `git describe` keeps working — it is
+      # happy with a lightweight tag — which is how v2.4.0 published a release carrying the full
+      # changelog link and none of the curated notes. Re-fetching the tags brings the objects back.
+      - name: Restore annotated tags
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: git fetch --tags --force
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -170,17 +178,22 @@ jobs:
         run: |
           SUMMARY=$(git tag -l --format='%(contents:body)' "$GITHUB_REF_NAME")
           PREVIOUS_TAG=$(git describe --tags --abbrev=0 --exclude="$GITHUB_REF_NAME" 2>/dev/null || true)
+          # An empty summary used to be tolerated, on the grounds that a terse release beats a failed
+          # one. v2.4.0 showed what that actually produces: a release with no changes listed and no
+          # contributors named, which is the one outcome the whole convention exists to prevent, and
+          # nobody notices until someone reads the release. A failure here is cheap — fix the tag and
+          # re-run — so it fails.
+          if [ -z "$SUMMARY" ]; then
+            echo "::error::$GITHUB_REF_NAME carries no annotation body, so the release would have no notes and credit nobody. Re-create it with 'git tag -a -F <file> --cleanup=verbatim' and force-push the tag." >&2
+            exit 1
+          fi
           {
             echo 'body<<HARNESS_RELEASE_NOTES_EOF'
             echo '## Release'
             echo
             echo "Stable Android release APK for Harness Remote \`${{ steps.version.outputs.app_version }}\`."
-            # A lightweight tag, or an annotation with only a subject line, leaves this empty. Better a
-            # terse release than a failed one, so it is skipped rather than treated as an error.
-            if [ -n "$SUMMARY" ]; then
-              echo
-              echo "$SUMMARY"
-            fi
+            echo
+            echo "$SUMMARY"
             echo
             echo '## Notes'
             echo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,8 +217,16 @@ push both. Everything else — the version code, the Android metadata, the signe
 release — is derived from that one field by CI.
 
 ```bash
-git tag -a v2.4.0 -F release-notes.txt
+git tag -a v2.4.0 --cleanup=verbatim -F release-notes.txt
 git push origin main && git push origin v2.4.0
+```
+
+**`--cleanup=verbatim` is not optional.** Git's default cleanup strips every line that starts with
+`#` as a comment, which silently deletes both `##` headings out of the message below — the tag looks
+fine, and the release renders two bullet lists with nothing naming them. Check before pushing:
+
+```bash
+git tag -l --format='%(contents:body)' v2.4.0
 ```
 
 **The tag annotation is the release notes.** CI publishes its body verbatim between its own


### PR DESCRIPTION
v2.4.0 published with the full changelog link, no changes listed and no contributors named — the one outcome the credit convention exists to prevent. I have restored that release's notes by hand; this is so it cannot happen again.

Two causes, both silent, both needed to produce it.

## The annotation never reached CI

`actions/checkout` writes the tag ref pointing at the **commit** rather than at the tag object, so the annotation is not in the clone even with `fetch-depth: 0`. `git tag -l --format='%(contents:body)'` therefore returned nothing.

Verified after the fact rather than assumed — the tag itself is intact on the remote:

```
$ gh api repos/giuliastro/harness-remote/git/ref/tags/v2.4.0
object.type = tag
$ gh api repos/giuliastro/harness-remote/git/tags/d83b7ff…
message: 28 lines, contains "## Contributors"
```

So nothing was lost in the tag, only in the checkout. And `git describe --tags` is happy with a lightweight tag, which is why the changelog link still appeared — the release looked terse rather than broken, and nothing failed.

`git fetch --tags --force` after checkout brings the objects back.

## An empty summary was tolerated

The step deliberately skipped the summary when empty: *"Better a terse release than a failed one."* I am reversing that call, so flag it if you disagree. What it actually bought was a published release crediting nobody, discoverable only by reading it. A failure costs one re-run after fixing the tag. The step now fails with the command needed to re-cut it.

## The tag was mis-written too

`git tag -a -F file` runs the message through git's default cleanup, which strips every line starting with `#` as a comment — deleting both `##` headings that the format in CONTRIBUTING.md mandates, right under the command that documents it. That is what happened when I cut this tag; I caught it before pushing only because I checked. CONTRIBUTING.md now specifies `--cleanup=verbatim` and gives the one-line check to run first.

## Verification

Both paths run locally against the real v2.4.0 tag, using the workflow's own shell:

- with the annotation present: `## Release`, `## What's Changed`, `## Contributors`, `## Notes` all present, 7 bullets carried through, previous tag resolved as `v2.3.0`
- against a lightweight tag: summary empty, guard trips, step exits 1

Workflow YAML re-parsed after the edit.

The real proof is the next release, since the checkout behaviour cannot be reproduced locally — which is exactly why the guard matters more than the fetch.
