### PR TITLE
feat(web): distinguish waiting sessions

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -104,6 +104,10 @@ function isBridgeBackend(backend: ServerConfig["backend"]): boolean {
   return backend === "omp" || backend === "pi" || backend === "claude"
 }
 
+function isSessionWorking(status: string): boolean {
+  return status === "busy" || status === "retry" || status === "waiting"
+}
+
 /**
  * A session card showed the whole absolute path, which on a phone wrapped to three lines and
  * took a third of the card. The last segments are what identifies a project; the full path stays
@@ -1953,12 +1957,12 @@ function App() {
         : eventStreamState === "fallback"
           ? t('events.fallback', { error: liveEventError ?? t('events.unknownError') })
           : ""
-  const isSessionRunning = Boolean(selectedSession && ["busy", "retry"].includes(selectedSession.status))
+  const isSessionRunning = Boolean(selectedSession && isSessionWorking(selectedSession.status))
   const isWaitingForOpenCodeReply = awaitingAssistantReply || busySending || isSessionRunning
   const isWorking = isWaitingForOpenCodeReply
   const showStopAction = isWorking && !composer.trim()
   const showTypingBubble = Boolean(selectedSession) && isWaitingForOpenCodeReply
-  const activeSessions = sessions.filter((session) => ["busy", "retry"].includes(session.status)).length
+  const activeSessions = sessions.filter((session) => isSessionWorking(session.status)).length
   const changedSessions = sessions.filter(
     (session) => session.files > 0 || session.additions > 0 || session.deletions > 0
   ).length
@@ -2987,13 +2991,12 @@ function App() {
     }
     wasAwaitingAssistantReplyRef.current = awaitingAssistantReply
   }, [awaitingAssistantReply])
-
   useEffect(() => {
     if (!selectedSession) {
       wasRunningRef.current = false
       return
     }
-    wasRunningRef.current = ["busy", "retry"].includes(selectedSession.status)
+    wasRunningRef.current = isSessionWorking(selectedSession.status)
   }, [selectedSession?.id, selectedSession?.status])
 
   // Shared between the mobile sessions panel and the desktop sidebar so both list sessions

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -619,6 +619,11 @@ p {
   background: var(--warning-soft);
 }
 
+.pill.waiting {
+  color: var(--primary);
+  background: var(--primary-soft);
+}
+
 .detail {
   min-height: calc(100dvh - 132px);
   display: flex;
@@ -1802,12 +1807,12 @@ button.compact {
   background: transparent;
 }
 
-/* On desktop the pill is dropped in favor of a left-border flag: a session is assumed idle
-   unless it's actively busy/retrying, which is the only state worth calling out at a glance. The
-   border uses the site's own accent color (rather than an off-palette warning yellow) and sweeps
-   like an indeterminate progress bar so a working session reads as "in motion" at a glance. */
+/* On desktop the pill is dropped in favor of a left-border flag. Busy/retrying sessions use
+   the primary accent; a session waiting on a subagent uses an animated violet marker so it stays
+   visibly distinct without pretending that the whole session is idle. */
 .sidebar-sessions .session-card.busy::before,
