### PR TITLE
feat(bridge): preserve reasoning and tool parts

### DIFF
--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -586,37 +586,94 @@ export class AcpService {
       if (!replaying) this.#persistSnapshot(sessionId)
       return
     }
-    if (update.sessionUpdate !== "user_message_chunk" && update.sessionUpdate !== "agent_message_chunk") return
+    if (update.sessionUpdate === "tool_call") {
+      if (!replaying && (!this.#active.has(sessionId) || this.#cancelledSessions.has(sessionId))) return
+      const chunkKey = `${sessionId}:assistant`
+      const messageID = this.#chunkMessageIDs.get(chunkKey) ?? randomUUID()
+      this.#chunkMessageIDs.set(chunkKey, messageID)
+      const messages = this.#messages.get(sessionId) ?? []
+      this.#messages.set(sessionId, messages)
+      let message = messages.find((item) => item.info.id === messageID)
+      if (!message) {
+        message = {
+          info: { id: messageID, role: "assistant", sessionID: sessionId, time: { created: Date.now() } },
+          parts: []
+        }
+        messages.push(message)
+      }
+      message.parts.push({
+        id: update.toolCallId,
+        messageID,
+        type: "tool",
+        tool: update._meta?.toolName ?? update.title,
+        callID: update.toolCallId,
+        state: {
+          status: update.status === "in_progress" ? "running" : update.status,
+          input: update.rawInput,
+          title: update.title,
+          time: { start: Date.now() }
+        }
+      })
+      if (!replaying) this.#emit("message.updated", sessionId)
+      return
+    }
+    if (update.sessionUpdate === "tool_call_update") {
+      const tool = (this.#messages.get(sessionId) ?? [])
+        .flatMap((message) => message.parts)
+        .find((part) => part.type === "tool" && part.callID === update.toolCallId)
+      if (!tool?.state) return
+      const output = update.rawOutput ?? update.content
+        ?.flatMap((item) => item.type === "content" && item.content?.type === "text" ? [item.content.text] : [])
+        .join("")
+      tool.state.status = update.status === "in_progress" ? "running" : update.status === "failed" ? "error" : update.status
+      if (output) tool.state.output = typeof output === "string" ? output : JSON.stringify(output)
+      if (tool.state.time && ["completed", "error"].includes(tool.state.status)) tool.state.time.end = Date.now()
+      if (!replaying) this.#emit("message.updated", sessionId)
+      return
+    }
+    const thought = update.sessionUpdate === "agent_thought_chunk"
+    const messageChunk = update.sessionUpdate === "user_message_chunk" || update.sessionUpdate === "agent_message_chunk"
+    if (!thought && !messageChunk) return
     if (update.content?.type !== "text" || !update.content.text) return
     const role = update.sessionUpdate === "user_message_chunk" ? "user" : "assistant"
+    const partType = thought ? "reasoning" : "text"
     // Acknowledgements only suppress a live echo of the prompt we just recorded;
     if (role === "assistant" && !replaying && this.#cancelledSessions.has(sessionId)) return
-    if (!update.messageId && role === "assistant" && !replaying && !this.#active.has(sessionId) && !this.#promptedSessions.has(sessionId)) return
+    if (role === "assistant" && !replaying && !this.#active.has(sessionId) && !this.#promptedSessions.has(sessionId)) return
     if (role === "user" && !replaying && this.#isAcknowledgedPromptChunk(sessionId, update.content.text)) return
     if (role === "user" && isHarnessInjectedText(update.content.text)) return
     if (!replaying && session) session.updatedAt = new Date().toISOString()
+    const counterpartKey = `${sessionId}:${role === "user" ? "assistant" : "user"}`
+    this.#chunkMessageIDs.delete(counterpartKey)
     const chunkKey = `${sessionId}:${role}`
-    let messageID = update.messageId
-    if (!messageID && replaying) {
-      // ACP has no message-boundary identifier. PI's adapter emits one full persisted
-      // text block per replay update, so keeping each update separate is safer than
-      // concatenating unrelated consecutive user or assistant messages.
-      messageID = randomUUID()
-    } else if (!messageID) {
-      messageID = this.#chunkMessageIDs.get(chunkKey) ?? randomUUID()
-      this.#chunkMessageIDs.set(chunkKey, messageID)
-    }
+    const messageID = update.messageId ?? this.#chunkMessageIDs.get(chunkKey) ?? randomUUID()
+    this.#chunkMessageIDs.set(chunkKey, messageID)
     const messages = this.#messages.get(sessionId) ?? []
     this.#messages.set(sessionId, messages)
     let message = messages.find((item) => item.info.id === messageID)
     if (!message) {
       message = {
         info: { id: messageID, role, sessionID: sessionId, time: { created: Date.now() } },
-        parts: [{ id: `${messageID}:text`, type: "text", text: "" }]
+        parts: []
       }
       messages.push(message)
     }
-    message.parts[0].text += update.content.text
+    const previous = message.parts.at(-1)
+    const now = Date.now()
+    if (previous?.type === "reasoning" && partType !== "reasoning" && previous.time && !previous.time.end) {
+      previous.time.end = now
+    }
+    if (previous?.type === partType) {
+      previous.text += update.content.text
+    } else {
+      message.parts.push({
+        id: `${messageID}:${partType}:${message.parts.length}`,
+        messageID,
+        type: partType,
+        text: update.content.text,
+        ...(partType === "reasoning" ? { time: { start: now } } : {})
+      })
+    }
     if (!replaying) this.#emit("message.updated", sessionId)
   }
 

--- a/bridge/src/omp-session-history.js
+++ b/bridge/src/omp-session-history.js
@@ -4,13 +4,18 @@ import { homedir } from "node:os"
 import path from "node:path"
 import { createInterface } from "node:readline"
 
-function messageText(content) {
-  if (typeof content === "string") return content
-  if (!Array.isArray(content)) return ""
-  return content
-    .filter((item) => item?.type === "text" && typeof item.text === "string")
-    .map((item) => item.text)
-    .join("")
+function messageParts(content, messageID) {
+  if (typeof content === "string") return [{ id: `${messageID}:text:0`, messageID, type: "text", text: content }]
+  if (!Array.isArray(content)) return []
+  return content.flatMap((item, index) => {
+    if (item?.type === "text" && typeof item.text === "string" && item.text) {
+      return [{ id: `${messageID}:text:${index}`, messageID, type: "text", text: item.text }]
+    }
+    if (item?.type === "thinking" && typeof item.thinking === "string" && item.thinking) {
+      return [{ id: `${messageID}:reasoning:${index}`, messageID, type: "reasoning", text: item.thinking }]
+    }
+    return []
+  })
 }
 
 export function createOmpHistoryLoader(sessionRoot = path.join(homedir(), ".omp", "agent", "sessions")) {
@@ -49,9 +54,9 @@ export function createOmpHistoryLoader(sessionRoot = path.join(homedir(), ".omp"
       if (record?.type !== "message") continue
       const role = record.message?.role
       if (role !== "user" && role !== "assistant") continue
-      const text = messageText(record.message.content)
-      if (!text) continue
       const messageID = record.id ?? `${sessionID}:${messages.length}`
+      const parts = messageParts(record.message.content, messageID)
+      if (parts.length === 0) continue
       const created = Date.parse(record.timestamp ?? "")
       messages.push({
         info: {
@@ -60,7 +65,7 @@ export function createOmpHistoryLoader(sessionRoot = path.join(homedir(), ".omp"
           sessionID,
           time: { created: Number.isFinite(created) ? created : Date.now() }
         },
-        parts: [{ id: `${messageID}:text`, type: "text", text }]
+        parts
       })
     }
     return messages

--- a/bridge/test/omp-session-history.test.js
+++ b/bridge/test/omp-session-history.test.js
@@ -21,10 +21,10 @@ test("reads persisted user and assistant text from an OMP session transcript", a
   try {
     const loadHistory = createOmpHistoryLoader(root)
     const messages = await loadHistory(sessionID)
-    assert.deepEqual(messages.map((message) => [message.info.role, message.parts[0].text]), [
-      ["user", "Question"],
-      ["assistant", "Abandoned answer"],
-      ["assistant", "Answer"]
+    assert.deepEqual(messages.map((message) => [message.info.role, message.parts.map((part) => [part.type, part.text])]), [
+      ["user", [["text", "Question"]]],
+      ["assistant", [["text", "Abandoned answer"]]],
+      ["assistant", [["reasoning", "hidden"], ["text", "Answer"]]]
     ])
   } finally {
     await rm(root, { recursive: true, force: true })

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -78,8 +78,43 @@ class ReplayAcp extends EventEmitter {
         params: {
           sessionId: "session-1",
           update: {
+            sessionUpdate: "agent_thought_chunk",
+            content: { type: "text", text: "Check persisted state." }
+          }
+        }
+      })
+      this.emit("notification", {
+        method: "session/update",
+        params: {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "tool_call",
+            toolCallId: "tool-1",
+            title: "read",
+            status: "pending",
+            rawInput: { path: "/tmp/state" },
+            _meta: { toolName: "read" }
+          }
+        }
+      })
+      this.emit("notification", {
+        method: "session/update",
+        params: {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId: "tool-1",
+            status: "completed",
+            content: [{ type: "content", content: { type: "text", text: "persisted state" } }]
+          }
+        }
+      })
+      this.emit("notification", {
+        method: "session/update",
+        params: {
+          sessionId: "session-1",
+          update: {
             sessionUpdate: "agent_message_chunk",
-            messageId: "persisted-assistant",
             content: { type: "text", text: "Persist this response" }
           }
         }
@@ -760,13 +795,28 @@ test("replays persistent user and assistant history when reopening an OMP sessio
   const bridge = await startServer({ acp: new ReplayAcp() })
   try {
     const response = await fetch(`${bridge.baseURL}/session/session-1/message`, { headers: authHeaders() })
-    assert.deepEqual((await response.json()).map((message) => ({
+    const messages = await response.json()
+    assert.deepEqual(messages.map((message) => ({
       role: message.info.role,
-      text: message.parts[0].text
+      parts: message.parts.map((part) => ({ type: part.type, text: part.text }))
     })), [
-      { role: "user", text: "Persist this prompt" },
-      { role: "assistant", text: "Persist this response" }
+      { role: "user", parts: [{ type: "text", text: "Persist this prompt" }] },
+      {
+        role: "assistant",
+        parts: [
+          { type: "reasoning", text: "Check persisted state." },
+          { type: "tool", text: undefined },
+          { type: "text", text: "Persist this response" }
+        ]
+      }
     ])
+    assert.deepEqual(messages[1].parts[1].state, {
+      status: "completed",
+      input: { path: "/tmp/state" },
+      title: "read",
+      output: "persisted state",
+      time: messages[1].parts[1].state.time
+    })
   } finally {
     await bridge.close()
   }


### PR DESCRIPTION
Preserves the structured activity already emitted by ACP adapters instead of flattening it into assistant text.

- Maps `agent_thought_chunk` to timed `reasoning` parts.
- Maps ACP tool calls and updates to structured `tool` parts.
- Keeps OMP JSONL `thinking` blocks during history replay.
- Lets the existing web timeline group reasoning, tool calls, and text across the full assistant run.

Verification: `npm test` in `bridge/`; `npm run test:ui` and `npm run build` in `web/`.