### PR TITLE
feat(web): add message copy actions

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1455,6 +1455,61 @@ function groupRenderedMessages(messages: (MessageEnvelope & { text: string })[])
   return groups
 }
 
+function MessageContextMenu({
+  message,
+  className,
+  t,
+  children
+}: {
+  message: MessageEnvelope & { text: string }
+  className: string
+  t: Translator
+  children: ReactNode
+}) {
+  const [position, setPosition] = useState<{ x: number, y: number } | null>(null)
+  const longPressTimer = useRef<number | undefined>(undefined)
+  const close = () => {
+    if (longPressTimer.current !== undefined) window.clearTimeout(longPressTimer.current)
+    longPressTimer.current = undefined
+  }
+  const open = (x: number, y: number) => {
+    close()
+    setPosition({
+      x: Math.max(8, Math.min(x, window.innerWidth - 220)),
+      y: Math.max(8, Math.min(y, window.innerHeight - 104))
+    })
+  }
+  const copy = (markdown: boolean) => {
+    const text = markdown ? normalizeMessageMarkdown(message.text) : message.text
+    void navigator.clipboard.writeText(text).catch(() => undefined)
+    setPosition(null)
+  }
+  return (
+    <article
+      className={className}
+      onContextMenu={(event) => {
+        event.preventDefault()
+        open(event.clientX, event.clientY)
+      }}
+      onPointerDown={(event) => {
+        if (event.pointerType !== "touch") return
+        const { clientX, clientY } = event
+        longPressTimer.current = window.setTimeout(() => open(clientX, clientY), 500)
+      }}
+      onPointerUp={close}
+      onPointerCancel={close}
+    >
+      {children}
+      {position && (
+        <div className="message-context-menu" role="menu" style={{ left: position.x, top: position.y }}>
+          <button type="button" role="menuitem" onClick={() => copy(false)}>{t('detail.copyText')}</button>
+          <button type="button" role="menuitem" onClick={() => copy(true)}>{t('detail.copyMarkdown')}</button>
+        </div>
+      )}
+    </article>
+  )
+}
+
 /** Renders one run's continuous timeline (see groupRenderedMessages) as a single message bubble, resolving
  *  each item's timestamp to the specific message that produced it. */
 function ConversationRunView({
@@ -1478,7 +1533,7 @@ function ConversationRunView({
     return owner ? formatTime(owner.info.time.created) : undefined
   }
   return (
-    <article className="message assistant fade-in">
+    <MessageContextMenu message={fallback!} className="message assistant fade-in" t={t}>
       {items.map((item) =>
         item.kind === "action-group" ? (
           <ActionGroupView
@@ -1502,7 +1557,7 @@ function ConversationRunView({
           />
         )
       )}
-    </article>
+    </MessageContextMenu>
   )
 }
 
@@ -1521,7 +1576,7 @@ const MessageArticle = memo(function MessageArticle({
   t: Translator
 }) {
   return (
-    <article className={`message ${message.info.role} fade-in`}>
+    <MessageContextMenu message={message} className={`message ${message.info.role} fade-in`} t={t}>
       {buildMessageTimeline(message.parts).map((item) =>
         item.kind === "action-group" ? (
           <ActionGroupView
@@ -1545,7 +1600,7 @@ const MessageArticle = memo(function MessageArticle({
           />
         )
       )}
-    </article>
+    </MessageContextMenu>
   )
 })
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1455,6 +1455,39 @@ function groupRenderedMessages(messages: (MessageEnvelope & { text: string })[])
   return groups
 }
 
+/**
+ * The Clipboard API is secure-context only, and this app is also meant to be served over plain http
+ * on a LAN, where `navigator.clipboard` is not rejected but absent: reaching through it throws
+ * before there is a promise to catch, so the copy fails with nothing in the clipboard and nothing on
+ * screen. The deprecated selection copy is the only thing that still works there.
+ */
+async function copyToClipboard(text: string): Promise<void> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text)
+      return
+    }
+  } catch {
+    // A missing API and a refused write need the same fallback from here.
+  }
+  const carrier = document.createElement("textarea")
+  carrier.value = text
+  carrier.setAttribute("readonly", "")
+  carrier.style.position = "fixed"
+  carrier.style.top = "0"
+  carrier.style.opacity = "0"
+  document.body.appendChild(carrier)
+  carrier.select()
+  carrier.setSelectionRange(0, text.length)
+  try {
+    document.execCommand("copy")
+  } catch {
+    // Out of options: both paths are gone.
+  } finally {
+    carrier.remove()
+  }
+}
+
 function MessageContextMenu({
   message,
   className,
@@ -1468,22 +1501,43 @@ function MessageContextMenu({
 }) {
   const [position, setPosition] = useState<{ x: number, y: number } | null>(null)
   const longPressTimer = useRef<number | undefined>(undefined)
-  const close = () => {
+  const cancelLongPress = () => {
     if (longPressTimer.current !== undefined) window.clearTimeout(longPressTimer.current)
     longPressTimer.current = undefined
   }
   const open = (x: number, y: number) => {
-    close()
+    cancelLongPress()
     setPosition({
       x: Math.max(8, Math.min(x, window.innerWidth - 220)),
       y: Math.max(8, Math.min(y, window.innerHeight - 104))
     })
   }
   const copy = (markdown: boolean) => {
-    const text = markdown ? normalizeMessageMarkdown(message.text) : message.text
-    void navigator.clipboard.writeText(text).catch(() => undefined)
+    void copyToClipboard(markdown ? normalizeMessageMarkdown(message.text) : message.text)
     setPosition(null)
   }
+  // Everything that means "not this" has to put the menu away: a press anywhere else, Escape, the
+  // transcript scrolling out from under a fixed menu, a resize moving the coordinates it was pinned
+  // to. Each bubble owns its own menu state, so without this a second right-click adds a second menu
+  // instead of moving the first, and neither ever leaves until an item is chosen.
+  useEffect(() => {
+    if (!position) return
+    const dismiss = () => setPosition(null)
+    const dismissOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") dismiss()
+    }
+    window.addEventListener("pointerdown", dismiss)
+    window.addEventListener("keydown", dismissOnEscape)
+    window.addEventListener("resize", dismiss)
+    // The transcript scrolls inside its own pane, and a scroll there never reaches window by itself.
+    window.addEventListener("scroll", dismiss, true)
+    return () => {
+      window.removeEventListener("pointerdown", dismiss)
+      window.removeEventListener("keydown", dismissOnEscape)
+      window.removeEventListener("resize", dismiss)
+      window.removeEventListener("scroll", dismiss, true)
+    }
+  }, [position])
   return (
     <article
       className={className}
@@ -1496,12 +1550,19 @@ function MessageContextMenu({
         const { clientX, clientY } = event
         longPressTimer.current = window.setTimeout(() => open(clientX, clientY), 500)
       }}
-      onPointerUp={close}
-      onPointerCancel={close}
+      onPointerUp={cancelLongPress}
+      onPointerCancel={cancelLongPress}
     >
       {children}
       {position && (
-        <div className="message-context-menu" role="menu" style={{ left: position.x, top: position.y }}>
+        // Pressing an item must not read as pressing "anywhere else": the dismissal above would
+        // unmount the menu on pointerdown and the click would never reach the button.
+        <div
+          className="message-context-menu"
+          role="menu"
+          style={{ left: position.x, top: position.y }}
+          onPointerDown={(event) => event.stopPropagation()}
+        >
           <button type="button" role="menuitem" onClick={() => copy(false)}>{t('detail.copyText')}</button>
           <button type="button" role="menuitem" onClick={() => copy(true)}>{t('detail.copyMarkdown')}</button>
         </div>

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -100,6 +100,8 @@ type TranslationKey =
   | 'detail.composerPlaceholder'
   | 'detail.externalSession'
   | 'detail.waiting'
+  | 'detail.copyText'
+  | 'detail.copyMarkdown'
   | 'detail.send'
   | 'detail.jumpToLatest'
   | 'detail.you'
@@ -327,6 +329,8 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.composerPlaceholder': 'Prompt, or / for commands',
     'detail.externalSession': 'Started by another client',
     'detail.waiting': 'Waiting...',
+    'detail.copyText': 'Copy text',
+    'detail.copyMarkdown': 'Copy as markdown',
     'detail.send': 'Send',
     'detail.jumpToLatest': 'Go to latest',
     'detail.you': '👤 You',
@@ -553,6 +557,8 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.composerPlaceholder': 'Prompt, o / per i comandi',
     'detail.externalSession': 'Avviata da un altro client',
     'detail.waiting': 'Attesa...',
+    'detail.copyText': 'Copia testo',
+    'detail.copyMarkdown': 'Copia come Markdown',
     'detail.send': 'Invia',
     'detail.jumpToLatest': 'Vai alla fine',
     'detail.you': '👤 Tu',
@@ -779,6 +785,8 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.composerPlaceholder': '輸入提示，或以 / 下命令',
     'detail.externalSession': '由其他用戶端啟動',
     'detail.waiting': '等待中...',
+    'detail.copyText': '複製文字',
+    'detail.copyMarkdown': '複製為 Markdown',
     'detail.send': '傳送',
     'detail.jumpToLatest': '前往最新',
     'detail.you': '👤 你',

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -984,6 +984,34 @@ p {
   background: var(--surface-subtle);
 }
 
+.message-context-menu {
+  position: fixed;
+  z-index: 20;
+  display: grid;
+  min-width: 212px;
+  padding: var(--space-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  box-shadow: var(--shadow-lg);
+}
+
+.message-context-menu button {
+  width: 100%;
+  min-height: 36px;
+  padding: 0 var(--space-3);
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text);
+  text-align: start;
+}
+
+.message-context-menu button:hover,
+.message-context-menu button:focus-visible {
+  background: var(--surface-strong);
+}
+
 .typing-bubble {
   width: auto;
   padding: 0.75rem 1rem;

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -347,7 +347,17 @@ assert.ok(app.includes('>{displayLabel}</span>'), 'the tool summary must show th
 
 assert.match(app, /onContextMenu=\{\(event\) => \{\s*event\.preventDefault\(\)\s*open\(event\.clientX, event\.clientY\)/, 'right-clicking a message must open its action menu')
 assert.match(app, /event\.pointerType !== "touch"/, 'touch messages must support long-press actions')
-assert.match(app, /navigator\.clipboard\.writeText\(text\)/, 'message actions must copy to the system clipboard')
+assert.match(app, /navigator\.clipboard\?\.writeText/, 'message actions must copy to the system clipboard')
 assert.match(app, /markdown \? normalizeMessageMarkdown\(message\.text\) : message\.text/, 'the menu must distinguish plain-text and markdown copies')
 assert.match(styles, /\.message-context-menu\s*\{[\s\S]*?position:\s*fixed/, 'message actions must render above the scrolling transcript')
+// A menu that only closes on its own items is a menu that stacks: the state is per bubble, so a
+// right-click on a second message left the first one hanging over the transcript.
+assert.match(app, /window\.addEventListener\("pointerdown", dismiss\)/, 'pressing outside an open message menu must dismiss it')
+assert.match(app, /if \(event\.key === "Escape"\) dismiss\(\)/, 'Escape must dismiss an open message menu')
+assert.match(app, /window\.addEventListener\("scroll", dismiss, true\)/, 'a fixed menu must not stay behind while the transcript scrolls under it')
+assert.match(app, /onPointerDown=\{\(event\) => event\.stopPropagation\(\)\}/, 'choosing an item must not count as pressing outside, or the menu unmounts before the click lands')
+// The Clipboard API needs a secure context, and the app is reachable over plain http on a LAN,
+// where `navigator.clipboard` is undefined and reaching into it throws past any `.catch()`.
+assert.match(app, /document\.execCommand\("copy"\)/, 'copying must still work where the Clipboard API is unavailable')
+
 console.log('ui regression tests passed')

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -344,4 +344,10 @@ assert.match(
 )
 assert.ok(app.includes('>{displayLabel}</span>'), 'the tool summary must show the preparing label')
 
+
+assert.match(app, /onContextMenu=\{\(event\) => \{\s*event\.preventDefault\(\)\s*open\(event\.clientX, event\.clientY\)/, 'right-clicking a message must open its action menu')
+assert.match(app, /event\.pointerType !== "touch"/, 'touch messages must support long-press actions')
+assert.match(app, /navigator\.clipboard\.writeText\(text\)/, 'message actions must copy to the system clipboard')
+assert.match(app, /markdown \? normalizeMessageMarkdown\(message\.text\) : message\.text/, 'the menu must distinguish plain-text and markdown copies')
+assert.match(styles, /\.message-context-menu\s*\{[\s\S]*?position:\s*fixed/, 'message actions must render above the scrolling transcript')
 console.log('ui regression tests passed')


### PR DESCRIPTION
Implements the copy portion of #90.

- Opens a message action menu on right-click or touch long-press.
- Copies either plain text or normalized Markdown to the system clipboard.
- Covers every user and agent message.

Revert actions are intentionally deferred per the current scope instruction.

Verification: `npm run test:ui`, `npm run test:i18n`, `npm run build`.