### PR TITLE
fix(web): tidy the saved-server controls on both layouts

### DIFF
--- a/.github/workflows/android-aab.yml
+++ b/.github/workflows/android-aab.yml
@@ -42,6 +42,7 @@ jobs:
           npm run test:settings
           npm run test:model
           npm run test:events
+          npm run test:profiles
         working-directory: web
 
       - name: Run bridge tests

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -58,6 +58,7 @@ jobs:
           npm run test:settings
           npm run test:model
           npm run test:events
+          npm run test:profiles
         working-directory: web
 
       - name: Run bridge tests

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -54,6 +54,7 @@ jobs:
           npm run test:settings
           npm run test:model
           npm run test:events
+          npm run test:profiles
         working-directory: web
 
       - name: Build web app

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1667,6 +1667,7 @@ function App() {
   const [activeProfileID, setActiveProfileID] = useState(initialProfile.id)
   const [config, setConfig] = useState<ServerConfig>(initialProfile.config)
   const [draftProfileName, setDraftProfileName] = useState(initialProfile.name)
+  const [profileToDelete, setProfileToDelete] = useState<SavedServerProfile | null>(null)
   const [language, setLanguage] = useState<LanguageCode>(() => {
     return normalizeLanguage(localStorage.getItem(LANGUAGE_STORAGE_KEY) || navigator.language)
   })
@@ -2058,6 +2059,7 @@ function App() {
   }
 
   function deleteActiveProfile() {
+    setProfileToDelete(null)
     if (profiles.length === 1) return
     const nextProfiles = profiles.filter((profile) => profile.id !== activeProfileID)
     const nextProfile = nextProfiles[0]
@@ -3129,15 +3131,16 @@ function App() {
     { view: "settings" as const, label: t('nav.settings'), icon: <SettingsIcon size={19} />, disabled: false },
     { view: "help" as const, label: t('nav.help'), icon: <HelpIcon size={19} />, disabled: false }
   ]
+  /* The select carries its own accessible name: a visible caption above it would spend a line of the
+     header on a word the chosen option already implies. */
   const profilePicker = (
-    <label className="server-profile-picker">
-      <span className="sr-only">{t('settings.serverProfile')}</span>
+    <div className="server-profile-picker">
       <select aria-label={t('settings.serverProfile')} value={activeProfileID} onChange={(event) => activateProfile(event.target.value)}>
         {profiles.map((profile) => (
           <option key={profile.id} value={profile.id}>{profile.name}</option>
         ))}
       </select>
-    </label>
+    </div>
   )
 
   return (
@@ -3262,12 +3265,14 @@ function App() {
         >
         <section className="panel settings fade-in">
           <div className="section-heading">
-            <div>
+            <div className="section-heading-text">
               <h2>{t('settings.title')}</h2>
               <p className="subtle">{hasConfiguredServer ? `${config.host}:${config.port}` : t('settings.hostPlaceholder')}</p>
               <p className="subtle">{t('settings.draftHint')}</p>
             </div>
-            <div className="inline-actions">
+            {/* Aligned to the bottom of the heading text: the pair costs no height of its own there,
+                and it stays clear of the corner the modal's close button occupies. */}
+            <div className="server-profile-actions">
               <button type="button" className="btn-secondary" onClick={addProfile}>
                 <PlusIcon size={16} />
                 {t('settings.addServer')}
@@ -3275,7 +3280,7 @@ function App() {
               <button
                 type="button"
                 className="btn-danger"
-                onClick={deleteActiveProfile}
+                onClick={() => setProfileToDelete(profiles.find((profile) => profile.id === activeProfileID) ?? null)}
                 disabled={profiles.length === 1}
                 title={profiles.length === 1 ? t('settings.deleteLastServerHint') : undefined}
               >
@@ -3984,6 +3989,39 @@ function App() {
                 </div>
               </div>
             )}
+          </section>
+        </div>
+      )}
+
+      {/* Deleting a saved server throws away a host, a username and a password that cannot be
+          recovered, so it is confirmed exactly like deleting a session. */}
+      {profileToDelete && (
+        <div className="modal-backdrop" role="presentation" onClick={() => setProfileToDelete(null)}>
+          <section
+            className="modal-card fade-in"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="delete-server-title"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <h2 id="delete-server-title">{t('settings.deleteServerTitle')}</h2>
+            <p>
+              {t('session.deleteBodyPrefix')} <strong>{profileToDelete.name}</strong>.
+            </p>
+            {/* A server saved but never filled in has no address to show, and the placeholder that
+                stands in for one inside the form reads as an actual host here. */}
+            {profileToDelete.config.host && (
+              <p className="subtle">{`${profileToDelete.config.host}:${profileToDelete.config.port}`}</p>
+            )}
+            <div className="modal-actions">
+              <button className="btn-secondary" onClick={() => setProfileToDelete(null)}>
+                {t('session.cancel')}
+              </button>
+              <button className="btn-danger" onClick={deleteActiveProfile}>
+                <TrashIcon size={16} />
+                {t('settings.deleteServer')}
+              </button>
+            </div>
           </section>
         </div>
       )}

--- a/web/src/i18n.test.mjs
+++ b/web/src/i18n.test.mjs
@@ -43,4 +43,8 @@ assert.equal(en('action.preparingTool', { tool: 'write' }), 'Preparing write')
 assert.equal(it('action.preparingTool', { tool: 'write' }), 'Preparazione di write')
 assert.equal(zh('action.preparingTool', { tool: 'write' }), '正在準備 write')
 
+assert.equal(en('settings.deleteServerTitle'), 'Delete saved server?')
+assert.equal(it('settings.deleteServerTitle'), 'Eliminare il server salvato?')
+assert.equal(zh('settings.deleteServerTitle'), '刪除已儲存的伺服器？')
+
 console.log('i18n tests passed')

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -19,6 +19,7 @@ type TranslationKey =
   | 'settings.newServerName'
   | 'settings.addServer'
   | 'settings.deleteServer'
+  | 'settings.deleteServerTitle'
   | 'settings.deleteLastServerHint'
   | 'settings.backend'
   | 'settings.host'
@@ -246,6 +247,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'settings.newServerName': 'New server',
     'settings.addServer': 'Add server',
     'settings.deleteServer': 'Delete server',
+    'settings.deleteServerTitle': 'Delete saved server?',
     'settings.deleteLastServerHint': 'Keep at least one server configuration.',
     'settings.backend': 'Backend',
     'settings.host': 'Host Address',
@@ -471,6 +473,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'settings.newServerName': 'Nuovo server',
     'settings.addServer': 'Aggiungi server',
     'settings.deleteServer': 'Elimina server',
+    'settings.deleteServerTitle': 'Eliminare il server salvato?',
     'settings.deleteLastServerHint': 'Mantieni almeno una configurazione server.',
     'settings.backend': 'Backend',
     'settings.host': 'Indirizzo host',
@@ -696,6 +699,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'settings.newServerName': '新伺服器',
     'settings.addServer': '新增伺服器',
     'settings.deleteServer': '刪除伺服器',
+    'settings.deleteServerTitle': '刪除已儲存的伺服器？',
     'settings.deleteLastServerHint': '請至少保留一個伺服器設定。',
     'settings.backend': '後端',
     'settings.host': '主機位址',

--- a/web/src/settings-regression.test.mjs
+++ b/web/src/settings-regression.test.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs'
 
 const app = readFileSync(new URL('./App.tsx', import.meta.url), 'utf8')
 const i18n = readFileSync(new URL('./i18n.ts', import.meta.url), 'utf8')
+const styles = readFileSync(new URL('./styles.css', import.meta.url), 'utf8')
 
 const testConnection = app.match(/async function testConnection[\s\S]*?async function refreshSessions/)
 assert.ok(testConnection, 'testConnection function should be present')
@@ -26,5 +27,26 @@ assert.ok(app.includes('<option value="pi">PI (ACP bridge)</option>'), 'Settings
 assert.ok(app.includes('health.backend && health.backend !== configToTest.backend'), 'Connection tests should reject a bridge for the wrong backend')
 assert.ok(app.includes('https://github.com/giuliastro/harness-remote#'), 'Help should link to the canonical repository')
 assert.equal(app.includes('https://github.com/gervaso-assistant/opencode-remote-android#'), false, 'Help must not link to the obsolete repository owner')
+
+// The server picker used to caption itself with a visually-hidden span, but no rule ever hid it: the
+// caption rendered as stray text above the header. Every class the picker and its actions rely on has
+// to exist in the stylesheet, or the layout falls back to whatever the bare markup does.
+for (const className of ['server-profile-picker', 'server-profile-actions', 'section-heading-text']) {
+  assert.ok(app.includes(`className="${className}"`), `${className} should be used by the saved-server UI`)
+  assert.ok(styles.includes(`.${className}`), `${className} should be styled instead of relying on default rendering`)
+}
+assert.equal(/className="sr-only"/.test(app), false, 'a caption the stylesheet cannot hide must not be rendered at all')
+
+// Sized to their labels the two actions came out visibly different widths, and a full row of their own
+// pushed a form that already fills the height cap into scrolling for a few pixels.
+assert.match(styles, /\.server-profile-actions\s*\{[^}]*grid-auto-columns:\s*1fr/, 'the saved-server actions must be equal width')
+assert.match(styles, /\.server-profile-actions\s*\{[^}]*align-self:\s*flex-end/, 'the saved-server actions must sit on the last line of the heading instead of taking a row')
+assert.match(styles, /\.desktop-panel-modal\s*\{[^}]*max-height:\s*calc\(100vh - 2 \* var\(--modal-margin\) - 2px\)/, 'a panel modal must claim every pixel the backdrop margin leaves so a form that fits does not scroll')
+assert.match(styles, /\.desktop-panel-modal > \.panel\s*\{[^}]*border:\s*0/, 'the panel inside a modal must not draw a second frame inside the card')
+
+// Deleting a saved server discards a host, a username and a password with no way back.
+assert.ok(app.includes('setProfileToDelete(profiles.find((profile) => profile.id === activeProfileID) ?? null)'), 'deleting a saved server must ask first')
+assert.ok(app.includes('aria-labelledby="delete-server-title"'), 'the saved-server deletion must be confirmed in a dialog')
+assert.ok(i18n.includes("'settings.deleteServerTitle'"), 'the deletion dialog needs a translated title')
 
 console.log('settings regression tests passed')

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1499,7 +1499,10 @@ p {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--space-4);
+  /* The gap a modal keeps from the screen edge, published so a card that caps its own height can
+     claim exactly the rest of the viewport instead of guessing and scrolling for the difference. */
+  --modal-margin: var(--space-3);
+  padding: var(--modal-margin);
   background: var(--modal-backdrop);
 }
 
@@ -2144,16 +2147,25 @@ button.compact {
 .desktop-panel-modal {
   position: relative;
   width: min(92vw, 720px);
-  max-height: 85vh;
+  /* Everything the backdrop's margin leaves: at 85vh the settings form missed fitting by a handful of
+     pixels and scrolled for them. The borders come off too, so the cap bounds the content, not the box. */
+  max-height: calc(100vh - 2 * var(--modal-margin) - 2px);
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  /* The panel inside brings its own padding, border and radius: keeping the card's as well drew a
+     frame inside a frame and spent 32px of the height cap on nothing, which is enough to make a form
+     that fits scroll anyway. */
+  padding: 0;
 }
 
 .desktop-panel-modal > .panel {
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
+  border: 0;
+  border-radius: inherit;
+  box-shadow: none;
 }
 
 .desktop-modal-close {
@@ -2486,8 +2498,62 @@ button.compact {
   font-weight: 700;
 }
 
+/* A share of the bar rather than a width of its own: sized to the chosen name, a long one pushed the
+   app title into an ellipsis, and the name is the part the open dropdown shows in full anyway. */
 .top-nav .server-profile-picker {
-  flex: 0 1 12rem;
+  flex: 0 1 40%;
+  max-width: 12rem;
+  min-width: 0;
+}
+
+/* Below roughly 344px even 40% of the bar leaves the title short of the width it needs, and a clipped
+   product name is worse than one more row on the narrowest phones. */
+@media (max-width: 360px) {
+  .top-nav {
+    flex-wrap: wrap;
+  }
+
+  .top-nav .server-profile-picker {
+    flex: 1 1 100%;
+    max-width: none;
+  }
+}
+
+/* The pair sits on the last line of the heading text rather than beside the title, so it neither
+   reaches the modal's close button nor spends a row of a form that already fills the height cap.
+   Both buttons keep their full label on one line; the heading text is what gives way. */
+.server-profile-actions {
+  display: grid;
+  grid-auto-flow: column;
+  /* Equal columns as wide as the longer label: two buttons acting on the same server should not be
+     two different sizes because one word is shorter than the other. */
+  grid-auto-columns: 1fr;
+  align-self: flex-end;
+  flex-shrink: 0;
+  gap: var(--space-3);
+}
+
+.server-profile-actions button {
+  white-space: nowrap;
+}
+
+.settings .section-heading-text {
+  min-width: 0;
+}
+
+/* Declared after the rule above so it actually overrides it: the phone block earlier in this file
+   loses to any later rule of the same specificity. The heading is a column at this width, so there is
+   no last line to sit on — the pair takes its own row and splits it in equal halves. */
+@media (max-width: 780px) {
+  .server-profile-actions {
+    grid-auto-flow: row;
+    grid-template-columns: 1fr 1fr;
+    align-self: stretch;
+  }
+
+  .server-profile-actions button {
+    white-space: normal;
+  }
 }
 
 .harness-badge.harness-omp {


### PR DESCRIPTION
Follow-up to #85, from looking at the deployed page.

## What was wrong
- **"Server salvato" printed above the header.** The picker captioned itself with a `<span className="sr-only">`, and nothing in the stylesheet defines `.sr-only`, so the caption rendered as ordinary text. The select already has an `aria-label`, so the span is gone rather than hidden, and a regression test now refuses any class the stylesheet cannot style.
- **"Add server" / "Delete server" at arbitrary sizes and places.** Sized to their labels they were 175px and 161px, and the heading gave them only what the title left, so they wrapped into a column. They are now equal columns as wide as the longer label, anchored to the last line of the heading text — clear of the corner the modal close button occupies — and a row of equal halves once the heading stacks on a phone.
- **Settings scrolled with nothing to scroll.** The modal card padded content that already pads itself, drawing a frame inside a frame and spending 32px of an 85vh cap on nothing; the form then missed fitting by ~5px. The card is now seamless and claims everything the backdrop margin leaves. No scrollbar down to ~745px of viewport height, and it still scrolls when the form genuinely does not fit.
- **A long server name clipped the app title.** The picker took a fixed 12rem of the header bar; it now takes a share of it, and drops to a row of its own below 360px where 40% is not enough for both.
- **Deleting a saved server was one unconfirmed click** on a host, a username and a password with no way back. It now asks first, in the same dialog the session deletion uses.
- **`test:profiles` gated nothing.** The three release paths run the same list of web suites — the Pages workflow says so in its own comment — but the suite added with the saved servers was left out of all three, so the migration of the old per-backend settings and the persistence of the profiles were the one thing that could not block a deploy or a release build.

## Testing
Measured in the browser at 320, 344, 375, 780, 790, 1280 and 1400 wide, and at 560, 760, 800 and 900 tall: no horizontal overflow, the app title and both button labels intact, the actions inside the panel, the modal on screen at every height, and the scrollbar present only when the content really exceeds the card.

The gate sequence was run in the order the workflows run it, followed by `npx tsc -b`:

- npm run test:i18n
- npm run test:config
- npm run test:ui
- npm run test:settings
- npm run test:model
- npm run test:events
- npm run test:profiles
- npm run build