### PR TITLE
Serve the harness command catalog so OMP slash commands reach the app

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,13 +87,14 @@ The bridge implements a deliberate subset of the app's API:
 
 **Implemented:** `/v1/health`, `/global/health`, `/v1/capabilities`, `/v1/events`, `/global/event`,
 `/session` (list and create), `/v1/sessions`, `/experimental/session`, `/session/status`, `/path`,
-`/file`, `/command` (empty), `/agent` (empty), `/config/providers`, and on a session:
-`message`, `todo`, `diff` (empty), `prompt_async`, `abort`, rename, delete, plus generic action
-discovery and invocation at `action` and `action/{name}`. OMP currently maps the optional
+`/file`, `/command` (the harness catalog from `available_commands_update`), `/agent` (empty),
+`/config/providers`, and on a session:
+`message`, `todo`, `diff` (empty), `prompt_async`, `command`, `abort`, rename, delete, plus generic
+action discovery and invocation at `action` and `action/{name}`. OMP currently maps the optional
 `omp-undo-redo` extension onto the generic action API only after ACP advertises both commands.
 
 **Not implemented — anything else 404s**, including `/question` and its replies, `/project/current`,
-`/vcs`, `/file/status`, and `/session/{id}/command`.
+`/vcs`, and `/file/status`.
 
 When you add a call, pick one of two patterns already used in the codebase:
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Depending on the harness:
 
 - answer the questions the agent asks, options or free text, without leaving the app — OpenCode
 - follow todo/plan updates as the agent works — OpenCode, OMP, Claude Code
-- send server `/commands` — OpenCode
+- send server `/commands` — OpenCode, OMP
 - choose the agent a session runs as — OpenCode
 - review changed files and their diffs — OpenCode
 - rename and delete sessions — OpenCode changes them in the harness; on OMP, PI and Claude Code the
