### PR TITLE
feat: offer Claude Code's models, which the bridge had been discarding

### DIFF
--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -248,11 +248,16 @@ export class AcpService {
   async setModel(sessionID, model) {
     await this.#loadForConfigOptions(sessionID)
     const option = this.#configOptions.get(sessionID)?.find((item) => item.id === "model")
-    if (!option?.options?.some((candidate) => candidate.value === model)) {
-      throw new Error(`Harness model is not available: ${model}`)
-    }
-    await this.#acp.request("session/set_config_option", { sessionId: sessionID, configId: "model", value: model })
-    option.currentValue = model
+    // The app addresses models as `provider/model` because that is what OpenCode's API does, but a
+    // harness whose ids carry no provider — Claude Code's `sonnet`, `opus[1m]` — is shown under the
+    // backend's name to keep it consistent. Resolve against what the agent actually offered rather
+    // than trusting either spelling: exact first, then the part after the synthesised provider.
+    const value = option?.options?.some((candidate) => candidate.value === model)
+      ? model
+      : option?.options?.find((candidate) => candidate.value === model.slice(model.indexOf("/") + 1))?.value
+    if (!value) throw new Error(`Harness model is not available: ${model}`)
+    await this.#acp.request("session/set_config_option", { sessionId: sessionID, configId: "model", value })
+    option.currentValue = value
   }
 
   /**

--- a/bridge/src/harness-profiles.js
+++ b/bridge/src/harness-profiles.js
@@ -67,7 +67,9 @@ export const HARNESS_PROFILES = {
     reloadOnHistoryRefresh: false,
     capabilities: {
       ...COMMON_CAPABILITIES,
-      models: false,
+      // The adapter advertises a `model` config option like OMP and PI do; its values are bare ids
+      // rather than `provider/model`, which is handled where the response is built.
+      models: true,
       todos: true,
       commands: false,
       sessionRename: true,

--- a/bridge/src/server.js
+++ b/bridge/src/server.js
@@ -70,12 +70,23 @@ function modelWireName(model) {
   return model.providerID && modelID ? `${model.providerID}/${modelID}` : undefined
 }
 
-function providersResponse(models) {
+/**
+ * The app's model API is OpenCode's, which names a model `provider/model`. ACP has no such rule:
+ * OMP and PI happen to use that shape, while Claude Code's adapter offers bare ids — `sonnet`,
+ * `opus[1m]`. Splitting on "/" and requiring both halves silently dropped every one of them, which
+ * is why that backend looked like it exposed no models at all.
+ *
+ * A bare id is presented under the backend's own name instead, so it reads and behaves like the
+ * others — `claude/sonnet`. `AcpService.setModel` puts it back to the id the agent knows.
+ */
+function providersResponse(models, fallbackProviderID) {
   const providers = new Map()
   const defaults = {}
   for (const option of models) {
-    const [providerID, ...modelParts] = option.value.split("/")
-    const modelID = modelParts.join("/")
+    const separator = option.value.indexOf("/")
+    const flat = separator <= 0
+    const providerID = flat ? fallbackProviderID : option.value.slice(0, separator)
+    const modelID = flat ? option.value : option.value.slice(separator + 1)
     if (!providerID || !modelID) continue
     const provider = providers.get(providerID) ?? { id: providerID, name: providerID, models: {} }
     provider.models[modelID] = { id: modelID, name: option.name ?? modelID, status: "active" }
@@ -224,7 +235,7 @@ export function createBridgeServer({ config, acp, serviceOptions }) {
           writeJSON(response, 200, { providers: [], default: {} })
           return
         }
-        writeJSON(response, 200, providersResponse(await service.models(sessionID)))
+        writeJSON(response, 200, providersResponse(await service.models(sessionID), backend))
         return
       }
       writeJSON(response, 404, { error: "Not found" })

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -1196,3 +1196,85 @@ test("drops an injected user chunk while keeping the surrounding conversation", 
   )
   assert.deepEqual(texts, ["a real question", "and a follow-up"], "the injected block must not become a user message")
 })
