### PR TITLE
Fix mobile chat scrolling and session return

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2752,19 +2752,28 @@ function App() {
    *  anything reading scroll position has to look at whichever of the two actually scrolls. */
   function messagesScrollMetrics(): ScrollMetrics {
     const container = messagesRef.current
-    return scrollsItself(container) ? elementScrollMetrics(container) : windowScrollMetrics()
+    if (scrollsItself(container)) return elementScrollMetrics(container)
+
+    // The fixed mobile composer is intentionally outside document flow. The transcript reserves
+    // enough tail space to place its sentinel just above that composer, so the visually-correct
+    // live tail is not the document's maximum scrollY. Measure the remaining transcript travel
+    // directly instead; using document.scrollHeight here leaves the pin false by roughly one
+    // composer height even while the last message is exactly where it belongs.
+    const endRect = messagesEndRef.current?.getBoundingClientRect()
+    const composerRect = composerRef.current?.getBoundingClientRect()
+    if (!endRect || !composerRect) return windowScrollMetrics()
+    const liveTailBottom = composerRect.top - 12
+    return {
+      fromTop: window.scrollY,
+      fromBottom: Math.max(0, endRect.bottom - liveTailBottom)
+    }
   }
 
   function isNearMessagesBottom(): boolean {
-    const container = messagesRef.current
-    if (!container) return true
-    const containerDistance = container.scrollHeight - container.scrollTop - container.clientHeight
-    if (containerDistance > BOTTOM_STICK_THRESHOLD) return false
-    // The page itself can also scroll (the composer is pinned via fixed positioning), so a user
-    // scrolling the outer window away from the bottom must also break the auto-scroll pin.
-    const doc = document.documentElement
-    const windowDistance = doc.scrollHeight - window.scrollY - window.innerHeight
-    return windowDistance <= BOTTOM_STICK_THRESHOLD
+    // Read only the scroller that is active for this layout. On mobile `.messages` deliberately has
+    // overflow: visible and the window scrolls; treating the overflowing element as a second scroller
+    // makes its permanently-zero scrollTop disable the live-tail pin after almost every swipe.
+    return messagesScrollMetrics().fromBottom <= BOTTOM_STICK_THRESHOLD
   }
 
   const handleMessagesScroll = useCallback(() => {
@@ -3357,7 +3366,7 @@ function App() {
     if (view !== "detail") return
     if (!stickToBottomRef.current) return
     scrollMessagesToBottom("auto")
-  }, [view, messageScrollSignature, isWorking, showTypingBubble, pendingQuestions, pendingPermissions])
+  }, [view, renderedMessages, isWorking, showTypingBubble, pendingQuestions, pendingPermissions])
 
   // Growing or swapping the transcript changes the distance to each end without any scroll event
   // firing, so the jump buttons have to be re-evaluated off the content too.
@@ -3396,12 +3405,28 @@ function App() {
       if (stickToBottomRef.current) scrollMessagesToBottom("auto")
     })
     observer.observe(container)
-    const timeout = setTimeout(() => observer.disconnect(), 2000)
     return () => {
       observer.disconnect()
-      clearTimeout(timeout)
     }
   }, [view, selectedID])
