### PR TITLE
docs: document non-Git file undo/redo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,11 @@ Depending on the harness:
 - review changed files and their diffs — OpenCode
 - rename and delete sessions — OpenCode changes them in the harness; on OMP, PI and Claude Code the
   same controls keep a bridge-local nickname and hide the session from that bridge only
-- extend bridge-backed harnesses through optional host extensions: bridge discovers compatible
-  commands, then enables actions only for sessions where available. OMP Undo/Redo integration uses
-  [`@baylarsadigov/omp-undo-redo`](https://github.com/Baylar55/omp-undo-redo). Version 1.2.0 or newer
-  restores both conversation and supported file changes in Git and non-Git workspaces.
+- extend bridge-backed harnesses through optional host extensions: the bridge discovers compatible
+  commands and the app enables their actions only for sessions where they are available; the first
+  integration is Undo and Redo for OMP through
+  [`@baylarsadigov/omp-undo-redo`](https://github.com/Baylar55/omp-undo-redo), which from version
+  1.2.0 restores supported file changes as well as the conversation, in Git and non-Git workspaces
 
 ## Desktop Mode
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ Depending on the harness:
 - review changed files and their diffs — OpenCode
 - rename and delete sessions — OpenCode changes them in the harness; on OMP, PI and Claude Code the
   same controls keep a bridge-local nickname and hide the session from that bridge only
-- extend bridge-backed harnesses through optional host extensions: the bridge discovers compatible
-  commands and the app enables their actions only for sessions where they are available; the first
-  integration is Undo and Redo for OMP through
-  [`@baylarsadigov/omp-undo-redo`](https://github.com/Baylar55/omp-undo-redo)
+- extend bridge-backed harnesses through optional host extensions: bridge discovers compatible
+  commands, then enables actions only for sessions where available. OMP Undo/Redo integration uses
+  [`@baylarsadigov/omp-undo-redo`](https://github.com/Baylar55/omp-undo-redo). Version 1.2.0 or newer
+  restores both conversation and supported file changes in Git and non-Git workspaces.
 
 ## Desktop Mode
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -48,8 +48,8 @@ Live action availability comes from extension version 1.1.0 or newer under
 changing this runtime contract. The bridge validates the runtime marker against the exact ACP child
 PID, then reads schema-2 session state containing `actions`, `sessionRevision`, `activeSessionLeaf`,
 and an invocation `actionResult` with a unique `token`. Process and runtime IDs prevent stale or
-concurrent OMP state from controlling the session. This contract works for Git, non-Git, and
-session-only workspaces.
+concurrent OMP state from controlling the session. This contract works for both Git and non-Git
+workspaces.
 
 File restoration remains extension-owned. Harness Remote invokes the same action and reloads the
 authoritative active branch; with extension 1.2.0 or newer, successful non-Git actions restore

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -44,11 +44,17 @@ host-side OMP plugin; it is not an app or bridge dependency. Its command catalog
 handlers were registered in that runtime.
 
 Live action availability comes from extension version 1.1.0 or newer under
-`~/.omp/omp-undo-redo/runtime/<acp-pid>/`. The bridge validates the runtime marker against the exact
-ACP child PID, then reads schema-2 session state containing `actions`, `sessionRevision`,
-`activeSessionLeaf`, and an invocation `actionResult` with a unique `token`. Process and runtime IDs
-prevent stale or concurrent OMP state from controlling the session. This contract works for both Git
-and session-only workspaces.
+`~/.omp/omp-undo-redo/runtime/<acp-pid>/`. Version 1.2.0 adds non-Git file restoration without
+changing this runtime contract. The bridge validates the runtime marker against the exact ACP child
+PID, then reads schema-2 session state containing `actions`, `sessionRevision`, `activeSessionLeaf`,
+and an invocation `actionResult` with a unique `token`. Process and runtime IDs prevent stale or
+concurrent OMP state from controlling the session. This contract works for Git, non-Git, and
+session-only workspaces.
+
+File restoration remains extension-owned. Harness Remote invokes the same action and reloads the
+authoritative active branch; with extension 1.2.0 or newer, successful non-Git actions restore
+supported workspace file changes as well as conversation state. No bridge package dependency or
+alternate action path is required.
 
 The repository Git common-directory sidecar at
 `omp-undo-redo/history/<sha256-session-id>.json` remains the durable fallback. The bridge adapts its


### PR DESCRIPTION
## Summary

- document conversation and supported file restoration in non-Git workspaces with `@baylarsadigov/omp-undo-redo` v1.2.0+
- record that v1.2.0 retains the schema-2 runtime action-state contract introduced in v1.1.0
- clarify that file restoration remains extension-owned, so Harness Remote needs no alternate bridge action path or package dependency

## Verification

- `cd bridge && npm test`
- 66 tests passed

Related to #103 and #105.