### PR TITLE
feat(web): expose session actions when the transcript is empty

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -34,7 +34,8 @@ import {
   RefreshIcon,
   OfflineIcon,
   PencilIcon,
-  CloseIcon
+  CloseIcon,
+  MoreVerticalIcon
 } from "./Icons"
 
 const REMARK_PLUGINS = [remarkGfm]
@@ -1512,6 +1513,74 @@ type MessageMenuAction = {
   onSelect: () => void
 }
 
+/** A ⋯ control in the conversation header exposing session-level actions from the connected
+ *  harness/extension (currently Undo/Redo). The message context menu only reaches those actions
+ *  when a bubble exists to host it — an Undo that empties the transcript leaves Redo enabled but
+ *  unreachable, so the header menu is the interaction surface that never depends on transcript
+ *  contents. Availability still comes from the harness via the caller. */
+function SessionActionsMenu({
+  actions,
+  t
+}: {
+  actions: MessageMenuAction[]
+  t: Translator
+}) {
+  const [open, setOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const dismiss = (event: PointerEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) setOpen(false)
+    }
+    const dismissOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false)
+    }
+    const dismissOnResize = () => setOpen(false)
+    window.addEventListener("pointerdown", dismiss)
+    window.addEventListener("keydown", dismissOnEscape)
+    window.addEventListener("resize", dismissOnResize)
+    return () => {
+      window.removeEventListener("pointerdown", dismiss)
+      window.removeEventListener("keydown", dismissOnEscape)
+      window.removeEventListener("resize", dismissOnResize)
+    }
+  }, [open])
+
+  return (
+    <div className="session-actions" ref={menuRef}>
+      <button
+        type="button"
+        className="btn-icon session-actions-toggle"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label={t('detail.sessionActions')}
+        title={t('detail.sessionActions')}
+      >
+        <MoreVerticalIcon size={20} />
+      </button>
+      {open && (
+        <div className="session-actions-menu" role="menu">
+          {actions.map((action) => (
+            <button
+              key={action.id}
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setOpen(false)
+                action.onSelect()
+              }}
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 /** Wraps a bubble in the copy menu. Takes the text to copy rather than a message, because what a
  *  bubble shows is not always one message's text: a run merges several, and some carry none at all. */
 function MessageContextMenu({
@@ -2109,6 +2178,24 @@ function App() {
     const supportsRedo = config.backend === "opencode" || !!redoAction || supported.has("redo")
     if (supportsUndo && hasUndo) actions.push({ id: "undo", label: t('detail.undo'), onSelect: () => void runNativeHistoryCommand("undo") })
     if (supportsRedo && hasRedo) actions.push({ id: "redo", label: t('detail.redo'), onSelect: () => void runNativeHistoryCommand("redo") })
+    return actions
+  }, [commands, config.backend, extensionActions, messages, selectedSession?.revertMessageID, t])
+  /** Session-level actions for the header ⋯ menu. Unlike the message context menu, availability
+   *  follows the harness/extension's own enabled state rather than the transcript contents: an
+   *  Undo that empties the conversation leaves Redo enabled but with no bubble left to host a menu,
+   *  so this menu stays reachable and mirrors exactly what the bridge reports. */
+  const sessionHeaderActions = useMemo(() => {
+    const supported = new Set(commands.map((command) => command.name.toLowerCase()))
+    const actions: MessageMenuAction[] = []
+    const revertMessageID = selectedSession?.revertMessageID
+    const undoAction = extensionActions.find((action) => action.id === "undo")
+    const redoAction = extensionActions.find((action) => action.id === "redo")
+    const hasUndo = config.backend === "opencode"
+      ? messages.some((message) => message.info.role === "user" && (!revertMessageID || message.info.id < revertMessageID))
+      : undoAction ? undoAction.enabled : supported.has("undo")
+    const hasRedo = config.backend === "opencode" ? !!revertMessageID : redoAction ? redoAction.enabled : supported.has("redo")
+    if (hasUndo) actions.push({ id: "undo", label: t('detail.undo'), onSelect: () => void runNativeHistoryCommand("undo") })
+    if (hasRedo) actions.push({ id: "redo", label: t('detail.redo'), onSelect: () => void runNativeHistoryCommand("redo") })
     return actions
   }, [commands, config.backend, extensionActions, messages, selectedSession?.revertMessageID, t])
   const selectedNewSessionDirectory = normalizeDirectory(newSessionDirectory)
@@ -3991,6 +4078,9 @@ function App() {
                 </p>
                 )}
               </div>
+              {selectedSession && sessionHeaderActions.length > 0 && (
+                <SessionActionsMenu actions={sessionHeaderActions} t={t} />
+              )}
             </div>
 
           {selectedSession && (

--- a/web/src/Icons.tsx
+++ b/web/src/Icons.tsx
@@ -363,6 +363,26 @@ export const MenuIcon = ({ className = "", size = 20 }: { className?: string; si
   </svg>
 )
 
+export const MoreVerticalIcon = ({ className = "", size = 20 }: { className?: string; size?: number }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    role="img"
+    aria-label="More actions"
+  >
+    <circle cx="12" cy="5" r="1" />
+    <circle cx="12" cy="12" r="1" />
+    <circle cx="12" cy="19" r="1" />
+  </svg>
+)
+
 export const CloseIcon = ({ className = "", size = 20 }: { className?: string; size?: number }) => (
   <svg 
     width={size} 

--- a/web/src/i18n.test.mjs
+++ b/web/src/i18n.test.mjs
@@ -26,6 +26,10 @@ assert.equal(en('detail.nothingToUndo'), 'Nothing to undo in this session.')
 assert.equal(it('detail.nothingToRedo'), 'Non c’è nulla da ripristinare in questa sessione.')
 assert.equal(zh('detail.nothingToUndo'), '此工作階段沒有可復原的內容。')
 
+assert.equal(en('detail.sessionActions'), 'Session actions')
+assert.equal(it('detail.sessionActions'), 'Azioni sessione')
+assert.equal(zh('detail.sessionActions'), '工作階段動作')
+
 // Unknown keys should remain visible during development instead of rendering blank UI.
 assert.equal(en('missing.key'), 'missing.key')
 assert.equal(en('detail.opencode'), '🤖 OpenCode')

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -103,6 +103,7 @@ type TranslationKey =
   | 'detail.copyMarkdown'
   | 'detail.undo'
   | 'detail.redo'
+  | 'detail.sessionActions'
   | 'detail.nothingToUndo'
   | 'detail.nothingToRedo'
   | 'detail.revertToMessage'
@@ -338,6 +339,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.copyMarkdown': 'Copy as markdown',
     'detail.undo': 'Undo last turn',
     'detail.redo': 'Redo last undone turn',
+    'detail.sessionActions': 'Session actions',
     'detail.nothingToUndo': 'Nothing to undo in this session.',
     'detail.nothingToRedo': 'Nothing to redo in this session.',
     'detail.revertToMessage': 'Revert to this message',
@@ -572,6 +574,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.copyMarkdown': 'Copia come Markdown',
     'detail.undo': 'Annulla ultimo turno',
     'detail.redo': 'Ripristina ultimo turno annullato',
+    'detail.sessionActions': 'Azioni sessione',
     'detail.nothingToUndo': 'Non c’è nulla da annullare in questa sessione.',
     'detail.nothingToRedo': 'Non c’è nulla da ripristinare in questa sessione.',
     'detail.revertToMessage': 'Ripristina fino a questo messaggio',
@@ -806,6 +809,7 @@ const translations: Record<LanguageCode, Record<TranslationKey, string>> = {
     'detail.copyMarkdown': '複製為 Markdown',
     'detail.undo': '復原上一個回合',
     'detail.redo': '重做上一個復原的回合',
+    'detail.sessionActions': '工作階段動作',
     'detail.nothingToUndo': '此工作階段沒有可復原的內容。',
     'detail.nothingToRedo': '此工作階段沒有可重做的內容。',
     'detail.revertToMessage': '還原到這則訊息',

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1031,6 +1031,73 @@ p {
   outline-offset: -2px;
 }
 
+/* The header actions menu is a sibling of the conversation title, so it must hold its own
+   positioning context for the dropdown it opens — nothing up the tree is positioned. */
+.session-actions {
+  position: relative;
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+
+.session-actions-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-md);
+  color: var(--muted);
+}
+
+.session-actions-toggle:hover:not(:disabled) {
+  color: var(--text);
+  background: var(--surface-strong);
+}
+
+.session-actions-toggle[aria-expanded="true"] {
+  color: var(--primary);
+  background: var(--primary-soft);
+}
+
+.session-actions-menu {
+  position: absolute;
+  top: calc(100% + var(--space-1));
+  right: 0;
+  z-index: 20;
+  display: grid;
+  min-width: 232px;
+  gap: 2px;
+  padding: var(--space-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  box-shadow: var(--shadow-lg);
+}
+
+.session-actions-menu button {
+  width: 100%;
+  min-height: 36px;
+  padding: 0 var(--space-3);
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text);
+  justify-content: flex-start;
+  text-align: left;
+}
+
+@media (hover: hover) {
+  .session-actions-menu button:hover {
+    background: var(--surface-strong);
+  }
+}
+
+.session-actions-menu button:focus-visible {
+  background: var(--surface-strong);
+  outline: 2px solid var(--primary);
+  outline-offset: -2px;
+}
+
 .message-context-menu--touch {
   left: 50%;
   bottom: max(var(--space-4), env(safe-area-inset-bottom));
@@ -2349,6 +2416,12 @@ button.compact {
 
   .detail-topbar .pill {
     align-self: flex-start;
+  }
+
+  /* The header row stacks on mobile; keep the ⋯ control out of the title's wrapping flow and
+     aligned to the same right edge the desktop layout gives it. */
+  .header-row .session-actions {
+    margin-left: auto;
   }
 
   /* On mobile the whole page scrolls (the composer is pinned with fixed positioning), so the list

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -439,4 +439,23 @@ assert.ok(app.includes('result.applied !== false'), 'unknown results should stil
 assert.ok(app.includes("command === \"undo\" ? 'detail.nothingToUndo' : 'detail.nothingToRedo'"), 'the no-op message should describe the attempted action')
 assert.ok(app.includes('{actionNotice && <div className=\"notice info fade-in\">'), 'no-op action feedback should render as visible information rather than an error')
 
+// Session actions in the header (issue #104): Undo can strip the transcript to nothing, leaving
+// Redo enabled but unreachable through the message context menu, which needs a bubble to exist.
+// A header ⋯ menu must therefore render the harness actions independently of transcript contents.
+assert.ok(app.includes('function SessionActionsMenu'), 'session actions should have their own header menu component')
+assert.ok(app.includes('<MoreVerticalIcon'), 'the session actions menu should open from a ⋯ control in the conversation header')
+assert.match(app, /sessionHeaderActions\.length > 0 && \(/, 'the header actions menu should appear only when the harness offers actions')
+assert.match(app, /session-actions-menu/, 'the header actions menu should render harness actions as menu items')
+assert.match(app, /aria-haspopup="menu"/, 'the session actions toggle should announce that it opens a menu')
+assert.match(app, /aria-expanded=\{open\}/, 'the session actions toggle should reflect the menu open state for assistive tech')
+assert.ok(app.includes('detail.sessionActions'), 'the session actions toggle should have a translated accessible label')
+assert.match(
+  app,
+  /const hasRedo = config\.backend === "opencode" \? !!revertMessageID : redoAction \? redoAction\.enabled : supported\.has\("redo"\)/,
+  'the header menu must follow harness/extension availability instead of gating Redo on transcript contents'
+)
+assert.match(app, /session-actions-menu/, 'the header actions menu should have its own styles')
+assert.match(styles, /\.session-actions-menu\s*\{[\s\S]*?position:\s*absolute/, 'the header actions menu must overlay the conversation rather than push its layout')
+assert.match(styles, /\.session-actions-menu\s*\{[\s\S]*?z-index:\s*20/, 'the header actions menu must stack above the message list')
+
 console.log('ui regression tests passed')


### PR DESCRIPTION
Closes #104

## Problem

Harness actions such as Undo and Redo were only reachable through the context menu attached to message bubbles. After Undo removes the visible transcript, no bubble is left to host that menu, so an enabled Redo became unreachable in the web app.

## Solution

Added an always-available session actions menu (\⋯\) in the conversation header, rendering the harness/extension-provided actions (currently Undo/Redo):

- \SessionActionsMenu\ component: header control with a dropdown, closes on outside click, Escape, or resize.
- \sessionHeaderActions\: availability follows the harness/extension's own enabled state rather than transcript contents, so Redo stays reachable even when Undo emptied the conversation.
- Message context menu keeps the same actions as convenient shortcuts.
- New \MoreVerticalIcon\, \detail.sessionActions\ i18n keys (en/it/zh-TW), and dedicated CSS (overlay stacking, mobile layout).

## Acceptance criteria

- If Redo is enabled and the transcript is empty, the user can invoke it from the session header. ✓
- Undo/Redo availability continues to come from the connected harness/extension. ✓
- Layout works in both mobile and desktop views. ✓

Tests updated: ui-regression, i18n.