-.sidebar-sessions .session-card.retry::before {
+.sidebar-sessions .session-card.retry::before,
+.sidebar-sessions .session-card.waiting::before {
   content: "";
   position: absolute;
   left: 0;
@@ -1819,6 +1824,20 @@ button.compact {
   background-size: 100% 24px;
   background-repeat: repeat-y;
   animation: session-busy-sweep 1s linear infinite;
+}
+
+.sidebar-sessions .session-card.waiting::before {
+  background-image: linear-gradient(var(--secondary-soft), var(--secondary), var(--secondary-soft));
+  animation-name: session-waiting-sweep;
+}
+
+@keyframes session-waiting-sweep {
+  from {
+    background-position: 0 24px;
+  }
+  to {
+    background-position: 0 0;
+  }
 }
 
 /* A plain pixel-length shift (one full tile per loop) rather than a percentage-based one: with a

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -11,6 +11,11 @@
   --primary: #1769e0;
   --primary-strong: #0f55bd;
   --primary-soft: #e7f0ff;
+  /* The second accent exists for states that are neither the primary action nor a warning — a
+     session waiting on a subagent is working, so it must read as active without borrowing the
+     colour that means "this session is running its own turn". */
+  --secondary: #7c3aed;
+  --secondary-soft: #f1e9ff;
   --success: #12805c;
   --success-soft: #e6f5ef;
   --danger: #c2413b;
@@ -65,6 +70,8 @@
   --primary: #60a5fa;
   --primary-strong: #93c5fd;
   --primary-soft: rgba(96, 165, 250, 0.16);
+  --secondary: #c4b5fd;
+  --secondary-soft: rgba(124, 58, 237, 0.22);
   --success: #34d399;
   --success-soft: rgba(18, 128, 92, 0.2);
   --danger: #f87171;
@@ -1617,7 +1624,7 @@ button.compact {
 .help-content .note {
   margin-top: var(--space-2);
   font-size: 0.88rem;
-  color: var(--text-secondary);
+  color: var(--muted);
 }
 
 .help ul,

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -352,4 +352,24 @@ assert.match(
 )
 assert.match(styles, /\.pill\.waiting\s*\{[^}]*background:\s*var\(--primary-soft\)/, 'waiting sessions need a distinct status pill')
 assert.match(styles, /\.session-card\.waiting::before\s*\{[\s\S]*?animation-name:\s*session-waiting-sweep/, 'desktop waiting sessions need their own animation')
+
+// The waiting marker first shipped naming two colours the palette never declared, and the
+// assertions above could not tell: they read the rule as text. A `var()` with no fallback pointing
+// at nothing is invalid at computed-value time, so the browser drops the whole declaration and the
+// marker paints nothing at all. Checked over the sheet rather than that one rule, since any other
+// token typo fails exactly as quietly.
+const declaredTokens = new Set([...styles.matchAll(/^\s*(--[a-z0-9-]+)\s*:/gm)].map((match) => match[1]))
+const undeclaredTokens = [...new Set(
+  [...styles.matchAll(/var\((--[a-z0-9-]+)\s*\)/g)]
+    .map((match) => match[1])
+    .filter((token) => !declaredTokens.has(token))
+)]
+assert.deepEqual(undeclaredTokens, [], 'a custom property used without a fallback must be declared')
+// Declared in one theme only fails just as silently, and half of it is invisible to whoever is not
+// using that theme. The dark block overrides `:root`, so every name it carries has to exist there.
+const themeTokens = (block) => new Set([...block.matchAll(/^\s*(--[a-z0-9-]+)\s*:/gm)].map((match) => match[1]))
+const rootTokens = themeTokens(styles.match(/^:root \{([\s\S]*?)^\}/m)[1])
+const darkOnlyTokens = [...themeTokens(styles.match(/color-scheme: dark;([\s\S]*?)^\}/m)[1])].filter((token) => !rootTokens.has(token))
+assert.deepEqual(darkOnlyTokens, [], 'a custom property overridden for dark mode must have a light-mode value too')
+
 console.log('ui regression tests passed')

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -344,4 +344,12 @@ assert.match(
 )
 assert.ok(app.includes('>{displayLabel}</span>'), 'the tool summary must show the preparing label')
 
+
+assert.match(
+  app,
+  /function isSessionWorking\(status: string\): boolean \{\s*return status === "busy" \|\| status === "retry" \|\| status === "waiting"/,
+  'waiting sessions must remain working sessions rather than becoming idle'
+)
+assert.match(styles, /\.pill\.waiting\s*\{[^}]*background:\s*var\(--primary-soft\)/, 'waiting sessions need a distinct status pill')
+assert.match(styles, /\.session-card\.waiting::before\s*\{[\s\S]*?animation-name:\s*session-waiting-sweep/, 'desktop waiting sessions need their own animation')
 console.log('ui regression tests passed')


### PR DESCRIPTION
Closes #89.

- Treats server-reported `waiting` sessions as active work.
- Gives the waiting pill its own visual treatment.
- Adds a distinct animated desktop sidebar marker for waiting sessions.

Verification: `npm run test:ui`, `npm run build`.