### PR TITLE
fix: stop claiming to load models a harness does not have, and hide injected turns

### DIFF
--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -94,6 +94,22 @@ function mergeTodos(previous, replayed) {
   })
 }
 
+/**
+ * Some harnesses inject their own bookkeeping into the model's context as user-role turns —
+ * background-task notifications and system reminders — and the ACP adapter forwards them as
+ * `user_message_chunk` because that is what they are at the protocol level. Rendered faithfully,
+ * the app then shows harness internals in a bubble attributed to the person holding the phone,
+ * text they never wrote and cannot see anywhere else.
+ *
+ * Matched only when the chunk is *entirely* one or more such blocks, so a message where someone
+ * quotes one while asking about it stays visible — which is exactly how this was reported.
+ */
+const HARNESS_INJECTED_BLOCK = /^(?:\s*<(task-notification|system-reminder)>[\s\S]*?<\/\1>\s*)+$/
+
+export function isHarnessInjectedText(text) {
+  return HARNESS_INJECTED_BLOCK.test(text)
+}
+
 export class AcpService {
   #acp
   #sessions = new Map()
@@ -572,6 +588,7 @@ export class AcpService {
     if (role === "assistant" && !replaying && this.#cancelledSessions.has(sessionId)) return
     if (!update.messageId && role === "assistant" && !replaying && !this.#active.has(sessionId) && !this.#promptedSessions.has(sessionId)) return
     if (role === "user" && !replaying && this.#isAcknowledgedPromptChunk(sessionId, update.content.text)) return
+    if (role === "user" && isHarnessInjectedText(update.content.text)) return
     if (!replaying && session) session.updatedAt = new Date().toISOString()
     const chunkKey = `${sessionId}:${role}`
     let messageID = update.messageId

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os"
 import path from "node:path"
 import test from "node:test"
 import { createBridgeServer } from "../src/server.js"
-import { AcpService } from "../src/acp-service.js"
+import { AcpService, isHarnessInjectedText } from "../src/acp-service.js"
 
 class FakeAcp extends EventEmitter {
   agentInfo = { version: "17.0.7" }
@@ -1140,4 +1140,59 @@ test("continues sessions created by another OMP client and reacquires them after
   assert.deepEqual(acp.prompts, ["desktop-session", "mobile-session"])
   await restarted.flushSnapshots()
   await rm(snapshotDirectory, { recursive: true, force: true })
+})
+
+// A harness that injects its own bookkeeping into the model's context sends it as a user turn, and
+// the adapter forwards it as a user_message_chunk. Rendered as-is the app attributes harness
+// internals to the person holding the phone: observed live on the Claude Code backend, where a
+// background-task notification appeared as a message the user had supposedly written.
+test("hides harness-injected blocks from the transcript without hiding a message that quotes one", () => {
+  assert.equal(isHarnessInjectedText("<task-notification><task-id>abc</task-id></task-notification>"), true)
+  assert.equal(isHarnessInjectedText("  <system-reminder>remember this</system-reminder>\n"), true)
+  assert.equal(
+    isHarnessInjectedText("<task-notification>a</task-notification><system-reminder>b</system-reminder>"),
+    true,
+    "several blocks back to back are still nothing but bookkeeping"
+  )
+  // The report itself was a message quoting one of these while asking about it. That must survive.
+  assert.equal(
+    isHarnessInjectedText("this appeared as if I wrote it: <task-notification>x</task-notification> why?"),
+    false
+  )
+  assert.equal(isHarnessInjectedText("deploy the <task-notification> tag docs"), false)
+  assert.equal(isHarnessInjectedText("ordinary prompt"), false)
+})
+
+test("drops an injected user chunk while keeping the surrounding conversation", async () => {
+  class ChatAcp extends EventEmitter {
+    agentInfo = { version: "0.63.0" }
+    async start() {}
+    async listSessions() {
+      return [{ sessionId: "session-1", cwd: process.cwd(), updatedAt: "2026-07-28T00:00:00.000Z" }]
+    }
+    async request() {
+      return {}
+    }
+    notify() {}
+  }
+
+  const acp = new ChatAcp()
+  const service = new AcpService(acp)
+  await service.listSessions()
+  const send = (messageId, text) => acp.emit("notification", {
+    method: "session/update",
+    params: {
+      sessionId: "session-1",
+      update: { sessionUpdate: "user_message_chunk", messageId, content: { type: "text", text } }
+    }
+  })
+
+  send("u1", "a real question")
+  send("u2", "<task-notification><task-id>abc</task-id><status>stopped</status></task-notification>")
+  send("u3", "and a follow-up")
+
+  const texts = (await service.messages("session-1")).map((message) =>
+    message.parts.filter((part) => part.type === "text").map((part) => part.text).join("")
+  )
+  assert.deepEqual(texts, ["a real question", "and a follow-up"], "the injected block must not become a user message")
 })

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1994,9 +1994,16 @@ function App() {
   const totalDiffAdditions = diffFiles.reduce((sum, file) => sum + file.additions, 0)
   const totalDiffDeletions = diffFiles.reduce((sum, file) => sum + file.deletions, 0)
   const showModelChip = modelOptions.length > 1 || Boolean(activeModelOption) || primaryAgentOptions.length > 0
-  /** Without this a failed model fetch is indistinguishable from one still in flight. */
+  /**
+   * Three distinct states, and conflating any two of them reads as a hang: a fetch in flight, a
+   * fetch that failed, and a harness that has no model list to fetch. `loadModels` returns early
+   * when the backend does not expose one, so without the first branch the label would sit on
+   * "loading" forever — which is what the Claude Code backend did.
+   */
   const modelStatusLabel = activeModelOption?.modelName
-    ?? (modelLoadError ? t('detail.modelUnavailable') : t('detail.modelLoading'))
+    ?? (!capabilities.models
+      ? t('detail.modelNotSupported')
+      : modelLoadError ? t('detail.modelUnavailable') : t('detail.modelLoading'))
 
   async function openSession(sessionID: string, directory: string) {
     setSelectedID(sessionID)
@@ -3880,7 +3887,11 @@ function App() {
                     )}
                   </div>
                 ) : (
-                  <p className="subtle">{modelLoadError ? t('detail.modelLoadError', { message: modelLoadError }) : t('detail.modelLoading')}</p>
+                  <p className="subtle">
+                    {!capabilities.models
+                      ? t('detail.modelNotSupported')
+                      : modelLoadError ? t('detail.modelLoadError', { message: modelLoadError }) : t('detail.modelLoading')}
+                  </p>
                 )}
               </div>
             )}

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -132,6 +132,7 @@ type TranslationKey =
   | 'detail.modelToolsNo'
   | 'detail.modelVariant'
   | 'detail.modelLoading'
+  | 'detail.modelNotSupported'
   | 'detail.modelUnavailable'
   | 'detail.modelLoadError'
   | 'detail.contextStripLabel'
@@ -350,6 +351,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.modelToolsNo': 'No tools',
     'detail.modelVariant': 'Variant: {variant}',
     'detail.modelLoading': 'Loading configured models...',
+    'detail.modelNotSupported': 'This harness does not expose model selection',
     'detail.modelUnavailable': 'Models unavailable — check the server',
     'detail.modelLoadError': 'Cannot load models: {message}',
     'detail.contextStripLabel': 'Session context shortcuts',
@@ -567,6 +569,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.modelToolsNo': 'Nessun tool',
     'detail.modelVariant': 'Variante: {variant}',
     'detail.modelLoading': 'Caricamento modelli configurati...',
+    'detail.modelNotSupported': 'Questo harness non espone la scelta del modello',
     'detail.modelUnavailable': 'Modelli non disponibili — controlla il server',
     'detail.modelLoadError': 'Impossibile caricare i modelli: {message}',
     'detail.contextStripLabel': 'Scorciatoie contesto sessione',
@@ -784,6 +787,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.modelToolsNo': '無工具',
     'detail.modelVariant': '變體：{variant}',
     'detail.modelLoading': '正在載入已設定模型...',
+    'detail.modelNotSupported': '此 harness 未提供模型選擇',
     'detail.modelUnavailable': '無法取得模型 — 請檢查伺服器',
     'detail.modelLoadError': '無法載入模型：{message}',
     'detail.contextStripLabel': '工作階段情境捷徑',

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -199,8 +199,10 @@ assert.ok(
 
 // A model list that never arrived used to render as "loading" forever, which reads as a slow
 // server rather than a failure — the reason a misconfigured server looked like a broken feature.
+// Asserted on the failure branch alone: the label now has three states, and pinning the whole
+// expression would break again the next time one is added.
 assert.ok(
-  app.includes("?? (modelLoadError ? t('detail.modelUnavailable') : t('detail.modelLoading'))"),
+  app.includes("modelLoadError ? t('detail.modelUnavailable') : t('detail.modelLoading')"),
   'a failed model fetch must be named, not shown as still loading'
 )
 assert.ok(
@@ -302,5 +304,21 @@ for (const kind of backendKinds) {
     `backend "${kind}" is declared in BackendKind but never compared against in App.tsx, so stored values and display names will not accept it`
   )
 }
+
+// `loadModels` returns early when the harness exposes no model list, so anything that reports
+// progress has to distinguish "nothing to load" from "still loading" or it sits on the loading text
+// forever. The Claude Code backend did exactly that: `models: false`, and an AI panel that claimed
+// to be loading for the life of the session.
+// Matched with \s+ rather than a literal newline: these sources are checked out with CRLF endings.
+assert.match(
+  app,
+  /\?\?\s*\(!capabilities\.models\s+\?\s*t\('detail\.modelNotSupported'\)/,
+  'the model status label must say a harness has no model selection rather than claiming to load'
+)
+assert.match(
+  app,
+  /\{!capabilities\.models\s+\?\s*t\('detail\.modelNotSupported'\)/,
+  'the AI panel must say a harness has no model selection rather than claiming to load'
+)
 
 console.log('ui regression tests passed')


### PR DESCRIPTION
Two bugs found while driving the Claude Code backend from the hosted app.

## "Loading configured models…" that never ends

`loadModels` returns early when `capabilities.models` is false, so on a harness with no model list nothing is ever fetched. But every place reporting progress treated an empty list as a fetch still in flight:

```
modelStatusLabel = activeModelOption?.modelName ?? (modelLoadError ? … : t('detail.modelLoading'))
{modelOptions.length > 0 ? (…picker…) : (modelLoadError ? … : t('detail.modelLoading'))}
```

Claude Code has `models: false`, so its AI panel and status chip sat on the loading text for the life of the session — a feature that is absent reading as a feature that is broken. There are three states, not two: nothing to load, loading, failed. The first one is now named, in all three locales.

## Harness bookkeeping rendered as the user's own words

Verified against the live bridge rather than inferred — in an active session:

```
messages containing task-notification: 2
role=user  chars=519
role=user  chars=921
```

A harness that injects background-task notifications and system reminders into the model's context sends them as user turns, and the ACP adapter forwards them as `user_message_chunk`. That is correct at the protocol level, and it is why the app showed a block of harness internals in a bubble attributed to the person holding the phone — text they never typed, and which does not appear in the harness's own view of the session.

Suppressed at the bridge, and deliberately narrowly:

```js
const HARNESS_INJECTED_BLOCK = /^(?:\s*<(task-notification|system-reminder)>[\s\S]*?<\/\1>\s*)+$/
```

Anchored at both ends, so it only fires when a chunk is *nothing but* such blocks. The message that reported this was itself a quote of one with a question around it — that has to stay visible, and it does. Covered both ways in the suite.

## Verification

- `web`: clean build, 6/6 suites
- `bridge`: 50/50, two new tests
- the existing "a failed model fetch must be named" assertion pinned the whole two-state expression and had to loosen to the failure branch alone, so adding a third state does not break it again

## Note on rollout

The web fix reaches the hosted app on merge, since Pages now follows `main`. The bridge fix needs the bridge restarted to take effect.
