### PR TITLE
fix(web): copy what the bubble actually shows

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1466,6 +1466,10 @@ function groupRenderedMessages(messages: (MessageEnvelope & { text: string })[])
  * screen. The deprecated selection copy is the only thing that still works there.
  */
 async function copyToClipboard(text: string): Promise<void> {
+  // Writing an empty string is not a harmless no-op: it succeeds, and it replaces whatever the user
+  // had in the clipboard with nothing. Refusing it keeps a bubble with no text from quietly wiping a
+  // selection the user copied a moment earlier.
+  if (!text) return
   try {
     if (navigator.clipboard?.writeText) {
       await navigator.clipboard.writeText(text)
@@ -1481,6 +1485,11 @@ async function copyToClipboard(text: string): Promise<void> {
   carrier.style.top = "0"
   carrier.style.opacity = "0"
   document.body.appendChild(carrier)
+  // The carrier has to own the selection to be copied, which takes it away from whatever the user
+  // had highlighted. Their range is put back afterwards, so falling back does not also cost them
+  // the selection they made.
+  const selection = window.getSelection()
+  const previousRange = selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null
   carrier.select()
   carrier.setSelectionRange(0, text.length)
   try {
@@ -1489,16 +1498,22 @@ async function copyToClipboard(text: string): Promise<void> {
     // Out of options: both paths are gone.
   } finally {
     carrier.remove()
+    if (previousRange && selection) {
+      selection.removeAllRanges()
+      selection.addRange(previousRange)
+    }
   }
 }
 
+/** Wraps a bubble in the copy menu. Takes the text to copy rather than a message, because what a
+ *  bubble shows is not always one message's text: a run merges several, and some carry none at all. */
 function MessageContextMenu({
-  message,
+  text,
   className,
   t,
   children
 }: {
-  message: MessageEnvelope & { text: string }
+  text: string
   className: string
   t: Translator
   children: ReactNode
@@ -1517,7 +1532,7 @@ function MessageContextMenu({
     })
   }
   const copy = (markdown: boolean) => {
-    void copyToClipboard(markdown ? normalizeMessageMarkdown(message.text) : message.text)
+    void copyToClipboard(markdown ? normalizeMessageMarkdown(text) : text)
     setPosition(null)
   }
   // Everything that means "not this" has to put the menu away: a press anywhere else, Escape, the
@@ -1542,6 +1557,11 @@ function MessageContextMenu({
       window.removeEventListener("scroll", dismiss, true)
     }
   }, [position])
+  // A bubble made only of tool calls and thinking has no message text to hand over. Offering the menu
+  // anyway gave two items that could do nothing, and taking over the context menu to show them also
+  // took away the browser's own — with its Copy, the one thing that would have worked on a selection
+  // the user made by hand. With nothing to copy, the bubble stays out of the way.
+  if (!text) return <article className={className}>{children}</article>
   return (
     <article
       className={className}
@@ -1597,8 +1617,12 @@ function ConversationRunView({
     const owner = (part.messageID && messagesByID.get(part.messageID)) || fallback
     return owner ? formatTime(owner.info.time.created) : undefined
   }
+  // The bubble shows the whole run, so copying it means copying every message in it. Handing over the
+  // last one copied a fraction of what is on screen, and nothing at all whenever the run happened to
+  // end on a tool call — which is most of the time.
+  const runText = [...messagesByID.values()].map((message) => message.text).filter(Boolean).join("\n\n")
   return (
-    <MessageContextMenu message={fallback!} className="message assistant fade-in" t={t}>
+    <MessageContextMenu text={runText} className="message assistant fade-in" t={t}>
       {items.map((item) =>
         item.kind === "action-group" ? (
           <ActionGroupView
@@ -1641,7 +1665,7 @@ const MessageArticle = memo(function MessageArticle({
   t: Translator
 }) {
   return (
-    <MessageContextMenu message={message} className={`message ${message.info.role} fade-in`} t={t}>
+    <MessageContextMenu text={message.text} className={`message ${message.info.role} fade-in`} t={t}>
       {buildMessageTimeline(message.parts).map((item) =>
         item.kind === "action-group" ? (
           <ActionGroupView

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -348,7 +348,7 @@ assert.ok(app.includes('>{displayLabel}</span>'), 'the tool summary must show th
 assert.match(app, /onContextMenu=\{\(event\) => \{\s*event\.preventDefault\(\)\s*open\(event\.clientX, event\.clientY\)/, 'right-clicking a message must open its action menu')
 assert.match(app, /event\.pointerType !== "touch"/, 'touch messages must support long-press actions')
 assert.match(app, /navigator\.clipboard\?\.writeText/, 'message actions must copy to the system clipboard')
-assert.match(app, /markdown \? normalizeMessageMarkdown\(message\.text\) : message\.text/, 'the menu must distinguish plain-text and markdown copies')
+assert.match(app, /markdown \? normalizeMessageMarkdown\(text\) : text/, 'the menu must distinguish plain-text and markdown copies')
 assert.match(styles, /\.message-context-menu\s*\{[\s\S]*?position:\s*fixed/, 'message actions must render above the scrolling transcript')
 // A menu that only closes on its own items is a menu that stacks: the state is per bubble, so a
 // right-click on a second message left the first one hanging over the transcript.
@@ -359,6 +359,23 @@ assert.match(app, /onPointerDown=\{\(event\) => event\.stopPropagation\(\)\}/, '
 // The Clipboard API needs a secure context, and the app is reachable over plain http on a LAN,
 // where `navigator.clipboard` is undefined and reaching into it throws past any `.catch()`.
 assert.match(app, /document\.execCommand\("copy"\)/, 'copying must still work where the Clipboard API is unavailable')
+// Both copy options did nothing on any bubble whose parts carry no text — a run ending on a tool
+// call, an agent turn that only worked and never spoke. The menu was handed the run's last message,
+// and `extractText` returns "" for those, so the copy wrote an empty string: the paste came back
+// empty and whatever the user had in the clipboard was gone with it.
+assert.match(
+  app,
+  /const runText = \[\.\.\.messagesByID\.values\(\)\]\.map\(\(message\) => message\.text\)\.filter\(Boolean\)\.join\("\\n\\n"\)/,
+  'a run bubble must copy every message it shows, not just the last one'
+)
+assert.match(app, /<MessageContextMenu text=\{runText\}/, 'the run bubble must hand the menu the whole run text')
+assert.ok(
+  !/<MessageContextMenu message=/.test(app),
+  'the menu takes the text to copy: passing a message let a bubble that shows several, or none, claim one'
+)
+assert.match(app, /if \(!text\) return <article className=\{className\}>\{children\}<\/article>/, 'a bubble with nothing to copy must not offer the menu, nor take over the browser one')
+assert.match(app, /if \(!text\) return\s*\n\s*try \{/, 'an empty copy must not replace what the user already had in the clipboard')
+assert.match(app, /selection\.addRange\(previousRange\)/, 'the fallback carrier must give the selection back after stealing it')
 // The rule was written for a field that no longer exists, but the class outlived it: dropping the
 // declaration with its original caller left the server name silently back in half a row.
 if (app.includes('className="field-row-span"')) {


### PR DESCRIPTION
Reported from the hosted app: both copy options do nothing, and a selection made with the mouse comes back empty too.

## What was wrong

`MessageContextMenu` received one message and read `text` off it, and `extractText` builds that from `type: "text"` parts only. A bubble whose parts are a thought and a tool call has none, so the text was `""` — and `writeText("")` does not fail: it succeeds and leaves the clipboard empty. Nothing to paste, and whatever had been copied a moment earlier gone with it. Selecting by hand was no way out, because the bubble prevents the context menu to show its own, so the browser's Copy was never on offer.

A run made it worse. The bubble shows every message of the run, but the menu was given `[...messagesByID.values()].pop()` — the last one, which for a run ending on a tool call carries no text. The copy was emptiest exactly where the transcript was fullest.

## What changed

- The menu takes the text to copy instead of a message, since what a bubble shows is not always one message's text.
- A run hands over all of its messages, joined.
- With nothing to copy the bubble adds no handlers at all, so the browser keeps its own menu.
- An empty write is refused, and the `execCommand` carrier returns the selection it borrows.

## Verified

Against a stub harness serving a transcript with each shape, driving the real app:

| bubble | our menu | copies |
| --- | --- | --- |
| user text | yes | its text |
| single assistant answer | yes | its text |
| run over two envelopes with a tool call between | yes | `Part one of the answer\n\nPart two of the answer` (was: `Part two` alone) |
| thought + tool call, no text | no, browser menu kept | nothing written |

Five bubbles with text produced five clipboard writes, none of them empty. Full web suite and build pass.