### PR TITLE
fix(web): remove HTTP server warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,29 +134,6 @@ in `--cors`:
 npx -y opencode-ai serve --hostname 0.0.0.0 --port 4096 --cors https://giuliastro.github.io
 ```
 
-### The hosted PWA cannot reach a plain-http server on your LAN
-
-CORS is only the second obstacle. The first is that the hosted app is served over HTTPS, and an
-HTTPS page is not allowed to talk to an `http://` address unless that address is loopback:
-
-- `http://localhost:4096` and `http://127.0.0.1:4096` work — browsers treat loopback as
-  trustworthy. Good enough when the server runs on the same machine as the browser.
-- `http://192.168.1.64:4096` is refused as mixed content, *before the request is sent*. The
-  server never sees it, so no amount of `--cors` helps, and the app can only report
-  `Failed to fetch`. Settings shows a warning next to the host field when the address you typed
-  falls into this case.
-
-So the phone-to-PC setup — the reason this app exists — needs one of:
-
-- **the Android app** from [Releases](https://github.com/giuliastro/harness-remote/releases/latest),
-  which is not a web page and has no such restriction. This stays the recommended route.
-- **HTTPS on the server**, via a reverse proxy holding a certificate the phone trusts.
-- **a tunnel** (Tailscale Serve, Cloudflare Tunnel, ngrok) that gives the server its own HTTPS
-  origin — remember to add that origin to `--cors`.
-- **self-hosting this build over plain http** on your LAN, e.g. `npm run preview -- --host` in
-  `web/`. An `http://` page may talk to an `http://` server freely; you lose installability and
-  the service worker, both of which require a secure context.
-
 ## Technology Stack
 
 - frontend: React + TypeScript + Vite

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,9 +1,9 @@
 import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from "react"
 import { App as CapacitorApp } from "@capacitor/app"
-import { Capacitor, type PluginListenerHandle } from "@capacitor/core"
+import { type PluginListenerHandle } from "@capacitor/core"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
-import { api, isMixedContentBlocked, isValidServerConfig } from "./api"
+import { api, isValidServerConfig } from "./api"
 import {
   createFetchOpenCodeEventSubscription,
   createNativeOpenCodeEventSubscription,
@@ -1922,12 +1922,6 @@ function App() {
 
   const hasConfiguredServer = isValidServerConfig(config)
   const draftConfigKey = configKey(draftConfig)
-  // The address is typed here but rejected by the browser, so the warning belongs next to the
-  // field rather than in the failure notice, where it would only appear after a pointless test.
-  // The native build goes through CapacitorHttp instead of the WebView and is never subject to
-  // this, whatever scheme `androidScheme` happens to serve the bundle under.
-  const draftBlockedByMixedContent = !Capacitor.isNativePlatform()
-    && isMixedContentBlocked(draftConfig, window.location.protocol)
   const canTestDraft = canTestConfig(draftConfig)
   const testAlreadyPassedForDraft = lastTestedConfigKey === draftConfigKey
   const connectionStatusText = connectionMessage || (connectionState === "connecting"
@@ -3347,7 +3341,7 @@ function App() {
             </select>
           </label>
 
-          <label htmlFor="host" className={draftBlockedByMixedContent ? "field-row-span" : undefined}>
+          <label htmlFor="host">
             {t('settings.host')}
             <input
               id="host"
@@ -3360,9 +3354,6 @@ function App() {
               spellCheck={false}
               autoComplete="off"
             />
-            {draftBlockedByMixedContent && (
-              <span className="field-warning">{t('settings.insecureHostWarning')}</span>
-            )}
           </label>
 
           <label htmlFor="port">

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,6 +1,6 @@
 import { Capacitor, CapacitorHttp } from "@capacitor/core"
 import { streamURL } from "./opencode-events"
-import { baseUrl, isMixedContentBlocked, isValidServerConfig } from "./serverConfig"
+import { baseUrl, isValidServerConfig } from "./serverConfig"
 import type {
   AgentOption,
   CommandInfo,
@@ -26,7 +26,7 @@ function authHeader(config: ServerConfig): string {
   return `Basic ${btoa(`${config.username}:${config.password}`)}`
 }
 
-export { baseUrl, isMixedContentBlocked, isValidServerConfig }
+export { baseUrl, isValidServerConfig }
 
 function withDirectory(path: string, directory?: string): string {
   if (!directory) return path

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -24,7 +24,6 @@ type TranslationKey =
   | 'settings.backend'
   | 'settings.host'
   | 'settings.hostPlaceholder'
-  | 'settings.insecureHostWarning'
   | 'settings.port'
   | 'settings.username'
   | 'settings.password'
@@ -252,7 +251,6 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'settings.backend': 'Backend',
     'settings.host': 'Host Address',
     'settings.hostPlaceholder': '192.168.1.100, localhost, or https://example.com',
-    'settings.insecureHostWarning': 'This app is served over HTTPS, so the browser will refuse a plain http:// server unless it runs on this same device. Serve the server over HTTPS, reach it through a tunnel, or use the installed Android app.',
     'settings.port': 'Port',
     'settings.username': 'Username',
     'settings.password': 'Password',
@@ -478,7 +476,6 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'settings.backend': 'Backend',
     'settings.host': 'Indirizzo host',
     'settings.hostPlaceholder': '192.168.1.100, localhost o https://example.com',
-    'settings.insecureHostWarning': 'Questa app è servita in HTTPS, quindi il browser rifiuta un server http:// che non sia su questo stesso dispositivo. Esponi il server in HTTPS, raggiungilo tramite un tunnel oppure usa l\'app Android installata.',
     'settings.port': 'Porta',
     'settings.username': 'Username',
     'settings.password': 'Password',
@@ -704,7 +701,6 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'settings.backend': '後端',
     'settings.host': '主機位址',
     'settings.hostPlaceholder': '192.168.1.100、localhost 或 https://example.com',
-    'settings.insecureHostWarning': '本應用透過 HTTPS 提供，因此除非伺服器就在這台裝置上，瀏覽器會拒絕連線至 http:// 伺服器。請改用 HTTPS 提供伺服器、透過通道連線，或使用已安裝的 Android 應用程式。',
     'settings.port': '連接埠',
     'settings.username': '使用者名稱',
     'settings.password': '密碼',

--- a/web/src/server-config.test.mjs
+++ b/web/src/server-config.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { streamURL } from './opencode-events.ts'
-import { baseUrl, isMixedContentBlocked, isValidServerConfig } from './serverConfig.ts'
+import { baseUrl, isValidServerConfig } from './serverConfig.ts'
 
 const config = (host, port = 4096) => ({ backend: 'opencode', host, port, username: 'opencode', password: 'secret' })
 
@@ -30,33 +30,11 @@ for (const host of ['Giulio-S7', 'http://192.168.1.64', 'https://example.com']) 
   assert.doesNotThrow(() => streamURL(baseUrl(config(host)), 'global'), `streamURL must not throw for ${host}`)
 }
 
-// Measured in a browser on an https page against one server bound to 0.0.0.0:4096: loopback
-// answered 200, the same server on 192.168.1.64 was refused. So the installed PWA reaches a
-// server on the same machine and nothing else, and the settings panel must say so — a blocked
-// request surfaces only as "Failed to fetch".
-for (const host of ['localhost', '127.0.0.1', '127.1.2.3', 'dev.localhost', '[::1]']) {
-  assert.equal(isMixedContentBlocked(config(host), 'https:'), false, `loopback host ${host} stays reachable from https`)
-}
-for (const host of ['192.168.1.64', 'Giulio-S7', 'http://192.168.1.64', 'http://example.com']) {
-  assert.equal(isMixedContentBlocked(config(host), 'https:'), true, `plain-http host ${host} is blocked from https`)
-}
-assert.equal(isMixedContentBlocked(config('https://example.com'), 'https:'), false, 'an https server is never mixed content')
-// The dev server and the Capacitor build are not https pages, so the warning must stay quiet there.
-for (const protocol of ['http:', 'capacitor:', 'file:']) {
-  assert.equal(isMixedContentBlocked(config('192.168.1.64'), protocol), false, `no warning on a ${protocol} page`)
-}
-assert.equal(isMixedContentBlocked(config('http://'), 'https:'), false, 'a half-typed host must not throw or warn')
-
 const app = readFileSync(new URL('./App.tsx', import.meta.url), 'utf8')
-assert.match(
-  app,
-  /isMixedContentBlocked\(draftConfig, window\.location\.protocol\)/,
-  'the settings panel must warn when the configured server cannot be reached from an https page'
-)
-assert.match(
-  app,
-  /!Capacitor\.isNativePlatform\(\)\s*\n?\s*&& isMixedContentBlocked/,
-  'the native build reaches the server through CapacitorHttp, so it must never show that warning'
+assert.equal(
+  app.includes('isMixedContentBlocked'),
+  false,
+  'settings must not warn that a plain-http server requires HTTPS'
 )
 assert.match(
   app,

--- a/web/src/serverConfig.ts
+++ b/web/src/serverConfig.ts
@@ -18,34 +18,6 @@ export function baseUrl(config: ServerConfig): string {
  * building any URL, because a throw on the render path blanks the whole app and a
  * persisted invalid host reproduces that crash on every launch.
  */
-/**
- * Browsers treat loopback as trustworthy even over plain http, so these hosts stay reachable
- * from an https page. Everything else does not.
- */
-function isLoopbackHostname(hostname: string): boolean {
-  if (hostname === "localhost" || hostname.endsWith(".localhost")) return true
-  if (hostname === "[::1]" || hostname === "::1") return true
-  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname)
-}
-
-/**
- * The installable web app is served over https, and an https page may not talk to a plain
- * `http://` server unless that server is loopback: the browser refuses the request as mixed
- * content before it leaves, and `fetch` reports it as a bare "Failed to fetch" that says nothing
- * about the cause. That is exactly the phone-to-PC setup this app exists for, so the settings
- * panel has to name the problem instead of letting the user retype the address.
- *
- * Irrelevant in the native Android build, which is not a page and has no scheme to be mixed with.
- */
-export function isMixedContentBlocked(config: ServerConfig, pageProtocol: string): boolean {
-  if (pageProtocol !== "https:") return false
-  try {
-    const url = new URL(baseUrl(config))
-    return url.protocol === "http:" && !isLoopbackHostname(url.hostname)
-  } catch {
-    return false
-  }
-}
 
 export function isValidServerConfig(config: ServerConfig): boolean {
   if (!config.host.trim() || !Number.isInteger(config.port) || config.port <= 0 || config.port > 65535) return false

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -370,23 +370,6 @@ p {
   grid-column: 1 / -1;
 }
 
-/* A field carrying an explanation needs the whole row: half of a two-column grid turns the
-   sentence into a narrow tower next to a two-line neighbour. */
-.settings .form-grid label.field-row-span {
-  grid-column: 1 / -1;
-}
-
-.field-warning {
-  display: block;
-  margin-top: var(--space-2);
-  padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-md);
-  background: var(--warning-soft);
-  color: var(--warning);
-  font-size: 0.8rem;
-  font-weight: 600;
-  line-height: 1.45;
-}
 
 .form-grid {
   display: grid;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -370,6 +370,11 @@ p {
   grid-column: 1 / -1;
 }
 
+/* The server name heads the form and names the whole profile, so it reads as a title over the
+   pairs below rather than as the left half of a row shared with the backend picker. */
+.settings .form-grid label.field-row-span {
+  grid-column: 1 / -1;
+}
 
 .form-grid {
   display: grid;

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -344,4 +344,14 @@ assert.match(
 )
 assert.ok(app.includes('>{displayLabel}</span>'), 'the tool summary must show the preparing label')
 
+// The rule was written for a field that no longer exists, but the class outlived it: dropping the
+// declaration with its original caller left the server name silently back in half a row.
+if (app.includes('className="field-row-span"')) {
+  assert.match(
+    styles,
+    /\.field-row-span\s*\{[^}]*grid-column:\s*1 \/ -1;/,
+    'a field asking for the whole settings row needs the rule that grants it'
+  )
+}
+
 console.log('ui regression tests passed')


### PR DESCRIPTION
Closes #91.

Removes the incorrect HTTPS requirement warning and its obsolete mixed-content guard, styles, translations, regression cases, and documentation.

Verification: all web regression scripts and `npm run build`.