+
+// Claude Code's adapter names models with bare ids rather than `provider/model`. The response
+// builder split on "/" and required both halves, so every option was dropped and the backend looked
+// like it exposed no models — the reason its profile carried `models: false`. Both directions are
+// asserted here: the list the app receives, and the value that reaches the agent when one is picked.
+class FlatModelAcp extends EventEmitter {
+  agentInfo = { version: "0.63.0" }
+  models = []
+
+  async start() {}
+
+  async listSessions() {
+    return [{ sessionId: "session-1", cwd: process.cwd(), updatedAt: "2026-07-28T00:00:00.000Z" }]
+  }
+
+  async request(method, params) {
+    if (method === "session/load" || method === "session/new") {
+      return {
+        sessionId: "session-1",
+        configOptions: [{
+          id: "model",
+          currentValue: "default",
+          options: [
+            { value: "default", name: "Default (recommended)" },
+            { value: "sonnet", name: "Sonnet" },
+            { value: "opus[1m]", name: "Opus (1M context)" }
+          ]
+        }]
+      }
+    }
+    if (method === "session/set_config_option") {
+      this.models.push(params.value)
+      return {}
+    }
+    if (method === "session/prompt") return { stopReason: "end_turn" }
+    return {}
+  }
+
+  notify() {}
+}
+
+test("offers models a harness names without a provider prefix, and sets them back verbatim", async () => {
+  const acp = new FlatModelAcp()
+  const bridge = await startServer({ acp, backend: "claude" })
+  try {
+    const listed = await fetch(`${bridge.baseURL}/config/providers?sessionID=session-1`, { headers: authHeaders() })
+    const body = await listed.json()
+    assert.equal(body.providers.length, 1, "bare ids must not be discarded")
+    const provider = body.providers[0]
+    assert.equal(provider.id, "claude", "a bare id is presented under the backend's own name")
+    assert.equal(provider.name, "claude")
+    assert.deepEqual(Object.keys(provider.models).sort(), ["default", "opus[1m]", "sonnet"])
+    assert.equal(provider.models.sonnet.name, "Sonnet")
+    assert.equal(body.default[provider.id], "default", "the current model is reported as the default")
+
+    // The app sends back the pair it was given; the agent must receive the original ACP value.
+    const prompted = await fetch(`${bridge.baseURL}/session/session-1/prompt_async`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ parts: [{ type: "text", text: "hello" }], model: { providerID: provider.id, modelID: "opus[1m]" } })
+    })
+    assert.equal(prompted.status, 200)
+    await new Promise((resolve) => setImmediate(resolve))
+    assert.deepEqual(acp.models, ["opus[1m]"], "a bare id must not be re-joined into provider/model")
+  } finally {
+    await bridge.close()
+  }
+})
+
+test("keeps provider/model values untouched for the harnesses that use them", async () => {
+  const acp = new HeldTurnOmpAcp()
+  const bridge = await startServer({ acp })
+  try {
+    const listed = await fetch(`${bridge.baseURL}/config/providers?sessionID=session-1`, { headers: authHeaders() })
+    const body = await listed.json()
+    assert.equal(body.providers[0].id, "omp", "a value with a provider part still yields that provider")
+    assert.equal(body.providers[0].name, "omp")
+    assert.deepEqual(Object.keys(body.providers[0].models).sort(), ["first", "second"])
+  } finally {
+    await bridge.close()
+  }
+})

--- a/web/src/backendCapabilities.ts
+++ b/web/src/backendCapabilities.ts
@@ -51,7 +51,7 @@ export const DEFAULT_HARNESS_CAPABILITIES: Record<BackendKind, HarnessCapabiliti
     prompt: true,
     abort: true,
     streaming: true,
-    models: false,
+    models: true,
     agents: false,
     todos: true,
     diff: false,


### PR DESCRIPTION
The Claude Code backend shipped with `models: false` because it looked like it exposed none. It exposes five — we were discarding them.

## What was actually happening

Asked the adapter directly over stdio, bypassing the bridge:

```
all option ids: mode, model, effort, agent
model option: currentValue "default"
  default            Default (recommended)   Sonnet 5
  sonnet             Sonnet
  claude-fable-5[1m] Fable
  opus[1m]           Opus (1M context)
  haiku              Haiku
```

Same `model` config id the bridge already looks for, same shape as OMP and PI. The difference is naming: the app's model API is OpenCode's, where a model is `provider/model`, and `providersResponse` did

```js
const [providerID, ...modelParts] = option.value.split("/")
if (!providerID || !modelID) continue
```

Claude Code's ids carry no provider, so every option hit that `continue` and the endpoint answered `{"providers":[],"default":{}}`. The profile's `models: false` was a reasonable conclusion from a wrong observation.

## What changes

- A bare id is presented under the backend's own name, so it reads and behaves like the other harnesses: `claude/sonnet`.
- Going back, `setModel` resolves against the options the agent actually offered — exact match first, then the segment after the synthesised provider — instead of trusting either spelling. `provider/model` harnesses match exactly and never reach the fallback; that is pinned by its own test so this cannot quietly change OMP or PI.
- `models: true` for the backend, in the bridge profile and in the app's defaults.

## Verified against the real adapter, both directions

```
provider id: claude
models: default, sonnet, claude-fable-5[1m], opus[1m], haiku
current: default

prompt with model claude/haiku  →  accepted
                                →  [assistant] PREFIX_OK
current model afterwards        →  haiku
```

`bridge`: 52/52, two new tests. `web`: clean build, 6/6 suites.

## Rollout

The app reads capabilities from the bridge at runtime, so this needs the **bridge restarted** to take effect — the web side alone will keep hiding the picker while a running bridge still reports `models: false`.

## Not included

The adapter also advertises `mode`, `effort` and `agent`. Left alone deliberately: `effort` and `mode` are worth having, and `agent` changes how the backend presents itself in the app, so each deserves its own change rather than riding along with this one.
