### PR TITLE
Add OMP extension-backed actions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,10 +88,12 @@ The bridge implements a deliberate subset of the app's API:
 **Implemented:** `/v1/health`, `/global/health`, `/v1/capabilities`, `/v1/events`, `/global/event`,
 `/session` (list and create), `/v1/sessions`, `/experimental/session`, `/session/status`, `/path`,
 `/file`, `/command` (empty), `/agent` (empty), `/config/providers`, and on a session:
-`message`, `todo`, `diff` (empty), `prompt_async`, `abort`.
+`message`, `todo`, `diff` (empty), `prompt_async`, `abort`, rename, delete, plus generic action
+discovery and invocation at `action` and `action/{name}`. OMP currently maps the optional
+`omp-undo-redo` extension onto the generic action API only after ACP advertises both commands.
 
 **Not implemented — anything else 404s**, including `/question` and its replies, `/project/current`,
-`/vcs`, `/file/status`, `/session/{id}/command`, and renaming or deleting a session.
+`/vcs`, `/file/status`, and `/session/{id}/command`.
 
 When you add a call, pick one of two patterns already used in the codebase:
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Depending on the harness:
 - review changed files and their diffs — OpenCode
 - rename and delete sessions — OpenCode changes them in the harness; on OMP, PI and Claude Code the
   same controls keep a bridge-local nickname and hide the session from that bridge only
+- use Undo and Redo for OMP sessions when the host has loaded the optional
+  `@baylarsadigov/omp-undo-redo` extension; the bridge discovers and invokes it without bundling it
+  into the app
 
 ## Desktop Mode
 
@@ -472,10 +475,12 @@ Against an OpenCode server, spoken directly: `/global/health`, `/global/event`, 
 `/config/providers`, `/command`, `/agent`, `/project/current`, `/vcs`, `/path`, `/file*`, and
 `/question*`.
 
-For OMP and PI the bridge implements a deliberate subset of those paths, plus its own `/v1/health`
-and `/v1/capabilities` — which is how the app learns what a harness can do and hides the rest, rather
-than calling something that 404s. [CONTRIBUTING.md](CONTRIBUTING.md) lists exactly what the bridge
-does and does not answer.
+For OMP, PI, and Claude Code the bridge implements a deliberate subset of those paths, plus its own
+`/v1/health` and `/v1/capabilities`. OMP also exposes generic session action discovery and invocation
+through `/session/:id/action` and `/session/:id/action/:name` when a known host extension is loaded.
+Capabilities tell the app which APIs are supported so it hides the rest rather than calling
+something that 404s. [CONTRIBUTING.md](CONTRIBUTING.md) lists exactly what the bridge does and does
+not answer.
 
 What each harness actually provides behind those paths, and what to re-check when one of them
 changes, is in [docs/DEPENDENCIES.md](docs/DEPENDENCIES.md).

--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -1,6 +1,12 @@
 import { randomUUID } from "node:crypto"
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
 import path from "node:path"