+
+  // Mobile detail and sessions share the window scroller. Leaving a long transcript therefore
+  // preserves a large page offset which is usually clamped to the end of the shorter sessions page.
+  // Restore the selected card after React has committed and the replacement page has laid out. This
+  // single path also covers the Android system back button, the header button and bottom navigation.
+  useEffect(() => {
+    if (isDesktop || mainView !== "sessions" || !selectedID) return
+    let innerFrame = 0
+    const outerFrame = requestAnimationFrame(() => {
+      innerFrame = requestAnimationFrame(() => {
+        document.querySelector<HTMLElement>(".session-card.active")?.scrollIntoView({ block: "center" })
+      })
+    })
+    return () => {
+      cancelAnimationFrame(outerFrame)
+      if (innerFrame) cancelAnimationFrame(innerFrame)
+    }
+  }, [isDesktop, mainView, selectedID])
 
   useEffect(() => {
     loadedMessagesRef.current = messages
@@ -4066,10 +4091,9 @@ function App() {
           <div className="detail-topbar">
             {!isDesktop && (
               <>
-                <button className="btn-secondary detail-back-button" onClick={() => {
-                  setView("sessions");
-                  requestAnimationFrame(() => document.querySelector<HTMLElement>(".session-card.active")?.scrollIntoView({ block: "center" }));
-                }}>{t('detail.backToSessions')}</button>
+                <button className="btn-secondary detail-back-button" onClick={() => setView("sessions")}>
+                  {t('detail.backToSessions')}
+                </button>
                 {selectedSession && sessionHeaderActions.length > 0 && (
                   <SessionActionsMenu actions={sessionHeaderActions} t={t} />
                 )}
@@ -4788,12 +4812,7 @@ http://YOUR_PC_IP:4096/global/health</pre>
           <button
             key={item.view}
             className={view === item.view ? "active" : ""}
-            onClick={() => {
-              setView(item.view);
-              if (item.view === "sessions") {
-                requestAnimationFrame(() => document.querySelector<HTMLElement>(".session-card.active")?.scrollIntoView({ block: "center" }));
-              }
-            }}
+            onClick={() => setView(item.view)}
             disabled={item.disabled}
             aria-label={item.label}
           >

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2438,9 +2438,8 @@ button.compact {
     min-height: 240px;
     overflow: visible;
     padding: 0;
-    /* The side padding goes away here, but the bottom clearance must not: the composer is sticky at
-       an offset above the page bottom, so without it the newest messages settle underneath it and
-       the page has no room left to scroll them clear. */
+    /* The side padding goes away here, but the bottom clearance must not: the fixed composer is out
+       of flow, so this is the one reserved area that lets the newest message settle above it. */
     padding-bottom: var(--chat-bottom-clearance, 140px);
     scroll-padding-bottom: var(--chat-bottom-clearance, 140px);
   }
@@ -2465,9 +2464,11 @@ button.compact {
   }
 
   .composer {
+    position: fixed;
+    left: calc(var(--space-5) + env(safe-area-inset-left));
+    right: calc(var(--space-5) + env(safe-area-inset-right));
     bottom: calc(72px + env(safe-area-inset-bottom));
-    margin-left: calc(var(--space-2) * -1);
-    margin-right: calc(var(--space-2) * -1);
+    margin: 0;
   }
 
   .help-tabs {

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -32,6 +32,21 @@ assert.ok(
   /if \(!stickToBottomRef\.current\) return[\s\S]*?scrollMessagesToBottom\("auto"\)/.test(app),
   'content-driven auto-scroll must be gated on the user already being pinned to the bottom, so background refreshes cannot force the conversation to scroll while the user has scrolled away'
 )
+assert.match(
+  app,
+  /return messagesScrollMetrics\(\)\.fromBottom <= BOTTOM_STICK_THRESHOLD/,
+  'the live-tail pin must measure only the active scroller; mobile messages overflow into the page and are not themselves scrollable'
+)
+assert.match(
+  app,
+  /const liveTailBottom = composerRect\.top - 12[\s\S]*?fromBottom: Math\.max\(0, endRect\.bottom - liveTailBottom\)/,
+  'mobile bottom distance must be measured between the transcript sentinel and fixed composer, not against unused document tail space'
+)
+assert.match(
+  app,
+  /\}, \[view, renderedMessages, isWorking, showTypingBubble, pendingQuestions, pendingPermissions\]\)/,
+  'auto-scroll must react to every rendered message update, including tool output that changes layout without changing message text'
+)
 assert.ok(app.includes('}, [view, selectedID])'), 'auto-scroll should run only when opening a selected session')
 assert.ok(app.includes('scrollMessagesToBottom("smooth")'), 'focusing the composer should scroll to the bottom')
 assert.ok(app.includes('messagesEndRef'), 'auto-scroll should target a bottom sentinel marker')
@@ -43,7 +58,12 @@ assert.ok(app.includes('scrollBy({ top: coveredByComposer'), 'page-level auto-sc
 assert.ok(/\.messages[\s\S]*?padding-bottom:\s*var\(--chat-bottom-clearance/.test(styles), 'messages pane should reserve bottom space for the sticky composer')
 assert.ok(/\.messages-end[\s\S]*?scroll-margin-bottom:\s*var\(--chat-bottom-clearance/.test(styles), 'bottom sentinel should keep the latest output above the sticky composer')
 assert.ok(/requestAnimationFrame\(\(\) => \{[\s\S]*?requestAnimationFrame\(\(\) => \{/.test(app), 'auto-scroll should wait for the next two frames so freshly rendered content is laid out before scrolling')
-assert.ok(app.includes('session-card.active') && app.includes('scrollIntoView({ block: "center" })'), 'returning to sessions should center the active session card instead of restoring a stale scroll coordinate')
+assert.match(
+  app,
+  /if \(isDesktop \|\| mainView !== "sessions" \|\| !selectedID\) return[\s\S]*?session-card\.active[\s\S]*?scrollIntoView\(\{ block: "center" \}\)/,
+  'every mobile return path, including Android back, should center the active session after the sessions page commits'
+)
+assert.match(styles, /@media \(max-width: 780px\)[\s\S]*?\.composer\s*\{[\s\S]*?position:\s*fixed;/, 'the mobile composer must be out of document flow so its reserved clearance cannot become a real blank gap')
 assert.ok(app.includes('typing-bubble'), 'detail view should render a temporary typing bubble while waiting for OpenCode output')
 assert.ok(app.includes('typing-dot'), 'typing bubble should show animated dots')
 assert.ok(app.includes('awaitingAssistantReply'), 'typing bubble should stay visible after the send request returns and until a new assistant message arrives')


### PR DESCRIPTION
## Cosa cambia
- mantiene la chat agganciata al fondo quando arrivano nuovi messaggi, se l'utente era già in fondo
- elimina lo spazio vuoto transitorio tra l'ultimo messaggio e il composer su mobile
- ripristina e centra la sessione selezionata tornando alla lista tramite back Android, header o navigazione inferiore
- aggiunge copertura di regressione per i comportamenti mobile

## Cause corrette
- il calcolo dell'auto-scroll usava il riferimento di scorrimento/fondo sbagliato rispetto al composer fisso
- l'osservazione del layout non reagiva stabilmente a tutti gli aggiornamenti dei messaggi
- il composer sticky contribuiva a conservare spazio nel flusso della pagina
- il ripristino della lista non era centralizzato per tutti i percorsi di ritorno

## Verifica
- 7 suite web superate
- build TypeScript/Vite superata
- 66 test bridge superati
- test browser mobile 390x844: nuovo messaggio, gap stabile di 16 px e sessione selezionata centrata
- build Android e verifica firma APK superate
- collaudo manuale dell'APK completato con esito positivo