### PR TITLE
Draw a real application menu on macOS

### DIFF
--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -89,6 +89,15 @@ jobs:
           npm run test:desktop
         working-directory: web
 
+      # macOS is the only platform that installs a native application menu, and the unit tests can
+      # only check the template the app builds — not that Electron accepts it. This boots Electron,
+      # installs the real menu and reads it back. Skipped on Linux, where Electron needs a display
+      # the runner does not have, and where the menu is never installed anyway.
+      - name: Verify the application menu installs
+        if: runner.os == 'macOS' || runner.os == 'Windows'
+        run: npm run test:desktop:menu
+        working-directory: web
+
       - name: Run bridge tests
         run: npm test
         working-directory: bridge

--- a/.github/workflows/desktop-menu.yml
+++ b/.github/workflows/desktop-menu.yml
@@ -1,0 +1,53 @@
+name: Verify desktop application menu
+
+# The packaging workflow only runs on main and on tags, so a change to the menu would not be
+# exercised on macOS until after it was merged. macOS is the one platform that installs a native
+# menu, and it is the one platform most contributors cannot test on — so this runs there, on the
+# pull request, and does nothing else.
+
+"on":
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - 'web/electron/**'
+      - 'web/scripts/menu-smoke.mjs'
+      - 'web/src/App.tsx'
+      - 'web/src/desktopBridge.ts'
+      - 'web/package.json'
+      - '.github/workflows/desktop-menu.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: desktop-menu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  menu:
+    name: Application menu on macOS
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install web dependencies
+        run: npm ci
+        working-directory: web
+
+      - name: Run desktop unit tests
+        run: npm run test:desktop
+        working-directory: web
+
+      # Boots Electron, installs the real menu and reads it back — the part the unit tests cannot
+      # reach, on the platform that actually shows it.
+      - name: Verify the application menu installs
+        run: npm run test:desktop:menu
+        working-directory: web

--- a/web/electron/app-menu.test.mjs
+++ b/web/electron/app-menu.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { test } from 'node:test'
+
+const { buildApplicationMenu } = await import('../dist-electron/electron/app-menu.js')
+const { DESKTOP_MENU_COMMANDS, parseDesktopMenuTemplate } = await import('../dist-electron/electron/ipc-contract.js')
+
+const template = [
+  {
+    id: 'file',
+    label: 'File',
+    items: [
+      { kind: 'item', command: 'session.new', label: 'New session', accelerator: 'CmdOrCtrl+N', enabled: true },
+      { kind: 'separator' },
+      { kind: 'item', command: 'server.settings', label: 'Settings', accelerator: 'CmdOrCtrl+,', enabled: false }
+    ]
+  },
+  {
+    id: 'view',
+    label: 'View',
+    items: [{ kind: 'item', command: 'view.theme.dark', label: 'Dark', checked: true }]
+  },
+  {
+    id: 'help',
+    label: 'Help',
+    items: [{ kind: 'item', command: 'help.open', label: 'Help' }]
+  }
+]
+
+const labelsOf = (menu) => menu.map((entry) => entry.label ?? entry.role)
+
+test('macOS menu keeps the app, Edit and Window menus in platform order', () => {
+  const menu = buildApplicationMenu(template, { appName: 'Harness Remote', isMac: true, onCommand: () => {} })
+  // Edit has to sit right after File or Cmd+C/V/X land in a menu nobody looks in, and Help is last.
+  assert.deepEqual(labelsOf(menu), ['Harness Remote', 'File', 'editMenu', 'View', 'windowMenu', 'Help'])
+})
+
+test('a renderer menu the platform does not name is still placed, not dropped', () => {
+  const renamed = [{ id: 'session', label: 'Session', items: template[1].items }]
+  const menu = buildApplicationMenu(renamed, { appName: 'App', isMac: true, onCommand: () => {} })
+  assert.deepEqual(labelsOf(menu), ['App', 'editMenu', 'Session', 'windowMenu'])
+})
+
+test('items carry their accelerator, enabled and checked state', () => {
+  const menu = buildApplicationMenu(template, { appName: 'App', isMac: true, onCommand: () => {} })
+  const file = menu.find((entry) => entry.label === 'File').submenu
+  assert.equal(file[0].accelerator, 'CmdOrCtrl+N')
+  assert.equal(file[0].enabled, true)
+  assert.equal(file[1].type, 'separator')
+  assert.equal(file[2].enabled, false, 'a disabled command must not be clickable in the platform menu')
+  const view = menu.find((entry) => entry.label === 'View').submenu
+  assert.equal(view[0].type, 'checkbox')
+  assert.equal(view[0].checked, true)
+})
+
+test('clicking an item reports the command id the renderer sent', () => {
+  const fired = []
+  const menu = buildApplicationMenu(template, { appName: 'App', isMac: true, onCommand: (id) => fired.push(id) })
+  menu.find((entry) => entry.label === 'File').submenu[0].click()
+  menu.find((entry) => entry.label === 'Help').submenu[0].click()
+  assert.deepEqual(fired, ['session.new', 'help.open'])
+})
+
+test('a malformed template is rejected outright rather than partly applied', () => {
+  assert.equal(parseDesktopMenuTemplate(null), null)
+  assert.equal(parseDesktopMenuTemplate([]), null)
+  assert.equal(parseDesktopMenuTemplate([{ id: 'file', label: 'File', items: [] }]), null)
+  assert.equal(
+    parseDesktopMenuTemplate([{ id: 'file', label: 'File', items: [{ kind: 'item', command: 'not.a.command', label: 'X' }] }]),
+    null,
+    'an unknown command id must not reach Electron'
+  )
+  assert.equal(
+    parseDesktopMenuTemplate([{ id: 'file', label: 'File', items: [{ kind: 'item', command: 'session.new', label: 'New\u0007' }] }]),
+    null,
+    'control characters must not reach a native menu'
+  )
+  assert.equal(
+    parseDesktopMenuTemplate([{ id: 'file', label: 'File', items: [{ kind: 'item', command: 'session.new', label: 'New', accelerator: 'rm -rf /' }] }]),
+    null,
+    'an accelerator outside Electron grammar must be refused'
+  )
+  assert.ok(parseDesktopMenuTemplate(template), 'the well-formed template must survive validation')
+})
+
+test('every command the renderer can bind is one the contract knows', async () => {
+  const app = await readFile(new URL('../src/App.tsx', import.meta.url), 'utf8')
+  const bindings = app.slice(app.indexOf('const KEY_BINDINGS'), app.indexOf('function bindingKeyLabel'))
+  const bound = [...bindings.matchAll(/"([a-z.]+)":\s*\{ key:/g)].map((match) => match[1])
+  assert.ok(bound.length >= 5, `expected the binding map to parse, got ${JSON.stringify(bound)}`)
+  for (const command of bound) {
+    assert.ok(
+      DESKTOP_MENU_COMMANDS.includes(command),
+      `"${command}" has a keyboard shortcut but is not a command the platform menu can carry`
+    )
+  }
+})

--- a/web/electron/app-menu.test.mjs
+++ b/web/electron/app-menu.test.mjs
@@ -83,15 +83,36 @@ test('a malformed template is rejected outright rather than partly applied', () 
   assert.ok(parseDesktopMenuTemplate(template), 'the well-formed template must survive validation')
 })
 