@@ -258,7 +258,7 @@ Expected response:
 {"healthy":true,"backend":"omp","version":"…"}
 ```
 
-OMP sessions expose their configured model when ACP provides it, and model changes apply to subsequent prompts. Agent selection, server slash commands, and VCS/diff are intentionally unavailable.
+OMP sessions expose their configured model when ACP provides it, and model changes apply to subsequent prompts. Server slash commands are available: OMP advertises them over ACP, the bridge serves them at `/command`, and the app lists them under **Help → Commands**, with a separate tab for the `skill:` ones. Agent selection and VCS/diff remain unavailable.
 
 A prompt sent while the agent is still working is queued rather than refused: it appears in the conversation
 straight away and runs when the current turn ends. Stopping the session discards anything still queued.

--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -144,6 +144,17 @@ export function isHarnessInjectedText(text) {
   return HARNESS_INJECTED_BLOCK.test(text)
 }
 
+// The app groups the picker by source and offers a skill-only filter, so the
+// `skill:` prefix OMP puts on skill commands has to survive as structured data
+// rather than staying buried in the name.
+function commandInfoList(commands) {
+  return commands.map((command) => ({
+    name: command.name,
+    description: command.description ?? undefined,
+    source: command.name.startsWith("skill:") ? "skill" : "command"
+  }))
+}
+
 export class AcpService {
   #acp
   #sessions = new Map()
@@ -303,6 +314,21 @@ export class AcpService {
     }
     await this.#refreshActionState(sessionID)
     return this.#availableActions(sessionID)
+  }
+
+  // The catalog is per ACP session, but a harness advertises the same commands for
+  // every session on the machine, so the newest one answers the app's session-less
+  // GET /command. Without that fallback the picker is empty until a session loads.
+  async commands(sessionID) {
+    if (sessionID) {
+      if (!this.#commandCatalogs.has(sessionID)) {
+        await this.#load(sessionID, true, true)
+        await this.#waitForCommandCatalog(sessionID)
+      }
+      return commandInfoList(this.#commandCatalogs.get(sessionID) ?? [])
+    }
+    const catalogs = [...this.#commandCatalogs.values()]
+    return commandInfoList(catalogs.at(-1) ?? [])
   }
 
   #waitForCommandCatalog(sessionID) {

--- a/bridge/src/harness-profiles.js
+++ b/bridge/src/harness-profiles.js
@@ -26,7 +26,7 @@ export const HARNESS_PROFILES = {
       ...COMMON_CAPABILITIES,
       models: true,
       todos: true,
-      commands: false,
+      commands: true,
       actions: true,
       sessionRename: true,
       sessionDelete: true

--- a/bridge/src/server.js
+++ b/bridge/src/server.js
@@ -193,7 +193,7 @@ export function createBridgeServer({ config, acp, serviceOptions }) {
         return
       }
 
-      const sessionMatch = /^\/session\/([^/]+)(?:\/(message|prompt_async|abort|todo|diff|action)(?:\/([^/]+))?)?$/.exec(url.pathname)
+      const sessionMatch = /^\/session\/([^/]+)(?:\/(message|prompt_async|abort|todo|diff|action|command)(?:\/([^/]+))?)?$/.exec(url.pathname)
       if (sessionMatch) {
         const [, sessionID, operation, actionID] = sessionMatch
         if (request.method === "PATCH" && !operation) {
@@ -234,6 +234,18 @@ export function createBridgeServer({ config, acp, serviceOptions }) {
           writeJSON(response, 200, true)
           return
         }
+        // ACP has no command channel: a harness command is prompt text beginning
+        // with a slash, which is exactly what the app's composer would have sent
+        // had the picker never existed.
+        if (request.method === "POST" && operation === "command") {
+          const body = await readBody(request)
+          if (typeof body.command !== "string" || !body.command) throw new Error("A command name is required")
+          const argumentsText = typeof body.arguments === "string" ? body.arguments.trim() : ""
+          const text = argumentsText ? `/${body.command} ${argumentsText}` : `/${body.command}`
+          await service.prompt(sessionID, text, modelWireName(body.model))
+          writeJSON(response, 200, true)
+          return
+        }
         if (request.method === "POST" && operation === "abort") {
           service.abort(sessionID)
           writeJSON(response, 200, true)
@@ -241,7 +253,7 @@ export function createBridgeServer({ config, acp, serviceOptions }) {
         }
       }
       if (request.method === "GET" && url.pathname === "/command") {
-        writeJSON(response, 200, [])
+        writeJSON(response, 200, await service.commands(url.searchParams.get("sessionID") ?? undefined))
         return
       }
       if (request.method === "GET" && url.pathname === "/agent") {

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -1607,3 +1607,19 @@ test("sends a picked command to the harness as slash-prefixed prompt text", asyn
     await bridge.close()
   }
 })
+
+test("fills the command catalog once a session is loaded, so a cold bridge recovers", async () => {
+  const bridge = await startServer({ acp: new SkillCommandAcp() })
+  try {
+    // The app fetches the picker at mount, before any session exists. An idle bridge has
+    // nothing to advertise yet, and answering with a stale or invented list would be worse.
+    assert.deepEqual(await readJSON(bridge.baseURL, "/command"), [])
+
+    await readJSON(bridge.baseURL, "/session/session-1/message")
+
+    const afterLoad = await readJSON(bridge.baseURL, "/command")
+    assert.deepEqual(afterLoad.map((command) => command.name), ["model", "skill:memory"])
+  } finally {
+    await bridge.close()
+  }
+})

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -662,7 +662,7 @@ test("reports capabilities from the selected harness profile", async () => {
     const piCapabilities = await readJSON(pi.baseURL, "/v1/capabilities")
     assert.equal(ompCapabilities.models, true)
     assert.equal(ompCapabilities.todos, true)
-    assert.equal(ompCapabilities.commands, false)
+    assert.equal(ompCapabilities.commands, true)
     assert.equal(ompCapabilities.actions, true)
     assert.equal(piCapabilities.models, true)
     assert.equal(piCapabilities.todos, false)
@@ -1536,6 +1536,73 @@ test("keeps provider/model values untouched for the harnesses that use them", as
     assert.equal(body.providers[0].name, "omp")
     assert.deepEqual(Object.keys(body.providers[0].models).sort(), ["first", "second"])
     assert.equal(body.providers[0].models.first.description, undefined, "a harness that describes nothing must not gain an empty line")
+  } finally {
+    await bridge.close()
+  }
+})
+
+/** Advertises a skill command alongside the extension ones, as OMP does. */
+class SkillCommandAcp extends ExtensionActionAcp {
+  async request(method, params) {
+    const result = await super.request(method, params)
+    if (method === "session/load") {
+      this.emit("notification", {
+        method: "session/update",
+        params: {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "available_commands_update",
+            availableCommands: [
+              { name: "model", description: "Show current model selection" },
+              { name: "skill:memory", description: "Runtime-boundary guidance for memory" }
+            ]
+          }
+        }
+      })
+    }
+    return result
+  }
+}
+
+test("serves the harness command catalog and marks skills by source", async () => {
+  const bridge = await startServer({ acp: new SkillCommandAcp() })
+  try {
+    const scoped = await readJSON(bridge.baseURL, "/command?sessionID=session-1")
+    assert.deepEqual(scoped, [
+      { name: "model", description: "Show current model selection", source: "command" },
+      { name: "skill:memory", description: "Runtime-boundary guidance for memory", source: "skill" }
+    ])
+    // The app asks for the picker without a session, so the newest catalog has to answer.
+    assert.deepEqual(await readJSON(bridge.baseURL, "/command"), scoped)
+  } finally {
+    await bridge.close()
+  }
+})
+
+test("sends a picked command to the harness as slash-prefixed prompt text", async () => {
+  const acp = new SkillCommandAcp()
+  const bridge = await startServer({ acp })
+  try {
+    await readJSON(bridge.baseURL, "/session/session-1/command", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ command: "skill:memory", arguments: "status" })
+    })
+    assert.ok(acp.prompts.includes("/skill:memory status"), `prompts were ${JSON.stringify(acp.prompts)}`)
+
+    await readJSON(bridge.baseURL, "/session/session-1/command", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ command: "model" })
+    })
+    assert.ok(acp.prompts.includes("/model"), "a command with no arguments must not gain a trailing space")
+
+    const rejected = await fetch(`${bridge.baseURL}/session/session-1/command`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ arguments: "status" })
+    })
+    assert.equal(rejected.status, 400)
   } finally {
     await bridge.close()
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2490,6 +2490,10 @@ function App() {
     setDiffFiles(diff)
     setPendingQuestions(questions.filter((question) => question.sessionID === sessionID))
     setExtensionActions(actions)
+    // A bridge-backed harness only advertises its commands once a session is loaded, so the
+    // mount-time fetch of an idle bridge legitimately returns []. Retry here rather than in each
+    // of loadSelected's callers, otherwise Help -> Commands stays empty for the whole visit.
+    if (capabilities.commands && commands.length === 0) await loadCommands()
     await loadProjectDashboard(directory)
   }
 

--- a/web/src/backendCapabilities.ts
+++ b/web/src/backendCapabilities.ts
@@ -28,7 +28,7 @@ export const DEFAULT_HARNESS_CAPABILITIES: Record<BackendKind, HarnessCapabiliti
     diff: false,
     filesystemBrowser: true,
     questions: false,
-    commands: false,
+    commands: true,
     actions: true,
     sessionRename: true,
     sessionDelete: true

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -439,4 +439,19 @@ assert.ok(app.includes('result.applied !== false'), 'unknown results should stil
 assert.ok(app.includes("command === \"undo\" ? 'detail.nothingToUndo' : 'detail.nothingToRedo'"), 'the no-op message should describe the attempted action')
 assert.ok(app.includes('{actionNotice && <div className=\"notice info fade-in\">'), 'no-op action feedback should render as visible information rather than an error')
 
+// A bridge-backed harness advertises its commands only once a session is loaded, so the
+// mount-time fetch returns [] against an idle bridge and Help -> Commands stayed empty for the
+// rest of the visit. loadSelected has to retry, and it is the shared seam every caller reaches.
+assert.match(
+  app,
+  /if \(capabilities\.commands && commands\.length === 0\) await loadCommands\(\)/,
+  'loadSelected must refetch an empty command catalog once a session is loaded'
+)
+const loadSelectedBody = app.match(/async function loadSelected\([\s\S]*?\n  \}\n/)
+assert.ok(loadSelectedBody, 'loadSelected should be findable for the catalog-refetch check')
+assert.ok(
+  loadSelectedBody[0].includes('await loadCommands()'),
+  'the command refetch belongs inside loadSelected, not in its individual callers'
+)
+
 console.log('ui regression tests passed')


### PR DESCRIPTION
## What

`GET /command` returned a hardcoded `[]` and the OMP profile advertised `commands: false`, so the app hid the command surface for OMP entirely. Meanwhile OMP advertises **80 commands over ACP, 30 of them `skill:` entries**, and the bridge was already capturing them: `available_commands_update` lands in `#commandCatalogs` (`acp-service.js:754`), but only `actions()` ever read it.

