### PR TITLE
fix(web): make mobile message actions reliable

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1518,17 +1518,20 @@ function MessageContextMenu({
   t: Translator
   children: ReactNode
 }) {
-  const [position, setPosition] = useState<{ x: number, y: number } | null>(null)
+  const [position, setPosition] = useState<{ x: number, y: number, touch: boolean } | null>(null)
   const longPressTimer = useRef<number | undefined>(undefined)
+  const touchStart = useRef<{ x: number, y: number } | null>(null)
   const cancelLongPress = () => {
     if (longPressTimer.current !== undefined) window.clearTimeout(longPressTimer.current)
     longPressTimer.current = undefined
+    touchStart.current = null
   }
-  const open = (x: number, y: number) => {
+  const open = (x: number, y: number, touch = false) => {
     cancelLongPress()
     setPosition({
       x: Math.max(8, Math.min(x, window.innerWidth - 220)),
-      y: Math.max(8, Math.min(y, window.innerHeight - 104))
+      y: Math.max(8, Math.min(y, window.innerHeight - 104)),
+      touch
     })
   }
   const copy = (markdown: boolean) => {
@@ -1567,12 +1570,19 @@ function MessageContextMenu({
       className={className}
       onContextMenu={(event) => {
         event.preventDefault()
-        open(event.clientX, event.clientY)
+        open(event.clientX, event.clientY, window.matchMedia("(pointer: coarse)").matches)
       }}
       onPointerDown={(event) => {
         if (event.pointerType !== "touch") return
         const { clientX, clientY } = event
-        longPressTimer.current = window.setTimeout(() => open(clientX, clientY), 500)
+        touchStart.current = { x: clientX, y: clientY }
+        longPressTimer.current = window.setTimeout(() => open(clientX, clientY, true), 500)
+      }}
+      onPointerMove={(event) => {
+        if (event.pointerType !== "touch" || !touchStart.current) return
+        const movedX = event.clientX - touchStart.current.x
+        const movedY = event.clientY - touchStart.current.y
+        if (Math.hypot(movedX, movedY) > 10) cancelLongPress()
       }}
       onPointerUp={cancelLongPress}
       onPointerCancel={cancelLongPress}
@@ -1582,9 +1592,9 @@ function MessageContextMenu({
         // Pressing an item must not read as pressing "anywhere else": the dismissal above would
         // unmount the menu on pointerdown and the click would never reach the button.
         <div
-          className="message-context-menu"
+          className={`message-context-menu${position.touch ? " message-context-menu--touch" : ""}`}
           role="menu"
-          style={{ left: position.x, top: position.y }}
+          style={position.touch ? undefined : { left: position.x, top: position.y }}
           onPointerDown={(event) => event.stopPropagation()}
         >
           <button type="button" role="menuitem" onClick={() => copy(false)}>{t('detail.copyText')}</button>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1016,6 +1016,35 @@ p {
   background: var(--surface-strong);
 }
 
+.message-context-menu--touch {
+  left: 50%;
+  bottom: max(var(--space-4), env(safe-area-inset-bottom));
+  width: min(360px, calc(100vw - var(--space-6)));
+  padding: var(--space-2);
+  border-radius: var(--radius-lg);
+  transform: translateX(-50%);
+}
+
+.message-context-menu--touch button {
+  min-height: 48px;
+  padding: 0 var(--space-4);
+  font-weight: 650;
+}
+
+.message-context-menu--touch button:active {
+  background: var(--primary-soft);
+  color: var(--primary);
+}
+
+@media (pointer: coarse) {
+  /* Long-press is reserved for the message actions. Avoid also starting the browser's text-selection
+     gesture; the menu always operates on the complete bubble. */
+  .message {
+    -webkit-user-select: none;
+    user-select: none;
+  }
+}
+
 .typing-bubble {
   width: auto;
   padding: 0.75rem 1rem;

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -348,11 +348,15 @@ assert.match(
 assert.ok(app.includes('>{displayLabel}</span>'), 'the tool summary must show the preparing label')
 
 
-assert.match(app, /onContextMenu=\{\(event\) => \{\s*event\.preventDefault\(\)\s*open\(event\.clientX, event\.clientY\)/, 'right-clicking a message must open its action menu')
+assert.match(app, /onContextMenu=\{\(event\) => \{\s*event\.preventDefault\(\)\s*open\(event\.clientX, event\.clientY, window\.matchMedia/, 'right-clicking a message must open its action menu')
 assert.match(app, /event\.pointerType !== "touch"/, 'touch messages must support long-press actions')
 assert.match(app, /navigator\.clipboard\?\.writeText/, 'message actions must copy to the system clipboard')
 assert.match(app, /markdown \? normalizeMessageMarkdown\(text\) : text/, 'the menu must distinguish plain-text and markdown copies')
 assert.match(styles, /\.message-context-menu\s*\{[\s\S]*?position:\s*fixed/, 'message actions must render above the scrolling transcript')
+assert.match(app, /window\.matchMedia\("\(pointer: coarse\)"\)\.matches/, 'a touch context-menu event must keep the mobile menu layout')
+assert.match(app, /Math\.hypot\(movedX, movedY\) > 10/, 'moving to scroll must cancel the pending long-press menu')
+assert.match(styles, /\.message-context-menu--touch\s*\{[\s\S]*?bottom:\s*max\(/, 'the touch menu must render as a reachable bottom sheet')
+assert.match(styles, /@media \(pointer: coarse\)\s*\{[\s\S]*?\.message\s*\{[\s\S]*?user-select:\s*none/, 'mobile long-press must not also select message text')
 // A menu that only closes on its own items is a menu that stacks: the state is per bubble, so a
 // right-click on a second message left the first one hanging over the transcript.
 assert.match(app, /window\.addEventListener\("pointerdown", dismiss\)/, 'pressing outside an open message menu must dismiss it')


### PR DESCRIPTION
## Summary
- prevent mobile long-press from also selecting message text
- present message actions as a touch-friendly bottom sheet
- cancel a pending action menu while scrolling

## Verification
- npm run test:ui
- npm run build

Revert actions are intentionally out of scope for this PR.