-test('every command the renderer can bind is one the contract knows', async () => {
+async function rendererKeyBindings() {
   const app = await readFile(new URL('../src/App.tsx', import.meta.url), 'utf8')
-  const bindings = app.slice(app.indexOf('const KEY_BINDINGS'), app.indexOf('function bindingKeyLabel'))
-  const bound = [...bindings.matchAll(/"([a-z.]+)":\s*\{ key:/g)].map((match) => match[1])
-  assert.ok(bound.length >= 5, `expected the binding map to parse, got ${JSON.stringify(bound)}`)
-  for (const command of bound) {
+  const source = app.slice(app.indexOf('const KEY_BINDINGS'), app.indexOf('function bindingKeyLabel'))
+  const bindings = [...source.matchAll(/"([a-z.]+)":\s*\{ key: "([^"]+)"(, shift: (true))?/g)]
+    .map((match) => ({ command: match[1], key: match[2], shift: match[4] === 'true' }))
+  assert.ok(bindings.length >= 5, `expected the binding map to parse, got ${JSON.stringify(bindings)}`)
+  return bindings
+}
+
+test('every command the renderer can bind is one the contract knows', async () => {
+  for (const { command } of await rendererKeyBindings()) {
     assert.ok(
       DESKTOP_MENU_COMMANDS.includes(command),
       `"${command}" has a keyboard shortcut but is not a command the platform menu can carry`
     )
   }
+})
+
+// The validator is strict on purpose, and the renderer is the only thing that ever feeds it. A
+// fixture proves the validator works; this proves the two agree — including the comma accelerator,
+// which is the one a tighter grammar would quietly refuse.
+test('the accelerators the renderer derives all pass the IPC validator', async () => {
+  const bindings = await rendererKeyBindings()
+  const items = bindings.map(({ command, key, shift }) => ({
+    kind: 'item',
+    command,
+    label: command,
+    accelerator: `CmdOrCtrl+${shift ? 'Shift+' : ''}${key.length === 1 && /[a-z]/.test(key) ? key.toUpperCase() : key}`
+  }))
+  const parsed = parseDesktopMenuTemplate([{ id: 'file', label: 'File', items }])
+  assert.ok(parsed, `the validator rejected accelerators the renderer produces: ${JSON.stringify(items.map((item) => item.accelerator))}`)
+  assert.equal(parsed[0].items.length, items.length)
 })

--- a/web/electron/app-menu.ts
+++ b/web/electron/app-menu.ts
@@ -1,0 +1,68 @@
+import type { MenuItemConstructorOptions } from "electron"
+import type { DesktopMenuCommand, DesktopMenuTemplate } from "./ipc-contract.js"
+
+/**
+ * Turns the renderer's menu description into an Electron template, adding the two menus the
+ * platform owns rather than the app: Edit, which is what binds Cmd+C/V/X and Select All on macOS,
+ * and Window, which is where Minimise and Zoom are expected to be. Both are pure `role` entries —
+ * Electron implements them, so they need no command ids and cannot drift.
+ *
+ * Kept free of `electron` runtime imports so it can be unit tested without starting an app.
+ */
+export function buildApplicationMenu(
+  template: DesktopMenuTemplate,
+  options: { appName: string; isMac: boolean; onCommand: (command: DesktopMenuCommand) => void }
+): MenuItemConstructorOptions[] {
+  const { appName, isMac, onCommand } = options
+
+  const appMenu: MenuItemConstructorOptions[] = isMac
+    ? [{
+        label: appName,
+        submenu: [
+          { role: "about" },
+          { type: "separator" },
+          { role: "services" },
+          { type: "separator" },
+          { role: "hide" },
+          { role: "hideOthers" },
+          { role: "unhide" },
+          { type: "separator" },
+          { role: "quit" }
+        ]
+      }]
+    : []
+
+  const editMenu: MenuItemConstructorOptions = {
+    role: "editMenu"
+  }
+
+  const windowMenu: MenuItemConstructorOptions = {
+    role: "windowMenu"
+  }
+
+  const appMenus = template.map<MenuItemConstructorOptions>((menu) => ({
+    label: menu.label,
+    submenu: menu.items.map<MenuItemConstructorOptions>((item) => {
+      if (item.kind === "separator") return { type: "separator" }
+      return {
+        label: item.label,
+        accelerator: item.accelerator,
+        enabled: item.enabled !== false,
+        // A checkbox rather than a radio: the renderer sends the checked state outright, and a radio
+        // group would have Electron manage a selection that is really owned by the other process.
+        type: item.checked === undefined ? undefined : "checkbox",
+        checked: item.checked,
+        click: () => onCommand(item.command)
+      }
+    })
+  }))
+
+  // Platform convention puts Edit second and Window/Help last. Placing them by menu id rather than
+  // by position keeps that true whatever the renderer sends, and degrades to "append" if the app's
+  // menus are ever renamed.
+  const fileMenus = appMenus.filter((_, index) => template[index].id === "file")
+  const helpMenus = appMenus.filter((_, index) => template[index].id === "help")
+  const otherMenus = appMenus.filter((_, index) => template[index].id !== "file" && template[index].id !== "help")
+
+  return [...appMenu, ...fileMenus, editMenu, ...otherMenus, windowMenu, ...helpMenus]
+}

--- a/web/electron/ipc-contract.ts
+++ b/web/electron/ipc-contract.ts
@@ -7,7 +7,8 @@ export const IPC_CHANNELS = Object.freeze({
   unsubscribeEvents: "desktop:events:unsubscribe",
   notifyCompletion: "desktop:completion:notify",
   event: "desktop:events:event",
-  menuCommand: "desktop:menu:command"
+  menuCommand: "desktop:menu:command",
+  setMenu: "desktop:menu:set"
 })
 
 export type DesktopProfileSyncResult = {
@@ -120,4 +121,92 @@ export type DesktopMenuCommand = (typeof DESKTOP_MENU_COMMANDS)[number]
 
 export function isDesktopMenuCommand(value: unknown): value is DesktopMenuCommand {
   return typeof value === "string" && (DESKTOP_MENU_COMMANDS as readonly string[]).includes(value)
+}
+
+/**
+ * The renderer owns what the menu says and when each item applies — it is the side that knows the
+ * language, the connected harness and the selected session. Main renders whatever it is handed and
+ * echoes clicks back as command ids, so the platform menu and the in-app one stay one implementation
+ * rather than two that drift.
+ */
+export type DesktopMenuItemDescriptor =
+  | {
+      kind: "item"
+      command: DesktopMenuCommand
+      label: string
+      accelerator?: string
+      enabled?: boolean
+      checked?: boolean
+    }
+  | { kind: "separator" }
+
+export type DesktopMenuDescriptor = {
+  id: string
+  label: string
+  items: DesktopMenuItemDescriptor[]
+}
+
+export type DesktopMenuTemplate = DesktopMenuDescriptor[]
+
+const MENU_LABEL_MAX_LENGTH = 80
+const MENU_ACCELERATOR_MAX_LENGTH = 40
+const MENU_MAX_MENUS = 12
+const MENU_MAX_ITEMS = 40
+/** Electron accelerators are a closed grammar; anything outside it either throws on
+ *  `buildFromTemplate` or silently binds something nobody asked for. */
+const ACCELERATOR_PATTERN = /^([A-Za-z0-9]+\+)*[A-Za-z0-9,.\/\\[\]`'-]+$/
+
+/** Menu text crosses a process boundary, so it is validated like every other IPC payload rather
+ *  than trusted: bounded, printable, and free of the control characters a native menu would render
+ *  as garbage. */
+function menuText(value: unknown, maxLength: number): value is string {
+  return typeof value === "string"
+    && value.length > 0
+    && value.length <= maxLength
+    && !/[\u0000-\u001f\u007f]/.test(value)
+}
+
+function parseMenuItem(value: unknown): DesktopMenuItemDescriptor | null {
+  if (!value || typeof value !== "object") return null
+  const candidate = value as Partial<DesktopMenuItemDescriptor> & { kind?: unknown }
+  if (candidate.kind === "separator") return { kind: "separator" }
+  if (candidate.kind !== "item") return null
+  const item = candidate as Partial<Extract<DesktopMenuItemDescriptor, { kind: "item" }>>
+  if (!isDesktopMenuCommand(item.command)) return null
+  if (!menuText(item.label, MENU_LABEL_MAX_LENGTH)) return null
+  if (item.accelerator !== undefined) {
+    if (!menuText(item.accelerator, MENU_ACCELERATOR_MAX_LENGTH)) return null
+    if (!ACCELERATOR_PATTERN.test(item.accelerator)) return null
+  }
+  if (item.enabled !== undefined && typeof item.enabled !== "boolean") return null
+  if (item.checked !== undefined && typeof item.checked !== "boolean") return null
+  return {
+    kind: "item",
+    command: item.command,
+    label: item.label,
+    accelerator: item.accelerator,
+    enabled: item.enabled,
+    checked: item.checked
+  }
+}
+
+/** Returns null rather than throwing on the first bad field: a malformed template must leave the
+ *  menu that is already installed alone, not replace it with a half-built one. */
+export function parseDesktopMenuTemplate(value: unknown): DesktopMenuTemplate | null {
+  if (!Array.isArray(value) || value.length === 0 || value.length > MENU_MAX_MENUS) return null
+  const template: DesktopMenuTemplate = []
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") return null
+    const menu = entry as Partial<DesktopMenuDescriptor>
+    if (!menuText(menu.id, MENU_LABEL_MAX_LENGTH) || !menuText(menu.label, MENU_LABEL_MAX_LENGTH)) return null
+    if (!Array.isArray(menu.items) || menu.items.length === 0 || menu.items.length > MENU_MAX_ITEMS) return null
+    const items: DesktopMenuItemDescriptor[] = []
+    for (const rawItem of menu.items) {
+      const item = parseMenuItem(rawItem)
+      if (!item) return null
+      items.push(item)
+    }
+    template.push({ id: menu.id, label: menu.label, items })
+  }
+  return template
 }

--- a/web/electron/main.ts
+++ b/web/electron/main.ts
@@ -2,11 +2,12 @@ import { app, BrowserWindow, Menu, Notification, nativeImage, screen, session, i
 import { readFileSync, writeFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
+import { buildApplicationMenu } from "./app-menu.js"
 import { DesktopEventTransport } from "./event-transport.js"
-import { IPC_CHANNELS } from "./ipc-contract.js"
+import { IPC_CHANNELS, parseDesktopMenuTemplate } from "./ipc-contract.js"
 import { DesktopProfileError, ProfileRegistry } from "./profile-registry.js"
 import { executeDesktopRequest } from "./request-transport.js"
-import type { DesktopCompletionNotification, DesktopEventSubscriptionOptions, DesktopRequest } from "./ipc-contract.js"
+import type { DesktopCompletionNotification, DesktopEventSubscriptionOptions, DesktopMenuCommand, DesktopRequest } from "./ipc-contract.js"
 import { MIN_WINDOW_HEIGHT, MIN_WINDOW_WIDTH, restoredBounds as calculateRestoredBounds } from "./window-state.js"
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const isDevelopment = !app.isPackaged
@@ -68,6 +69,35 @@ function ensureTrustedSender(event: IpcMainInvokeEvent): void {
 
 function notificationText(value: unknown, maxLength: number): value is string {
   return typeof value === "string" && value.length > 0 && value.length <= maxLength && !/[\u0000-\u001f\u007f]/.test(value)
+}
+
+/**
+ * Only macOS gets a platform menu. Its menu bar lives outside the window, so the app has to put
+ * something there — and if it does not, Electron leaves its own untranslated default sitting next to
+ * the app's own menu bar. Windows and Linux would draw a second menu bar inside the window frame,
+ * directly beneath the one the renderer already draws, which is why they keep the in-window one
+ * alone. The renderer is told which of the two it is dealing with through `platform.usesNativeMenu`.
+ */
+function applyApplicationMenu(template: unknown): boolean {
+  if (!isMac) return false
+  const parsed = parseDesktopMenuTemplate(template)
+  if (!parsed) return false
+  const sendCommand = (command: DesktopMenuCommand) => {
+    if (mainWindow && !mainWindow.isDestroyed()) mainWindow.webContents.send(IPC_CHANNELS.menuCommand, command)
+  }
+  try {
+    Menu.setApplicationMenu(Menu.buildFromTemplate(buildApplicationMenu(parsed, {
+      appName: app.getName(),
+      isMac,
+      onCommand: sendCommand
+    })))
+    return true
+  } catch {
+    // A template Electron refuses is not worth taking the window down for: keep whatever menu is
+    // already installed and carry on.
+    log("application menu could not be built")
+    return false
+  }
 }
 
 function notifyCompletion(notification: DesktopCompletionNotification): void {
@@ -202,6 +232,10 @@ function installIPC(): void {
     if (typeof subscriptionId !== "string") throw new Error("Subscription ID is invalid")
     eventTransport.unsubscribe(event.sender, subscriptionId)
   })
+  ipcMain.handle(IPC_CHANNELS.setMenu, async (event, template: unknown) => {
+    ensureTrustedSender(event)
+    return applyApplicationMenu(template)
+  })
   ipcMain.handle(IPC_CHANNELS.notifyCompletion, async (event, notification: unknown) => {
     ensureTrustedSender(event)
     if (!notification || typeof notification !== "object") throw new Error("Notification payload is invalid")
@@ -222,7 +256,9 @@ async function start(): Promise<void> {
   installIPC()
   // macOS keeps its menu: the app menu is where Cmd+Q lives and the Edit menu is what binds
   // Cmd+C/V/X, so stripping it there costs the user the shortcuts they expect rather than just
-  // hiding chrome. Windows and Linux draw an in-window menu bar that the app has no use for.
+  // hiding chrome. The renderer replaces Electron's untranslated default with the real one as soon
+  // as it mounts. Windows and Linux draw an in-window menu bar underneath the app's own, which is
+  // one menu bar too many.
   if (!isDevelopment && !isMac) Menu.setApplicationMenu(null)
   session.defaultSession.setPermissionRequestHandler((_webContents, _permission, callback) => callback(false))
   mainWindow = createWindow()

--- a/web/electron/preload.cts
+++ b/web/electron/preload.cts
@@ -6,6 +6,7 @@ import type {
   DesktopEventStatus,
   DesktopEventSubscriptionOptions,
   DesktopMenuCommand,
+  DesktopMenuTemplate,
   DesktopProfile,
   DesktopProfileSyncResult,
   DesktopRequest,
@@ -20,7 +21,8 @@ const IPC_CHANNELS = Object.freeze({
   unsubscribeEvents: "desktop:events:unsubscribe",
   notifyCompletion: "desktop:completion:notify",
   event: "desktop:events:event",
-  menuCommand: "desktop:menu:command"
+  menuCommand: "desktop:menu:command",
+  setMenu: "desktop:menu:set"
 })
 
 type EventCallbacks = {
@@ -42,7 +44,10 @@ ipcRenderer.on(IPC_CHANNELS.menuCommand, (_event: Electron.IpcRendererEvent, com
 })
 
 const harnessDesktop = Object.freeze({
-  platform: Object.freeze({ isDesktop: true, os: process.platform }),
+  // `usesNativeMenu` is what tells the renderer to stop drawing its own menu bar and stop binding
+  // its own accelerators: on the platform that has a real menu, both would be duplicates, and a
+  // shortcut handled twice toggles a panel back to where it started.
+  platform: Object.freeze({ isDesktop: true, os: process.platform, usesNativeMenu: process.platform === "darwin" }),
   replaceProfiles(profiles: DesktopProfile[], revision: number): Promise<DesktopProfileSyncResult> {
     return ipcRenderer.invoke(IPC_CHANNELS.replaceProfiles, profiles, revision)
   },
@@ -69,6 +74,9 @@ const harnessDesktop = Object.freeze({
   onMenuCommand(callback: (command: DesktopMenuCommand) => void): () => void {
     menuCallbacks.add(callback)
     return () => menuCallbacks.delete(callback)
+  },
+  setApplicationMenu(template: DesktopMenuTemplate): Promise<boolean> {
+    return ipcRenderer.invoke(IPC_CHANNELS.setMenu, template)
   }
 })
 

--- a/web/package.json
+++ b/web/package.json
@@ -33,7 +33,8 @@
     "test:profiles": "node --experimental-strip-types src/server-profiles.test.mjs",
     "test:config": "node --experimental-strip-types src/server-config.test.mjs",
     "test:platform": "node src/platform-regression.test.mjs",
-    "test:desktop": "npm run build:electron && node --test electron/*.test.mjs"
+    "test:desktop": "npm run build:electron && node --test electron/*.test.mjs",
+    "test:desktop:menu": "npm run build:electron && electron scripts/menu-smoke.mjs"
   },
   "build": {
     "appId": "com.harnessremote.desktop",

--- a/web/scripts/menu-smoke.mjs
+++ b/web/scripts/menu-smoke.mjs
@@ -1,0 +1,125 @@
+/**
+ * Boots Electron and installs the real application menu, then reads it back.
+ *
+ * The unit tests in electron/app-menu.test.mjs check the template this app produces; they cannot
+ * check that Electron accepts it. That is a different class of failure and not a theoretical one:
+ * an accelerator outside Electron's grammar, a `role` that a given Electron version does not have,
+ * or a submenu shape it refuses all throw inside `Menu.buildFromTemplate`, which no amount of
+ * asserting on our own object graph would catch.
+ *
+ * Runs anywhere Electron can reach a display. CI runs it on macOS, which is the platform that
+ * actually installs this menu.
+ *
+ * Exit code 0 means the menu built and installed with the structure we asked for.
+ */
+import { app, Menu } from "electron"
+import { buildApplicationMenu } from "../dist-electron/electron/app-menu.js"
+import { parseDesktopMenuTemplate } from "../dist-electron/electron/ipc-contract.js"
+
+// Deliberately the shape the renderer really sends, accelerators included: a checkbox item, a
+// disabled item, a separator, and the comma accelerator that a stricter grammar would reject.
+const TEMPLATE = [
+  {
+    id: "file",
+    label: "File",
+    items: [
+      { kind: "item", command: "session.new", label: "New session", accelerator: "CmdOrCtrl+N", enabled: true },
+      { kind: "item", command: "session.refresh", label: "Refresh sessions", accelerator: "CmdOrCtrl+R", enabled: false },
+      { kind: "separator" },
+      { kind: "item", command: "server.add", label: "Connect a server", accelerator: "CmdOrCtrl+Shift+N", enabled: true },
+      { kind: "item", command: "server.settings", label: "Settings", accelerator: "CmdOrCtrl+,", enabled: true }
+    ]
+  },
+  {
+    id: "session",
+    label: "Session",
+    items: [{ kind: "item", command: "focus.composer", label: "Focus composer", enabled: false }]
+  },
+  {
+    id: "view",
+    label: "View",
+    items: [
+      { kind: "item", command: "view.palette", label: "Commands", accelerator: "CmdOrCtrl+K", enabled: true },
+      { kind: "item", command: "view.inspector", label: "Toggle inspector", accelerator: "CmdOrCtrl+B", enabled: true, checked: false },
+      { kind: "separator" },
+      { kind: "item", command: "view.theme.dark", label: "Dark", enabled: true, checked: true }
+    ]
+  },
+  {
+    id: "help",
+    label: "Help",
+    items: [{ kind: "item", command: "help.open", label: "Open help", enabled: true }]
+  }
+]
+
+const failures = []
+
+function check(condition, message) {
+  if (!condition) failures.push(message)
+}
+
+// A menu is all this needs; a window would only add a surface that can fail for unrelated reasons.
+app.disableHardwareAcceleration()
+
+app.whenReady().then(() => {
+  const parsed = parseDesktopMenuTemplate(TEMPLATE)
+  check(parsed !== null, "the renderer's own template was rejected by the IPC validator")
+  if (!parsed) return finish()
+
+  const isMac = process.platform === "darwin"
+  let installed
+  try {
+    Menu.setApplicationMenu(Menu.buildFromTemplate(buildApplicationMenu(parsed, {
+      appName: "Harness Remote",
+      isMac,
+      onCommand: () => {}
+    })))
+    installed = Menu.getApplicationMenu()
+  } catch (error) {
+    check(false, `Electron refused the menu template: ${error instanceof Error ? error.message : String(error)}`)
+    return finish()
+  }
+
+  check(Boolean(installed), "no application menu was installed")
+  if (!installed) return finish()
+
+  const labels = installed.items.map((item) => item.label)
+  for (const expected of ["File", "Session", "View", "Help"]) {
+    check(labels.includes(expected), `the "${expected}" menu is missing from the installed menu (got ${JSON.stringify(labels)})`)
+  }
+  // Electron fills these in from the role, so their exact wording is the platform's business — that
+  // there are two more menus than the app supplied is what matters.
+  check(installed.items.length === (isMac ? 7 : 6), `expected the app menus plus Edit and Window, got ${JSON.stringify(labels)}`)
+  if (isMac) check(labels[0] === "Harness Remote", `the macOS app menu must come first and carry the app name, got ${JSON.stringify(labels[0])}`)
+
+  const file = installed.items.find((item) => item.label === "File")?.submenu
+  check(Boolean(file), "the File menu has no submenu")
+  if (file) {
+    const newSession = file.items[0]
+    check(newSession.label === "New session", `unexpected first File item: ${newSession.label}`)
+    check(newSession.accelerator === "CmdOrCtrl+N", `accelerator did not survive: ${newSession.accelerator}`)
+    check(file.items[1].enabled === false, "a disabled command arrived enabled")
+    check(file.items[2].type === "separator", "the separator did not survive")
+    check(
+      file.items.some((item) => item.accelerator === "CmdOrCtrl+,"),
+      "Electron dropped the comma accelerator"
+    )
+  }
+
+  const view = installed.items.find((item) => item.label === "View")?.submenu
+  const dark = view?.items.find((item) => item.label === "Dark")
+  check(dark?.type === "checkbox", `a checked item must install as a checkbox, got ${dark?.type}`)
+  check(dark?.checked === true, "the checked state did not survive")
+
+  finish()
+})
+
+function finish() {
+  if (failures.length === 0) {
+    console.log(`application menu smoke test passed on ${process.platform}`)
+    app.exit(0)
+    return
+  }
+  for (const failure of failures) console.error(`  ✗ ${failure}`)
+  app.exit(1)
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,8 @@ import {
   isAndroidPlatform,
   isDesktopPlatform,
   notifyDesktopCompletion,
+  desktopUsesNativeMenu,
+  setDesktopApplicationMenu,
   subscribeDesktopMenuCommands,
   syncDesktopProfiles
 } from "./desktopBridge"
@@ -29,6 +31,7 @@ import { backendDisplayName, isBridgeBackend } from "./backendSetup"
 import { CommandPalette, MenuBar, ServerSwitcher, type MenuDefinition, type MenuEntry, type PaletteCommand } from "./components/shell"
 import { ConnectServerWizard, NewSessionDialog } from "./components/panels"
 import { createServerProfile, loadActiveServerProfile, loadServerProfiles, persistServerProfiles, type SavedServerProfile } from "./serverProfiles"
+import type { DesktopMenuCommand, DesktopMenuTemplate } from "../electron/ipc-contract"
 import type { AgentOption, CommandInfo, DiffFile, FileEntry, FileStatusEntry, HarnessAction, HarnessCapabilities, MessageEnvelope, MessagePart, ModelOption, ModelSelection, PathInfo, PermissionRequest, ProjectDashboard, QuestionInfo, QuestionRequest, ServerConfig, Session, SessionStatus, SessionView, TodoItem } from "./types"
 import {
   SettingsIcon,
@@ -118,6 +121,51 @@ const IS_APPLE = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navi
 
 function shortcut(key: string): string {
   return IS_APPLE ? `⌘${key}` : `Ctrl+${key}`
+}
+
+/**
+ * One place binding a command to a key. Three consumers read from it and previously each spelled the
+ * binding out for itself: the label shown in menus and the palette, the accelerator the platform
+ * menu registers, and the in-app keydown handler. Keeping them derived is what stops a menu from
+ * advertising a shortcut the handler does not implement — and it is what fixes "Ctrl+N+Shift",
+ * which was written by hand in the wrong order.
+ */
+const KEY_BINDINGS: Record<string, { key: string; shift?: boolean }> = {
+  "view.palette": { key: "k" },
+  "session.new": { key: "n" },
+  "server.add": { key: "n", shift: true },
+  "focus.search": { key: "f" },
+  "session.refresh": { key: "r" },
+  "server.settings": { key: "," },
+  "view.inspector": { key: "b" }
+}
+
+function bindingKeyLabel(binding: { key: string }): string {
+  return binding.key.length === 1 && /[a-z]/.test(binding.key) ? binding.key.toUpperCase() : binding.key
+}
+
+function displayShortcut(command: string): string | undefined {
+  const binding = KEY_BINDINGS[command]
+  if (!binding) return undefined
+  const shift = binding.shift ? (IS_APPLE ? "⇧" : "Shift+") : ""
+  return IS_APPLE ? `⌘${shift}${bindingKeyLabel(binding)}` : `Ctrl+${shift}${bindingKeyLabel(binding)}`
+}
+
+/** Electron's own accelerator grammar, which is neither the label nor the DOM key name. */
+function electronAccelerator(command: string): string | undefined {
+  const binding = KEY_BINDINGS[command]
+  if (!binding) return undefined
+  return `CmdOrCtrl+${binding.shift ? "Shift+" : ""}${bindingKeyLabel(binding)}`
+}
+
+/** The command a keystroke means, or null. Shared by the in-app handler so it can never disagree
+ *  with what the menus say. */
+function commandForKeyEvent(event: KeyboardEvent): string | null {
+  const key = event.key.toLowerCase()
+  for (const [command, binding] of Object.entries(KEY_BINDINGS)) {
+    if (binding.key === key && Boolean(binding.shift) === event.shiftKey) return command
+  }
+  return null
 }
 
 function readStoredWidth(key: string, fallback: number, min: number, max: number): number {
@@ -2040,6 +2088,9 @@ function App() {
   // Desktop gets a persistent left sidebar instead of the mobile top bar/bottom nav; this mirrors
   // the existing 780px CSS breakpoint so JS layout and stylesheet layout never disagree.
   const [isDesktop, setIsDesktop] = useState(() => window.matchMedia(DESKTOP_MEDIA_QUERY).matches)
+  /* Whether the platform draws the menu itself. Fixed for the life of the process — it is a
+     property of the build, not of the window — so it is read once. */
+  const [usesNativeMenu] = useState(desktopUsesNativeMenu)
   useEffect(() => {
     const query = window.matchMedia(DESKTOP_MEDIA_QUERY)
     const onChange = (event: MediaQueryListEvent) => setIsDesktop(event.matches)
@@ -3720,26 +3771,22 @@ function App() {
   // Keyboard shortcuts belong to the window, not to any one control, so they keep working while
   // focus is in the transcript or the sidebar. The composer's own Enter/Shift+Enter handling is
   // untouched: nothing here fires without a modifier.
+  //
+  // Skipped entirely where the platform menu owns the same accelerators, or every one of them would
+  // fire twice — harmless for "New session", but a toggle run twice lands back where it started.
   useEffect(() => {
+    if (usesNativeMenu) return
     const onKeyDown = (event: KeyboardEvent) => {
       const accelerator = IS_APPLE ? event.metaKey : event.ctrlKey
       if (!accelerator || event.altKey) return
-      const key = event.key.toLowerCase()
-      const command = key === "k" ? "view.palette"
-        : key === "n" && !event.shiftKey ? "session.new"
-        : key === "n" && event.shiftKey ? "server.add"
-        : key === "f" ? "focus.search"
-        : key === "r" ? "session.refresh"
-        : key === "," ? "server.settings"
-        : key === "b" ? "view.inspector"
-        : null
+      const command = commandForKeyEvent(event)
       if (!command) return
       event.preventDefault()
       runAppCommandRef.current(command)
     }
     window.addEventListener("keydown", onKeyDown)
     return () => window.removeEventListener("keydown", onKeyDown)
-  }, [])
+  }, [usesNativeMenu])
 
   // The packaged desktop app draws the platform's own menu bar; its items arrive here as commands
   // so the native menu and the in-app one stay a single implementation.
@@ -3747,11 +3794,11 @@ function App() {
     return subscribeDesktopMenuCommands((id) => runAppCommandRef.current(id))
   }, [])
 
-  const menuItem = (id: string, label: string, options: { shortcut?: string; disabled?: boolean; checked?: boolean } = {}): MenuEntry => ({
+  const menuItem = (id: string, label: string, options: { disabled?: boolean; checked?: boolean } = {}): MenuEntry => ({
     kind: "item",
     id,
     label,
-    shortcut: options.shortcut,
+    shortcut: displayShortcut(id),
     disabled: options.disabled,
     checked: options.checked,
     onSelect: () => runAppCommand(id)
@@ -3762,11 +3809,11 @@ function App() {
       id: "file",
       label: t('menubar.file'),
       entries: [
-        menuItem("session.new", t('command.newSession'), { shortcut: shortcut("N"), disabled: !hasConfiguredServer || isOffline }),
-        menuItem("session.refresh", t('command.refreshSessions'), { shortcut: shortcut("R"), disabled: !hasConfiguredServer }),
+        menuItem("session.new", t('command.newSession'), { disabled: !hasConfiguredServer || isOffline }),
+        menuItem("session.refresh", t('command.refreshSessions'), { disabled: !hasConfiguredServer }),
         { kind: "separator", id: "file-sep" },
-        menuItem("server.add", t('command.addServer'), { shortcut: `${shortcut("N")}+Shift` }),
-        menuItem("server.settings", t('command.openSettings'), { shortcut: shortcut(",") })
+        menuItem("server.add", t('command.addServer')),
+        menuItem("server.settings", t('command.openSettings'))
       ]
     },
     {
@@ -3787,9 +3834,9 @@ function App() {
       id: "view",
       label: t('menubar.view'),
       entries: [
-        menuItem("view.palette", t('command.commandPalette'), { shortcut: shortcut("K") }),
-        menuItem("focus.search", t('command.searchSessions'), { shortcut: shortcut("F") }),
-        menuItem("view.inspector", t('command.toggleInspector'), { shortcut: shortcut("B"), checked: inspectorOpen }),
+        menuItem("view.palette", t('command.commandPalette')),
+        menuItem("focus.search", t('command.searchSessions')),
+        menuItem("view.inspector", t('command.toggleInspector'), { checked: inspectorOpen }),
         { kind: "separator", id: "view-sep" },
         menuItem("view.theme.system", t('settings.themeSystem'), { checked: theme === "system" }),
         menuItem("view.theme.light", t('settings.themeLight'), { checked: theme === "light" }),
@@ -3803,18 +3850,44 @@ function App() {
     }
   ]
 
+  /* Where the platform draws the menu, it is handed the same definitions the in-app bar would have
+     rendered — labels, enabled state and all — so the two can only ever say the same thing. Sent on
+     change rather than on every render: the signature is what the menu actually depends on, and the
+     definitions are rebuilt each time the transcript ticks. */
+  const nativeMenuTemplate = usesNativeMenu
+    ? menuDefinitions.map((menu) => ({
+        id: menu.id,
+        label: menu.label,
+        items: menu.entries.map((entry) => entry.kind === "separator"
+          ? { kind: "separator" as const }
+          : {
+              kind: "item" as const,
+              command: entry.id as DesktopMenuCommand,
+              label: entry.label,
+              accelerator: electronAccelerator(entry.id),
+              enabled: !entry.disabled,
+              checked: entry.checked
+            })
+      }))
+    : null
+  const nativeMenuSignature = nativeMenuTemplate ? JSON.stringify(nativeMenuTemplate) : ""
+  useEffect(() => {
+    if (!nativeMenuSignature) return
+    setDesktopApplicationMenu(JSON.parse(nativeMenuSignature) as DesktopMenuTemplate)
+  }, [nativeMenuSignature])
+
   const paletteCommands: PaletteCommand[] = [
-    { id: "session.new", group: t('command.groupSession'), label: t('command.newSession'), hint: shortcut("N"), icon: <PlusIcon size={16} />, disabled: !hasConfiguredServer || isOffline },
-    { id: "session.refresh", group: t('command.groupSession'), label: t('command.refreshSessions'), hint: shortcut("R"), icon: <RefreshIcon size={16} />, disabled: !hasConfiguredServer },
+    { id: "session.new", group: t('command.groupSession'), label: t('command.newSession'), hint: displayShortcut("session.new"), icon: <PlusIcon size={16} />, disabled: !hasConfiguredServer || isOffline },
+    { id: "session.refresh", group: t('command.groupSession'), label: t('command.refreshSessions'), hint: displayShortcut("session.refresh"), icon: <RefreshIcon size={16} />, disabled: !hasConfiguredServer },
     { id: "session.rename", group: t('command.groupSession'), label: t('session.renameTitle'), icon: <PencilIcon size={16} />, disabled: !selectedSession || !capabilities.sessionRename },
     { id: "session.delete", group: t('command.groupSession'), label: t('sessions.delete'), icon: <TrashIcon size={16} />, disabled: !selectedSession || !capabilities.sessionDelete },
     { id: "session.stop", group: t('command.groupSession'), label: t('command.stopAgent'), icon: <StopCircleIcon size={16} />, disabled: !selectedSession || !isWorking },
     { id: "session.undo", group: t('command.groupSession'), label: t('detail.undo'), disabled: !sessionHeaderActions.some((action) => action.id === "undo") },
     { id: "session.redo", group: t('command.groupSession'), label: t('detail.redo'), disabled: !sessionHeaderActions.some((action) => action.id === "redo") },
     { id: "server.add", group: t('command.groupServer'), label: t('command.addServer'), icon: <ServerIcon size={16} /> },
-    { id: "server.settings", group: t('command.groupServer'), label: t('command.openSettings'), hint: shortcut(","), icon: <SettingsIcon size={16} /> },
-    { id: "view.palette", group: t('command.groupView'), label: t('command.commandPalette'), hint: shortcut("K"), icon: <CommandIcon size={16} /> },
-    { id: "view.inspector", group: t('command.groupView'), label: t('command.toggleInspector'), hint: shortcut("B"), icon: <PanelRightIcon size={16} />, disabled: !selectedSession || !hasRoomForInspector },
+    { id: "server.settings", group: t('command.groupServer'), label: t('command.openSettings'), hint: displayShortcut("server.settings"), icon: <SettingsIcon size={16} /> },
+    { id: "view.palette", group: t('command.groupView'), label: t('command.commandPalette'), hint: displayShortcut("view.palette"), icon: <CommandIcon size={16} /> },
+    { id: "view.inspector", group: t('command.groupView'), label: t('command.toggleInspector'), hint: displayShortcut("view.inspector"), icon: <PanelRightIcon size={16} />, disabled: !selectedSession || !hasRoomForInspector },
     { id: "view.theme.light", group: t('command.groupView'), label: t('settings.themeLight') },
     { id: "view.theme.dark", group: t('command.groupView'), label: t('settings.themeDark') },
     { id: "view.theme.system", group: t('command.groupView'), label: t('settings.themeSystem') },
@@ -4009,7 +4082,7 @@ function App() {
     <div className={`app-shell${isDesktop ? " app-shell-desktop" : ""}`}>
       {isDesktop ? (
         <MenuBar
-          menus={menuDefinitions}
+          menus={usesNativeMenu ? [] : menuDefinitions}
           brand={brandBlock}
           right={(
             <>

--- a/web/src/desktopBridge.ts
+++ b/web/src/desktopBridge.ts
@@ -4,6 +4,7 @@ import type {
   DesktopEventStatus,
   DesktopEventSubscriptionOptions,
   DesktopMenuCommand,
+  DesktopMenuTemplate,
   DesktopProfile,
   DesktopProfileSyncResult,
   DesktopRequest,
@@ -14,9 +15,9 @@ import type { SavedServerProfile } from "./serverProfiles"
 import { isValidServerConfig } from "./serverConfig"
 import type { ServerConfig } from "./types"
 
-export type DesktopPlatform = { isDesktop: true; os: string }
+export type DesktopPlatform = { isDesktop: true; os: string; usesNativeMenu?: boolean }
 export type DesktopBridgeAPI = {
-  readonly platform: Readonly<{ readonly isDesktop: true; readonly os: string }>
+  readonly platform: Readonly<{ readonly isDesktop: true; readonly os: string; readonly usesNativeMenu?: boolean }>
   replaceProfiles(profiles: DesktopProfile[], revision: number): Promise<DesktopProfileSyncResult>
   request(profileId: string, request: DesktopRequest): Promise<DesktopRequestResult>
   subscribeEvents(
@@ -28,6 +29,7 @@ export type DesktopBridgeAPI = {
   unsubscribeEvents(subscriptionId: string): Promise<void>
   notifyCompletion(notification: DesktopCompletionNotification): Promise<void>
   onMenuCommand(callback: (command: DesktopMenuCommand) => void): () => void
+  setApplicationMenu(template: DesktopMenuTemplate): Promise<boolean>
 }
 declare global {
   interface Window {
@@ -159,6 +161,16 @@ export function notifyDesktopCompletion(notification: DesktopCompletionNotificat
 
 export function subscribeDesktopMenuCommands(callback: (command: DesktopMenuCommand) => void): () => void {
   return bridge()?.onMenuCommand(callback) ?? (() => undefined)
+}
+
+/** True only where the platform draws the menu itself, which today means macOS. Everywhere else —
+ *  the browser, Windows, Linux — the app draws its own menu bar and binds its own accelerators. */
+export function desktopUsesNativeMenu(): boolean {
+  return desktopPlatform()?.usesNativeMenu === true
+}
+
+export function setDesktopApplicationMenu(template: DesktopMenuTemplate): void {
+  void bridge()?.setApplicationMenu(template).catch(() => undefined)
 }
 
 export async function desktopRequest(config: ServerConfig, request: DesktopRequest): Promise<DesktopResponse> {


### PR DESCRIPTION
## Summary

Completes the platform-menu wiring that #113 left as scaffolding. The IPC channel, the command list and the preload callback were all there, but nothing ever sent on the channel, so the code did nothing.

- the renderer hands main a description of the menu it would otherwise draw itself; main renders it and echoes clicks back as command ids
- macOS only: Windows and Linux would draw a second menu bar inside the window frame, right under the one the renderer already draws
- where the platform menu is active, the renderer stops binding its own accelerators
- key bindings now come from one map shared by the menu label, the Electron accelerator and the keydown handler
- menu payloads are validated at the process boundary like every other IPC message

## Why

On macOS `main.ts` never nulled the menu, so the app showed **Electron's default menu** — English, generic, knowing nothing about the app — in the system menu bar, next to the app's own translated in-window menu bar. That is the wart this fixes.

Main stays ignorant of what any command means: it renders whatever it is handed. The two menus are the same definitions, so they cannot drift into saying different things.

Splitting by platform matters. A native menu bar on Windows/Linux is drawn inside the window frame, which would stack it directly beneath the in-app one — two menu bars where there was one. And leaving the renderer's keydown handler active alongside native accelerators makes every shortcut fire twice; harmless for "New session", but `Cmd+B` toggles the inspector back to where it started.

## Incidental fix

The `Connetti server` item advertised `Ctrl+N+Shift`. The accelerator string was assembled by hand in the wrong order. Deriving label and accelerator from one binding map makes that unrepresentable; it now reads `Ctrl+Shift+N`.

## Validation

- `npm run build`
- `npm run test:desktop` — 13 tests, including 6 new ones covering menu order, item state, click routing, and template rejection
- `test:ui`, `test:model`, `test:settings`, `test:i18n`, `test:events`, `test:profiles`, `test:config`, `test:platform`
- browser build checked at 1280px: menus render, shortcuts and checked states correct, no console errors

**Not verified on a Mac.** I have no macOS machine here, so the native menu itself is covered by unit tests against `buildApplicationMenu` rather than by running it. The non-macOS paths are unchanged and were exercised in the browser.