### PR TITLE
fix(bridge): make OMP extension action state authoritative

### DIFF
--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -2,8 +2,8 @@ import { randomUUID } from "node:crypto"
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
 import path from "node:path"
 import {
-  applyExtensionActionSuccess,
   listExtensionActions,
+  loadExtensionActionState,
   resetExtensionActionState,
   resolveExtensionAction
 } from "./extension-actions.js"
@@ -153,6 +153,7 @@ export class AcpService {
   #commandCatalogs = new Map()
   #commandCatalogWaiters = new Map()
   #actionStates = new Map()
+  #authoritativeActionStates = new Map()
   #actionProviders
   #loaded = new Set()
   #loads = new Map()
@@ -262,6 +263,7 @@ export class AcpService {
     for (const resolve of this.#commandCatalogWaiters.get(sessionID) ?? []) resolve()
     this.#commandCatalogWaiters.delete(sessionID)
     this.#actionStates.delete(sessionID)
+    this.#authoritativeActionStates.delete(sessionID)
     this.#loaded.delete(sessionID)
     this.#ownedSessions.delete(sessionID)
     this.#promptAcknowledgements.delete(sessionID)
@@ -299,6 +301,7 @@ export class AcpService {
       await this.#load(sessionID, true, true)
       await this.#waitForCommandCatalog(sessionID)
     }
+    await this.#refreshActionState(sessionID)
     return this.#availableActions(sessionID)
   }
 
@@ -332,26 +335,55 @@ export class AcpService {
     )
     if (!resolved) throw new Error(`Harness action is not available: ${actionID}`)
 
-    const before = semanticHistorySignature(this.#messages.get(sessionID) ?? [])
+    const beforeState = this.#authoritativeActionStates.get(sessionID)
     this.#ownedSessions.add(sessionID)
     this.#active.add(sessionID)
     this.#emit("session.updated", sessionID)
-    let applied = false
+    let applied = null
+    let authoritativeState
     try {
       await this.#acp.request("session/prompt", {
         sessionId: sessionID,
         prompt: [{ type: "text", text: `/${resolved.action.command}` }]
       }, 300_000)
+      authoritativeState = await this.#refreshActionState(sessionID)
+      if (
+        authoritativeState?.actionResult?.id === actionID &&
+        authoritativeState.actionResult.token !== beforeState?.actionResult?.token
+      ) {
+        applied = authoritativeState.actionResult.applied
+      } else if (
+        typeof beforeState?.sessionRevision === "string" &&
+        typeof authoritativeState?.sessionRevision === "string"
+      ) {
+        applied = authoritativeState.sessionRevision !== beforeState.sessionRevision
+      }
       await this.#loadSession(sessionID, true, true)
-      applied = semanticHistorySignature(this.#messages.get(sessionID) ?? []) !== before
-      if (applied) applyExtensionActionSuccess(this.#actionState(sessionID), resolved.action)
       this.#emit("message.updated", sessionID)
       this.#persistSnapshot(sessionID)
     } finally {
       this.#active.delete(sessionID)
       this.#emit("session.updated", sessionID)
     }
-    return { action: actionID, applied, actions: this.#availableActions(sessionID) }
+    return {
+      action: actionID,
+      applied,
+      actions: this.#availableActions(sessionID),
+      ...(authoritativeState?.sessionRevision ? { sessionRevision: authoritativeState.sessionRevision } : {})
+    }
+  }
+
+  async #refreshActionState(sessionID, requireCommands = true) {
+    const session = this.#sessions.get(sessionID)
+    if (!session) return undefined
+    const state = await loadExtensionActionState(
+      this.#actionProviders,
+      requireCommands ? this.#commandCatalogs.get(sessionID) ?? [] : undefined,
+      { sessionID, directory: session.cwd }
+    )
+    if (state) this.#authoritativeActionStates.set(sessionID, state)
+    else this.#authoritativeActionStates.delete(sessionID)
+    return state
   }
 
   #actionState(sessionID) {
@@ -368,7 +400,8 @@ export class AcpService {
       this.#actionProviders,
       this.#commandCatalogs.get(sessionID) ?? [],
       this.#actionState(sessionID),
-      this.#isBusy(sessionID)
+      this.#isBusy(sessionID),
+      this.#authoritativeActionStates.get(sessionID)
     )
   }
 
@@ -597,14 +630,19 @@ export class AcpService {
     const session = this.#sessions.get(sessionID)
     if (!session) throw new Error("Harness session not found")
     await this.#restoreSnapshot(sessionID)
+    const authoritativeState = await this.#refreshActionState(sessionID, false)
     let previousMessages = this.#messages.get(sessionID) ?? []
     const previousTodos = this.#todos.get(sessionID) ?? []
     const previousMessageSnapshot = semanticHistorySignature(previousMessages)
     if (this.#historyLoader) {
       try {
-        const persistedMessages = await this.#historyLoader(sessionID)
-        if (persistedMessages.length > 0) {
-          previousMessages = mergeExternalHistory(persistedMessages, previousMessages)
+        const persistedMessages = await this.#historyLoader(sessionID, {
+          activeSessionLeaf: authoritativeState?.activeSessionLeaf
+        })
+        if (persistedMessages.length > 0 || authoritativeState) {
+          previousMessages = authoritativeState
+            ? persistedMessages
+            : mergeExternalHistory(persistedMessages, previousMessages)
           this.#messages.set(sessionID, previousMessages)
           if (!this.#ownedSessions.has(sessionID) && !requireConfigOptions) {
             this.#todos.set(sessionID, [])

--- a/bridge/src/extension-actions.js
+++ b/bridge/src/extension-actions.js
@@ -1,3 +1,5 @@
+import { createOmpUndoRedoActionStateLoader } from "./omp-extension-action-state.js"
+
 function commandNames(commands) {
   return new Set(commands.map((command) => command.name?.replace(/^\//, "").toLowerCase()).filter(Boolean))
 }
@@ -6,9 +8,10 @@ export const OMP_EXTENSION_ACTION_PROVIDERS = [{
   id: "omp-undo-redo",
   requiredCommands: ["undo", "redo"],
   resetOnSessionChange: ["redo"],
+  loadState: createOmpUndoRedoActionStateLoader(),
   actions: [
-    { id: "undo", command: "undo", enabledByDefault: true, onSuccess: { redo: true } },
-    { id: "redo", command: "redo", enabledByDefault: false, onSuccess: { redo: false } }
+    { id: "undo", command: "undo", enabledByDefault: true },
+    { id: "redo", command: "redo", enabledByDefault: false }
   ]
 }]
 
@@ -17,12 +20,24 @@ function availableProviders(providers, commands) {
   return providers.filter((provider) => provider.requiredCommands.every((command) => names.has(command)))
 }
 
-export function listExtensionActions(providers, commands, state, busy = false) {
+export function listExtensionActions(providers, commands, state, busy = false, authoritativeState) {
   return availableProviders(providers, commands).flatMap((provider) => provider.actions.map((action) => ({
     id: action.id,
     source: provider.id,
-    enabled: !busy && (state.get(action.id) ?? action.enabledByDefault)
+    enabled: !busy && (authoritativeState?.source === provider.id
+      ? authoritativeState.actions.find((candidate) => candidate.id === action.id)?.enabled ?? false
+      : state.get(action.id) ?? action.enabledByDefault)
   })))
+}
+
+export async function loadExtensionActionState(providers, commands, context) {
+  const candidates = commands ? availableProviders(providers, commands) : providers
+  for (const provider of candidates) {
+    if (!provider.loadState) continue
+    const state = await provider.loadState(context)
+    if (state) return { ...state, source: provider.id }
+  }
+  return undefined
 }
 
 export function resolveExtensionAction(providers, commands, actionID) {
@@ -33,9 +48,6 @@ export function resolveExtensionAction(providers, commands, actionID) {
   return undefined
 }
 
-export function applyExtensionActionSuccess(state, action) {
-  for (const [actionID, enabled] of Object.entries(action.onSuccess ?? {})) state.set(actionID, enabled)
-}
 
 export function resetExtensionActionState(providers, commands, state) {
   for (const provider of availableProviders(providers, commands)) {

--- a/bridge/src/omp-extension-action-state.js
+++ b/bridge/src/omp-extension-action-state.js
@@ -1,0 +1,100 @@
+import { execFile } from "node:child_process"
+import { createHash } from "node:crypto"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const ACTION_IDS = new Set(["undo", "redo"])
+
+function sessionHash(sessionID) {
+  return createHash("sha256").update(sessionID).digest("hex")
+}
+
+function normalizeProtocolState(value) {
+  if (!value || typeof value !== "object" || !Array.isArray(value.actions)) return undefined
+  if (typeof value.sessionRevision !== "string") return undefined
+  const actions = value.actions.flatMap((action) => (
+    ACTION_IDS.has(action?.id) && typeof action.enabled === "boolean"
+      ? [{ id: action.id, enabled: action.enabled }]
+      : []
+  ))
+  if (actions.length !== ACTION_IDS.size) return undefined
+  const actionResult = value.actionResult &&
+    ACTION_IDS.has(value.actionResult.id) &&
+    typeof value.actionResult.applied === "boolean" &&
+    typeof value.actionResult.token === "string"
+    ? { id: value.actionResult.id, applied: value.actionResult.applied, token: value.actionResult.token }
+    : undefined
+  return {
+    actions,
+    sessionRevision: value.sessionRevision,
+    activeSessionLeaf: value.activeSessionLeaf === null || typeof value.activeSessionLeaf === "string"
+      ? value.activeSessionLeaf
+      : undefined,
+    actionResult
+  }
+}
+
+function normalizeLegacyHistory(value, expectedHash) {
+  if (value?.schemaVersion !== 1 || value.sessionHash !== expectedHash || !Array.isArray(value.checkpoints)) return undefined
+  const currentIndex = value.currentIndex
+  if (!Number.isInteger(currentIndex) || currentIndex < -1 || currentIndex >= value.checkpoints.length) return undefined
+  if (value.checkpoints.length === 0) return undefined
+  const activeSessionLeaf = currentIndex >= 0
+    ? value.checkpoints[currentIndex]?.leafId
+    : value.checkpoints[0]?.parentLeafId
+  if (activeSessionLeaf !== null && typeof activeSessionLeaf !== "string") return undefined
+  return {
+    actions: [
+      { id: "undo", enabled: currentIndex >= 0 },
+      { id: "redo", enabled: currentIndex < value.checkpoints.length - 1 }
+    ],
+    sessionRevision: `${currentIndex}:${activeSessionLeaf ?? "root"}`,
+    activeSessionLeaf
+  }
+}
+
+/**
+ * Reads the optional state contract published by omp-undo-redo. Schema 1 is the
+ * extension's durable navigation store; newer publishers may expose the small
+ * normalized actions/sessionRevision contract directly in the same sidecar.
+ */
+export function createOmpUndoRedoActionStateLoader({ runGit = execFileAsync } = {}) {
+  const commonDirectories = new Map()
+
+  async function resolveCommonDirectory(directory) {
+    let loading = commonDirectories.get(directory)
+    if (!loading) {
+      loading = runGit("git", ["rev-parse", "--path-format=absolute", "--git-common-dir"], {
+        cwd: directory,
+        encoding: "utf8",
+        windowsHide: true,
+        maxBuffer: 64 * 1024
+      }).then(({ stdout }) => stdout.trim())
+      commonDirectories.set(directory, loading)
+    }
+    try {
+      const commonDirectory = await loading
+      if (!commonDirectory) commonDirectories.delete(directory)
+      return commonDirectory
+    } catch (error) {
+      commonDirectories.delete(directory)
+      throw error
+    }
+  }
+
+  return async function loadOmpUndoRedoActionState({ sessionID, directory }) {
+    if (!sessionID || !directory) return undefined
+    try {
+      const commonDirectory = await resolveCommonDirectory(directory)
+      if (!commonDirectory) return undefined
+      const expectedHash = sessionHash(sessionID)
+      const statePath = path.join(commonDirectory, "omp-undo-redo", "history", `${expectedHash}.json`)
+      const value = JSON.parse(await readFile(statePath, "utf8"))
+      return normalizeProtocolState(value) ?? normalizeLegacyHistory(value, expectedHash)
+    } catch {
+      return undefined
+    }
+  }
+}

--- a/bridge/src/omp-session-history.js
+++ b/bridge/src/omp-session-history.js
@@ -39,10 +39,11 @@ export function createOmpHistoryLoader(sessionRoot = path.join(homedir(), ".omp"
     }
   }
 
-  return async function loadOmpHistory(sessionID) {
+  return async function loadOmpHistory(sessionID, { activeSessionLeaf } = {}) {
     const file = await locateSession(sessionID)
     if (!file) return []
-    const messages = []
+    const records = []
+    const entries = new Map()
     const lines = createInterface({ input: createReadStream(file), crlfDelay: Infinity })
     for await (const line of lines) {
       let record
@@ -51,7 +52,33 @@ export function createOmpHistoryLoader(sessionRoot = path.join(homedir(), ".omp"
       } catch {
         continue
       }
-      if (record?.type !== "message") continue
+      if (typeof record?.id === "string") {
+        records.push(record)
+        entries.set(record.id, record)
+      }
+    }
+
+    const selected = []
+    const leafID = activeSessionLeaf !== undefined ? activeSessionLeaf : records.at(-1)?.id
+    if (leafID === null) {
+      // The extension selected the session root.
+    } else if (leafID && entries.has(leafID)) {
+      const branch = []
+      const visited = new Set()
+      let entry = entries.get(leafID)
+      while (entry && !visited.has(entry.id)) {
+        visited.add(entry.id)
+        branch.push(entry)
+        entry = typeof entry.parentId === "string" ? entries.get(entry.parentId) : undefined
+      }
+      selected.push(...branch.reverse())
+    } else {
+      selected.push(...records)
+    }
+
+    const messages = []
+    for (const record of selected) {
+      if (record.type !== "message") continue
       const role = record.message?.role
       if (role !== "user" && role !== "assistant") continue
       const messageID = record.id ?? `${sessionID}:${messages.length}`

--- a/bridge/test/omp-extension-action-state.test.js
+++ b/bridge/test/omp-extension-action-state.test.js
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict"
+import { createHash } from "node:crypto"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import test from "node:test"
+import { createOmpUndoRedoActionStateLoader } from "../src/omp-extension-action-state.js"
+
+const sessionID = "session-1"
+const sessionHash = createHash("sha256").update(sessionID).digest("hex")
+
+test("normalizes the omp-undo-redo navigation store into authoritative action state", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-actions-"))
+  const historyDirectory = path.join(root, "omp-undo-redo", "history")
+  const statePath = path.join(historyDirectory, `${sessionHash}.json`)
+  await mkdir(historyDirectory, { recursive: true })
+  const loadState = createOmpUndoRedoActionStateLoader({
+    runGit: async () => ({ stdout: `${root}\n` })
+  })
+
+  try {
+    const checkpoints = [
+      { kind: "session", parentLeafId: "user-1", leafId: "assistant-1" },
+      { kind: "session", parentLeafId: "user-2", leafId: "assistant-2" }
+    ]
+    await writeFile(statePath, JSON.stringify({ schemaVersion: 1, sessionHash, checkpoints, currentIndex: 1 }))
+    assert.deepEqual(await loadState({ sessionID, directory: root }), {
+      actions: [{ id: "undo", enabled: true }, { id: "redo", enabled: false }],
+      sessionRevision: "1:assistant-2",
+      activeSessionLeaf: "assistant-2"
+    })
+
+    await writeFile(statePath, JSON.stringify({ schemaVersion: 1, sessionHash, checkpoints, currentIndex: 0 }))
+    assert.deepEqual(await loadState({ sessionID, directory: root }), {
+      actions: [{ id: "undo", enabled: true }, { id: "redo", enabled: true }],
+      sessionRevision: "0:assistant-1",
+      activeSessionLeaf: "assistant-1"
+    })
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test("accepts the normalized optional action protocol with an explicit invocation result", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-actions-"))
+  const historyDirectory = path.join(root, "omp-undo-redo", "history")
+  await mkdir(historyDirectory, { recursive: true })
+  await writeFile(path.join(historyDirectory, `${sessionHash}.json`), JSON.stringify({
+    actions: [{ id: "undo", enabled: false }, { id: "redo", enabled: true }],
+    sessionRevision: "revision-2",
+    activeSessionLeaf: "user-1",
+    actionResult: { id: "undo", applied: false, token: "action-2" }
+  }))
+  const loadState = createOmpUndoRedoActionStateLoader({ runGit: async () => ({ stdout: root }) })
+
+  try {
+    assert.deepEqual(await loadState({ sessionID, directory: root }), {
+      actions: [{ id: "undo", enabled: false }, { id: "redo", enabled: true }],
+      sessionRevision: "revision-2",
+      activeSessionLeaf: "user-1",
+      actionResult: { id: "undo", applied: false, token: "action-2" }
+    })
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/bridge/test/omp-session-history.test.js
+++ b/bridge/test/omp-session-history.test.js
@@ -23,9 +23,11 @@ test("reads persisted user and assistant text from an OMP session transcript", a
     const messages = await loadHistory(sessionID)
     assert.deepEqual(messages.map((message) => [message.info.role, message.parts.map((part) => [part.type, part.text])]), [
       ["user", [["text", "Question"]]],
-      ["assistant", [["text", "Abandoned answer"]]],
       ["assistant", [["reasoning", "hidden"], ["text", "Answer"]]]
-    ])
+    ], "the latest active branch must exclude abandoned siblings")
+
+    const undone = await loadHistory(sessionID, { activeSessionLeaf: "user-1" })
+    assert.deepEqual(undone.map((message) => message.parts[0].text), ["Question"])
   } finally {
     await rm(root, { recursive: true, force: true })
   }

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -689,7 +689,7 @@ test("does not advertise extension actions when OMP did not load their commands"
   }
 })
 
-test("reports a repeated Undo at the history boundary as a semantic no-op", async () => {
+test("does not infer extension action success from transcript changes", async () => {
   const acp = new ExtensionActionAcp()
   const bridge = await startServer({ acp })
   try {
@@ -705,66 +705,106 @@ test("reports a repeated Undo at the history boundary as a semantic no-op", asyn
       body: "{}"
     })
 
-    assert.equal(first.applied, true)
-    assert.equal(second.applied, false, "replayed timestamps and message ids must not make unchanged history look applied")
-    assert.equal(second.actions.find((action) => action.id === "redo").enabled, true)
+    assert.equal(first.applied, null)
+    assert.equal(second.applied, null)
+    assert.equal(second.actions.find((action) => action.id === "redo").enabled, false)
   } finally {
     await bridge.close()
   }
 })
 
-test("invokes loaded OMP extension actions and keeps Redo state session-specific", async () => {
+test("uses extension revisions and availability as authoritative action state", async () => {
   const acp = new ExtensionActionAcp()
-  const bridge = await startServer({ acp })
-  try {
-    assert.deepEqual(await readJSON(bridge.baseURL, "/session/session-1/action"), [
-      { id: "undo", source: "omp-undo-redo", enabled: true },
-      { id: "redo", source: "omp-undo-redo", enabled: false }
-    ])
-
-    const undo = await readJSON(bridge.baseURL, "/session/session-1/action/undo", {
-      method: "POST",
-      headers: jsonHeaders(),
-      body: "{}"
-    })
-    assert.equal(undo.applied, true)
-    assert.equal(undo.actions.find((action) => action.id === "redo").enabled, true)
-    assert.deepEqual(acp.prompts, ["/undo"])
-    assert.deepEqual(conversation(await readJSON(bridge.baseURL, "/session/session-1/message")), [
-      "user: Change the file"
-    ], "the structured action must not appear as a user prompt")
-
-    const redo = await readJSON(bridge.baseURL, "/session/session-1/action/redo", {
-      method: "POST",
-      headers: jsonHeaders(),
-      body: "{}"
-    })
-    assert.equal(redo.applied, true)
-    assert.equal(redo.actions.find((action) => action.id === "redo").enabled, false)
-    assert.deepEqual(acp.prompts, ["/undo", "/redo"])
-    assert.deepEqual(conversation(await readJSON(bridge.baseURL, "/session/session-1/message")), [
-      "user: Change the file",
-      "assistant: Changed the file"
-    ])
-
-    await readJSON(bridge.baseURL, "/session/session-1/action/undo", {
-      method: "POST",
-      headers: jsonHeaders(),
-      body: "{}"
-    })
-    assert.equal((await readJSON(bridge.baseURL, "/session/session-1/action"))
-      .find((action) => action.id === "redo").enabled, true)
-    await readJSON(bridge.baseURL, "/session/session-1/prompt_async", {
-      method: "POST",
-      headers: jsonHeaders(),
-      body: JSON.stringify({ parts: [{ type: "text", text: "Start a new branch" }] })
-    })
-    await waitForIdle(bridge.baseURL, "session-1")
-    assert.equal((await readJSON(bridge.baseURL, "/session/session-1/action"))
-      .find((action) => action.id === "redo").enabled, false, "a new prompt must invalidate bridge-local Redo")
-  } finally {
-    await bridge.close()
+  let actionState = {
+    actions: [{ id: "undo", enabled: true }, { id: "redo", enabled: false }],
+    sessionRevision: "1:assistant-1",
+    activeSessionLeaf: "assistant-1"
   }
+  let nextUndoIsNoOp = false
+  const request = acp.request.bind(acp)
+  acp.request = async (method, params) => {
+    const result = await request(method, params)
+    if (method !== "session/prompt") return result
+    const command = params.prompt[0].text
+    if (command === "/undo") {
+      acp.history = [...acp.fullHistory]
+      actionState = nextUndoIsNoOp
+        ? {
+            ...actionState,
+            actionResult: { id: "undo", applied: false, token: "action-no-op" }
+          }
+        : {
+            actions: [{ id: "undo", enabled: false }, { id: "redo", enabled: true }],
+            sessionRevision: "0:user-1",
+            activeSessionLeaf: "user-1"
+          }
+    } else if (command === "/redo") {
+      actionState = {
+        actions: [{ id: "undo", enabled: true }, { id: "redo", enabled: false }],
+        sessionRevision: "1:assistant-1",
+        activeSessionLeaf: "assistant-1"
+      }
+    }
+    return result
+  }
+  const provider = {
+    id: "omp-undo-redo",
+    requiredCommands: ["undo", "redo"],
+    actions: [
+      { id: "undo", command: "undo", enabledByDefault: true },
+      { id: "redo", command: "redo", enabledByDefault: false }
+    ],
+    loadState: async () => actionState
+  }
+  const service = new AcpService(acp, { actionProviders: [provider] })
+
+  assert.deepEqual(await service.actions("session-1"), [
+    { id: "undo", source: "omp-undo-redo", enabled: true },
+    { id: "redo", source: "omp-undo-redo", enabled: false }
+  ])
+  const undo = await service.invokeAction("session-1", "undo")
+  assert.equal(undo.applied, true, "the revision change is authoritative even when replayed text is unchanged")
+  assert.equal(undo.sessionRevision, "0:user-1")
+  assert.equal(undo.actions.find((action) => action.id === "redo").enabled, true)
+  assert.deepEqual((await service.messages("session-1")).map((message) => message.parts[0].text), [
+    "Change the file",
+    "Changed the file"
+  ])
+
+  const redo = await service.invokeAction("session-1", "redo")
+  assert.equal(redo.applied, true)
+  assert.equal(redo.actions.find((action) => action.id === "redo").enabled, false)
+
+  nextUndoIsNoOp = true
+  const noOp = await service.invokeAction("session-1", "undo")
+  assert.equal(noOp.applied, false, "a fresh explicit extension result must report a no-op")
+})
+
+test("loads an external session from the extension-selected tree leaf", async () => {
+  const acp = new ExtensionActionAcp()
+  let selectedLeaf
+  const provider = {
+    id: "omp-undo-redo",
+    requiredCommands: ["undo", "redo"],
+    actions: [],
+    loadState: async () => ({
+      actions: [{ id: "undo", enabled: false }, { id: "redo", enabled: true }],
+      sessionRevision: "0:user-1",
+      activeSessionLeaf: "user-1"
+    })
+  }
+  const historyLoader = async (_sessionID, options) => {
+    selectedLeaf = options.activeSessionLeaf
+    return [{
+      info: { id: "user-1", role: "user", sessionID: "session-1", time: { created: Date.now() } },
+      parts: [{ id: "user-1:text", type: "text", text: "Change the file" }]
+    }]
+  }
+  const service = new AcpService(acp, { actionProviders: [provider], historyLoader })
+
+  assert.deepEqual((await service.messages("session-1")).map((message) => message.parts[0].text), ["Change the file"])
+  assert.equal(selectedLeaf, "user-1")
+  assert.equal(acp.loads, 0, "external history should not activate or replay the ACP session")
 })
 
 test("renames and hides ACP sessions through OpenCode-compatible endpoints", async () => {

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -41,9 +41,19 @@ First-party command, no third party in the path. The bridge uses `session/new`, 
 The bridge recognizes [`@baylarsadigov/omp-undo-redo`](https://www.npmjs.com/package/@baylarsadigov/omp-undo-redo)
 only when the active `omp acp` session advertises both `undo` and `redo`. The package remains a
 host-side OMP plugin; it is not an app or bridge dependency. Its command catalog proves that the
-handlers were registered in that runtime, while the bridge keeps the initial session-specific Redo
-state locally. A bridge restart or Undo/Redo performed elsewhere can therefore leave that enabled
-state stale until a new action or prompt updates it.
+handlers were registered in that runtime.
+
+Action availability and the active tree revision come from the extension-owned sidecar under the
+repository's Git common directory at `omp-undo-redo/history/<sha256-session-id>.json`. The bridge
+adapts the extension's durable schema 1 (`checkpoints` plus `currentIndex`) into `undo`/`redo`
+availability and an active leaf revision. A future sidecar may publish the normalized optional
+contract directly: `actions`, `sessionRevision`, `activeSessionLeaf`, and an invocation
+`actionResult` with a unique `token`. That token prevents a stale result from being attributed to a
+later invocation. The selected leaf also constrains JSONL reconstruction to the active parent chain,
+so abandoned append-only branches are not rendered after reload.
+
+If no authoritative sidecar is available, command execution returns `applied: null`; the bridge does
+not treat a transcript difference as proof of success or failure and keeps fallback Redo disabled.
 
 ### PI — ACP over stdio, via a third-party adapter
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2518,10 +2518,10 @@ function App() {
       } else if (capabilities.actions && extensionActions.some((action) => action.id === command)) {
         const result = await api.invokeAction(config, selectedSession.id, command, selectedSession.directory)
         setExtensionActions(result.actions)
-        if (!result.applied) {
+        if (result.applied === false) {
           setActionNotice(t(command === "undo" ? 'detail.nothingToUndo' : 'detail.nothingToRedo'))
         }
-        await loadSelected(selectedSession.id, selectedSession.directory, true, result.applied)
+        await loadSelected(selectedSession.id, selectedSession.directory, true, result.applied !== false)
       } else {
         await api.sendCommand(config, selectedSession.id, command, "", selectedSession.directory, activeModel, activeAgentID)
         await loadSelected(selectedSession.id, selectedSession.directory, true)

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -239,6 +239,7 @@ export type HarnessAction = {
 
 export type HarnessActionResult = {
   action: string
-  applied: boolean
+  applied: boolean | null
   actions: HarnessAction[]
+  sessionRevision?: string
 }

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -434,7 +434,8 @@ assert.ok(app.includes('capabilities.actions ? api.listActions'), 'the selected 
 assert.ok(app.includes('api.invokeAction(config, selectedSession.id, command, selectedSession.directory)'), 'OMP Undo/Redo should execute through the action API')
 assert.ok(app.includes('replaceMessages ? msg : mergeFetchedMessages(prev, msg)'), 'a successful Undo must be allowed to shrink the rendered conversation')
 assert.ok(app.includes('setExtensionActions(result.actions)'), 'action execution should apply the returned session-specific enabled state immediately')
-assert.ok(app.includes("if (!result.applied)"), 'a semantic no-op action must have an explicit frontend path')
+assert.ok(app.includes("if (result.applied === false)"), 'only an authoritative no-op result should show no-op feedback')
+assert.ok(app.includes('result.applied !== false'), 'unknown results should still refresh the active ACP context without being called no-ops')
 assert.ok(app.includes("command === \"undo\" ? 'detail.nothingToUndo' : 'detail.nothingToRedo'"), 'the no-op message should describe the attempted action')
 assert.ok(app.includes('{actionNotice && <div className=\"notice info fade-in\">'), 'no-op action feedback should render as visible information rather than an error')
 


### PR DESCRIPTION
## Summary

- read authoritative Undo/Redo availability and active tree revision from the `omp-undo-redo` sidecar
- derive `applied` from extension revisions or a token-correlated explicit action result, never from transcript differences
- rebuild external OMP history from the extension-selected parent chain so abandoned append-only branches are not rendered
- return `applied: null` when no authoritative extension state exists and keep fallback Redo disabled
- refresh the active ACP context for unknown results without showing false no-op feedback

## Protocol

The adapter supports the extension's current durable schema 1 (`checkpoints` + `currentIndex`) and a normalized optional sidecar contract with `actions`, `sessionRevision`, `activeSessionLeaf`, and token-correlated `actionResult`.

## Verification

- `cd bridge && npm test` — 58 passed
- `cd web && npm run test:ui` — passed
- `cd web && npm run build` — passed
- web i18n, settings, model, events, profiles, and config regression checks — passed
- live installed `omp-undo-redo` schema-1 sidecar smoke check resolved revision `6:df8ecc4e`; active JSONL reconstruction ended at leaf `df8ecc4e`

Closes #101
