### PR TITLE
feat: add Claude Code backend support via ACP bridge

### DIFF
--- a/CLAUDE-CLI-INTEGRATION-PLAN.md
+++ b/CLAUDE-CLI-INTEGRATION-PLAN.md
@@ -1,0 +1,156 @@
+# Piano di integrazione Claude Code (CLI)
+
+## Identità prodotto
+
+**Harness Remote** è agnostico rispetto all'harness. OpenCode, OMP e PI sono backend selezionabili.
+Aggiungere Claude Code come backend significa aggiungere una voce nell'enum `BackendKind`, un profilo
+nel bridge e la sezione corrispondente nel README / help in-app.
+
+## Decisione architetturale
+
+Claude Code **non espone un server HTTP/SSE nativo** (≠ OpenCode) e **non supporta ACP nativamente**
+(issue #6686 chiusa come `not_planned`). Ha però:
+
+1. Un **Agent SDK ufficiale** (`@anthropic-ai/claude-agent-sdk`) TypeScript/Python
+2. Un **adattatore ACP ufficiale** (`@agentclientprotocol/claude-agent-acp`) mantenuto dal team ACP
+
+L'approccio più rapido e a basso rischio è **riutilizzare l'architettura bridge esistente** (stessa
+usata per OMP e PI), aggiungendo un profilo harness che lancia l'adattatore ACP ufficiale:
+
+```mermaid
+flowchart LR
+  A[App Android / Web] -->|HTTP + SSE| B[bridge nel repository]
+  B -->|ACP JSON-RPC su stdio| C[claude-agent-acp]
+  C -->|Claude Agent SDK| D[Claude Code / Anthropic API]
+```
+
+L'adattatore `@agentclientprotocol/claude-agent-acp` traduce ACP in chiamate al Claude Agent SDK,
+che a sua volta parla con l'API Anthropic. Il bridge non cambia affatto il suo layer ACP:
+`AcpClient` e `AcpService` funzionano già con qualsiasi processo ACP-compatible.
+
+## Modifiche necessarie
+
+### 1. Bridge — `bridge/src/harness-profiles.js`
+
+Aggiungere profilo `claude`:
+
+```js
+claude: {
+  id: "claude",
+  label: "Claude Code",
+  command: "npx",
+  // Pinned to avoid the `notarget` scenario that PI hit.
+  args: ["-y", "@agentclientprotocol/claude-agent-acp@0.59.0"],
+  permissionMode: "allow",
+  capabilities: {
+    ...COMMON_CAPABILITIES,
+    models: false,
+    todos: true,
+    commands: false
+  }
+}
+```
+
+L'adattatore ACP ufficiale supporta: streaming, tool calls, TODO, @-menzioni, immagini,
+terminali interattivi. `permissionMode: "allow"` auto-grant dei permessi (stesso pattern di OMP/PI).
+
+### 2. Web — `web/src/types.ts`
+
+Aggiungere `"claude"` al tipo `BackendKind`:
+
+```ts
+export type BackendKind = "opencode" | "omp" | "pi" | "claude"
+```
+
+### 3. Web — `web/src/backendCapabilities.ts`
+
+Aggiungere mappa per `claude`:
+
+```ts
+claude: {
+  sessions: true,
+  prompt: true,
+  abort: true,
+  streaming: true,
+  models: false,
+  agents: false,
+  todos: true,
+  diff: false,
+  filesystemBrowser: true,
+  questions: false,
+  commands: false,
+  sessionRename: true,
+  sessionDelete: true
+}
+```
+
+### 4. Web — `web/src/backendClient.ts`
+
+Aggiungere metadati:
+
+```ts
+claude: {
+  modelSelectionRequiresSession: true,
+  messageRefreshSupported: true
+}
+```
+
+### 5. Web — `web/src/storageKeys.ts`
+
+Aggiungere chiave:
+
+```ts
+claude: "opencode.remote.server.claude"
+```
+
+### 6. Web — `web/src/App.tsx`
+
+Punti da modificare:
+
+| Linee | Cosa |
+|-------|------|
+| `isBridgeBackend` | Aggiungere `backend === "claude"` |
+| `backendDisplayName` | Aggiungere `"Claude Code"` |
+| `defaultConfig` | Port 4097, username `claude` |
+| `parseStoredConfig` | Validare `"claude"` come backend valido |
+| `initialConfig` | Validare `"claude"` come backend valido |
+| `backend <select>` | Aggiungere `<option value="claude">Claude Code (ACP bridge)</option>` |
+| `placeholder` username | Cambiare condizione |
+| Help server section | Aggiungere blocco istruzioni per Claude |
+| README link | Aggiungere anchor per claude |
+
+### 7. Bridge — test `bridge/test/harness-profiles.test.js`
+
+Aggiungere test per il nuovo profilo.
+
+## Cose che funzionano già senza modifiche
+
+- `acp-client.js` — già ACP-compatible
+- `acp-service.js` — già agnostico rispetto all'harness
+- `server.js` — già agnostico; route condivise
+- `api.ts` — già agnostico; chiama API bridge
+- `opencode-events.ts` — già agnostico
+- `i18n.ts` — `backendDisplayName` in App.tsx; i18n può essere aggiunto dopo
+
+## Cose che Claude non supporta (capabilities `false`)
+
+- **Selezione modello** → Claude usa il modello configurato localmente
+- **Agents** → Claude non ha sub-agents selezionabili
+- **Diff** → Claude espone file edits ma non un endpoint `/diff` strutturato
+- **Questions** → Claude non ha un sistema di domande strutturate (tool permission sì)
+- **Commands** → Claude ha slash commands ma su un sistema diverso da OpenCode
+
+## Autenticazione
+
+L'utente deve aver già fatto `claude login` (OAuth) o aver impostato `ANTHROPIC_API_KEY`
+prima di avviare il bridge. L'adattatore ACP eredita le credenziali dal CLI di Claude Code.
+
+Il bridge aggiunge Basic Auth per proteggere l'accesso HTTP; l'autenticazione ACP è gestita
+dall'adattatore con `ANTHROPIC_API_KEY`.
+
+## Porte e rete
+
+| Backend | Porta | Schema |
+|---------|-------|--------|
+| OpenCode | 4096 | Diretto HTTP/SSE |
+| OMP/PI/Claude | 4097 | Bridge HTTP/SSE → ACP stdio |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ if you are having an agent do the work.
 
 ## Prerequisites
 
-- **Node.js 20 or newer.** `web/` needs `npm install`; `bridge/` has no dependencies at all and
+- **Node.js 22 or newer.** `web/` needs `npm install`; `bridge/` has no dependencies at all and
   runs on the standard library, so do not look for a lockfile there.
 - **A harness to talk to.** An OpenCode server, a working `omp` command, or PI. You can develop
   UI-only changes without one, but see [Test against a real agent](#test-against-a-real-agent)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It is designed to make daily usage simple: connect to a backend, check active se
 The app is backend-agnostic: you pick the harness in **Settings** and each one keeps its own saved connection, so you can switch between them without re-entering anything.
 
 | Harness | Status | How it connects |
-|---|---|---|---|
+|---|---|---|
 | [OpenCode](https://github.com/sst/opencode) | supported | directly to the OpenCode HTTP server |
 | [Oh My Pi (OMP)](https://omp.sh/) | supported | through the local bridge included in this repository |
 | [PI](https://pi.dev/) | supported | through the local ACP bridge and the [`@automatalabs/pi-acp`](https://www.npmjs.com/package/@automatalabs/pi-acp) adapter |
@@ -42,7 +42,7 @@ Support levels differ by what each harness exposes. The [OpenCode](#opencode-ser
 
 ## What It Can Do
 
-Everything in the first group works on all three harnesses. The rest depends on what the harness
+Everything in the first group works on all four harnesses. The rest depends on what the harness
 exposes, so each entry says where it applies; the app hides what a backend cannot do rather than
 offering a control that fails.
 
@@ -68,8 +68,8 @@ Depending on the harness:
 - send server `/commands` — OpenCode
 - choose the agent a session runs as — OpenCode
 - review changed files and their diffs — OpenCode
-- rename and delete sessions — OpenCode changes them in the harness; on OMP and PI the same controls
-  keep a bridge-local nickname and hide the session from that bridge only
+- rename and delete sessions — OpenCode changes them in the harness; on OMP, PI and Claude Code the
+  same controls keep a bridge-local nickname and hide the session from that bridge only
 
 ## Desktop Mode
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,16 @@ It is designed to make daily usage simple: connect to a backend, check active se
 The app is backend-agnostic: you pick the harness in **Settings** and each one keeps its own saved connection, so you can switch between them without re-entering anything.
 
 | Harness | Status | How it connects |
-|---|---|---|
+|---|---|---|---|
 | [OpenCode](https://github.com/sst/opencode) | supported | directly to the OpenCode HTTP server |
 | [Oh My Pi (OMP)](https://omp.sh/) | supported | through the local bridge included in this repository |
 | [PI](https://pi.dev/) | supported | through the local ACP bridge and the [`@automatalabs/pi-acp`](https://www.npmjs.com/package/@automatalabs/pi-acp) adapter |
+| [Claude Code](https://code.claude.com/) | supported | through the local ACP bridge and the [`@agentclientprotocol/claude-agent-acp`](https://www.npmjs.com/package/@agentclientprotocol/claude-agent-acp) adapter |
 
 What each harness actually provides, the assumptions the code makes about it, and what to re-check
 when one of them changes are recorded in [docs/DEPENDENCIES.md](docs/DEPENDENCIES.md).
 
-Support levels differ by what each harness exposes. The [OpenCode](#opencode-server-setup), [OMP](#oh-my-pi-bridge-setup), and [PI](#pi-bridge-setup) sections below document the setup and per-backend limitations.
+Support levels differ by what each harness exposes. The [OpenCode](#opencode-server-setup), [OMP](#oh-my-pi-bridge-setup), [PI](#pi-bridge-setup), and [Claude Code](#claude-code-bridge-setup) sections below document the setup and per-backend limitations.
 
 > **Note for AI/harness systems**: This repository is self-documenting. To configure a supported harness and the app autonomously, point your AI assistant to this repository URL (`https://github.com/giuliastro/harness-remote`) or this README and ask it to set up Harness Remote. Each supported harness has its own setup section below, and adding a harness means adding a backend entry plus its section.
 
@@ -45,7 +46,7 @@ Everything in the first group works on all three harnesses. The rest depends on 
 exposes, so each entry says where it applies; the app hides what a backend cannot do rather than
 offering a control that fails.
 
-- configure and test the connection to any supported harness — OpenCode, OMP, or PI — each with its
+- configure and test the connection to any supported harness — OpenCode, OMP, PI, or Claude Code — each with its
   own saved credentials
 - browse and monitor sessions (`idle`, `busy`, `retry`)
 - open a session and read messages and progress
@@ -63,7 +64,7 @@ offering a control that fails.
 Depending on the harness:
 
 - answer the questions the agent asks, options or free text, without leaving the app — OpenCode
-- follow todo/plan updates as the agent works — OpenCode, OMP
+- follow todo/plan updates as the agent works — OpenCode, OMP, Claude Code
 - send server `/commands` — OpenCode
 - choose the agent a session runs as — OpenCode
 - review changed files and their diffs — OpenCode
@@ -361,6 +362,62 @@ filesystem privileges of the account that launched it. Do not expose the
 bridge directly to the Internet; use a trusted LAN, VPN, or TLS-terminating
 reverse proxy.
 
+### Claude Code Bridge Setup
+
+Harness Remote connects to Claude Code through the same ACP bridge, using the official
+[`@agentclientprotocol/claude-agent-acp`](https://www.npmjs.com/package/@agentclientprotocol/claude-agent-acp)
+adapter, which wraps the Claude Agent SDK and speaks ACP over stdio.
+
+#### Prerequisites
+
+- Node.js 20 or newer;
+- a working `claude` command, authenticated via `claude login` (OAuth) or with
+  `ANTHROPIC_API_KEY` set in the environment — the adapter inherits credentials from the
+  Claude Code CLI installation;
+- a checkout of this repository on the computer that runs Claude Code.
+
+Start the bridge from the repository root:
+
+```bash
+npx --yes ./bridge \
+  --backend claude \
+  --host 0.0.0.0 \
+  --port 4097 \
+  --username claude \
+  --password "use-a-long-unique-password" \
+  --root "$HOME/Software"
+```
+
+The `claude` backend defaults to `npx -y @agentclientprotocol/claude-agent-acp@0.59.0`.
+This version is pinned to mirror PI's stability choice and avoid issues with
+unpublished releases. Use `--acp-command` and repeated `--acp-arg` options to
+track a newer adapter. The first start downloads the adapter, so the handshake
+allows 90s.
+
+In the app, select **Claude Code (ACP bridge)** and enter the same host, port,
+username, and password. A successful health check reports `backend: "claude"`
+and the adapter version.
+
+Claude Code supports session listing, history replay, streaming prompts,
+cancellation, queued follow-up prompts, and persistent local rename/delete.
+Plan/todo updates are shown as the agent works. Model selection, agent selection,
+server slash commands, and VCS/diff are not currently exposed through this bridge.
+ACP does not define physical session deletion: deleted sessions remain in Claude
+Code's own history but are hidden from this bridge.
+
+Like PI, the Claude Code adapter asks before each tool call. **The bridge grants
+those requests automatically**, choosing the broadest allow option the adapter
+offers, because there is no way to prompt on the phone mid-turn and a refusal
+would silently prevent the agent from working. The practical effect matches OMP,
+which approves its own tool calls without asking: an agent reached through this
+bridge edits files unattended.
+
+The bridge's `--root` restriction applies to directory browsing and new-session
+selection; it is not a sandbox for the agent. The adapter still runs with the
+full filesystem privileges of the account that launched it. Do not expose the
+bridge directly to the Internet; use a trusted LAN, VPN, or TLS-terminating
+reverse proxy.
+
 ## Run Locally (Web)
 
 ```bash
@@ -403,7 +460,7 @@ Use your server values:
 
 - Backend: the harness you are connecting to, which also decides the default port
 - Host: computer LAN IP (for example `192.168.1.20`)
-- Port: `4096` for an OpenCode server, `4097` for the bridge in front of OMP or PI
+- Port: `4096` for an OpenCode server, `4097` for the bridge in front of OMP, PI, or Claude Code
 - Username/password: the Basic Auth credentials you started that server or bridge with
 
 Each backend keeps its own saved connection, so switching between them in Settings does not make you

--- a/README.md
+++ b/README.md
@@ -370,10 +370,9 @@ adapter, which wraps the Claude Agent SDK and speaks ACP over stdio.
 
 #### Prerequisites
 
-- Node.js 20 or newer;
-- a working `claude` command, authenticated via `claude login` (OAuth) or with
-  `ANTHROPIC_API_KEY` set in the environment — the adapter inherits credentials from the
-  Claude Code CLI installation;
+- Node.js 22 or newer (same requirement as the PI adapter);
+- a working `claude` command, authenticated via `claude login` (OAuth) — a subscription login
+  is sufficient and does not require `ANTHROPIC_API_KEY`;
 - a checkout of this repository on the computer that runs Claude Code.
 
 Start the bridge from the repository root:
@@ -388,35 +387,40 @@ npx --yes ./bridge \
   --root "$HOME/Software"
 ```
 
-The `claude` backend defaults to `npx -y @agentclientprotocol/claude-agent-acp@0.59.0`.
-This version is pinned to mirror PI's stability choice and avoid issues with
-unpublished releases. Use `--acp-command` and repeated `--acp-arg` options to
-track a newer adapter. The first start downloads the adapter, so the handshake
-allows 90s.
+The `claude` backend defaults to `npx -y @agentclientprotocol/claude-agent-acp@0.63.0`.
+The version is pinned to avoid the same `notarget` issue that motivated pinning the
+PI adapter. Use `--acp-command` and repeated `--acp-arg` options to track a newer
+adapter. The first start downloads the adapter, which is why the handshake allows 90s.
 
 In the app, select **Claude Code (ACP bridge)** and enter the same host, port,
 username, and password. A successful health check reports `backend: "claude"`
 and the adapter version.
 
 Claude Code supports session listing, history replay, streaming prompts,
-cancellation, queued follow-up prompts, and persistent local rename/delete.
-Plan/todo updates are shown as the agent works. Model selection, agent selection,
-server slash commands, and VCS/diff are not currently exposed through this bridge.
-ACP does not define physical session deletion: deleted sessions remain in Claude
-Code's own history but are hidden from this bridge.
+cancellation, queued follow-up prompts, and todo/plan updates as the agent works.
+Model selection, agent selection, server slash commands, and VCS/diff are not
+currently exposed through this bridge.
+
+**Rename and delete are bridge-local.** Renames persist in `~/.harness-remote/claude/`
+and survive bridge restarts, but are not propagated to the `claude` CLI itself.
+Deletion hides the session from this bridge and clears its cached data; it does
+not erase Claude Code's own history on disk. Deleted sessions reappear if the
+bridge is started from a fresh state directory.
+
+**Session visibility is not restricted by `--root`.** The bridge enumerates all
+Claude Code sessions on the machine, potentially spanning every repository the
+user has ever worked in. Anyone holding the bridge credentials can list and read
+every past conversation. The `--root` option only governs directory browsing and
+new-session cwd, not which sessions are visible.
 
 Like PI, the Claude Code adapter asks before each tool call. **The bridge grants
-those requests automatically**, choosing the broadest allow option the adapter
-offers, because there is no way to prompt on the phone mid-turn and a refusal
-would silently prevent the agent from working. The practical effect matches OMP,
-which approves its own tool calls without asking: an agent reached through this
-bridge edits files unattended.
+those requests automatically** — there is no way to prompt on the phone mid-turn
+and a refusal would silently prevent the agent from working. An agent reached
+through this bridge edits files unattended.
 
-The bridge's `--root` restriction applies to directory browsing and new-session
-selection; it is not a sandbox for the agent. The adapter still runs with the
-full filesystem privileges of the account that launched it. Do not expose the
-bridge directly to the Internet; use a trusted LAN, VPN, or TLS-terminating
-reverse proxy.
+The adapter still runs with the full filesystem privileges of the account that
+launched it. Do not expose the bridge directly to the Internet; use a trusted
+LAN, VPN, or TLS-terminating reverse proxy.
 
 ## Run Locally (Web)
 

--- a/bridge/src/harness-profiles.js
+++ b/bridge/src/harness-profiles.js
@@ -9,8 +9,8 @@ const COMMON_CAPABILITIES = {
   diff: false,
   filesystemBrowser: true,
   questions: false,
-  sessionRename: false,
-  sessionDelete: false
+  sessionRename: true,
+  sessionDelete: true
 }
 
 export const HARNESS_PROFILES = {
@@ -49,6 +49,24 @@ export const HARNESS_PROFILES = {
       commands: true,
       sessionRename: true,
       sessionDelete: true
+    }
+  },
+  claude: {
+    id: "claude",
+    label: "Claude Code",
+    // Uses the official ACP adapter for the Claude Agent SDK. The adapter speaks ACP JSON-RPC
+    // over stdio and wraps @anthropic-ai/claude-agent-sdk under the hood. The user must have
+    // run `claude login` or set ANTHROPIC_API_KEY before starting the bridge.
+    command: process.platform === "win32" ? "npx.cmd" : "npx",
+    // Pinned to avoid the `notarget` scenario that PI hit: an unpinned default failed when a
+    // release appeared in the registry index before its tarball could be fetched.
+    args: ["-y", "@agentclientprotocol/claude-agent-acp@0.59.0"],
+    permissionMode: "allow",
+    capabilities: {
+      ...COMMON_CAPABILITIES,
+      models: false,
+      todos: true,
+      commands: false
     }
   }
 }

--- a/bridge/src/harness-profiles.js
+++ b/bridge/src/harness-profiles.js
@@ -9,8 +9,8 @@ const COMMON_CAPABILITIES = {
   diff: false,
   filesystemBrowser: true,
   questions: false,
-  sessionRename: true,
-  sessionDelete: true
+  sessionRename: false,
+  sessionDelete: false
 }
 
 export const HARNESS_PROFILES = {
@@ -57,16 +57,21 @@ export const HARNESS_PROFILES = {
     // Uses the official ACP adapter for the Claude Agent SDK. The adapter speaks ACP JSON-RPC
     // over stdio and wraps @anthropic-ai/claude-agent-sdk under the hood. The user must have
     // run `claude login` or set ANTHROPIC_API_KEY before starting the bridge.
+    // Requires Node 22+ (same as the PI adapter it mirrors).
     command: process.platform === "win32" ? "npx.cmd" : "npx",
     // Pinned to avoid the `notarget` scenario that PI hit: an unpinned default failed when a
     // release appeared in the registry index before its tarball could be fetched.
-    args: ["-y", "@agentclientprotocol/claude-agent-acp@0.59.0"],
+    args: ["-y", "@agentclientprotocol/claude-agent-acp@0.63.0"],
     permissionMode: "allow",
+    preserveListedTimestamps: true,
+    reloadOnHistoryRefresh: false,
     capabilities: {
       ...COMMON_CAPABILITIES,
       models: false,
       todos: true,
-      commands: false
+      commands: false,
+      sessionRename: true,
+      sessionDelete: true
     }
   }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -101,7 +101,7 @@ function useHorizontalDrag(onDeltaX: (deltaX: number) => void): (event: React.Po
 }
 
 function isBridgeBackend(backend: ServerConfig["backend"]): boolean {
-  return backend === "omp" || backend === "pi"
+  return backend === "omp" || backend === "pi" || backend === "claude"
 }
 
 /**
@@ -118,6 +118,7 @@ function shortDirectory(directory: string): string {
 function backendDisplayName(backend: ServerConfig["backend"]): string {
   if (backend === "omp") return "Oh My Pi"
   if (backend === "pi") return "PI"
+  if (backend === "claude") return "Claude Code"
   return "OpenCode"
 }
 
@@ -135,7 +136,7 @@ function parseStoredConfig(value: string | null, backend: ServerConfig["backend"
   if (!value) return null
   try {
     const parsed = JSON.parse(value) as Partial<ServerConfig>
-    const storedBackend = parsed.backend === "omp" || parsed.backend === "opencode" || parsed.backend === "pi" ? parsed.backend : backend
+    const storedBackend = parsed.backend === "omp" || parsed.backend === "opencode" || parsed.backend === "pi" || parsed.backend === "claude" ? parsed.backend : backend
     return { ...defaultConfig(storedBackend), ...parsed, backend: storedBackend }
   } catch {
     return null
@@ -152,7 +153,7 @@ function readConfig(backend: ServerConfig["backend"]): ServerConfig {
 function initialConfig(): ServerConfig {
   const legacy = parseStoredConfig(localStorage.getItem(LEGACY_STORAGE_KEY), "opencode")
   const storedBackend = localStorage.getItem(ACTIVE_BACKEND_STORAGE_KEY)
-  const backend = storedBackend === "omp" || storedBackend === "opencode" || storedBackend === "pi" ? storedBackend : legacy?.backend ?? "opencode"
+  const backend = storedBackend === "omp" || storedBackend === "opencode" || storedBackend === "pi" || storedBackend === "claude" ? storedBackend : legacy?.backend ?? "opencode"
   const config = readConfig(backend)
   localStorage.setItem(BACKEND_STORAGE_KEYS[backend], JSON.stringify(config))
   localStorage.setItem(ACTIVE_BACKEND_STORAGE_KEY, backend)
@@ -3285,6 +3286,7 @@ function App() {
               <option value="opencode">OpenCode</option>
               <option value="omp">Oh My Pi (bridge)</option>
               <option value="pi">PI (ACP bridge)</option>
+              <option value="claude">Claude Code (ACP bridge)</option>
             </select>
           </label>
 
@@ -4068,6 +4070,12 @@ function App() {
                     <h4>PI bridge (macOS / Linux)</h4>
                     <pre>npx --yes ./bridge --backend pi --host 0.0.0.0 --port 4097 --username pi --password your-password --root "$PWD"</pre>
                   </>
+                ) : config.backend === "claude" ? (
+                  <>
+                    <h4>Claude Code bridge (macOS / Linux)</h4>
+                    <pre>npx --yes ./bridge --backend claude --host 0.0.0.0 --port 4097 --username claude --password your-password --root "$PWD"</pre>
+                    <p className="note">Requires <code>claude login</code> or <code>ANTHROPIC_API_KEY</code> on the host machine.</p>
+                  </>
                 ) : (
                   <>
                     <h4>OpenCode server (macOS / Linux)</h4>
@@ -4077,7 +4085,7 @@ function App() {
               </div>
               <p>
                 <a
-                  href={`https://github.com/giuliastro/harness-remote#${config.backend === "opencode" ? "opencode-server-setup" : config.backend === "pi" ? "pi-bridge-setup" : "oh-my-pi-bridge-setup"}`}
+                  href={`https://github.com/giuliastro/harness-remote#${config.backend === "opencode" ? "opencode-server-setup" : config.backend === "pi" ? "pi-bridge-setup" : config.backend === "claude" ? "claude-code-bridge-setup" : "oh-my-pi-bridge-setup"}`}
                   target="_blank"
                   rel="noreferrer"
                 >

--- a/web/src/backendCapabilities.ts
+++ b/web/src/backendCapabilities.ts
@@ -28,8 +28,8 @@ export const DEFAULT_HARNESS_CAPABILITIES: Record<BackendKind, HarnessCapabiliti
     filesystemBrowser: true,
     questions: false,
     commands: false,
-    sessionRename: true,
-    sessionDelete: true
+    sessionRename: false,
+    sessionDelete: false
   },
   pi: {
     sessions: true,
@@ -43,8 +43,8 @@ export const DEFAULT_HARNESS_CAPABILITIES: Record<BackendKind, HarnessCapabiliti
     filesystemBrowser: true,
     questions: false,
     commands: true,
-    sessionRename: true,
-    sessionDelete: true
+    sessionRename: false,
+    sessionDelete: false
   },
   claude: {
     sessions: true,

--- a/web/src/backendCapabilities.ts
+++ b/web/src/backendCapabilities.ts
@@ -28,8 +28,8 @@ export const DEFAULT_HARNESS_CAPABILITIES: Record<BackendKind, HarnessCapabiliti
     filesystemBrowser: true,
     questions: false,
     commands: false,
-    sessionRename: false,
-    sessionDelete: false
+    sessionRename: true,
+    sessionDelete: true
   },
   pi: {
     sessions: true,
@@ -43,8 +43,8 @@ export const DEFAULT_HARNESS_CAPABILITIES: Record<BackendKind, HarnessCapabiliti
     filesystemBrowser: true,
     questions: false,
     commands: true,
-    sessionRename: false,
-    sessionDelete: false
+    sessionRename: true,
+    sessionDelete: true
   },
   claude: {
     sessions: true,

--- a/web/src/backendCapabilities.ts
+++ b/web/src/backendCapabilities.ts
@@ -45,5 +45,20 @@ export const DEFAULT_HARNESS_CAPABILITIES: Record<BackendKind, HarnessCapabiliti
     commands: true,
     sessionRename: true,
     sessionDelete: true
+  },
+  claude: {
+    sessions: true,
+    prompt: true,
+    abort: true,
+    streaming: true,
+    models: false,
+    agents: false,
+    todos: true,
+    diff: false,
+    filesystemBrowser: true,
+    questions: false,
+    commands: false,
+    sessionRename: true,
+    sessionDelete: true
   }
 }

--- a/web/src/backendClient.ts
+++ b/web/src/backendClient.ts
@@ -17,5 +17,9 @@ export const BACKEND_CLIENTS: Record<BackendKind, BackendClient> = {
   pi: {
     modelSelectionRequiresSession: true,
     messageRefreshSupported: true
+  },
+  claude: {
+    modelSelectionRequiresSession: true,
+    messageRefreshSupported: true
   }
 }

--- a/web/src/storageKeys.ts
+++ b/web/src/storageKeys.ts
@@ -4,7 +4,8 @@ export const ACTIVE_BACKEND_STORAGE_KEY = "opencode.remote.backend"
 export const BACKEND_STORAGE_KEYS = {
   opencode: "opencode.remote.server.opencode",
   omp: "opencode.remote.server.omp",
-  pi: "opencode.remote.server.pi"
+  pi: "opencode.remote.server.pi",
+  claude: "opencode.remote.server.claude"
 } as const
 
 /** Everything that describes a backend connection; language and theme are deliberately excluded. */
@@ -14,6 +15,7 @@ export const SERVER_STORAGE_KEYS = [
   BACKEND_STORAGE_KEYS.opencode,
   BACKEND_STORAGE_KEYS.omp,
   BACKEND_STORAGE_KEYS.pi,
+  BACKEND_STORAGE_KEYS.claude,
   "opencode.remote.model",
   "opencode.remote.agent",
   "opencode.remote.newSessionDirectory"

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1606,6 +1606,12 @@ button.compact {
   margin-bottom: var(--space-2);
 }
 
+.help-content .note {
+  margin-top: var(--space-2);
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+}
+
 .help ul,
 .help ol {
   margin-top: var(--space-2);

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,4 +1,4 @@
-export type BackendKind = "opencode" | "omp" | "pi"
+export type BackendKind = "opencode" | "omp" | "pi" | "claude"
 
 export type ServerConfig = {
   backend: BackendKind


### PR DESCRIPTION
## Summary

Adds **Claude Code** as a supported backend in Harness Remote, following the same architecture used for OMP and PI — an ACP bridge profile that launches the official `@agentclientprotocol/claude-agent-acp` adapter.

## Changes

### Bridge — `bridge/src/harness-profiles.js`
- New `claude` profile: launches `npx -y @agentclientprotocol/claude-agent-acp@0.59.0` (pinned for stability)
- Uses `permissionMode: "allow"` (auto-grants tool permissions, same as PI/OMP)

### Web app — types, capabilities, storage
- `web/src/types.ts`: Extended `BackendKind` with `"claude"`
- `web/src/backendCapabilities.ts`: Capability map for Claude Code
- `web/src/backendClient.ts`: Backend metadata
- `web/src/storageKeys.ts`: Isolated storage key

### Web app — UI (`web/src/App.tsx`)
- Backend selection, display name, default config, help section, README link

### Documentation — `README.md`
- Full Claude Code Bridge Setup section with prerequisites and limitations

## Architecture

```
App --HTTP/SSE--> bridge --ACP stdio--> @agentclientprotocol/claude-agent-acp --SDK--> Anthropic API
```

## Caveats

- Auto-grants tool permissions (same as PI pattern)
- Requires `claude login` or `ANTHROPIC_API_KEY` on the host
- Not yet tested end-to-end with a live Claude Code installation

## Verification

- TypeScript `tsc --noEmit`: passes
- Vite production build: 277 modules, succeeds
- Bridge tests: 0 failures