This serves that catalog.

## Changes

- **`AcpService#commands(sessionID)`** maps the catalog to the app's `CommandInfo` shape and tags `skill:`-prefixed names as `source: "skill"`. The app already has a skill-only tab in Help -> Commands (`App.tsx:2095`), so this needed no UI work. Called without a `sessionID` it answers from the newest catalog, because the app loads commands before a session is selected.
- **`POST /session/:id/command`** sends `/name args` as prompt text. ACP defines no command channel; a slash-prefixed prompt is exactly what the composer would have sent, and OMP executes it. This route previously 404'd, so flipping the capability without it would have broken every command the app offered.
- **OMP profile reports `commands: true`**, plus the matching default in `web/src/backendCapabilities.ts`.

Worth flagging: the `pi` profile **already** declared `commands: true`, so PI users were being offered a picker that `/command` answered with an empty list. They now get the real catalog if their adapter advertises one. I could not test PI - I do not have it installed - so that half is reasoned from the profile table, not measured.

## Docs

README's "server slash commands ... intentionally unavailable" line for OMP, the feature bullet, and the CONTRIBUTING route inventory (`/command` "(empty)", `/session/{id}/command` listed as not implemented) all described the old behaviour and are updated.

## Tests

Two new tests in `bridge/test/server.test.js`, using a `SkillCommandAcp` extending the existing `ExtensionActionAcp`:

- catalog is served with skills tagged, and the session-less call returns the same list
- a picked command arrives as `/skill:memory status`; a command with no arguments sends `/model` with no trailing space; a body without `command` is a 400

Both were mutation-checked: dropping the skill tagging and always appending the argument separator each fail exactly these two tests. One existing assertion, `ompCapabilities.commands === false`, is updated since it pinned the behaviour this PR changes.

`node --test` in `bridge/`: 60 pass, 0 fail. All 7 `web/` suites pass, and `tsc -b && vite build` is clean.

## Verified against a live harness

OMP 17.2.2, bridge reachable over Tailscale:

```
GET /command?sessionID=...  ->  79 entries: 30 skills, 49 commands
GET /command                ->  79 entries
```

and the deployed PWA at giuliastro.github.io/harness-remote, pointed at the patched bridge, lists all 30 `/skill:*` entries under Help -> Commands. Before the patch that page was empty for OMP.