### PR TITLE
feat(web): support multiple saved server configurations

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "test:settings": "node src/settings-regression.test.mjs",
     "test:model": "node src/model-regression.test.mjs",
     "test:events": "node --experimental-strip-types src/opencode-events.test.mjs",
+    "test:profiles": "node --experimental-strip-types src/server-profiles.test.mjs",
     "test:config": "node --experimental-strip-types src/server-config.test.mjs"
   },
   "dependencies": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,7 +4,7 @@ import { Capacitor, type PluginListenerHandle } from "@capacitor/core"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { api, isMixedContentBlocked, isValidServerConfig } from "./api"
-import { ACTIVE_BACKEND_STORAGE_KEY, BACKEND_STORAGE_KEYS, LEGACY_STORAGE_KEY } from "./storageKeys"
+import { BACKEND_STORAGE_KEYS } from "./storageKeys"
 import {
   createFetchOpenCodeEventSubscription,
   createNativeOpenCodeEventSubscription,
@@ -16,6 +16,7 @@ import {
 import { createTranslator, languageOptions, normalizeLanguage, type LanguageCode } from "./i18n"
 import { DEFAULT_HARNESS_CAPABILITIES } from "./backendCapabilities"
 import { BACKEND_CLIENTS } from "./backendClient"
+import { createServerProfile, loadActiveServerProfile, loadServerProfiles, persistServerProfiles, type SavedServerProfile } from "./serverProfiles"
 import type { AgentOption, CommandInfo, DiffFile, FileEntry, FileStatusEntry, HarnessCapabilities, MessageEnvelope, MessagePart, ModelOption, ModelSelection, PathInfo, ProjectDashboard, QuestionInfo, QuestionRequest, ServerConfig, Session, SessionStatus, SessionView, TodoItem } from "./types"
 import {
   SettingsIcon,
@@ -122,43 +123,6 @@ function backendDisplayName(backend: ServerConfig["backend"]): string {
   return "OpenCode"
 }
 
-function defaultConfig(backend: ServerConfig["backend"]): ServerConfig {
-  return {
-    backend,
-    host: "",
-    port: backend === "opencode" ? 4096 : 4097,
-    username: backend === "opencode" ? "opencode" : backend,
-    password: ""
-  }
-}
-
-function parseStoredConfig(value: string | null, backend: ServerConfig["backend"]): ServerConfig | null {
-  if (!value) return null
-  try {
-    const parsed = JSON.parse(value) as Partial<ServerConfig>
-    const storedBackend = parsed.backend === "omp" || parsed.backend === "opencode" || parsed.backend === "pi" || parsed.backend === "claude" ? parsed.backend : backend
-    return { ...defaultConfig(storedBackend), ...parsed, backend: storedBackend }
-  } catch {
-    return null
-  }
-}
-
-function readConfig(backend: ServerConfig["backend"]): ServerConfig {
-  const saved = parseStoredConfig(localStorage.getItem(BACKEND_STORAGE_KEYS[backend]), backend)
-  if (saved) return { ...saved, backend }
-  const legacy = parseStoredConfig(localStorage.getItem(LEGACY_STORAGE_KEY), "opencode")
-  return legacy?.backend === backend ? legacy : defaultConfig(backend)
-}
-
-function initialConfig(): ServerConfig {
-  const legacy = parseStoredConfig(localStorage.getItem(LEGACY_STORAGE_KEY), "opencode")
-  const storedBackend = localStorage.getItem(ACTIVE_BACKEND_STORAGE_KEY)
-  const backend = storedBackend === "omp" || storedBackend === "opencode" || storedBackend === "pi" || storedBackend === "claude" ? storedBackend : legacy?.backend ?? "opencode"
-  const config = readConfig(backend)
-  localStorage.setItem(BACKEND_STORAGE_KEYS[backend], JSON.stringify(config))
-  localStorage.setItem(ACTIVE_BACKEND_STORAGE_KEY, backend)
-  return config
-}
 
 function formatTime(epoch: number): string {
   if (!epoch) return "-"
@@ -1695,7 +1659,12 @@ const MessagesPane = memo(function MessagesPane({
 function App() {
   type NoticeType = "info" | "success" | "error"
   type ThemePreference = "system" | "light" | "dark"
-  const [config, setConfig] = useState<ServerConfig>(initialConfig)
+  const initialProfiles = useMemo(loadServerProfiles, [])
+  const initialProfile = useMemo(() => loadActiveServerProfile(initialProfiles), [initialProfiles])
+  const [profiles, setProfiles] = useState<SavedServerProfile[]>(initialProfiles)
+  const [activeProfileID, setActiveProfileID] = useState(initialProfile.id)
+  const [config, setConfig] = useState<ServerConfig>(initialProfile.config)
+  const [draftProfileName, setDraftProfileName] = useState(initialProfile.name)
   const [language, setLanguage] = useState<LanguageCode>(() => {
     return normalizeLanguage(localStorage.getItem(LANGUAGE_STORAGE_KEY) || navigator.language)
   })
@@ -2032,7 +2001,7 @@ function App() {
     setLoadingSessionID((activeID) => (activeID === sessionID ? null : activeID))
   }
 
-  function applyConfig(nextConfig: ServerConfig) {
+  function applyConfig(nextConfig: ServerConfig, profileID = activeProfileID, sourceProfiles = profiles) {
     const serverChanged = configKey(nextConfig) !== configKey(config)
     if (serverChanged) {
       loadSelectedRequestRef.current += 1
@@ -2055,15 +2024,44 @@ function App() {
       setModelOptions([])
       setSelectedModelKey(readStoredModel(nextConfig.backend))
     }
+    const nextProfiles = sourceProfiles.map((profile) => profile.id === profileID ? { ...profile, config: nextConfig } : profile)
+    setProfiles(nextProfiles)
+    setActiveProfileID(profileID)
+    persistServerProfiles(nextProfiles, profileID)
+    setDraftConfig(nextConfig)
     setConfig(nextConfig)
     localStorage.setItem(BACKEND_STORAGE_KEYS[nextConfig.backend], JSON.stringify(nextConfig))
-    localStorage.setItem(ACTIVE_BACKEND_STORAGE_KEY, nextConfig.backend)
     setSettingsNotice({ type: "success", text: t('settings.saved') })
     setConnectionState("connecting")
     setConnectionMessage(t('connection.connecting'))
     setRuntimeError(null)
     backgroundFailureCountRef.current = 0
     initialSessionLoadRef.current = true
+  }
+
+  function activateProfile(profileID: string) {
+    const profile = profiles.find((candidate) => candidate.id === profileID)
+    if (!profile || profile.id === activeProfileID) return
+    setDraftProfileName(profile.name)
+    setDraftConfig(profile.config)
+    applyConfig(profile.config, profile.id)
+  }
+
+  function addProfile() {
+    const profile = createServerProfile(t('settings.newServerName'), "opencode")
+    const nextProfiles = [...profiles, profile]
+    setDraftProfileName(profile.name)
+    applyConfig(profile.config, profile.id, nextProfiles)
+    setView("settings")
+  }
+
+  function deleteActiveProfile() {
+    if (profiles.length === 1) return
+    const nextProfiles = profiles.filter((profile) => profile.id !== activeProfileID)
+    const nextProfile = nextProfiles[0]
+    setDraftProfileName(nextProfile.name)
+    setDraftConfig(nextProfile.config)
+    applyConfig(nextProfile.config, nextProfile.id, nextProfiles)
   }
   async function testConnection(configToTest: ServerConfig) {
     setTestingConnection(true)
@@ -2719,6 +2717,10 @@ function App() {
   }, [theme])
 
   useEffect(() => {
+    persistServerProfiles(profiles, activeProfileID)
+  }, [])
+
+  useEffect(() => {
     localStorage.setItem(NEW_SESSION_DIRECTORY_STORAGE_KEY, newSessionDirectory)
   }, [newSessionDirectory])
 
@@ -3125,6 +3127,16 @@ function App() {
     { view: "settings" as const, label: t('nav.settings'), icon: <SettingsIcon size={19} />, disabled: false },
     { view: "help" as const, label: t('nav.help'), icon: <HelpIcon size={19} />, disabled: false }
   ]
+  const profilePicker = (
+    <label className="server-profile-picker">
+      <span className="sr-only">{t('settings.serverProfile')}</span>
+      <select aria-label={t('settings.serverProfile')} value={activeProfileID} onChange={(event) => activateProfile(event.target.value)}>
+        {profiles.map((profile) => (
+          <option key={profile.id} value={profile.id}>{profile.name}</option>
+        ))}
+      </select>
+    </label>
+  )
 
   return (
     <div className={`app-shell${isDesktop ? " app-shell-desktop" : ""}`}>
@@ -3148,6 +3160,7 @@ function App() {
               </div>
             </div>
           </div>
+          {profilePicker}
         </header>
       )}
 
@@ -3169,6 +3182,7 @@ function App() {
               </p>
             </div>
           </div>
+          {profilePicker}
 
           <div className="sidebar-toolbar">
             <input
@@ -3251,9 +3265,40 @@ function App() {
               <p className="subtle">{hasConfiguredServer ? `${config.host}:${config.port}` : t('settings.hostPlaceholder')}</p>
               <p className="subtle">{t('settings.draftHint')}</p>
             </div>
+            <div className="inline-actions">
+              <button type="button" className="btn-secondary" onClick={addProfile}>
+                <PlusIcon size={16} />
+                {t('settings.addServer')}
+              </button>
+              <button
+                type="button"
+                className="btn-danger"
+                onClick={deleteActiveProfile}
+                disabled={profiles.length === 1}
+                title={profiles.length === 1 ? t('settings.deleteLastServerHint') : undefined}
+              >
+                <TrashIcon size={16} />
+                {t('settings.deleteServer')}
+              </button>
+            </div>
           </div>
 
           <div className="form-grid">
+          <label htmlFor="server-name" className="field-row-span">
+            {t('settings.serverName')}
+            <input
+              id="server-name"
+              value={draftProfileName}
+              onChange={(event) => {
+                const name = event.target.value
+                setDraftProfileName(name)
+                const nextProfiles = profiles.map((profile) => profile.id === activeProfileID ? { ...profile, name } : profile)
+                setProfiles(nextProfiles)
+                persistServerProfiles(nextProfiles, activeProfileID)
+              }}
+              autoComplete="off"
+            />
+          </label>
           <label htmlFor="language">
             {t('settings.language')}
             <select
@@ -3287,7 +3332,7 @@ function App() {
               value={draftConfig.backend}
               onChange={(event) => {
                 const backend = event.target.value as ServerConfig["backend"]
-                setDraftConfig(readConfig(backend))
+                setDraftConfig(createServerProfile("", backend).config)
               }}
             >
               <option value="opencode">OpenCode</option>

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -14,6 +14,12 @@ type TranslationKey =
   | 'menu.detailDescription'
   | 'menu.helpDescription'
   | 'settings.title'
+  | 'settings.serverProfile'
+  | 'settings.serverName'
+  | 'settings.newServerName'
+  | 'settings.addServer'
+  | 'settings.deleteServer'
+  | 'settings.deleteLastServerHint'
   | 'settings.backend'
   | 'settings.host'
   | 'settings.hostPlaceholder'
@@ -234,6 +240,12 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'menu.detailDescription': 'Chat with your selected backend',
     'menu.helpDescription': 'Documentation & support',
     'settings.title': 'Server Configuration',
+    'settings.serverProfile': 'Saved server',
+    'settings.serverName': 'Server name',
+    'settings.newServerName': 'New server',
+    'settings.addServer': 'Add server',
+    'settings.deleteServer': 'Delete server',
+    'settings.deleteLastServerHint': 'Keep at least one server configuration.',
     'settings.backend': 'Backend',
     'settings.host': 'Host Address',
     'settings.hostPlaceholder': '192.168.1.100, localhost, or https://example.com',
@@ -452,6 +464,12 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'menu.detailDescription': 'Chatta con il backend selezionato',
     'menu.helpDescription': 'Documentazione e supporto',
     'settings.title': 'Configurazione server',
+    'settings.serverProfile': 'Server salvato',
+    'settings.serverName': 'Nome server',
+    'settings.newServerName': 'Nuovo server',
+    'settings.addServer': 'Aggiungi server',
+    'settings.deleteServer': 'Elimina server',
+    'settings.deleteLastServerHint': 'Mantieni almeno una configurazione server.',
     'settings.backend': 'Backend',
     'settings.host': 'Indirizzo host',
     'settings.hostPlaceholder': '192.168.1.100, localhost o https://example.com',
@@ -670,6 +688,12 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'menu.detailDescription': '與已選後端對話',
     'menu.helpDescription': '文件與支援',
     'settings.title': '伺服器設定',
+    'settings.serverProfile': '已儲存的伺服器',
+    'settings.serverName': '伺服器名稱',
+    'settings.newServerName': '新伺服器',
+    'settings.addServer': '新增伺服器',
+    'settings.deleteServer': '刪除伺服器',
+    'settings.deleteLastServerHint': '請至少保留一個伺服器設定。',
     'settings.backend': '後端',
     'settings.host': '主機位址',
     'settings.hostPlaceholder': '192.168.1.100、localhost 或 https://example.com',

--- a/web/src/server-profiles.test.mjs
+++ b/web/src/server-profiles.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+
+const storage = new Map()
+globalThis.localStorage = {
+  getItem(key) { return storage.get(key) ?? null },
+  setItem(key, value) { storage.set(key, String(value)) },
+  removeItem(key) { storage.delete(key) },
+  clear() { storage.clear() }
+}
+
+const {
+  ACTIVE_PROFILE_STORAGE_KEY,
+  SERVER_PROFILES_STORAGE_KEY,
+  createServerProfile,
+  loadActiveServerProfile,
+  loadServerProfiles,
+  persistServerProfiles
+} = await import('./serverProfiles.ts')
+
+storage.set('opencode.remote.server.opencode', JSON.stringify({ backend: 'opencode', host: 'desktop.local', port: 4096, username: 'opencode', password: '' }))
+storage.set('opencode.remote.server.omp', JSON.stringify({ backend: 'omp', host: 'pi.local', port: 4097, username: 'omp', password: 'secret' }))
+
+const migrated = loadServerProfiles()
+assert.equal(migrated.length, 2, 'each legacy backend configuration should migrate to its own saved server')
+assert.deepEqual(migrated.map((profile) => profile.config.backend), ['opencode', 'omp'])
+
+const added = createServerProfile('Work PI', 'pi')
+const profiles = [...migrated, added]
+persistServerProfiles(profiles, added.id)
+assert.equal(JSON.parse(storage.get(SERVER_PROFILES_STORAGE_KEY)).length, 3, 'saved profiles should persist as one collection')
+assert.equal(storage.get(ACTIVE_PROFILE_STORAGE_KEY), added.id, 'the selected server should persist independently')
+assert.equal(loadActiveServerProfile(loadServerProfiles()).name, 'Work PI', 'the saved selection should be restored at launch')
+
+console.log('server profile tests passed')

--- a/web/src/serverProfiles.ts
+++ b/web/src/serverProfiles.ts
@@ -1,0 +1,115 @@
+import type { BackendKind, ServerConfig } from "./types"
+const LEGACY_STORAGE_KEY = "opencode.remote.server"
+const ACTIVE_BACKEND_STORAGE_KEY = "opencode.remote.backend"
+const BACKEND_STORAGE_KEYS = {
+  opencode: "opencode.remote.server.opencode",
+  omp: "opencode.remote.server.omp",
+  pi: "opencode.remote.server.pi",
+  claude: "opencode.remote.server.claude"
+} as const
+
+export const SERVER_PROFILES_STORAGE_KEY = "opencode.remote.serverProfiles"
+export const ACTIVE_PROFILE_STORAGE_KEY = "opencode.remote.activeServerProfile"
+
+export type SavedServerProfile = {
+  id: string
+  name: string
+  config: ServerConfig
+}
+
+const BACKENDS: BackendKind[] = ["opencode", "omp", "pi", "claude"]
+
+function defaultConfig(backend: BackendKind): ServerConfig {
+  return {
+    backend,
+    host: "",
+    port: backend === "opencode" ? 4096 : 4097,
+    username: backend === "opencode" ? "opencode" : backend,
+    password: ""
+  }
+}
+
+function isBackend(value: unknown): value is BackendKind {
+  return value === "opencode" || value === "omp" || value === "pi" || value === "claude"
+}
+
+function parseConfig(value: unknown, fallbackBackend: BackendKind): ServerConfig | null {
+  if (!value || typeof value !== "object") return null
+  const candidate = value as Partial<ServerConfig>
+  const backend = isBackend(candidate.backend) ? candidate.backend : fallbackBackend
+  if (typeof candidate.host !== "string" || typeof candidate.port !== "number" || typeof candidate.username !== "string" || typeof candidate.password !== "string") return null
+  return { ...defaultConfig(backend), ...candidate, backend }
+}
+
+function profileID(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `profile-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+function profileName(backend: BackendKind, position: number): string {
+  const label = backend === "omp" ? "Oh My Pi" : backend === "pi" ? "PI" : backend === "claude" ? "Claude Code" : "OpenCode"
+  return position === 0 ? `${label} server` : `${label} server ${position + 1}`
+}
+
+function parseProfiles(value: string | null): SavedServerProfile[] | null {
+  if (!value) return null
+  try {
+    const parsed = JSON.parse(value)
+    if (!Array.isArray(parsed)) return null
+    const profiles = parsed.flatMap((candidate, index) => {
+      if (!candidate || typeof candidate !== "object") return []
+      const source = candidate as { id?: unknown; name?: unknown; config?: unknown }
+      const config = parseConfig(source.config, "opencode")
+      if (!config) return []
+      return [{
+        id: typeof source.id === "string" && source.id ? source.id : profileID(),
+        name: typeof source.name === "string" && source.name.trim() ? source.name.trim() : profileName(config.backend, index),
+        config
+      }]
+    })
+    return profiles.length > 0 ? profiles : null
+  } catch {
+    return null
+  }
+}
+
+function legacyProfiles(): SavedServerProfile[] {
+  const profiles: SavedServerProfile[] = []
+  for (const backend of BACKENDS) {
+    const raw = localStorage.getItem(BACKEND_STORAGE_KEYS[backend])
+    if (!raw) continue
+    try {
+      const config = parseConfig(JSON.parse(raw), backend)
+      if (config) profiles.push({ id: profileID(), name: profileName(config.backend, profiles.length), config })
+    } catch {
+      // Ignore malformed old storage and continue with the remaining saved servers.
+    }
+  }
+  if (profiles.length > 0) return profiles
+  try {
+    const legacy = parseConfig(JSON.parse(localStorage.getItem(LEGACY_STORAGE_KEY) ?? "null"), "opencode")
+    if (legacy) return [{ id: profileID(), name: profileName(legacy.backend, 0), config: legacy }]
+  } catch {
+    // Start with a blank OpenCode profile when legacy storage is malformed.
+  }
+  const backend = localStorage.getItem(ACTIVE_BACKEND_STORAGE_KEY)
+  const fallback = isBackend(backend) ? backend : "opencode"
+  return [{ id: profileID(), name: profileName(fallback, 0), config: defaultConfig(fallback) }]
+}
+
+export function loadServerProfiles(): SavedServerProfile[] {
+  return parseProfiles(localStorage.getItem(SERVER_PROFILES_STORAGE_KEY)) ?? legacyProfiles()
+}
+
+export function loadActiveServerProfile(profiles: SavedServerProfile[]): SavedServerProfile {
+  const storedID = localStorage.getItem(ACTIVE_PROFILE_STORAGE_KEY)
+  return profiles.find((profile) => profile.id === storedID) ?? profiles[0]
+}
+
+export function persistServerProfiles(profiles: SavedServerProfile[], activeProfileID: string): void {
+  localStorage.setItem(SERVER_PROFILES_STORAGE_KEY, JSON.stringify(profiles))
+  localStorage.setItem(ACTIVE_PROFILE_STORAGE_KEY, activeProfileID)
+}
+
+export function createServerProfile(name: string, backend: BackendKind): SavedServerProfile {
+  return { id: profileID(), name: name.trim() || profileName(backend, 0), config: defaultConfig(backend) }
+}

--- a/web/src/storageKeys.ts
+++ b/web/src/storageKeys.ts
@@ -18,5 +18,7 @@ export const SERVER_STORAGE_KEYS = [
   BACKEND_STORAGE_KEYS.claude,
   "opencode.remote.model",
   "opencode.remote.agent",
-  "opencode.remote.newSessionDirectory"
+  "opencode.remote.newSessionDirectory",
+  "opencode.remote.serverProfiles",
+  "opencode.remote.activeServerProfile"
 ]

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2472,6 +2472,24 @@ button.compact {
   white-space: nowrap;
 }
 
+.server-profile-picker {
+  display: block;
+  min-width: 0;
+}
+
+.server-profile-picker select {
+  width: 100%;
+  min-width: 0;
+  margin: 0;
+  color: var(--muted-strong);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.top-nav .server-profile-picker {
+  flex: 0 1 12rem;
+}
+
 .harness-badge.harness-omp {
   border-color: var(--harness-omp-border);
   background: var(--harness-omp-soft);


### PR DESCRIPTION
## Summary
- persist multiple named server configurations and migrate existing backend-specific settings
- add a header selector that switches the active server and refreshes the connected workspace
- add settings controls to create, rename, edit, and delete saved servers, including different backends

## Testing
- npm run test:profiles
- npm run test:i18n
- npm run test:ui
- npm run test:settings
- npm run test:model
- npm run test:events
- npm run test:config
- npm run build
- browser smoke test for switching, creating, and renaming saved servers

Fixes #71