### PR TITLE
docs: record Claude Code model selection, and release v2.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,9 +402,14 @@ username, and password. A successful health check reports `backend: "claude"`
 and the adapter version.
 
 Claude Code supports session listing, history replay, streaming prompts,
-cancellation, queued follow-up prompts, and todo/plan updates as the agent works.
-Model selection, agent selection, server slash commands, and VCS/diff are not
-currently exposed through this bridge.
+cancellation, queued follow-up prompts, todo/plan updates as the agent works, and
+model selection. The picker offers whatever the adapter reports — Default, Sonnet,
+Fable, Opus with 1M context, Haiku — each with the version it stands for, so
+"Sonnet" reads as `Sonnet 5 · Efficient for routine tasks`. Agent selection, server
+slash commands, and VCS/diff are not currently exposed through this bridge.
+
+The adapter also advertises a permission `mode` and an `effort` level, which the app
+does not use yet.
 
 **Rename and delete are bridge-local.** Renames persist in `~/.harness-remote/claude/`
 and survive bridge restarts, but are not propagated to the `claude` CLI itself.

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harness-remote-web",
   "private": true,
-  "version": "2.4.0",
+  "version": "2.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host",


### PR DESCRIPTION
The Claude Code section still listed model selection among the things the bridge does not expose. That stopped being true with #81 and #82.

- says what the picker offers, and that each entry carries the version it stands for
- notes the permission `mode` and `effort` level the adapter advertises but the app does not use yet
- `web/package.json` to `2.5.0`, which is what CI derives the release and the Android version code from

Checked the rest of the README for the same staleness: `pick the model a session uses` sits in the group that applies to every harness and is now true for all four.

Clean build, 6/6 web suites.