### PR TITLE
feat: show which Sonnet, by keeping the description the harness sends

### DIFF
--- a/bridge/src/server.js
+++ b/bridge/src/server.js
@@ -89,7 +89,13 @@ function providersResponse(models, fallbackProviderID) {
     const modelID = flat ? option.value : option.value.slice(separator + 1)
     if (!providerID || !modelID) continue
     const provider = providers.get(providerID) ?? { id: providerID, name: providerID, models: {} }
-    provider.models[modelID] = { id: modelID, name: option.name ?? modelID, status: "active" }
+    provider.models[modelID] = {
+      id: modelID,
+      name: option.name ?? modelID,
+      // Where the harness puts the version: "Sonnet 5 · Efficient for routine tasks".
+      description: option.description || undefined,
+      status: "active"
+    }
     providers.set(providerID, provider)
     if (option.currentValue) defaults[providerID] = modelID
   }

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -1219,9 +1219,9 @@ class FlatModelAcp extends EventEmitter {
           id: "model",
           currentValue: "default",
           options: [
-            { value: "default", name: "Default (recommended)" },
-            { value: "sonnet", name: "Sonnet" },
-            { value: "opus[1m]", name: "Opus (1M context)" }
+            { value: "default", name: "Default (recommended)", description: "Sonnet 5 · Efficient for routine tasks" },
+            { value: "sonnet", name: "Sonnet", description: "Sonnet 5 · Efficient for routine tasks" },
+            { value: "opus[1m]", name: "Opus (1M context)", description: "Opus 5 with 1M context" }
           ]
         }]
       }
@@ -1249,6 +1249,10 @@ test("offers models a harness names without a provider prefix, and sets them bac
     assert.equal(provider.name, "claude")
     assert.deepEqual(Object.keys(provider.models).sort(), ["default", "opus[1m]", "sonnet"])
     assert.equal(provider.models.sonnet.name, "Sonnet")
+    // The harness puts the model version in the description; dropping it left the picker showing
+    // "Sonnet" with no way to tell which Sonnet.
+    assert.equal(provider.models["opus[1m]"].description, "Opus 5 with 1M context")
+    assert.equal(provider.models.sonnet.description, "Sonnet 5 · Efficient for routine tasks")
     assert.equal(body.default[provider.id], "default", "the current model is reported as the default")
 
     // The app sends back the pair it was given; the agent must receive the original ACP value.
@@ -1274,6 +1278,7 @@ test("keeps provider/model values untouched for the harnesses that use them", as
     assert.equal(body.providers[0].id, "omp", "a value with a provider part still yields that provider")
     assert.equal(body.providers[0].name, "omp")
     assert.deepEqual(Object.keys(body.providers[0].models).sort(), ["first", "second"])
+    assert.equal(body.providers[0].models.first.description, undefined, "a harness that describes nothing must not gain an empty line")
   } finally {
     await bridge.close()
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3867,7 +3867,13 @@ function App() {
                             >
                               <span>
                                 <strong>{option.modelName}</strong>
-                                <small>{option.providerName}{option.variant ? ` · ${option.variant}` : ""}</small>
+                                {/* The harness's own description carries the version — "Sonnet 5 ·
+                                    Efficient for routine tasks" — which is what someone picking a
+                                    model wants. The provider only earns the line when there is
+                                    nothing better, as with OpenCode. */}
+                                <small>
+                                  {[option.description ?? option.providerName, option.variant].filter(Boolean).join(" · ")}
+                                </small>
                               </span>
                               {option.isDefault && <em>{t('detail.modelDefault')}</em>}
                             </button>

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -75,6 +75,7 @@ type ConfigProvidersResponse = {
     models: Record<string, {
       id?: string
       name?: string
+      description?: string
       status?: string
       capabilities?: {
         attachment?: boolean
@@ -265,6 +266,7 @@ export const api = {
           providerName: provider.name || provider.id,
           modelID: model.id || modelID,
           modelName: model.name || model.id || modelID,
+          description: model.description,
           status: model.status,
           contextLimit: model.limit?.context,
           outputLimit: model.limit?.output,

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -47,6 +47,8 @@ export type AgentOption = {
 export type ModelOption = ModelSelection & {
   providerName: string
   modelName: string
+  /** Present when the harness describes its models, as the ACP adapters do; OpenCode does not. */
+  description?: string
   status?: string
   contextLimit?: number
   outputLimit?: number

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -321,4 +321,13 @@ assert.match(
   'the AI panel must say a harness has no model selection rather than claiming to load'
 )
 
+// The harness names a model "Sonnet" and puts which Sonnet in the description. Showing the provider
+// there instead was fine when it distinguished anything; with one synthesised provider it read as
+// "claude" on all five rows while the version stayed invisible.
+assert.match(
+  app,
+  /\[option\.description \?\? option\.providerName, option\.variant\]/,
+  "the model picker's secondary line must prefer the harness description, falling back to the provider"
+)
+
 console.log('ui regression tests passed')


### PR DESCRIPTION
The picker listed `Sonnet`, `Haiku`, `Opus (1M context)` with no version, while the desktop client shows `Sonnet 5`, `Haiku 4.5`.

The version was never missing. The adapter sends it in each option's `description`, and `providersResponse` kept only `id`, `name` and `status`. Measured against the real adapter:

```
default              Default (recommended)    Sonnet 5 · Efficient for routine tasks
sonnet               Sonnet                   Sonnet 5 · Efficient for routine tasks
claude-fable-5[1m]   Fable                    Fable 5 · Most capable … · Requires usage credits
opus[1m]             Opus (1M context)        Opus 5 with 1M context · Best for everyday, complex tasks
haiku                Haiku                    Haiku 4.5 · Fastest for quick answers
```

## What changes

- the description is passed through the bridge and mapped into `ModelOption`
- it takes the picker's secondary line, which until now held the provider name. That line earned its place when the provider distinguished something; with one synthesised provider it read `claude` on all five rows while the useful text stayed invisible
- the provider still fills that line for a harness that describes nothing, so OpenCode, OMP and PI look exactly as before — pinned by an assertion that OMP's models come back with no description rather than an empty one
- a variant, when there is one, is still appended

`description` is optional the whole way through: OpenCode's API has no such field, so nothing is assumed of a harness that does not send it.

## Verification

Live against the adapter, all five versions present. `bridge`: 52/52. `web`: clean build, 6/6 suites.