+import {
+  applyExtensionActionSuccess,
+  listExtensionActions,
+  resetExtensionActionState,
+  resolveExtensionAction
+} from "./extension-actions.js"
 
 function toEpoch(value) {
   const epoch = Date.parse(value ?? "")
@@ -116,6 +122,10 @@ export class AcpService {
   #messages = new Map()
   #todos = new Map()
   #configOptions = new Map()
+  #commandCatalogs = new Map()
+  #commandCatalogWaiters = new Map()
+  #actionStates = new Map()
+  #actionProviders
   #loaded = new Set()
   #loads = new Map()
   #sessionListing
@@ -138,12 +148,19 @@ export class AcpService {
   #snapshotWrites = new Map()
   #preserveListedTimestamps
   #reloadOnHistoryRefresh
-  constructor(acp, { snapshotDirectory, historyLoader, preserveListedTimestamps = false, reloadOnHistoryRefresh = true } = {}) {
+  constructor(acp, {
+    snapshotDirectory,
+    historyLoader,
+    preserveListedTimestamps = false,
+    reloadOnHistoryRefresh = true,
+    actionProviders = []
+  } = {}) {
     this.#acp = acp
     this.#snapshotDirectory = snapshotDirectory
     this.#historyLoader = historyLoader
     this.#preserveListedTimestamps = preserveListedTimestamps
     this.#reloadOnHistoryRefresh = reloadOnHistoryRefresh
+    this.#actionProviders = actionProviders
     acp.on("notification", (notification) => this.#handleNotification(notification))
   }
 
@@ -213,6 +230,10 @@ export class AcpService {
     this.#todos.delete(sessionID)
     this.#titles.delete(sessionID)
     this.#configOptions.delete(sessionID)
+    this.#commandCatalogs.delete(sessionID)
+    for (const resolve of this.#commandCatalogWaiters.get(sessionID) ?? []) resolve()
+    this.#commandCatalogWaiters.delete(sessionID)
+    this.#actionStates.delete(sessionID)
     this.#loaded.delete(sessionID)
     this.#ownedSessions.delete(sessionID)
     this.#promptAcknowledgements.delete(sessionID)
@@ -243,6 +264,92 @@ export class AcpService {
     await this.#loadForConfigOptions(sessionID)
     const option = this.#configOptions.get(sessionID)?.find((item) => item.id === "model")
     return option?.options?.map((candidate) => ({ ...candidate, currentValue: candidate.value === option.currentValue })) ?? []
+  }
+
+  async actions(sessionID) {
+    if (!this.#commandCatalogs.has(sessionID)) {
+      await this.#load(sessionID, true, true)
+      await this.#waitForCommandCatalog(sessionID)
+    }
+    return this.#availableActions(sessionID)
+  }
+
+  #waitForCommandCatalog(sessionID) {
+    if (this.#commandCatalogs.has(sessionID)) return Promise.resolve()
+    return new Promise((resolve) => {
+      let waiters = this.#commandCatalogWaiters.get(sessionID)
+      if (!waiters) {
+        waiters = new Set()
+        this.#commandCatalogWaiters.set(sessionID, waiters)
+      }
+      const finish = () => {
+        clearTimeout(timer)
+        waiters.delete(finish)
+        if (waiters.size === 0) this.#commandCatalogWaiters.delete(sessionID)
+        resolve()
+      }
+      const timer = setTimeout(finish, 500)
+      waiters.add(finish)
+    })
+  }
+
+  async invokeAction(sessionID, actionID) {
+    const available = await this.actions(sessionID)
+    if (!available.some((action) => action.id === actionID)) throw new Error(`Harness action is not available: ${actionID}`)
+    if (!available.some((action) => action.id === actionID && action.enabled)) throw new Error(`Harness action is disabled: ${actionID}`)
+    const resolved = resolveExtensionAction(
+      this.#actionProviders,
+      this.#commandCatalogs.get(sessionID) ?? [],
+      actionID
+    )
+    if (!resolved) throw new Error(`Harness action is not available: ${actionID}`)
+
+    const before = JSON.stringify(this.#messages.get(sessionID) ?? [])
+    this.#ownedSessions.add(sessionID)
+    this.#active.add(sessionID)
+    this.#emit("session.updated", sessionID)
+    let applied = false
+    try {
+      await this.#acp.request("session/prompt", {
+        sessionId: sessionID,
+        prompt: [{ type: "text", text: `/${resolved.action.command}` }]
+      }, 300_000)
+      await this.#loadSession(sessionID, true, true)
+      applied = JSON.stringify(this.#messages.get(sessionID) ?? []) !== before
+      if (applied) applyExtensionActionSuccess(this.#actionState(sessionID), resolved.action)
+      this.#emit("message.updated", sessionID)
+      this.#persistSnapshot(sessionID)
+    } finally {
+      this.#active.delete(sessionID)
+      this.#emit("session.updated", sessionID)
+    }
+    return { action: actionID, applied, actions: this.#availableActions(sessionID) }
+  }
+
+  #actionState(sessionID) {
+    let state = this.#actionStates.get(sessionID)
+    if (!state) {
+      state = new Map()
+      this.#actionStates.set(sessionID, state)
+    }
+    return state
+  }
+
+  #availableActions(sessionID) {
+    return listExtensionActions(
+      this.#actionProviders,
+      this.#commandCatalogs.get(sessionID) ?? [],
+      this.#actionState(sessionID),
+      this.#isBusy(sessionID)
+    )
+  }
+
+  #resetActionsForSessionChange(sessionID) {
+    resetExtensionActionState(
+      this.#actionProviders,
+      this.#commandCatalogs.get(sessionID) ?? [],
+      this.#actionState(sessionID)
+    )
   }
 
   async setModel(sessionID, model) {
@@ -278,6 +385,7 @@ export class AcpService {
     } else {
       await this.#load(sessionID)
     }
+    this.#resetActionsForSessionChange(sessionID)
     if (this.#active.has(sessionID)) {
       const messageID = this.#recordPrompt(sessionID, text)
       const queue = this.#queues.get(sessionID) ?? []
@@ -457,12 +565,13 @@ export class AcpService {
     }
   }
 
-  async #loadSession(sessionID, requireConfigOptions = false) {
+  async #loadSession(sessionID, requireConfigOptions = false, replaceHistory = false) {
     const session = this.#sessions.get(sessionID)
     if (!session) throw new Error("Harness session not found")
     await this.#restoreSnapshot(sessionID)
     let previousMessages = this.#messages.get(sessionID) ?? []
     const previousTodos = this.#todos.get(sessionID) ?? []
+    const previousMessageSnapshot = JSON.stringify(previousMessages)
     if (this.#historyLoader) {
       try {
         const persistedMessages = await this.#historyLoader(sessionID)
@@ -489,9 +598,12 @@ export class AcpService {
       const result = await this.#acp.request("session/load", { sessionId: sessionID, cwd: session.cwd, mcpServers: [] }, 300_000)
       this.#rememberConfigOptions(sessionID, result.configOptions)
       const replayedMessages = this.#messages.get(sessionID) ?? []
-      this.#messages.set(sessionID, mergeReplay(previousMessages, replayedMessages))
+      this.#messages.set(sessionID, replaceHistory ? replayedMessages : mergeReplay(previousMessages, replayedMessages))
       const replayedTodos = this.#todos.get(sessionID) ?? []
-      this.#todos.set(sessionID, mergeTodos(previousTodos, replayedTodos))
+      this.#todos.set(sessionID, replaceHistory ? replayedTodos : mergeTodos(previousTodos, replayedTodos))
+      if (JSON.stringify(this.#messages.get(sessionID) ?? []) !== previousMessageSnapshot) {
+        this.#resetActionsForSessionChange(sessionID)
+      }
       this.#loaded.add(sessionID)
       this.#persistSnapshot(sessionID)
     } catch (error) {
@@ -573,6 +685,16 @@ export class AcpService {
     const { sessionId, update } = params
     const replaying = this.#replaying.has(sessionId)
     const session = this.#sessions.get(sessionId)
+    if (update.sessionUpdate === "available_commands_update") {
+      const commands = Array.isArray(update.availableCommands)
+        ? update.availableCommands.filter((command) => typeof command?.name === "string")
+        : []
+      this.#commandCatalogs.set(sessionId, commands)
+      for (const resolve of this.#commandCatalogWaiters.get(sessionId) ?? []) resolve()
+      this.#commandCatalogWaiters.delete(sessionId)
+      if (!replaying) this.#emit("session.updated", sessionId)
+      return
+    }
     if (update.sessionUpdate === "plan") {
       const todos = update.entries.map((entry, index) => ({
         id: `${sessionId}:${index}`,

--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -38,6 +38,34 @@ function sessionView(session, status = "idle", title = session.title, external =
 function messageSignature(message) {
   return `${message?.info?.role ?? ""}\u0000${(message?.parts ?? []).map((part) => part?.text ?? "").join("")}`
 }
+function stableSemanticValue(value) {
+  if (Array.isArray(value)) return value.map(stableSemanticValue)
+  if (!value || typeof value !== "object") return value
+  return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stableSemanticValue(value[key])]))
+}
+
+function semanticMessagePart(part) {
+  if (!part || typeof part !== "object") return part
+  const semantic = {}
+  for (const key of Object.keys(part).sort()) {
+    if (["id", "messageID", "sessionID", "callID", "time"].includes(key)) continue
+    if (key === "state" && part.state && typeof part.state === "object") {
+      const { time: _time, ...state } = part.state
+      semantic.state = stableSemanticValue(state)
+      continue
+    }
+    semantic[key] = stableSemanticValue(part[key])
+  }
+  return semantic
+}
+
+function semanticHistorySignature(messages) {
+  return JSON.stringify(messages.map((message) => ({
+    role: message?.info?.role,
+    parts: (message?.parts ?? []).map(semanticMessagePart)
+  })))
+}
+
 
 function mergeReplay(previous, replayed) {
   if (previous.length === 0) return replayed
@@ -304,7 +332,7 @@ export class AcpService {
     )
     if (!resolved) throw new Error(`Harness action is not available: ${actionID}`)
 
-    const before = JSON.stringify(this.#messages.get(sessionID) ?? [])
+    const before = semanticHistorySignature(this.#messages.get(sessionID) ?? [])
     this.#ownedSessions.add(sessionID)
     this.#active.add(sessionID)
     this.#emit("session.updated", sessionID)
@@ -315,7 +343,7 @@ export class AcpService {
         prompt: [{ type: "text", text: `/${resolved.action.command}` }]
       }, 300_000)
       await this.#loadSession(sessionID, true, true)
-      applied = JSON.stringify(this.#messages.get(sessionID) ?? []) !== before
+      applied = semanticHistorySignature(this.#messages.get(sessionID) ?? []) !== before
       if (applied) applyExtensionActionSuccess(this.#actionState(sessionID), resolved.action)
       this.#emit("message.updated", sessionID)
       this.#persistSnapshot(sessionID)
@@ -571,7 +599,7 @@ export class AcpService {
     await this.#restoreSnapshot(sessionID)
     let previousMessages = this.#messages.get(sessionID) ?? []
     const previousTodos = this.#todos.get(sessionID) ?? []
-    const previousMessageSnapshot = JSON.stringify(previousMessages)
+    const previousMessageSnapshot = semanticHistorySignature(previousMessages)
     if (this.#historyLoader) {
       try {
         const persistedMessages = await this.#historyLoader(sessionID)
@@ -601,7 +629,7 @@ export class AcpService {
       this.#messages.set(sessionID, replaceHistory ? replayedMessages : mergeReplay(previousMessages, replayedMessages))
       const replayedTodos = this.#todos.get(sessionID) ?? []
       this.#todos.set(sessionID, replaceHistory ? replayedTodos : mergeTodos(previousTodos, replayedTodos))
-      if (JSON.stringify(this.#messages.get(sessionID) ?? []) !== previousMessageSnapshot) {
+      if (semanticHistorySignature(this.#messages.get(sessionID) ?? []) !== previousMessageSnapshot) {
         this.#resetActionsForSessionChange(sessionID)
       }
       this.#loaded.add(sessionID)

--- a/bridge/src/extension-actions.js
+++ b/bridge/src/extension-actions.js
@@ -1,0 +1,44 @@
+function commandNames(commands) {
+  return new Set(commands.map((command) => command.name?.replace(/^\//, "").toLowerCase()).filter(Boolean))
+}
+
+export const OMP_EXTENSION_ACTION_PROVIDERS = [{
+  id: "omp-undo-redo",
+  requiredCommands: ["undo", "redo"],
+  resetOnSessionChange: ["redo"],
+  actions: [
+    { id: "undo", command: "undo", enabledByDefault: true, onSuccess: { redo: true } },
+    { id: "redo", command: "redo", enabledByDefault: false, onSuccess: { redo: false } }
+  ]
+}]
+
+function availableProviders(providers, commands) {
+  const names = commandNames(commands)
+  return providers.filter((provider) => provider.requiredCommands.every((command) => names.has(command)))
+}
+
+export function listExtensionActions(providers, commands, state, busy = false) {
+  return availableProviders(providers, commands).flatMap((provider) => provider.actions.map((action) => ({
+    id: action.id,
+    source: provider.id,
+    enabled: !busy && (state.get(action.id) ?? action.enabledByDefault)
+  })))
+}
+
+export function resolveExtensionAction(providers, commands, actionID) {
+  for (const provider of availableProviders(providers, commands)) {
+    const action = provider.actions.find((candidate) => candidate.id === actionID)
+    if (action) return { provider, action }
+  }
+  return undefined
+}
+
+export function applyExtensionActionSuccess(state, action) {
+  for (const [actionID, enabled] of Object.entries(action.onSuccess ?? {})) state.set(actionID, enabled)
+}
+
+export function resetExtensionActionState(providers, commands, state) {
+  for (const provider of availableProviders(providers, commands)) {
+    for (const actionID of provider.resetOnSessionChange ?? []) state.delete(actionID)
+  }
+}

--- a/bridge/src/harness-profiles.js
+++ b/bridge/src/harness-profiles.js
@@ -1,4 +1,5 @@
 import { createOmpHistoryLoader } from "./omp-session-history.js"
+import { OMP_EXTENSION_ACTION_PROVIDERS } from "./extension-actions.js"
 
 const COMMON_CAPABILITIES = {
   sessions: true,
@@ -26,9 +27,11 @@ export const HARNESS_PROFILES = {
       models: true,
       todos: true,
       commands: false,
+      actions: true,
       sessionRename: true,
       sessionDelete: true
-    }
+    },
+    actionProviders: OMP_EXTENSION_ACTION_PROVIDERS
   },
   pi: {
     id: "pi",
@@ -47,6 +50,7 @@ export const HARNESS_PROFILES = {
       models: true,
       todos: false,
       commands: true,
+      actions: false,
       sessionRename: true,
       sessionDelete: true
     }
@@ -72,6 +76,7 @@ export const HARNESS_PROFILES = {
       models: true,
       todos: true,
       commands: false,
+      actions: false,
       sessionRename: true,
       sessionDelete: true
     }

--- a/bridge/src/server.js
+++ b/bridge/src/server.js
@@ -110,7 +110,7 @@ function providersResponse(models, fallbackProviderID) {
 export function createBridgeServer({ config, acp, serviceOptions }) {
   const backend = config.backend ?? "omp"
   const profile = harnessProfile(backend)
-  const service = new AcpService(acp, serviceOptions)
+  const service = new AcpService(acp, { ...serviceOptions, actionProviders: profile.actionProviders })
   return http.createServer(async (request, response) => {
     applyCorsHeaders(request, response, config)
     // Browsers omit credentials on the preflight, so it must be answered before auth.
@@ -193,9 +193,9 @@ export function createBridgeServer({ config, acp, serviceOptions }) {
         return
       }
 
-      const sessionMatch = /^\/session\/([^/]+)(?:\/(message|prompt_async|abort|todo|diff))?$/.exec(url.pathname)
+      const sessionMatch = /^\/session\/([^/]+)(?:\/(message|prompt_async|abort|todo|diff|action)(?:\/([^/]+))?)?$/.exec(url.pathname)
       if (sessionMatch) {
-        const [, sessionID, operation] = sessionMatch
+        const [, sessionID, operation, actionID] = sessionMatch
         if (request.method === "PATCH" && !operation) {
           const body = await readBody(request)
           writeJSON(response, 200, await service.renameSession(sessionID, typeof body.title === "string" ? body.title : ""))
@@ -216,6 +216,14 @@ export function createBridgeServer({ config, acp, serviceOptions }) {
         }
         if (request.method === "GET" && operation === "diff") {
           writeJSON(response, 200, [])
+          return
+        }
+        if (request.method === "GET" && operation === "action" && !actionID) {
+          writeJSON(response, 200, await service.actions(sessionID))
+          return
+        }
+        if (request.method === "POST" && operation === "action" && actionID) {
+          writeJSON(response, 200, await service.invokeAction(sessionID, actionID))
           return
         }
         if (request.method === "POST" && operation === "prompt_async") {

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -299,6 +299,7 @@ class ExtensionActionAcp extends EventEmitter {
   agentInfo = { version: "17.1.3" }
   prompts = []
   commands
+  loads = 0
   fullHistory = [
     { role: "user", id: "user-1", text: "Change the file" },
     { role: "assistant", id: "assistant-1", text: "Changed the file" }
@@ -325,6 +326,7 @@ class ExtensionActionAcp extends EventEmitter {
       return { stopReason: "end_turn" }
     }
     if (method !== "session/load") return {}
+    this.loads += 1
     this.emit("notification", {
       method: "session/update",
       params: {
@@ -347,7 +349,7 @@ class ExtensionActionAcp extends EventEmitter {
           sessionId: "session-1",
           update: {
             sessionUpdate: message.role === "user" ? "user_message_chunk" : "agent_message_chunk",
-            messageId: message.id,
+            messageId: `${message.id}-replay-${this.loads}`,
             content: { type: "text", text: message.text }
           }
         }
@@ -682,6 +684,30 @@ test("does not advertise extension actions when OMP did not load their commands"
     })
     assert.equal(response.status, 400)
     assert.match((await response.json()).error, /not available/)
+  } finally {
+    await bridge.close()
+  }
+})
+
+test("reports a repeated Undo at the history boundary as a semantic no-op", async () => {
+  const acp = new ExtensionActionAcp()
+  const bridge = await startServer({ acp })
+  try {
+    await readJSON(bridge.baseURL, "/session/session-1/action")
+    const first = await readJSON(bridge.baseURL, "/session/session-1/action/undo", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: "{}"
+    })
+    const second = await readJSON(bridge.baseURL, "/session/session-1/action/undo", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: "{}"
+    })
+
+    assert.equal(first.applied, true)
+    assert.equal(second.applied, false, "replayed timestamps and message ids must not make unchanged history look applied")
+    assert.equal(second.actions.find((action) => action.id === "redo").enabled, true)
   } finally {
     await bridge.close()
   }

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -295,6 +295,70 @@ class HeldTurnOmpAcp extends EventEmitter {
   }
 }
 
+class ExtensionActionAcp extends EventEmitter {
+  agentInfo = { version: "17.1.3" }
+  prompts = []
+  commands
+  fullHistory = [
+    { role: "user", id: "user-1", text: "Change the file" },
+    { role: "assistant", id: "assistant-1", text: "Changed the file" }
+  ]
+  history = [...this.fullHistory]
+
+  constructor({ commands = true } = {}) {
+    super()
+    this.commands = commands
+  }
+
+  async start() {}
+
+  async listSessions() {
+    return [{ sessionId: "session-1", title: "Actions", cwd: process.cwd(), updatedAt: "2026-07-31T00:00:00.000Z" }]
+  }
+
+  async request(method, params) {
+    if (method === "session/prompt") {
+      const command = params.prompt[0].text
+      this.prompts.push(command)
+      if (command === "/undo" && this.history.length === this.fullHistory.length) this.history = [this.fullHistory[0]]
+      if (command === "/redo" && this.history.length < this.fullHistory.length) this.history = [...this.fullHistory]
+      return { stopReason: "end_turn" }
+    }
+    if (method !== "session/load") return {}
+    this.emit("notification", {
+      method: "session/update",
+      params: {
+        sessionId: "session-1",
+        update: {
+          sessionUpdate: "available_commands_update",
+          availableCommands: this.commands
+            ? [
+                { name: "undo", description: "Revert file changes and session context for the last turn" },
+                { name: "redo", description: "Restore the most recently undone turn" }
+              ]
+            : [{ name: "help", description: "Show help" }]
+        }
+      }
+    })
+    for (const message of this.history) {
+      this.emit("notification", {
+        method: "session/update",
+        params: {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: message.role === "user" ? "user_message_chunk" : "agent_message_chunk",
+            messageId: message.id,
+            content: { type: "text", text: message.text }
+          }
+        }
+      })
+    }
+    return { configOptions: [] }
+  }
+
+  notify() {}
+}
+
 async function startServer({ acp = new FakeAcp(), ...options } = {}) {
   const server = createBridgeServer({
     acp,
@@ -597,11 +661,83 @@ test("reports capabilities from the selected harness profile", async () => {
     assert.equal(ompCapabilities.models, true)
     assert.equal(ompCapabilities.todos, true)
     assert.equal(ompCapabilities.commands, false)
+    assert.equal(ompCapabilities.actions, true)
     assert.equal(piCapabilities.models, true)
     assert.equal(piCapabilities.todos, false)
     assert.equal(piCapabilities.commands, true)
+    assert.equal(piCapabilities.actions, false)
   } finally {
     await Promise.all([omp.close(), pi.close()])
+  }
+})
+
+test("does not advertise extension actions when OMP did not load their commands", async () => {
+  const bridge = await startServer({ acp: new ExtensionActionAcp({ commands: false }) })
+  try {
+    assert.deepEqual(await readJSON(bridge.baseURL, "/session/session-1/action"), [])
+    const response = await fetch(`${bridge.baseURL}/session/session-1/action/undo`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: "{}"
+    })
+    assert.equal(response.status, 400)
+    assert.match((await response.json()).error, /not available/)
+  } finally {
+    await bridge.close()
+  }
+})
+
+test("invokes loaded OMP extension actions and keeps Redo state session-specific", async () => {
+  const acp = new ExtensionActionAcp()
+  const bridge = await startServer({ acp })
+  try {
+    assert.deepEqual(await readJSON(bridge.baseURL, "/session/session-1/action"), [
+      { id: "undo", source: "omp-undo-redo", enabled: true },
+      { id: "redo", source: "omp-undo-redo", enabled: false }
+    ])
+
+    const undo = await readJSON(bridge.baseURL, "/session/session-1/action/undo", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: "{}"
+    })
+    assert.equal(undo.applied, true)
+    assert.equal(undo.actions.find((action) => action.id === "redo").enabled, true)
+    assert.deepEqual(acp.prompts, ["/undo"])
+    assert.deepEqual(conversation(await readJSON(bridge.baseURL, "/session/session-1/message")), [
+      "user: Change the file"
+    ], "the structured action must not appear as a user prompt")
+
+    const redo = await readJSON(bridge.baseURL, "/session/session-1/action/redo", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: "{}"
+    })
+    assert.equal(redo.applied, true)
+    assert.equal(redo.actions.find((action) => action.id === "redo").enabled, false)
+    assert.deepEqual(acp.prompts, ["/undo", "/redo"])
+    assert.deepEqual(conversation(await readJSON(bridge.baseURL, "/session/session-1/message")), [
+      "user: Change the file",
+      "assistant: Changed the file"
+    ])
+
+    await readJSON(bridge.baseURL, "/session/session-1/action/undo", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: "{}"
+    })
+    assert.equal((await readJSON(bridge.baseURL, "/session/session-1/action"))
+      .find((action) => action.id === "redo").enabled, true)
+    await readJSON(bridge.baseURL, "/session/session-1/prompt_async", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ parts: [{ type: "text", text: "Start a new branch" }] })
+    })
+    await waitForIdle(bridge.baseURL, "session-1")
+    assert.equal((await readJSON(bridge.baseURL, "/session/session-1/action"))
+      .find((action) => action.id === "redo").enabled, false, "a new prompt must invalidate bridge-local Redo")
+  } finally {
+    await bridge.close()
   }
 })
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -32,9 +32,18 @@ First-party command, no third party in the path. The bridge uses `session/new`, 
 | Chunks carry a `messageId` | without one, chunk aggregation falls back to per-turn tracking |
 | No `agent_plan` is emitted | the todo panel stays empty by design |
 | The agent approves its own tool calls and never sends `session/request_permission` | the permission path would start being exercised |
+| `available_commands_update` is emitted after extension initialization and contains registered command names | optional extension actions are not discovered |
 
-**Watch:** any of the above, and new `sessionUpdate` kinds we silently ignore (`tool_call`,
-`tool_call_update` and `agent_thought_chunk` are dropped today).
+**Watch:** any of the above and new `sessionUpdate` kinds; unknown updates are ignored by design.
+
+#### Optional OMP extension actions
+
+The bridge recognizes [`@baylarsadigov/omp-undo-redo`](https://www.npmjs.com/package/@baylarsadigov/omp-undo-redo)
+only when the active `omp acp` session advertises both `undo` and `redo`. The package remains a
+host-side OMP plugin; it is not an app or bridge dependency. Its command catalog proves that the
+handlers were registered in that runtime, while the bridge keeps the initial session-specific Redo
+state locally. A bridge restart or Undo/Redo performed elsewhere can therefore leave that enabled
+state stale until a new action or prompt updates it.
 
 ### PI — ACP over stdio, via a third-party adapter
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1980,6 +1980,7 @@ function App() {
   const [awaitingAssistantReply, setAwaitingAssistantReply] = useState(false)
   const [settingsNotice, setSettingsNotice] = useState<{ type: NoticeType; text: string } | null>(null)
   const [runtimeError, setRuntimeError] = useState<string | null>(null)
+  const [actionNotice, setActionNotice] = useState<string | null>(null)
   const [connectionState, setConnectionState] = useState<"idle" | "connecting" | "connected" | "reconnecting" | "offline">(
     config.host && config.port > 0 ? "connecting" : "idle"
   )
@@ -2201,6 +2202,7 @@ function App() {
     setDashboardError(null)
     setAwaitingAssistantReply(false)
     setRuntimeError(null)
+    setActionNotice(null)
     setView("detail")
     setLoadingSessionID(sessionID)
     try {
@@ -2232,6 +2234,7 @@ function App() {
       setConnectedVersion("")
       setCommands([])
       setExtensionActions([])
+      setActionNotice(null)
       setAgentOptions([])
       setModelOptions([])
       setSelectedModelKey(readStoredModel(nextConfig.backend))
@@ -2496,6 +2499,7 @@ function App() {
 
     setBusySending(true)
     setRuntimeError(null)
+    setActionNotice(null)
     try {
       let revertedSession: Session | undefined
       if (config.backend === "opencode") {
@@ -2514,6 +2518,9 @@ function App() {
       } else if (capabilities.actions && extensionActions.some((action) => action.id === command)) {
         const result = await api.invokeAction(config, selectedSession.id, command, selectedSession.directory)
         setExtensionActions(result.actions)
+        if (!result.applied) {
+          setActionNotice(t(command === "undo" ? 'detail.nothingToUndo' : 'detail.nothingToRedo'))
+        }
         await loadSelected(selectedSession.id, selectedSession.directory, true, result.applied)
       } else {
         await api.sendCommand(config, selectedSession.id, command, "", selectedSession.directory, activeModel, activeAgentID)
@@ -2756,6 +2763,7 @@ function App() {
     if (!selectedSession) return
     const text = composer.trim()
     if (!text) return
+    setActionNotice(null)
 
     if (text.startsWith("/")) {
       const normalized = text.slice(1)
@@ -4102,6 +4110,7 @@ function App() {
           </div>
 
           {runtimeError && <div className="error fade-in">✗ {runtimeError}</div>}
+          {actionNotice && <div className="notice info fade-in">ℹ {actionNotice}</div>}
         </main>
       )}
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,7 +16,7 @@ import { createTranslator, languageOptions, normalizeLanguage, type LanguageCode
 import { DEFAULT_HARNESS_CAPABILITIES } from "./backendCapabilities"
 import { BACKEND_CLIENTS } from "./backendClient"
 import { createServerProfile, loadActiveServerProfile, loadServerProfiles, persistServerProfiles, type SavedServerProfile } from "./serverProfiles"
-import type { AgentOption, CommandInfo, DiffFile, FileEntry, FileStatusEntry, HarnessCapabilities, MessageEnvelope, MessagePart, ModelOption, ModelSelection, PathInfo, ProjectDashboard, QuestionInfo, QuestionRequest, ServerConfig, Session, SessionStatus, SessionView, TodoItem } from "./types"
+import type { AgentOption, CommandInfo, DiffFile, FileEntry, FileStatusEntry, HarnessAction, HarnessCapabilities, MessageEnvelope, MessagePart, ModelOption, ModelSelection, PathInfo, ProjectDashboard, QuestionInfo, QuestionRequest, ServerConfig, Session, SessionStatus, SessionView, TodoItem } from "./types"
 import {
   SettingsIcon,
   FolderIcon,
@@ -1875,6 +1875,7 @@ function App() {
   const [capabilities, setCapabilities] = useState<HarnessCapabilities>(() => DEFAULT_HARNESS_CAPABILITIES[config.backend])
   const [connectedVersion, setConnectedVersion] = useState<string>("")
   const [commands, setCommands] = useState<CommandInfo[]>([])
+  const [extensionActions, setExtensionActions] = useState<HarnessAction[]>([])
   const [commandFilter, setCommandFilter] = useState<"all" | "skill">("all")
   const [agentOptions, setAgentOptions] = useState<AgentOption[]>([])
   const [agentLoadError, setAgentLoadError] = useState<string | null>(null)
@@ -2097,14 +2098,18 @@ function App() {
     const supported = new Set(commands.map((command) => command.name.toLowerCase()))
     const actions: MessageMenuAction[] = []
     const revertMessageID = selectedSession?.revertMessageID
-    const hasUndo = config.backend !== "opencode" || messages.some((message) => message.info.role === "user" && (!revertMessageID || message.info.id < revertMessageID))
-    const hasRedo = config.backend !== "opencode" || !!revertMessageID
-    const supportsUndo = config.backend === "opencode" || supported.has("undo")
-    const supportsRedo = config.backend === "opencode" || supported.has("redo")
+    const undoAction = extensionActions.find((action) => action.id === "undo")
+    const redoAction = extensionActions.find((action) => action.id === "redo")
+    const hasUndo = config.backend === "opencode"
+      ? messages.some((message) => message.info.role === "user" && (!revertMessageID || message.info.id < revertMessageID))
+      : undoAction ? undoAction.enabled && messages.some((message) => message.info.role === "user") : true
+    const hasRedo = config.backend === "opencode" ? !!revertMessageID : redoAction ? redoAction.enabled : true
+    const supportsUndo = config.backend === "opencode" || !!undoAction || supported.has("undo")
+    const supportsRedo = config.backend === "opencode" || !!redoAction || supported.has("redo")
     if (supportsUndo && hasUndo) actions.push({ id: "undo", label: t('detail.undo'), onSelect: () => void runNativeHistoryCommand("undo") })
     if (supportsRedo && hasRedo) actions.push({ id: "redo", label: t('detail.redo'), onSelect: () => void runNativeHistoryCommand("redo") })
     return actions
-  }, [commands, config.backend, messages, selectedSession?.revertMessageID, t])
+  }, [commands, config.backend, extensionActions, messages, selectedSession?.revertMessageID, t])
   const selectedNewSessionDirectory = normalizeDirectory(newSessionDirectory)
 
   const renderedMessages = useMemo(() => {
@@ -2184,6 +2189,7 @@ function App() {
     setSelectedModelKey(readStoredModel(config.backend, sessionID))
     loadModelsRequestRef.current += 1
     setModelOptions([])
+    setExtensionActions([])
     setMessages([])
     loadedMessagesRef.current = []
     setLoadedSessionID(null)
@@ -2225,6 +2231,7 @@ function App() {
       setAwaitingAssistantReply(false)
       setConnectedVersion("")
       setCommands([])
+      setExtensionActions([])
       setAgentOptions([])
       setModelOptions([])
       setSelectedModelKey(readStoredModel(nextConfig.backend))
@@ -2452,13 +2459,14 @@ function App() {
     localStorage.setItem(AGENT_STORAGE_KEY, nextAgentID)
   }
 
-  async function loadSelected(sessionID: string, directory: string, refreshHistory = false) {
+  async function loadSelected(sessionID: string, directory: string, refreshHistory = false, replaceMessages = false) {
     const requestID = ++loadSelectedRequestRef.current
-    const [msg, todo, diff, questions] = await Promise.all([
+    const [msg, todo, diff, questions, actions] = await Promise.all([
       api.loadMessages(config, sessionID, directory, backendClient.messageRefreshSupported && refreshHistory),
       capabilities.todos ? api.loadTodo(config, sessionID, directory) : Promise.resolve([]),
       capabilities.diff ? api.loadDiff(config, sessionID, directory).catch(() => []) : Promise.resolve([]),
-      capabilities.questions ? api.loadQuestions(config, directory).catch(() => []) : Promise.resolve([])
+      capabilities.questions ? api.loadQuestions(config, directory).catch(() => []) : Promise.resolve([]),
+      capabilities.actions ? api.listActions(config, sessionID, directory).catch(() => []) : Promise.resolve([])
     ])
     if (requestID !== loadSelectedRequestRef.current) return
     setLoadedSessionID(sessionID)
@@ -2472,12 +2480,13 @@ function App() {
     if (!messagesHaveSameContent(current, msg)) {
       shouldAutoScrollRef.current = messagesExtendContent(current, msg) && isNearMessagesBottom()
       loadedMessagesRef.current = msg
-      setMessages((prev) => mergeFetchedMessages(prev, msg))
+      setMessages((prev) => replaceMessages ? msg : mergeFetchedMessages(prev, msg))
     }
     setOptimisticUserMessages((current) => current.filter((message) => !hasMatchingUserMessage(msg, message)))
     setTodos(todo)
     setDiffFiles(diff)
     setPendingQuestions(questions.filter((question) => question.sessionID === sessionID))
+    setExtensionActions(actions)
     await loadProjectDashboard(directory)
   }
 
@@ -2502,10 +2511,15 @@ function App() {
             ? await api.revertMessage(config, selectedSession.id, next.info.id, selectedSession.directory)
             : await api.unrevertSession(config, selectedSession.id, selectedSession.directory)
         }
+      } else if (capabilities.actions && extensionActions.some((action) => action.id === command)) {
+        const result = await api.invokeAction(config, selectedSession.id, command, selectedSession.directory)
+        setExtensionActions(result.actions)
+        await loadSelected(selectedSession.id, selectedSession.directory, true, result.applied)
       } else {
         await api.sendCommand(config, selectedSession.id, command, "", selectedSession.directory, activeModel, activeAgentID)
+        await loadSelected(selectedSession.id, selectedSession.directory, true)
       }
-      await loadSelected(selectedSession.id, selectedSession.directory, true)
+      if (config.backend === "opencode") await loadSelected(selectedSession.id, selectedSession.directory, true)
       await refreshSessions(true)
       if (revertedSession) {
         setSessions((current) => current.map((item) => item.id === revertedSession.id ? { ...item, revertMessageID: revertedSession.revert?.messageID } : item))

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -9,6 +9,8 @@ import type {
   FileEntry,
   HealthResponse,
   HarnessCapabilities,
+  HarnessAction,
+  HarnessActionResult,
   MessageEnvelope,
   ModelOption,
   ModelSelection,
@@ -327,6 +329,18 @@ export const api = {
 
   loadFileStatus(config: ServerConfig, directory?: string) {
     return request<FileStatusEntry[] | Record<string, FileStatusEntry>>(config, withDirectory("/file/status", directory))
+  },
+
+  listActions(config: ServerConfig, sessionID: string, directory?: string) {
+    return request<HarnessAction[]>(config, withDirectory(`/session/${sessionID}/action`, directory))
+  },
+
+  invokeAction(config: ServerConfig, sessionID: string, actionID: string, directory?: string) {
+    return request<HarnessActionResult>(config, withDirectory(`/session/${sessionID}/action/${encodeURIComponent(actionID)}`, directory), {
+      method: "POST",
+      body: {},
+      readTimeout: 300_000
+    })
   },
 
   sendPrompt(config: ServerConfig, sessionID: string, text: string, directory?: string, model?: ModelSelection, agentID?: string) {

--- a/web/src/backendCapabilities.ts
+++ b/web/src/backendCapabilities.ts
@@ -13,6 +13,7 @@ export const DEFAULT_HARNESS_CAPABILITIES: Record<BackendKind, HarnessCapabiliti
     filesystemBrowser: true,
     questions: true,
     commands: true,
+    actions: false,
     sessionRename: true,
     sessionDelete: true
   },
@@ -28,6 +29,7 @@ export const DEFAULT_HARNESS_CAPABILITIES: Record<BackendKind, HarnessCapabiliti
     filesystemBrowser: true,
     questions: false,
     commands: false,
+    actions: true,
     sessionRename: true,
     sessionDelete: true
   },
@@ -43,6 +45,7 @@ export const DEFAULT_HARNESS_CAPABILITIES: Record<BackendKind, HarnessCapabiliti
     filesystemBrowser: true,
     questions: false,
     commands: true,
+    actions: false,
     sessionRename: true,
     sessionDelete: true
   },
@@ -58,6 +61,7 @@ export const DEFAULT_HARNESS_CAPABILITIES: Record<BackendKind, HarnessCapabiliti
     filesystemBrowser: true,
     questions: false,
     commands: false,
+    actions: false,
     sessionRename: true,
     sessionDelete: true
   }

--- a/web/src/i18n.test.mjs
+++ b/web/src/i18n.test.mjs
@@ -22,6 +22,10 @@ assert.equal(en('session.deleteTitle'), 'Delete session?')
 assert.equal(it('session.deleteTitle'), 'Eliminare la sessione?')
 assert.equal(zh('session.deleteTitle'), '刪除工作階段？')
 
+assert.equal(en('detail.nothingToUndo'), 'Nothing to undo in this session.')
+assert.equal(it('detail.nothingToRedo'), 'Non c’è nulla da ripristinare in questa sessione.')
+assert.equal(zh('detail.nothingToUndo'), '此工作階段沒有可復原的內容。')
+
 // Unknown keys should remain visible during development instead of rendering blank UI.
 assert.equal(en('missing.key'), 'missing.key')
 assert.equal(en('detail.opencode'), '🤖 OpenCode')

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -103,6 +103,8 @@ type TranslationKey =
   | 'detail.copyMarkdown'
   | 'detail.undo'
   | 'detail.redo'
+  | 'detail.nothingToUndo'
+  | 'detail.nothingToRedo'
   | 'detail.revertToMessage'
   | 'detail.undoConfirm'
   | 'detail.revertConfirm'
@@ -336,6 +338,8 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.copyMarkdown': 'Copy as markdown',
     'detail.undo': 'Undo last turn',
     'detail.redo': 'Redo last undone turn',
+    'detail.nothingToUndo': 'Nothing to undo in this session.',
+    'detail.nothingToRedo': 'Nothing to redo in this session.',
     'detail.revertToMessage': 'Revert to this message',
     'detail.undoConfirm': 'Undo the last turn and restore its file changes?',
     'detail.revertConfirm': 'Revert the conversation and file changes to this message?',
@@ -568,6 +572,8 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.copyMarkdown': 'Copia come Markdown',
     'detail.undo': 'Annulla ultimo turno',
     'detail.redo': 'Ripristina ultimo turno annullato',
+    'detail.nothingToUndo': 'Non c’è nulla da annullare in questa sessione.',
+    'detail.nothingToRedo': 'Non c’è nulla da ripristinare in questa sessione.',
     'detail.revertToMessage': 'Ripristina fino a questo messaggio',
     'detail.undoConfirm': 'Annullare l’ultimo turno e ripristinare le sue modifiche ai file?',
     'detail.revertConfirm': 'Ripristinare conversazione e modifiche ai file fino a questo messaggio?',
@@ -800,6 +806,8 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.copyMarkdown': '複製為 Markdown',
     'detail.undo': '復原上一個回合',
     'detail.redo': '重做上一個復原的回合',
+    'detail.nothingToUndo': '此工作階段沒有可復原的內容。',
+    'detail.nothingToRedo': '此工作階段沒有可重做的內容。',
     'detail.revertToMessage': '還原到這則訊息',
     'detail.undoConfirm': '要復原上一個回合及其檔案變更嗎？',
     'detail.revertConfirm': '要將對話和檔案變更還原到這則訊息嗎？',

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -20,6 +20,7 @@ export type HarnessCapabilities = {
   filesystemBrowser: boolean
   questions: boolean
   commands: boolean
+  actions: boolean
   sessionRename: boolean
   sessionDelete: boolean
 }
@@ -228,4 +229,16 @@ export type CommandInfo = {
   name: string
   description?: string
   source?: "command" | "mcp" | "skill"
+}
+
+export type HarnessAction = {
+  id: string
+  source?: string
+  enabled: boolean
+}
+
+export type HarnessActionResult = {
+  action: string
+  applied: boolean
+  actions: HarnessAction[]
 }

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -387,8 +387,8 @@ assert.match(app, /supported\.has\("undo"\)/, 'Undo must appear only when the co
 assert.match(app, /supported\.has\("redo"\)/, 'Redo must appear only when the connected harness exposes the command')
 assert.match(app, /api\.revertMessage\(config, selectedSession\.id, messageID/, 'OpenCode message actions must use its targeted revert endpoint')
 assert.match(app, /message\.info\.id < revertMessageID/, 'a staged OpenCode revert must hide messages from its boundary onward')
-assert.match(app, /const hasRedo = config\.backend !== "opencode" \|\| !!revertMessageID/, 'OpenCode Redo must only appear while a revert is staged')
-assert.match(app, /const supportsRedo = config\.backend === "opencode" \|\| supported\.has\("redo"\)/, 'OpenCode native history actions must not depend on the server command list')
+assert.match(app, /const hasRedo = config\.backend === "opencode" \? !!revertMessageID : redoAction \? redoAction\.enabled : true/, 'OpenCode Redo must only appear while a revert is staged and extension Redo must follow session state')
+assert.match(app, /const supportsRedo = config\.backend === "opencode" \|\| !!redoAction \|\| supported\.has\("redo"\)/, 'OpenCode native history actions must not depend on the server command list')
 assert.match(app, /message-context-menu__separator/, 'harness actions must be visually separated from copy actions')
 assert.match(styles, /\.message-context-menu button\s*\{[\s\S]*?justify-content:\s*flex-start[\s\S]*?text-align:\s*left/, 'message action labels must align to the menu edge')
 // The rule was written for a field that no longer exists, but the class outlived it: dropping the
@@ -427,5 +427,12 @@ const themeTokens = (block) => new Set([...block.matchAll(/^\s*(--[a-z0-9-]+)\s*
 const rootTokens = themeTokens(styles.match(/^:root \{([\s\S]*?)^\}/m)[1])
 const darkOnlyTokens = [...themeTokens(styles.match(/color-scheme: dark;([\s\S]*?)^\}/m)[1])].filter((token) => !rootTokens.has(token))
 assert.deepEqual(darkOnlyTokens, [], 'a custom property overridden for dark mode must have a light-mode value too')
+
+assert.ok(api.includes('`/session/${sessionID}/action`'), 'session action discovery should use the generic bridge endpoint')
+assert.ok(api.includes('`/session/${sessionID}/action/${encodeURIComponent(actionID)}`'), 'action execution should use a structured endpoint rather than a chat prompt')
+assert.ok(app.includes('capabilities.actions ? api.listActions'), 'the selected session should discover actions only when the bridge supports them')
+assert.ok(app.includes('api.invokeAction(config, selectedSession.id, command, selectedSession.directory)'), 'OMP Undo/Redo should execute through the action API')
+assert.ok(app.includes('replaceMessages ? msg : mergeFetchedMessages(prev, msg)'), 'a successful Undo must be allowed to shrink the rendered conversation')
+assert.ok(app.includes('setExtensionActions(result.actions)'), 'action execution should apply the returned session-specific enabled state immediately')
 
 console.log('ui regression tests passed')

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -434,5 +434,8 @@ assert.ok(app.includes('capabilities.actions ? api.listActions'), 'the selected 
 assert.ok(app.includes('api.invokeAction(config, selectedSession.id, command, selectedSession.directory)'), 'OMP Undo/Redo should execute through the action API')
 assert.ok(app.includes('replaceMessages ? msg : mergeFetchedMessages(prev, msg)'), 'a successful Undo must be allowed to shrink the rendered conversation')
 assert.ok(app.includes('setExtensionActions(result.actions)'), 'action execution should apply the returned session-specific enabled state immediately')
+assert.ok(app.includes("if (!result.applied)"), 'a semantic no-op action must have an explicit frontend path')
+assert.ok(app.includes("command === \"undo\" ? 'detail.nothingToUndo' : 'detail.nothingToRedo'"), 'the no-op message should describe the attempted action')
+assert.ok(app.includes('{actionNotice && <div className=\"notice info fade-in\">'), 'no-op action feedback should render as visible information rather than an error')
 
 console.log('ui regression tests passed')


### PR DESCRIPTION
## Summary

Adds the OMP-only proof of concept discussed in #90 for discovering and invoking optional host extension actions through a generic bridge API.

- capture session-scoped ACP `available_commands_update` catalogs
- expose generic `GET /session/:id/action` and `POST /session/:id/action/:name` endpoints
- recognize Undo/Redo only when the active `omp acp` runtime advertises both extension commands
- invoke actions without recording `/undo` or `/redo` as user prompts
- refresh authoritative conversation/session state after execution
- keep initial Redo availability in bridge-local, session-specific state
- integrate the existing message menu with the structured action endpoints
- keep `@baylarsadigov/omp-undo-redo` as an optional host-side plugin, not a frontend dependency

## State model and limitations

This deliberately implements the agreed proof-of-concept boundary:

- Redo becomes enabled only after an Undo produces an observed history change.
- Redo is cleared after Redo, a new prompt, or another observed session-history change.
- State is bridge-local, so restarting the bridge or invoking commands elsewhere can temporarily lose synchronization.
- The extension provides sequential Undo/Redo; this does not add arbitrary targeted revert-to-message or a selectable conversation-only mode.
- PI remains unchanged and can be investigated separately.

The action-provider registry and HTTP contract are generic so other known bridge extensions can be added without redesigning the frontend API.

## Verification

- `cd bridge && npm test` — 55 tests passed
- Web i18n, UI, settings, model, event, profile, and configuration regression checks passed
- `cd web && npm run build` passed
- Real OMP smoke test with `@baylarsadigov/omp-undo-redo@1.0.32`: first action discovery returned Undo enabled and Redo disabled; the browser message menu showed Undo and correctly hid Redo

Closes #90 only partially: this contributes extension-backed sequential Undo/Redo, while the issue's targeted revert variants remain separate work.