### PR TITLE
ci: deploy the hosted app on every merge to main, as the staging surface

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,14 +1,17 @@
 name: Deploy web app to GitHub Pages
 
-# Tags only, to match how the APK is published: built on every push, released only on a `v*` tag.
-# Deploying from main would make the public app track the tip of the branch while the public APK
-# tracks releases — two channels telling users two different stories, and every merge live with no
-# step in between. `workflow_dispatch` stays for a manual redeploy.
+# Every merge to main, deliberately. The hosted app is the staging surface: the point is to exercise
+# what just landed on a real phone against a real server, which only works if it is there without
+# waiting for a release. The APK stays release-only, so the two are not redundant — one is what
+# people install, this is what we test. The suites below gate it, so a broken merge does not deploy.
 "on":
   workflow_dispatch: {}
   push:
-    tags:
-      - "v*"
+    branches:
+      - main
+    paths:
+      - "web/**"
+      - ".github/workflows/gh-pages.yml"
 
 permissions:
   contents: read
@@ -41,8 +44,8 @@ jobs:
         run: npx tsc -b
         working-directory: web
 
-      # This job now publishes to users, so it gates on the same suites as the APK release rather
-      # than on the type-check alone.
+      # Deploying on every merge only works if a bad merge cannot reach the URL, so this gates on the
+      # same suites as the APK release rather than on the type-check alone.
       - name: Run web regression tests
         run: |
           npm run test:i18n

--- a/README.md
+++ b/README.md
@@ -110,8 +110,13 @@ The web app is installable and is published straight from this repo via GitHub P
 https://giuliastro.github.io/harness-remote/. Open that URL over HTTPS and browsers will offer to
 add it to the home screen / app list, opening in its own standalone window.
 
-It is deployed from `v*` tags, the same tags that publish the APK, so the hosted app is always the
-current release rather than the tip of `main`.
+It is redeployed on every merge to `main` that touches `web/`, so it carries the current tip of the
+branch rather than the last release. That is the point: it is where a change gets tried on a real
+phone against a real server before it ships. The Android APK in [Releases](https://github.com/giuliastro/harness-remote/releases/latest)
+is the stable channel and still comes only from `v*` tags — if you want a version that was cut
+deliberately, install that one.
+
+The deploy runs the web regression suites first, so a merge that breaks them does not reach the URL.
 
 - A service worker caches the app shell (`index.html`, the manifest, and the icons) plus other
   same-origin static assets on a stale-while-revalidate basis, so the UI still loads offline or on


### PR DESCRIPTION
Reverses the trigger #74 introduced, on purpose.

#74 moved the deploy to \*\ tags so the public web app and the public APK would not disagree about which version users were getting. That treated the hosted app as a distribution channel. It is more useful as a staging one — the reason to have it is trying what just landed on a real phone against a real server, and waiting for a release defeats that.

## What changes

- trigger is \push\ on \main\ filtered to \web/**\ again, plus the workflow file itself
- the \*\ tag trigger is dropped rather than kept alongside: a release commit reaches main anyway, so the tag would only redeploy the same tree
- \workflow_dispatch\ stays, so a redeploy from any ref is still one click
- the six web suites stay ahead of the build, and matter more now than before — deploying every merge is only safe if a merge that breaks them cannot reach the URL
- the README no longer claims the hosted app is the current release; it says the URL follows main and is the test surface, while the APK is release-only and is what to install

## Verification

Workflow YAML re-parsed after the edit: triggers are \workflow_dispatch\ and \push\ on \main\ with the two path filters. No statement anywhere in README.md or CONTRIBUTING.md still says the site follows tags.