### PR TITLE
chore(web): keep one definition per server storage key

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,7 +4,6 @@ import { Capacitor, type PluginListenerHandle } from "@capacitor/core"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { api, isMixedContentBlocked, isValidServerConfig } from "./api"
-import { BACKEND_STORAGE_KEYS } from "./storageKeys"
 import {
   createFetchOpenCodeEventSubscription,
   createNativeOpenCodeEventSubscription,
@@ -2032,7 +2031,6 @@ function App() {
     persistServerProfiles(nextProfiles, profileID)
     setDraftConfig(nextConfig)
     setConfig(nextConfig)
-    localStorage.setItem(BACKEND_STORAGE_KEYS[nextConfig.backend], JSON.stringify(nextConfig))
     setSettingsNotice({ type: "success", text: t('settings.saved') })
     setConnectionState("connecting")
     setConnectionMessage(t('connection.connecting'))

--- a/web/src/server-profiles.test.mjs
+++ b/web/src/server-profiles.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 
 const storage = new Map()
 globalThis.localStorage = {
@@ -30,5 +31,14 @@ persistServerProfiles(profiles, added.id)
 assert.equal(JSON.parse(storage.get(SERVER_PROFILES_STORAGE_KEY)).length, 3, 'saved profiles should persist as one collection')
 assert.equal(storage.get(ACTIVE_PROFILE_STORAGE_KEY), added.id, 'the selected server should persist independently')
 assert.equal(loadActiveServerProfile(loadServerProfiles()).name, 'Work PI', 'the saved selection should be restored at launch')
+
+// A crash caused by a bad saved server has to be recoverable, so the reset must clear the profiles
+// too: leaving them behind would restore the same broken connection on every retry. The reset list is
+// asserted as source text because storageKeys.ts imports this module with an extensionless specifier,
+// which the node test runner cannot resolve.
+const storageKeys = readFileSync(new URL('./storageKeys.ts', import.meta.url), 'utf8')
+assert.match(storageKeys, /SERVER_PROFILES_STORAGE_KEY/, 'the crash-recovery reset must clear saved servers')
+assert.match(storageKeys, /ACTIVE_PROFILE_STORAGE_KEY/, 'the crash-recovery reset must clear the selected server')
+assert.ok(!/"opencode\.remote\.(serverProfiles|activeServerProfile)"/.test(storageKeys), 'storage keys must have a single definition')
 
 console.log('server profile tests passed')

--- a/web/src/serverProfiles.ts
+++ b/web/src/serverProfiles.ts
@@ -1,7 +1,11 @@
 import type { BackendKind, ServerConfig } from "./types"
-const LEGACY_STORAGE_KEY = "opencode.remote.server"
-const ACTIVE_BACKEND_STORAGE_KEY = "opencode.remote.backend"
-const BACKEND_STORAGE_KEYS = {
+
+/** Every server storage key lives here: the crash-recovery reset in storageKeys.ts composes them,
+    and only this module reads or writes them. Keep this file free of runtime sibling imports so the
+    node test runner, which cannot resolve extensionless specifiers, can load it directly. */
+export const LEGACY_STORAGE_KEY = "opencode.remote.server"
+export const ACTIVE_BACKEND_STORAGE_KEY = "opencode.remote.backend"
+export const BACKEND_STORAGE_KEYS = {
   opencode: "opencode.remote.server.opencode",
   omp: "opencode.remote.server.omp",
   pi: "opencode.remote.server.pi",

--- a/web/src/storageKeys.ts
+++ b/web/src/storageKeys.ts
@@ -1,14 +1,14 @@
-/** Storage keys are shared with the crash-recovery reset, so they live outside App.tsx. */
-export const LEGACY_STORAGE_KEY = "opencode.remote.server"
-export const ACTIVE_BACKEND_STORAGE_KEY = "opencode.remote.backend"
-export const BACKEND_STORAGE_KEYS = {
-  opencode: "opencode.remote.server.opencode",
-  omp: "opencode.remote.server.omp",
-  pi: "opencode.remote.server.pi",
-  claude: "opencode.remote.server.claude"
-} as const
+import {
+  ACTIVE_BACKEND_STORAGE_KEY,
+  ACTIVE_PROFILE_STORAGE_KEY,
+  BACKEND_STORAGE_KEYS,
+  LEGACY_STORAGE_KEY,
+  SERVER_PROFILES_STORAGE_KEY
+} from "./serverProfiles"
 
-/** Everything that describes a backend connection; language and theme are deliberately excluded. */
+/** Everything that describes a backend connection; language and theme are deliberately excluded. The
+    keys themselves belong to serverProfiles.ts, the only module that reads or writes them: this list
+    exists so the crash-recovery reset can clear a broken connection without importing App.tsx. */
 export const SERVER_STORAGE_KEYS = [
   LEGACY_STORAGE_KEY,
   ACTIVE_BACKEND_STORAGE_KEY,
@@ -19,6 +19,6 @@ export const SERVER_STORAGE_KEYS = [
   "opencode.remote.model",
   "opencode.remote.agent",
   "opencode.remote.newSessionDirectory",
-  "opencode.remote.serverProfiles",
-  "opencode.remote.activeServerProfile"
+  SERVER_PROFILES_STORAGE_KEY,
+  ACTIVE_PROFILE_STORAGE_KEY
 ]


### PR DESCRIPTION
## Summary
- move the server storage keys into `serverProfiles.ts`, the only module that reads or writes them, so the saved-server migration and the crash-recovery reset can no longer disagree about a key name
- drop the per-backend `localStorage` write left in `applyConfig`: nothing reads it now that saved profiles are the source of truth, and two profiles on the same backend overwrote each other in it
- assert that the crash-recovery reset still clears the profile keys, and that no key has a second definition

The keys live in `serverProfiles.ts` rather than the other way round because that module has to stay free of runtime sibling imports: `node --experimental-strip-types` cannot resolve the extensionless specifiers the rest of the codebase uses, so `server-profiles.test.mjs` can only import a leaf module.

Follow-up to #85. No behaviour change.

## Testing
- npm run test:profiles
- npm run test:i18n
- npm run test:ui
- npm run test:settings
- npm run test:model
- npm run test:events
- npm run test:config
- npm run build