### PR TITLE
ci: move the workflow actions onto Node 24

### DIFF
--- a/.github/workflows/android-aab.yml
+++ b/.github/workflows/android-aab.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -50,13 +50,13 @@ jobs:
         working-directory: bridge
 
       - name: Setup JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       - name: Install Android 36 SDK packages
         run: sdkmanager "platform-tools" "platforms;android-36" "build-tools;36.0.0"
@@ -122,7 +122,7 @@ jobs:
           fi
 
       - name: Upload AAB artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: harness-remote-aab-v${{ steps.version.outputs.app_version }}
           path: ${{ steps.aab.outputs.path }}

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Release notes are built from the tag's own annotation and the tag before it, and a
           # depth-1 clone has neither.
@@ -37,7 +37,7 @@ jobs:
         run: git fetch --tags --force
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -66,13 +66,13 @@ jobs:
         working-directory: bridge
 
       - name: Setup JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       - name: Install Android 36 SDK packages
         run: sdkmanager "platform-tools" "platforms;android-36" "build-tools;36.0.0"
@@ -119,7 +119,7 @@ jobs:
           "$ANDROID_HOME/build-tools/36.0.0/apksigner" verify --verbose web/android/app/build/outputs/apk/debug/app-debug.apk
 
       - name: Upload test APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: harness-remote-debug-apk-v${{ steps.version.outputs.app_version }}
           path: web/android/app/build/outputs/apk/debug/app-debug.apk
@@ -163,7 +163,7 @@ jobs:
           fi
 
       - name: Upload release APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: harness-remote-release-apk-v${{ steps.version.outputs.app_version }}
           path: ${{ steps.apk.outputs.path }}
@@ -209,7 +209,7 @@ jobs:
 
       - name: Publish GitHub release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: Harness Remote v${{ steps.version.outputs.app_version }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -64,10 +64,10 @@ jobs:
         working-directory: web
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: web/dist
 
@@ -80,4 +80,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Every action the three workflows use still targets Node 20. The runners already force those to Node 24 and annotate every run with a deprecation warning, so the pinned versions no longer describe what actually runs. Each one moves to its current major, where `runs.using` is `node24` for real (checked against `action.yml` at each tag, not assumed).

| action | before | after |
| --- | --- | --- |
| actions/checkout | v4 | v7 |
| actions/setup-node | v4 | v7 |
| actions/setup-java | v4 | v5 |
| android-actions/setup-android | v3 | v4 |
| actions/upload-artifact | v4 | v7 |
| actions/configure-pages | v5 | v6 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |
| softprops/action-gh-release | v2 | v3 |

## Breaking changes in those majors, against what this repo does
- **setup-java v5** stops installing JetBrains pre-releases by default. Both Android builds ask for `temurin`, so it does not apply.
- **setup-node v5** caches automatically when `package.json` has a `packageManager` field. `web/package.json` has none, and all three workflows set `cache: npm` with an explicit `cache-dependency-path` regardless.
- **upload-pages-artifact v4** stops including dotfiles in the artifact. The Vite output has none, and the app is served from `/assets/`, so nothing depended on one.
- **upload-artifact v5** is labelled a breaking change only because of the Node 24 runtime.
- **setup-android v4** is the one real change of behaviour: it defaults to cmdline-tools 20.0.

## Testing
`Build Android APK` dispatched on this branch, which exercises checkout, setup-node, setup-java, setup-android and upload-artifact on the path where a wrong SDK would show up. The release step is gated on `refs/tags/v*`, so a branch dispatch builds and uploads the artifact without publishing anything.

The Pages trio (`configure-pages`, `upload-pages-artifact`, `deploy-pages`) is left to the run that follows the merge: dispatching that workflow from a branch would republish the live site, and there is no way to exercise the deploy job without deploying.