### PR TITLE
fix(bridge): support OMP undo/redo outside Git

### DIFF
--- a/bridge/src/acp-client.js
+++ b/bridge/src/acp-client.js
@@ -33,6 +33,10 @@ export class AcpClient extends EventEmitter {
     return this.#agentInfo
   }
 
+  /** PID identifies extension runtime state published by this exact ACP process. */
+  get processID() {
+    return Number.isInteger(this.#child?.pid) ? this.#child.pid : undefined
+  }
 
   async start() {
     if (this.#child) return

--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -379,7 +379,7 @@ export class AcpService {
     const state = await loadExtensionActionState(
       this.#actionProviders,
       requireCommands ? this.#commandCatalogs.get(sessionID) ?? [] : undefined,
-      { sessionID, directory: session.cwd }
+      { sessionID, directory: session.cwd, processID: this.#acp.processID }
     )
     if (state) this.#authoritativeActionStates.set(sessionID, state)
     else this.#authoritativeActionStates.delete(sessionID)

--- a/bridge/src/extension-actions.js
+++ b/bridge/src/extension-actions.js
@@ -21,13 +21,22 @@ function availableProviders(providers, commands) {
 }
 
 export function listExtensionActions(providers, commands, state, busy = false, authoritativeState) {
-  return availableProviders(providers, commands).flatMap((provider) => provider.actions.map((action) => ({
-    id: action.id,
-    source: provider.id,
-    enabled: !busy && (authoritativeState?.source === provider.id
-      ? authoritativeState.actions.find((candidate) => candidate.id === action.id)?.enabled ?? false
-      : state.get(action.id) ?? action.enabledByDefault)
-  })))
+  return availableProviders(providers, commands).flatMap((provider) => {
+    if (authoritativeState?.source === provider.id) {
+      return provider.actions.map((action) => ({
+        id: action.id,
+        source: provider.id,
+        enabled: !busy && (authoritativeState.actions.find((candidate) => candidate.id === action.id)?.enabled ?? false)
+      }))
+    }
+    // Stateful providers stay hidden until their availability is authoritative.
+    if (provider.loadState) return []
+    return provider.actions.map((action) => ({
+      id: action.id,
+      source: provider.id,
+      enabled: !busy && (state.get(action.id) ?? action.enabledByDefault)
+    }))
+  })
 }
 
 export async function loadExtensionActionState(providers, commands, context) {

--- a/bridge/src/omp-extension-action-state.js
+++ b/bridge/src/omp-extension-action-state.js
@@ -1,37 +1,51 @@
 import { execFile } from "node:child_process"
 import { createHash } from "node:crypto"
-import { readFile } from "node:fs/promises"
+import { readFile, stat } from "node:fs/promises"
+import { homedir } from "node:os"
 import path from "node:path"
 import { promisify } from "node:util"
 
 const execFileAsync = promisify(execFile)
 const ACTION_IDS = new Set(["undo", "redo"])
+const MAX_STATE_BYTES = 64 * 1024
+const RUNTIME_MARKER_PROTOCOL = "omp-undo-redo/runtime"
+const ACTION_STATE_PROTOCOL = "omp-undo-redo/action-state"
 
 function sessionHash(sessionID) {
   return createHash("sha256").update(sessionID).digest("hex")
 }
 
+async function readBoundedJSON(file) {
+  const metadata = await stat(file)
+  if (!metadata.isFile() || metadata.size <= 0 || metadata.size > MAX_STATE_BYTES) return undefined
+  const source = await readFile(file, "utf8")
+  if (Buffer.byteLength(source, "utf8") > MAX_STATE_BYTES) return undefined
+  return JSON.parse(source)
+}
+
 function normalizeProtocolState(value) {
   if (!value || typeof value !== "object" || !Array.isArray(value.actions)) return undefined
-  if (typeof value.sessionRevision !== "string") return undefined
+  if (typeof value.sessionRevision !== "string" || !value.sessionRevision) return undefined
+  if (value.activeSessionLeaf !== null && typeof value.activeSessionLeaf !== "string") return undefined
   const actions = value.actions.flatMap((action) => (
     ACTION_IDS.has(action?.id) && typeof action.enabled === "boolean"
       ? [{ id: action.id, enabled: action.enabled }]
       : []
   ))
-  if (actions.length !== ACTION_IDS.size) return undefined
+  if (actions.length !== ACTION_IDS.size || new Set(actions.map((action) => action.id)).size !== ACTION_IDS.size) {
+    return undefined
+  }
   const actionResult = value.actionResult &&
     ACTION_IDS.has(value.actionResult.id) &&
     typeof value.actionResult.applied === "boolean" &&
-    typeof value.actionResult.token === "string"
+    typeof value.actionResult.token === "string" &&
+    value.actionResult.token
     ? { id: value.actionResult.id, applied: value.actionResult.applied, token: value.actionResult.token }
     : undefined
   return {
     actions,
     sessionRevision: value.sessionRevision,
-    activeSessionLeaf: value.activeSessionLeaf === null || typeof value.activeSessionLeaf === "string"
-      ? value.activeSessionLeaf
-      : undefined,
+    activeSessionLeaf: value.activeSessionLeaf,
     actionResult
   }
 }
@@ -55,12 +69,33 @@ function normalizeLegacyHistory(value, expectedHash) {
   }
 }
 
-/**
- * Reads the optional state contract published by omp-undo-redo. Schema 1 is the
- * extension's durable navigation store; newer publishers may expose the small
- * normalized actions/sessionRevision contract directly in the same sidecar.
- */
-export function createOmpUndoRedoActionStateLoader({ runGit = execFileAsync } = {}) {
+function normalizeRuntimeMarker(value, processID) {
+  if (
+    value?.schemaVersion !== 1 ||
+    value.protocol !== RUNTIME_MARKER_PROTOCOL ||
+    value.pid !== processID ||
+    typeof value.runtimeId !== "string" ||
+    !value.runtimeId
+  ) return undefined
+  return { pid: value.pid, runtimeId: value.runtimeId }
+}
+
+function normalizeRuntimeState(value, marker, expectedHash) {
+  if (
+    value?.schemaVersion !== 2 ||
+    value.protocol !== ACTION_STATE_PROTOCOL ||
+    value.sessionHash !== expectedHash ||
+    value.pid !== marker.pid ||
+    value.runtimeId !== marker.runtimeId
+  ) return undefined
+  return normalizeProtocolState(value)
+}
+
+/** Reads authoritative live state first, then falls back to durable Git schema 1. */
+export function createOmpUndoRedoActionStateLoader({
+  runGit = execFileAsync,
+  runtimeRoot = process.env.OMP_UNDO_REDO_RUNTIME_DIR ?? path.join(homedir(), ".omp", "omp-undo-redo", "runtime")
+} = {}) {
   const commonDirectories = new Map()
 
   async function resolveCommonDirectory(directory) {
@@ -84,17 +119,38 @@ export function createOmpUndoRedoActionStateLoader({ runGit = execFileAsync } = 
     }
   }
 
-  return async function loadOmpUndoRedoActionState({ sessionID, directory }) {
-    if (!sessionID || !directory) return undefined
+  async function loadRuntimeState(expectedHash, processID) {
+    if (!Number.isInteger(processID) || processID <= 0) return undefined
+    try {
+      const runtimeDirectory = path.join(runtimeRoot, String(processID))
+      const marker = normalizeRuntimeMarker(
+        await readBoundedJSON(path.join(runtimeDirectory, "runtime.json")),
+        processID
+      )
+      if (!marker) return undefined
+      const value = await readBoundedJSON(path.join(runtimeDirectory, "sessions", `${expectedHash}.json`))
+      return normalizeRuntimeState(value, marker, expectedHash)
+    } catch {
+      return undefined
+    }
+  }
+
+  async function loadGitState(expectedHash, directory) {
+    if (!directory) return undefined
     try {
       const commonDirectory = await resolveCommonDirectory(directory)
       if (!commonDirectory) return undefined
-      const expectedHash = sessionHash(sessionID)
       const statePath = path.join(commonDirectory, "omp-undo-redo", "history", `${expectedHash}.json`)
-      const value = JSON.parse(await readFile(statePath, "utf8"))
+      const value = await readBoundedJSON(statePath)
       return normalizeProtocolState(value) ?? normalizeLegacyHistory(value, expectedHash)
     } catch {
       return undefined
     }
+  }
+
+  return async function loadOmpUndoRedoActionState({ sessionID, directory, processID }) {
+    if (!sessionID) return undefined
+    const expectedHash = sessionHash(sessionID)
+    return await loadRuntimeState(expectedHash, processID) ?? await loadGitState(expectedHash, directory)
   }
 }

--- a/bridge/src/omp-session-history.js
+++ b/bridge/src/omp-session-history.js
@@ -40,6 +40,9 @@ export function createOmpHistoryLoader(sessionRoot = path.join(homedir(), ".omp"
   }
 
   return async function loadOmpHistory(sessionID, { activeSessionLeaf } = {}) {
+    // JSONL is append-only: its final record may belong to an abandoned branch.
+    // Without an authoritative selected leaf, ACP replay is safer than guessing.
+    if (activeSessionLeaf === undefined) return []
     const file = await locateSession(sessionID)
     if (!file) return []
     const records = []
@@ -59,13 +62,12 @@ export function createOmpHistoryLoader(sessionRoot = path.join(homedir(), ".omp"
     }
 
     const selected = []
-    const leafID = activeSessionLeaf !== undefined ? activeSessionLeaf : records.at(-1)?.id
-    if (leafID === null) {
+    if (activeSessionLeaf === null) {
       // The extension selected the session root.
-    } else if (leafID && entries.has(leafID)) {
+    } else if (entries.has(activeSessionLeaf)) {
       const branch = []
       const visited = new Set()
-      let entry = entries.get(leafID)
+      let entry = entries.get(activeSessionLeaf)
       while (entry && !visited.has(entry.id)) {
         visited.add(entry.id)
         branch.push(entry)
@@ -73,7 +75,7 @@ export function createOmpHistoryLoader(sessionRoot = path.join(homedir(), ".omp"
       }
       selected.push(...branch.reverse())
     } else {
-      selected.push(...records)
+      throw new Error("OMP active session leaf is missing from transcript")
     }
 
     const messages = []

--- a/bridge/test/acp-client.test.js
+++ b/bridge/test/acp-client.test.js
@@ -5,6 +5,7 @@ import { AcpClient } from "../src/acp-client.js"
 
 class FakeChild extends EventEmitter {
   killed = false
+  pid = 4242
   stdout = new EventEmitter()
   stderr = new EventEmitter()
   writes = []
@@ -74,7 +75,9 @@ test("initializes, authenticates, and lists ACP sessions", async () => {
 
   assert.deepEqual(await client.listSessions(), [{ sessionId: "session-1" }])
   assert.deepEqual(client.agentInfo, { name: "oh-my-pi", version: "17.0.7" })
+  assert.equal(client.processID, 4242)
   client.close()
+  assert.equal(client.processID, undefined)
 })
 
 test("launches an ACP adapter with the configured command and arguments", async () => {

--- a/bridge/test/omp-extension-action-state.test.js
+++ b/bridge/test/omp-extension-action-state.test.js
@@ -41,6 +41,110 @@ test("normalizes the omp-undo-redo navigation store into authoritative action st
   }
 })
 
+test("returns no authoritative state outside Git instead of synthesizing action availability", async () => {
+  let calls = 0
+  const loadState = createOmpUndoRedoActionStateLoader({
+    runGit: async () => {
+      calls += 1
+      throw new Error("fatal: not a git repository")
+    }
+  })
+
+  assert.equal(await loadState({ sessionID, directory: tmpdir() }), undefined)
+  assert.equal(calls, 1)
+})
+
+test("loads authoritative runtime state for a non-Git ACP process", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-runtime-"))
+  const processID = 4242
+  const runtimeDirectory = path.join(root, String(processID))
+  const sessionsDirectory = path.join(runtimeDirectory, "sessions")
+  await mkdir(sessionsDirectory, { recursive: true })
+  await writeFile(path.join(runtimeDirectory, "runtime.json"), JSON.stringify({
+    schemaVersion: 1,
+    protocol: "omp-undo-redo/runtime",
+    runtimeId: "runtime-1",
+    pid: processID,
+    startedAt: "2026-08-01T12:00:00.000Z"
+  }))
+  await writeFile(path.join(sessionsDirectory, `${sessionHash}.json`), JSON.stringify({
+    schemaVersion: 2,
+    protocol: "omp-undo-redo/action-state",
+    sessionHash,
+    runtimeId: "runtime-1",
+    pid: processID,
+    actions: [{ id: "undo", enabled: false }, { id: "redo", enabled: true }],
+    sessionRevision: "runtime-revision-2",
+    activeSessionLeaf: "user-1",
+    actionResult: { id: "undo", applied: true, token: "runtime-action-1" }
+  }))
+  const loadState = createOmpUndoRedoActionStateLoader({
+    runtimeRoot: root,
+    runGit: async () => { throw new Error("fatal: not a git repository") }
+  })
+
+  try {
+    assert.deepEqual(await loadState({ sessionID, directory: root, processID }), {
+      actions: [{ id: "undo", enabled: false }, { id: "redo", enabled: true }],
+      sessionRevision: "runtime-revision-2",
+      activeSessionLeaf: "user-1",
+      actionResult: { id: "undo", applied: true, token: "runtime-action-1" }
+    })
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test("rejects runtime state from a different ACP process or runtime", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-runtime-"))
+  const runtimeDirectory = path.join(root, "4242")
+  await mkdir(path.join(runtimeDirectory, "sessions"), { recursive: true })
+  await writeFile(path.join(runtimeDirectory, "runtime.json"), JSON.stringify({
+    schemaVersion: 1,
+    protocol: "omp-undo-redo/runtime",
+    runtimeId: "current-runtime",
+    pid: 4242
+  }))
+  await writeFile(path.join(runtimeDirectory, "sessions", `${sessionHash}.json`), JSON.stringify({
+    schemaVersion: 2,
+    protocol: "omp-undo-redo/action-state",
+    sessionHash,
+    runtimeId: "stale-runtime",
+    pid: 4242,
+    actions: [{ id: "undo", enabled: true }, { id: "redo", enabled: false }],
+    sessionRevision: "stale",
+    activeSessionLeaf: "assistant-1"
+  }))
+  const loadState = createOmpUndoRedoActionStateLoader({
+    runtimeRoot: root,
+    runGit: async () => { throw new Error("fatal: not a git repository") }
+  })
+
+  try {
+    assert.equal(await loadState({ sessionID, directory: root, processID: 4242 }), undefined)
+    assert.equal(await loadState({ sessionID, directory: root, processID: 9999 }), undefined)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test("rejects normalized action state without an authoritative active leaf", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-actions-"))
+  const historyDirectory = path.join(root, "omp-undo-redo", "history")
+  await mkdir(historyDirectory, { recursive: true })
+  await writeFile(path.join(historyDirectory, `${sessionHash}.json`), JSON.stringify({
+    actions: [{ id: "undo", enabled: false }, { id: "redo", enabled: true }],
+    sessionRevision: "revision-2"
+  }))
+  const loadState = createOmpUndoRedoActionStateLoader({ runGit: async () => ({ stdout: root }) })
+
+  try {
+    assert.equal(await loadState({ sessionID, directory: root }), undefined)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
 test("accepts the normalized optional action protocol with an explicit invocation result", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-actions-"))
   const historyDirectory = path.join(root, "omp-undo-redo", "history")

--- a/bridge/test/omp-session-history.test.js
+++ b/bridge/test/omp-session-history.test.js
@@ -5,7 +5,7 @@ import path from "node:path"
 import test from "node:test"
 import { createOmpHistoryLoader } from "../src/omp-session-history.js"
 
-test("reads persisted user and assistant text from an OMP session transcript", async () => {
+test("reads only the authoritative branch from an OMP session transcript", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-history-"))
   const nested = path.join(root, "workspace")
   await mkdir(nested)
@@ -20,7 +20,9 @@ test("reads persisted user and assistant text from an OMP session transcript", a
 
   try {
     const loadHistory = createOmpHistoryLoader(root)
-    const messages = await loadHistory(sessionID)
+    assert.deepEqual(await loadHistory(sessionID), [], "append order must not be treated as the active branch")
+
+    const messages = await loadHistory(sessionID, { activeSessionLeaf: "assistant-1" })
     assert.deepEqual(messages.map((message) => [message.info.role, message.parts.map((part) => [part.type, part.text])]), [
       ["user", [["text", "Question"]]],
       ["assistant", [["reasoning", "hidden"], ["text", "Answer"]]]
@@ -28,6 +30,10 @@ test("reads persisted user and assistant text from an OMP session transcript", a
 
     const undone = await loadHistory(sessionID, { activeSessionLeaf: "user-1" })
     assert.deepEqual(undone.map((message) => message.parts[0].text), ["Question"])
+    await assert.rejects(
+      loadHistory(sessionID, { activeSessionLeaf: "missing-leaf" }),
+      /active session leaf is missing/
+    )
   } finally {
     await rm(root, { recursive: true, force: true })
   }

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -297,6 +297,7 @@ class HeldTurnOmpAcp extends EventEmitter {
 
 class ExtensionActionAcp extends EventEmitter {
   agentInfo = { version: "17.1.3" }
+  processID = 4242
   prompts = []
   commands
   loads = 0
@@ -689,25 +690,19 @@ test("does not advertise extension actions when OMP did not load their commands"
   }
 })
 
-test("does not infer extension action success from transcript changes", async () => {
+test("does not advertise extension actions without authoritative state", async () => {
   const acp = new ExtensionActionAcp()
   const bridge = await startServer({ acp })
   try {
-    await readJSON(bridge.baseURL, "/session/session-1/action")
-    const first = await readJSON(bridge.baseURL, "/session/session-1/action/undo", {
+    assert.deepEqual(await readJSON(bridge.baseURL, "/session/session-1/action"), [])
+    const response = await fetch(`${bridge.baseURL}/session/session-1/action/undo`, {
       method: "POST",
       headers: jsonHeaders(),
       body: "{}"
     })
-    const second = await readJSON(bridge.baseURL, "/session/session-1/action/undo", {
-      method: "POST",
-      headers: jsonHeaders(),
-      body: "{}"
-    })
-
-    assert.equal(first.applied, null)
-    assert.equal(second.applied, null)
-    assert.equal(second.actions.find((action) => action.id === "redo").enabled, false)
+    assert.equal(response.status, 400)
+    assert.match((await response.json()).error, /not available/)
+    assert.deepEqual(acp.prompts, [])
   } finally {
     await bridge.close()
   }
@@ -805,6 +800,35 @@ test("loads an external session from the extension-selected tree leaf", async ()
   assert.deepEqual((await service.messages("session-1")).map((message) => message.parts[0].text), ["Change the file"])
   assert.equal(selectedLeaf, "user-1")
   assert.equal(acp.loads, 0, "external history should not activate or replay the ACP session")
+})
+
+test("replays ACP history when extension state is unavailable", async () => {
+  const acp = new ExtensionActionAcp()
+  let selectedLeaf = "not-called"
+  let stateProcessID
+  const provider = {
+    id: "omp-undo-redo",
+    requiredCommands: ["undo", "redo"],
+    actions: [{ id: "undo", command: "undo", enabledByDefault: true }],
+    loadState: async ({ processID }) => {
+      stateProcessID = processID
+      return undefined
+    }
+  }
+  const historyLoader = async (_sessionID, options) => {
+    selectedLeaf = options.activeSessionLeaf
+    return []
+  }
+  const service = new AcpService(acp, { actionProviders: [provider], historyLoader })
+
+  assert.deepEqual((await service.messages("session-1")).map((message) => message.parts[0].text), [
+    "Change the file",
+    "Changed the file"
+  ])
+  assert.equal(selectedLeaf, undefined)
+  assert.equal(stateProcessID, 4242)
+  assert.equal(acp.loads, 1, "ACP must supply active branch when no authoritative leaf exists")
+  assert.deepEqual(await service.actions("session-1"), [])
 })
 
 test("renames and hides ACP sessions through OpenCode-compatible endpoints", async () => {

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -43,17 +43,22 @@ only when the active `omp acp` session advertises both `undo` and `redo`. The pa
 host-side OMP plugin; it is not an app or bridge dependency. Its command catalog proves that the
 handlers were registered in that runtime.
 
-Action availability and the active tree revision come from the extension-owned sidecar under the
-repository's Git common directory at `omp-undo-redo/history/<sha256-session-id>.json`. The bridge
-adapts the extension's durable schema 1 (`checkpoints` plus `currentIndex`) into `undo`/`redo`
-availability and an active leaf revision. A future sidecar may publish the normalized optional
-contract directly: `actions`, `sessionRevision`, `activeSessionLeaf`, and an invocation
-`actionResult` with a unique `token`. That token prevents a stale result from being attributed to a
-later invocation. The selected leaf also constrains JSONL reconstruction to the active parent chain,
-so abandoned append-only branches are not rendered after reload.
+Live action availability comes from extension version 1.1.0 or newer under
+`~/.omp/omp-undo-redo/runtime/<acp-pid>/`. The bridge validates the runtime marker against the exact
+ACP child PID, then reads schema-2 session state containing `actions`, `sessionRevision`,
+`activeSessionLeaf`, and an invocation `actionResult` with a unique `token`. Process and runtime IDs
+prevent stale or concurrent OMP state from controlling the session. This contract works for both Git
+and session-only workspaces.
 
-If no authoritative sidecar is available, command execution returns `applied: null`; the bridge does
-not treat a transcript difference as proof of success or failure and keeps fallback Redo disabled.
+The repository Git common-directory sidecar at
+`omp-undo-redo/history/<sha256-session-id>.json` remains the durable fallback. The bridge adapts its
+schema 1 (`checkpoints` plus `currentIndex`) into action availability and an active leaf revision.
+The selected leaf constrains JSONL reconstruction to the active parent chain, so abandoned
+append-only branches are not rendered after reload.
+
+If neither authoritative source is available, the bridge hides Undo/Redo instead of synthesizing
+availability from defaults. It also declines to select an active branch from JSONL append order and
+lets ACP replay the live branch.
 
 ### PI — ACP over stdio, via a third-party adapter
 


### PR DESCRIPTION
## Summary

Fixes the remaining OMP Undo/Redo integration gap for session-only workspaces outside Git.

- consume the extension's PID-scoped schema-2 runtime action state from `@baylarsadigov/omp-undo-redo` v1.1.0+
- validate ACP PID, runtime ID, session hash, action availability, revision, active leaf, and invocation token
- prefer live runtime state while retaining the durable Git schema-1 sidecar as fallback
- hide actions when no authoritative state exists instead of synthesizing availability from defaults
- avoid treating the final append-only JSONL record as the active branch; use ACP replay when no authoritative leaf exists
- reject stale state from another process/runtime

## Why

In a non-Git scratch workspace, `git rev-parse --git-common-dir` cannot locate the old sidecar. That left Undo on fallback defaults, never enabled Redo, and could render an abandoned JSONL branch. Extension v1.1.0 now publishes equivalent runtime state independently of Git, so the bridge can use the actual live session tree.

## Testing

- `cd bridge && npm test`
- 63 tests passed
- added runtime non-Git, stale-runtime rejection, ACP PID propagation, unavailable-state replay, and authoritative-branch coverage

Closes #103. Related: #101, #102.