### PR TITLE
fix(web): show preparing state for streamed tool calls

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -915,6 +915,8 @@ function ToolPartView({
   const { label, diff } = describeToolAction(part, directory, t)
   const tool = (part.tool || "").toLowerCase()
   const input = (part.state?.input ?? {}) as Record<string, unknown>
+  const isPreparing = (status === "pending" || status === "running") && Object.keys(input).length === 0
+  const displayLabel = isPreparing ? t('action.preparingTool', { tool: part.tool || t('action.actionsFallback') }) : label
   let patch: string | null = null
   if (tool === "edit" && typeof input.oldString === "string" && typeof input.newString === "string") {
     patch = buildSimpleDiff(input.oldString, input.newString)
@@ -926,7 +928,7 @@ function ToolPartView({
   return (
     <>
       <button type="button" className={`message-tool-summary message-tool-${status}`} onClick={() => setOpen(true)}>
-        <span className="message-tool-label">{label}</span>
+        <span className="message-tool-label">{displayLabel}</span>
         <span className="message-tool-meta">
           {diff && (diff.additions > 0 || diff.deletions > 0) && (
             <span className="message-tool-diff-stats">
@@ -948,7 +950,7 @@ function ToolPartView({
       </button>
 
       {open && (
-        <Modal title={truncateForTitle(label)} timestamp={timestamp} onClose={() => setOpen(false)} t={t}>
+        <Modal title={truncateForTitle(displayLabel)} timestamp={timestamp} onClose={() => setOpen(false)} t={t}>
           {todos ? (
             <TodoListView items={todos} />
           ) : questions ? (

--- a/web/src/i18n.test.mjs
+++ b/web/src/i18n.test.mjs
@@ -39,4 +39,8 @@ assert.equal(it('settings.themeDark'), 'Scuro')
 assert.equal(zh('settings.themeSystem'), '跟隨系統')
 assert.equal(en('todo.title'), 'Todo Items')
 
+assert.equal(en('action.preparingTool', { tool: 'write' }), 'Preparing write')
+assert.equal(it('action.preparingTool', { tool: 'write' }), 'Preparazione di write')
+assert.equal(zh('action.preparingTool', { tool: 'write' }), '正在準備 write')
+
 console.log('i18n tests passed')

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -188,6 +188,7 @@ type TranslationKey =
   | 'action.usedSkillNamed'
   | 'action.toolFailed'
   | 'action.running'
+  | 'action.preparingTool'
   | 'action.showDiffFor'
   | 'action.actionsFallback'
   | 'action.countReadOne'
@@ -407,6 +408,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'action.usedSkillNamed': 'Used skill: {name}',
     'action.toolFailed': 'Tool failed',
     'action.running': 'Running…',
+    'action.preparingTool': 'Preparing {tool}',
     'action.showDiffFor': 'Show diff for {file}',
     'action.actionsFallback': 'Actions',
     'action.countReadOne': 'read 1 file',
@@ -625,6 +627,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'action.usedSkillNamed': 'Usata skill: {name}',
     'action.toolFailed': 'Tool fallito',
     'action.running': 'In esecuzione…',
+    'action.preparingTool': 'Preparazione di {tool}',
     'action.showDiffFor': 'Mostra diff per {file}',
     'action.actionsFallback': 'Azioni',
     'action.countReadOne': 'letto 1 file',
@@ -843,6 +846,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'action.usedSkillNamed': '已使用技能：{name}',
     'action.toolFailed': '工具失敗',
     'action.running': '執行中…',
+    'action.preparingTool': '正在準備 {tool}',
     'action.showDiffFor': '顯示 {file} 的差異',
     'action.actionsFallback': '動作',
     'action.countReadOne': '讀取 1 個檔案',

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -330,4 +330,18 @@ assert.match(
   "the model picker's secondary line must prefer the harness description, falling back to the provider"
 )
 
+// A tool event is created before its streamed arguments arrive. Calling that action complete (or
+// exposing its empty `{}` payload) falsely signals that the tool has already run.
+assert.match(
+  app,
+  /const isPreparing = \(status === "pending" \|\| status === "running"\) && Object\.keys\(input\)\.length === 0/,
+  'an active tool with no streamed input must remain in its preparing state'
+)
+assert.match(
+  app,
+  /const displayLabel = isPreparing \? t\('action\.preparingTool', \{ tool: part\.tool \|\| t\('action\.actionsFallback'\) \}\) : label/,
+  'preparing tools must identify the pending tool instead of presenting an empty call as complete'
+)
+assert.ok(app.includes('>{displayLabel}</span>'), 'the tool summary must show the preparing label')
+
 console.log('ui regression tests passed')


### PR DESCRIPTION
## Summary
- show a tool-specific preparation label while an active tool call has not received any streamed input
- localize the preparation label in English, Italian, and Traditional Chinese
- cover the pending-state rendering and translations with regression tests

## Testing
- npm run test:i18n
- npm run test:ui
- npm run test:settings
- npm run test:model
- npm run test:events
- npm run test:config
- npm run build

Fixes #72