### PR TITLE
Leave the browser its own keyboard shortcuts

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -130,14 +130,23 @@ function shortcut(key: string): string {
  * advertising a shortcut the handler does not implement — and it is what fixes "Ctrl+N+Shift",
  * which was written by hand in the wrong order.
  */
-const KEY_BINDINGS: Record<string, { key: string; shift?: boolean }> = {
+const KEY_BINDINGS: Record<string, { key: string; shift?: boolean; desktopOnly?: boolean }> = {
   "view.palette": { key: "k" },
   "session.new": { key: "n" },
   "server.add": { key: "n", shift: true },
-  "focus.search": { key: "f" },
-  "session.refresh": { key: "r" },
+  // Reload and find-in-page belong to the browser, and a page that takes them is a page that
+  // misbehaves: the user loses the two keys they reach for when something looks stuck. The packaged
+  // app has no such owner for them, so there they are ours.
+  "focus.search": { key: "f", desktopOnly: true },
+  "session.refresh": { key: "r", desktopOnly: true },
   "server.settings": { key: "," },
   "view.inspector": { key: "b" }
+}
+
+/** Whether a binding applies here. Fixed for the life of the process: it is a property of the
+ *  build, not of the window, so nothing has to react to it changing. */
+function bindingApplies(binding: { desktopOnly?: boolean }): boolean {
+  return !binding.desktopOnly || isDesktopPlatform()
 }
 
 function bindingKeyLabel(binding: { key: string }): string {
@@ -146,7 +155,9 @@ function bindingKeyLabel(binding: { key: string }): string {
 
 function displayShortcut(command: string): string | undefined {
   const binding = KEY_BINDINGS[command]
-  if (!binding) return undefined
+  // A shortcut the build does not bind must not be advertised either: a menu promising Ctrl+F while
+  // the browser keeps find-in-page is worse than a menu item with no shortcut at all.
+  if (!binding || !bindingApplies(binding)) return undefined
   const shift = binding.shift ? (IS_APPLE ? "⇧" : "Shift+") : ""
   return IS_APPLE ? `⌘${shift}${bindingKeyLabel(binding)}` : `Ctrl+${shift}${bindingKeyLabel(binding)}`
 }
@@ -163,6 +174,7 @@ function electronAccelerator(command: string): string | undefined {
 function commandForKeyEvent(event: KeyboardEvent): string | null {
   const key = event.key.toLowerCase()
   for (const [command, binding] of Object.entries(KEY_BINDINGS)) {
+    if (!bindingApplies(binding)) continue
     if (binding.key === key && Boolean(binding.shift) === event.shiftKey) return command
   }
   return null

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -524,4 +524,34 @@ assert.ok(
   'the command refetch belongs inside loadSelected, not in its individual callers'
 )
 
+// Ctrl+R reloads and Ctrl+F opens find-in-page. Taking either one away from someone using the app
+// in a browser costs them the two keys they reach for when something looks stuck — and it is the
+// browser's to give, not ours. The packaged app has no such owner, so there the app may bind them.
+// Asserted on the binding map rather than on the handler: the map is the one place that decides,
+// and a new browser-reserved key added without the flag is exactly the regression worth catching.
+const keyBindings = app.slice(app.indexOf('const KEY_BINDINGS'), app.indexOf('function bindingApplies'))
+assert.ok(keyBindings, 'the keyboard binding map should be findable')
+for (const [command, key] of [['focus.search', 'f'], ['session.refresh', 'r']]) {
+  assert.match(
+    keyBindings,
+    new RegExp(`"${command}":\\s*\\{ key: "${key}",[^}]*desktopOnly: true`),
+    `${command} binds a key the browser owns, so it must be marked desktopOnly`
+  )
+}
+assert.match(
+  app,
+  /function bindingApplies\([\s\S]*?return !binding\.desktopOnly \|\| isDesktopPlatform\(\)/,
+  'a desktop-only binding must be gated on actually running in the desktop app'
+)
+assert.match(
+  app,
+  /if \(!binding \|\| !bindingApplies\(binding\)\) return undefined/,
+  'a shortcut the build does not bind must not be advertised in menus either'
+)
+assert.match(
+  app,
+  /for \(const \[command, binding\] of Object\.entries\(KEY_BINDINGS\)\) \{\s*if \(!bindingApplies\(binding\)\) continue/,
+  'the keydown handler must skip bindings that do not apply to this build'
+)
+
 console.log('ui regression tests passed')


### PR DESCRIPTION
## Summary

`Ctrl+R` and `Ctrl+F` now bind only in the packaged desktop app. In a browser they go back to the browser.

- `focus.search` (`Ctrl+F`) and `session.refresh` (`Ctrl+R`) are marked `desktopOnly` in the binding map
- a binding that does not apply is neither handled nor advertised — the menu item keeps its label and loses its shortcut
- everything else is unchanged

## Why

The app called `preventDefault` on both. In a browser that costs the user reload and find-in-page: the two keys people reach for when something looks stuck, and neither of them is the page's to take. The packaged app has no other owner for them, so there they stay bound.

The keys that remain are ones the browser does not own. `Ctrl+K` for a command palette is the convention every app with one follows; `Ctrl+B`, `Ctrl+N` and `Ctrl+,` are not browser bindings.

Dropping the label matters as much as dropping the binding — a menu promising `Ctrl+F` while the browser keeps find-in-page is worse than a menu item with no shortcut at all.

## Validation

Measured in the browser build by dispatching each keystroke and reading `defaultPrevented`:

| key | before | after |
| --- | --- | --- |
| `Ctrl+F` | intercepted | **browser keeps it** |
| `Ctrl+R` | intercepted | **browser keeps it** |
| `Ctrl+K` | intercepted | intercepted |
| `Ctrl+B` | intercepted | intercepted |

The File and View menus no longer show `Ctrl+R` / `Ctrl+F` in the browser, and still show the rest.

- `npm run build`
- all nine suites green, including four new `test:ui` assertions
- confirmed the new assertions fail when the flag is removed, rather than passing vacuously
- no console errors

Not exercised in the packaged app: the desktop path is the pre-existing behaviour, unchanged, and is gated on `isDesktopPlatform()` which the browser build cannot reach.