### PR TITLE
Make the mobile interface hold up under a keyboard and a poll

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harness-remote-web",
   "private": true,
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Companion app for controlling coding-agent harnesses from phone or desktop",
   "homepage": "https://github.com/giuliastro/harness-remote",
   "author": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -289,6 +289,19 @@ function messagesHaveSameContent(left: MessageEnvelope[], right: MessageEnvelope
   })
 }
 
+/**
+ * Polling refetches the whole set of side lists every few seconds, and handing React a fresh array
+ * each time is a state change even when the contents are identical. That re-rendered the transcript
+ * — re-parsing every message's markdown — six times per poll for data nobody had changed, which is
+ * what made a busy chat lock the app up for seconds on a phone. These lists are short, so comparing
+ * them is far cheaper than the render it avoids.
+ */
+function keepIfUnchanged<T>(previous: T[], next: T[]): T[] {
+  if (previous === next) return previous
+  if (previous.length !== next.length) return next
+  return JSON.stringify(previous) === JSON.stringify(next) ? previous : next
+}
+
 function messagesExtendContent(current: MessageEnvelope[], next: MessageEnvelope[]): boolean {
   if (next.length < current.length) return false
   return current.every((message, index) => {
@@ -2107,6 +2120,9 @@ function App() {
   const [selectedAgentID, setSelectedAgentID] = useState<string>(() => localStorage.getItem(AGENT_STORAGE_KEY) || "build")
   const [modelOptions, setModelOptions] = useState<ModelOption[]>([])
   const [modelLoadError, setModelLoadError] = useState<string | null>(null)
+  /** Read inside loadSelected, which must not re-declare itself every time this changes. */
+  const modelLoadErrorRef = useRef<string | null>(null)
+  modelLoadErrorRef.current = modelLoadError
   const [selectedModelKey, setSelectedModelKey] = useState<string | null>(() => readStoredModel(config.backend))
   const [modelQuery, setModelQuery] = useState("")
   const [helpPage, setHelpPage] = useState<"overview" | "server" | "network" | "troubleshooting" | "commands">(
@@ -2274,6 +2290,12 @@ function App() {
   const initialSessionLoadRef = useRef(true)
   const latestMessageTimesRef = useRef(new Map<string, { sessionUpdated: number; activityTime: number }>())
   const selectedSessionRef = useRef<SessionView | null>(null)
+  /** The session `openSession` is currently working on, so its retry can tell it is still wanted. */
+  const openingSessionRef = useRef<string | null>(null)
+  /** Set once the project/vcs/file endpoints prove absent, so polling stops asking for them. */
+  const dashboardUnsupportedRef = useRef(false)
+  /** When the model list was last re-fetched after a failure, so the retry stays occasional. */
+  const modelRetryRef = useRef<{ sessionID: string; at: number } | null>(null)
   const eventStreamStateRef = useRef<"idle" | "connecting" | "live" | "reconnecting" | "fallback">("idle")
   /** Last time an SSE event arrived for a given session, used to spot sessions the stream isn't covering. */
   const lastEventBySessionRef = useRef(new Map<string, number>())
@@ -2479,8 +2501,20 @@ function App() {
     setActionNotice(null)
     setView("detail")
     setLoadingSessionID(sessionID)
+    openingSessionRef.current = sessionID
     try {
-      await loadSelected(sessionID, directory, true)
+      try {
+        await loadSelected(sessionID, directory, true)
+      } catch (first) {
+        // Opening a session fires several requests at once and one of them losing a flaky mobile
+        // connection is common enough that it was the usual way this screen failed. Announcing it
+        // immediately made the app look broken for the second it took to come good on its own, so
+        // one quiet retry comes first and only a second failure is worth telling anyone about.
+        if (openingSessionRef.current !== sessionID) throw first
+        await new Promise((resolve) => setTimeout(resolve, 600))
+        if (openingSessionRef.current !== sessionID) throw first
+        await loadSelected(sessionID, directory, true)
+      }
       await Promise.all([loadAgents(), loadModels(sessionID, directory)])
     } catch (err) {
       const message = (err as Error).message
@@ -2496,6 +2530,7 @@ function App() {
       loadSelectedRequestRef.current += 1
       loadModelsRequestRef.current += 1
       autoSelectAttemptedRef.current = false
+      dashboardUnsupportedRef.current = false
       setSessions([])
       setSelectedID(null)
       setMessages([])
@@ -2582,11 +2617,23 @@ function App() {
     }
     try {
       const items = await api.listGlobalSessions(config).catch(() => api.listSessions(config))
-      const directories = [...new Set(items.map((session) => session.directory).filter(Boolean))]
-      const [sessionLists, statusMaps] = await Promise.all([
-        Promise.all(directories.map((directory) => api.listSessions(config, directory).catch(() => [] as Session[]))),
-        Promise.all(directories.map((directory) => api.listStatuses(config, directory).catch(() => ({} as Record<string, SessionStatus>))))
-      ])
+      // OpenCode scopes both of these to a project directory, so each one has to be asked
+      // separately. The bridge does not: called without a directory it answers for every session it
+      // knows. Fanning out there turned one refresh into two requests per distinct directory — over
+      // a hundred requests every eight seconds on a real session list, which is what made the app
+      // stall for seconds at a time on a phone.
+      const directories = isBridgeBackend(config.backend)
+        ? []
+        : [...new Set(items.map((session) => session.directory).filter(Boolean))]
+      const [sessionLists, statusMaps] = isBridgeBackend(config.backend)
+        ? await Promise.all([
+            api.listSessions(config).then((list) => [list]).catch(() => [[]] as Session[][]),
+            api.listStatuses(config).then((map) => [map]).catch(() => [{}] as Record<string, SessionStatus>[])
+          ])
+        : await Promise.all([
+            Promise.all(directories.map((directory) => api.listSessions(config, directory).catch(() => [] as Session[]))),
+            Promise.all(directories.map((directory) => api.listStatuses(config, directory).catch(() => ({} as Record<string, SessionStatus>))))
+          ])
       const scopedSessions = new Map(sessionLists.flat().map((session) => [session.id, session]))
       const statuses = Object.assign({}, ...statusMaps)
       const hydratedItems = items.map((session) => ({ ...session, ...scopedSessions.get(session.id), project: session.project }))
@@ -2595,10 +2642,19 @@ function App() {
         .map((session) => toSessionView(session, statuses[session.id], activityTimes.get(session.id)))
         .sort((a, b) => b.updated - a.updated)
       setSessions((current) => {
-        const selected = selectedID ? current.find((session) => session.id === selectedID) : null
+        // `current` is the list this refresh started from, so a session opened moments ago may not
+        // be in it yet; the ref holds what is actually on screen. Falling back to `current` alone
+        // let a refresh that raced an open drop the selected session, and the sessions list then
+        // came back with nothing selected.
+        const selected = selectedID
+          ? current.find((session) => session.id === selectedID)
+            ?? (selectedSessionRef.current?.id === selectedID ? selectedSessionRef.current : null)
+          : null
         const toPreserve = preserveSession ?? selected
-        if (!toPreserve || mapped.some((session) => session.id === toPreserve.id)) return mapped
-        return [toPreserve, ...mapped].sort((a, b) => b.updated - a.updated)
+        const next = !toPreserve || mapped.some((session) => session.id === toPreserve.id)
+          ? mapped
+          : [toPreserve, ...mapped].sort((a, b) => b.updated - a.updated)
+        return keepIfUnchanged(current, next)
       })
       backgroundFailureCountRef.current = 0
       initialSessionLoadRef.current = false
@@ -2760,12 +2816,28 @@ function App() {
       loadedMessagesRef.current = msg
       setMessages((prev) => replaceMessages ? msg : mergeFetchedMessages(prev, msg))
     }
-    setOptimisticUserMessages((current) => current.filter((message) => !hasMatchingUserMessage(msg, message)))
-    setTodos(todo)
-    setDiffFiles(diff)
-    setPendingQuestions(questions.filter((question) => question.sessionID === sessionID))
-    setPendingPermissions(permissions.filter((permission) => permission.sessionID === sessionID))
-    setExtensionActions(actions)
+    setOptimisticUserMessages((current) => {
+      const remaining = current.filter((message) => !hasMatchingUserMessage(msg, message))
+      return remaining.length === current.length ? current : remaining
+    })
+    setTodos((current) => keepIfUnchanged(current, todo))
+    setDiffFiles((current) => keepIfUnchanged(current, diff))
+    setPendingQuestions((current) => keepIfUnchanged(current, questions.filter((question) => question.sessionID === sessionID)))
+    setPendingPermissions((current) => keepIfUnchanged(current, permissions.filter((permission) => permission.sessionID === sessionID)))
+    setExtensionActions((current) => keepIfUnchanged(current, actions))
+    // A model list that failed to load once is never retried on its own — the fetch is tied to the
+    // session changing — so a transient failure left the picker disabled and marked in warning for
+    // as long as the session stayed open. The transcript arriving is the signal that the server is
+    // answering again. Spaced out because some failures are permanent rather than transient: Codex
+    // will not list models for a conversation another client holds open, and retrying that on every
+    // poll would be a request every few seconds for an answer that is not going to change.
+    if (capabilities.models && modelLoadErrorRef.current) {
+      const lastAttempt = modelRetryRef.current
+      if (lastAttempt?.sessionID !== sessionID || Date.now() - lastAttempt.at > 30_000) {
+        modelRetryRef.current = { sessionID, at: Date.now() }
+        void loadModels(sessionID, directory)
+      }
+    }
     // A bridge-backed harness only advertises its commands once a session is loaded, so the
     // mount-time fetch of an idle bridge legitimately returns []. Retry here rather than in each
     // of loadSelected's callers, otherwise Help -> Commands stays empty for the whole visit.
@@ -2837,6 +2909,10 @@ function App() {
   }
 
   async function loadProjectDashboard(directory: string) {
+    // The bridge implements none of these three, so on a bridge-backed harness this was nine
+    // guaranteed 404s a second during polling. One round of them settles the question for the
+    // rest of the connection.
+    if (dashboardUnsupportedRef.current) return
     setDashboardError(null)
     try {
       const [project, vcs, fileStatus] = await Promise.all([
@@ -2844,7 +2920,16 @@ function App() {
         api.loadVcs(config, directory).catch(() => null),
         api.loadFileStatus(config, directory).catch(() => [])
       ])
-      setProjectDashboard({ project, vcs, files: toFileStatusList(fileStatus) })
+      const files = toFileStatusList(fileStatus)
+      if (project === null && vcs === null && files.length === 0) {
+        dashboardUnsupportedRef.current = true
+        setProjectDashboard(null)
+        return
+      }
+      setProjectDashboard((current) => {
+        const next = { project, vcs, files }
+        return current && JSON.stringify(current) === JSON.stringify(next) ? current : next
+      })
     } catch (err) {
       setDashboardError((err as Error).message)
     }
@@ -2945,6 +3030,26 @@ function App() {
   const handleJumpToBottom = useCallback(() => {
     stickToBottomRef.current = true
     scrollMessagesToBottom("smooth")
+  }, [])
+
+  /**
+   * Both of these reach the memoized transcript, and `onRevertMessage` goes on to every message in
+   * it. Declared inline they were a new function on every render of this component, which defeated
+   * the memo on all of them and re-parsed every message's markdown each time — the other half of
+   * why opening a long chat froze the app. The bodies are read through refs so the callbacks can
+   * stay identity-stable while still calling the current version.
+   */
+  const revertToMessageRef = useRef(revertToMessage)
+  revertToMessageRef.current = revertToMessage
+  const handleRevertMessage = useCallback((messageID: string) => {
+    void revertToMessageRef.current(messageID)
+  }, [])
+
+  const openSessionRef = useRef(openSession)
+  openSessionRef.current = openSession
+  const handleRetrySession = useCallback(() => {
+    const session = selectedSessionRef.current
+    if (session) void openSessionRef.current(session.id, session.directory)
   }, [])
 
   const handleSessionsJumpToTop = useCallback(() => {
@@ -4753,9 +4858,7 @@ function App() {
             loadingSessionID={loadingSessionID}
             loadedSessionID={loadedSessionID}
             loadFailure={loadFailure}
-            onRetrySession={() => {
-              if (selectedSession) void openSession(selectedSession.id, selectedSession.directory)
-            }}
+            onRetrySession={handleRetrySession}
             selectedID={selectedID}
             renderedMessages={renderedMessages}
             timelineGroups={timelineGroups}
@@ -4765,7 +4868,7 @@ function App() {
             config={config}
             directory={selectedSession?.directory}
             actions={messageMenuActions}
-            onRevertMessage={(messageID) => void revertToMessage(messageID)}
+            onRevertMessage={handleRevertMessage}
             t={t}
             jumpAffordances={jumpAffordances}
             onJumpToTop={handleJumpToTop}

--- a/web/src/components/panels.tsx
+++ b/web/src/components/panels.tsx
@@ -305,17 +305,30 @@ export function ConnectServerWizard({
           </button>
         </div>
 
+        {/* The steps double as navigation. A failed test is usually the address or the port rather
+            than the password, and stepping back one screen at a time to check made that a chore. */}
         <ol className="wizard-steps">
-          {WIZARD_STEPS.map((candidate, index) => (
-            <li
-              key={candidate}
-              className={`wizard-step${candidate === step ? " active" : index < stepIndex ? " done" : ""}`}
-            >
-              <span className="wizard-step-index" aria-hidden="true">{index < stepIndex ? "✓" : index + 1}</span>
-              {t(`connect.step.${candidate}`)}
-              {index < WIZARD_STEPS.length - 1 && <span className="wizard-step-divider" aria-hidden="true" />}
-            </li>
-          ))}
+          {WIZARD_STEPS.map((candidate, index) => {
+            const reachable = candidate !== "credentials" || canLeaveAddress
+            return (
+              <li
+                key={candidate}
+                className={`wizard-step${candidate === step ? " active" : index < stepIndex ? " done" : ""}`}
+              >
+                <button
+                  type="button"
+                  className="wizard-step-button"
+                  onClick={() => setStep(candidate)}
+                  disabled={!reachable}
+                  aria-current={candidate === step ? "step" : undefined}
+                >
+                  <span className="wizard-step-index" aria-hidden="true">{index < stepIndex ? "✓" : index + 1}</span>
+                  {t(`connect.step.${candidate}`)}
+                </button>
+                {index < WIZARD_STEPS.length - 1 && <span className="wizard-step-divider" aria-hidden="true" />}
+              </li>
+            )
+          })}
         </ol>
 
         <div className="wizard-body">
@@ -414,21 +427,28 @@ export function ConnectServerWizard({
                 </label>
               </div>
               <p className="field-hint">{t('connect.credentialsHint')}</p>
-              <div className="inline-actions">
-                <button type="button" className="btn-secondary" onClick={() => void test()} disabled={testing || !canSave}>
-                  {testing ? <LoadingIcon size={15} /> : <TestIcon size={15} />}
-                  {testing ? t('settings.testing') : t('settings.test')}
-                </button>
-              </div>
-              {testResult && (
-                <div className={`notice ${testResult.ok ? "success" : "error"} fade-in`}>
-                  {testResult.ok ? "✓ " : "✗ "}
-                  {testResult.message}
-                </div>
-              )}
             </>
           )}
         </div>
+
+        {/* Outside the scrolling body on purpose. Testing the connection is the first thing anyone
+            does on this step, and with a keyboard open the body is only a couple of lines tall — a
+            test button living at the end of it scrolled out of sight and came to rest against the
+            save button, which is the one press you do not want to hit by accident. */}
+        {step === "credentials" && (
+          <div className="wizard-test">
+            <button type="button" className="btn-secondary" onClick={() => void test()} disabled={testing || !canSave}>
+              {testing ? <LoadingIcon size={15} /> : <TestIcon size={15} />}
+              {testing ? t('settings.testing') : t('settings.test')}
+            </button>
+            {testResult && (
+              <div className={`notice ${testResult.ok ? "success" : "error"} fade-in`}>
+                {testResult.ok ? "✓ " : "✗ "}
+                {testResult.message}
+              </div>
+            )}
+          </div>
+        )}
 
         <div className="wizard-footer">
           {step !== "harness" && (

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -197,6 +197,10 @@ html {
 body {
   margin: 0;
   min-height: 100dvh;
+  /* This is an application shell sized to the viewport, never a document that scrolls sideways. The
+     guard is deliberate: one overflowing descendant used to widen the whole page on a phone, and
+     the only way back was pinch-zooming to find the composer. */
+  overflow-x: hidden;
   font-family: var(--font-family);
   font-size: var(--font-md);
   color: var(--text);
@@ -1902,6 +1906,10 @@ a:focus-visible,
   flex-direction: column;
   gap: var(--space-4);
   overflow-y: auto;
+  /* Transcript content is not the page's to widen: anything too wide for the column scrolls in its
+     own box (code blocks and tool output already do). Without this a single overlong token turned
+     into a horizontally scrolling page, which on a phone moved the composer out of reach. */
+  overflow-x: hidden;
   padding: var(--space-4);
   padding-bottom: var(--chat-bottom-clearance, 140px);
   scroll-padding-bottom: var(--chat-bottom-clearance, 140px);
@@ -2064,6 +2072,10 @@ a:focus-visible,
   justify-content: space-between;
   gap: var(--space-2);
   width: 100%;
+  /* A flex item refuses to shrink below its content, so a summary naming a long path used to widen
+     the row rather than wrap inside it. */
+  min-width: 0;
+  overflow-wrap: anywhere;
   margin-top: var(--space-2);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
@@ -2107,9 +2119,16 @@ a:focus-visible,
   margin-top: 0;
 }
 
+/* `pre-wrap` breaks at whitespace only, so a single long token — a URL, an absolute path, a hash —
+   ran straight out of the box. Nothing clipped it, so on a phone it widened the page itself and
+   pushed the composer and its send button off-screen. Long tokens now break, and anything that
+   still cannot (a wide table of fixed-width columns) scrolls inside this block instead of the page. */
 .message-reasoning-text {
   margin: 0;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  overflow-x: auto;
+  max-width: 100%;
   font-family: var(--font-mono);
   font-size: var(--font-sm);
 }
@@ -3079,6 +3098,24 @@ a:focus-visible,
   font-weight: 550;
 }
 
+/* The label is a button now, but it has to keep reading as a step marker rather than a control. */
+.wizard-step-button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  border: 0;
+  background: none;
+  padding: var(--space-1) 0;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.wizard-step-button:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
 .wizard-step-index {
   display: grid;
   place-items: center;
@@ -3120,6 +3157,31 @@ a:focus-visible,
   display: grid;
   align-content: start;
   gap: var(--space-4);
+}
+
+/* Sits between the scrolling body and the footer, so it survives the keyboard taking most of the
+   screen. Its own border keeps the test action visually apart from the footer's save button.
+   The card clips its overflow, which sacrifices whichever child comes last — the footer — so the
+   order in which space is surrendered is stated rather than left to the default: the body first,
+   then this strip, and the footer never. */
+.wizard-test {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-5);
+  border-top: 1px solid var(--border);
+  flex: 0 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.wizard-header,
+.wizard-steps,
+.wizard-footer {
+  flex: 0 0 auto;
+}
+
+.wizard-test .notice {
+  margin: 0;
 }
 
 .wizard-footer {
@@ -4055,6 +4117,11 @@ a:focus-visible,
     padding-right: var(--space-4);
   }
 
+  .wizard-test {
+    padding-left: var(--space-4);
+    padding-right: var(--space-4);
+  }
+
   .wizard-footer {
     flex-wrap: wrap;
   }
@@ -4085,6 +4152,47 @@ a:focus-visible,
 
   .sheet-handle {
     display: block;
+  }
+}
+
+/* An on-screen keyboard leaves roughly this much of a phone, and `interactive-widget=resizes-content`
+   in index.html means the viewport really does shrink to it. Everything the wizard can spare is
+   given back so the test action and the footer both stay on screen: the subtitle goes, the paddings
+   tighten, the footer stops wrapping onto extra rows, and a long failure message scrolls in place. */
+@media (max-height: 560px) {
+  .wizard-header {
+    padding-top: var(--space-3);
+    padding-bottom: var(--space-2);
+  }
+
+  .wizard-header-text p.subtle {
+    display: none;
+  }
+
+  .wizard-steps {
+    padding-top: var(--space-1);
+    padding-bottom: var(--space-1);
+  }
+
+  .wizard-test {
+    padding-top: var(--space-2);
+    padding-bottom: var(--space-2);
+  }
+
+  .wizard-test .notice {
+    max-height: 4.5rem;
+    overflow-y: auto;
+  }
+
+  .wizard-footer {
+    flex-wrap: nowrap;
+    padding-top: var(--space-2);
+    padding-bottom: var(--space-2);
+  }
+
+  .wizard-footer button {
+    flex: 0 1 auto;
+    white-space: nowrap;
   }
 }
 
@@ -4198,6 +4306,21 @@ button,
 .palette-item,
 .message-diff-row {
   -webkit-tap-highlight-color: transparent;
+}
+
+/* Every control opts out of double-tap-to-zoom. Without it a tap is held back until the browser has
+   ruled out a second one, which reads as a control that ignored the first press — the bottom
+   navigation especially, where taps land in quick succession. */
+button,
+a,
+label,
+select,
+summary,
+[role="button"],
+[role="option"],
+[role="menuitem"],
+[role="tab"] {
+  touch-action: manipulation;
 }
 
 /* Deliberately excludes .messages: outside the desktop layout its height is unbounded, so it never


### PR DESCRIPTION
Five things reported from a phone, which turned out to be three causes.

## The connection test was unreachable with the keyboard open

The wizard caps itself to the viewport and scrolls its body, and `interactive-widget=resizes-content` means the keyboard really does shrink that viewport — to a couple of lines. The test button sat at the end of the body, so it scrolled out of sight and came to rest against the save button.

It moves to a strip of its own between the body and the footer. The card clips its overflow, which sacrifices whichever child is last, so the order in which space is surrendered is now stated: body first, then that strip, never the footer. Below 560px of height the subtitle goes and the paddings tighten.

Measured with the wizard on the credentials step:

| viewport height | test button | save button |
|---|---|---|
| 812 (no keyboard) | visible | visible |
| 380 (keyboard) | visible | visible |
| 300 (extreme) | visible | visible |

The step markers are buttons now — a failed test is usually the address or the port, not the password.

## Long reasoning text escaped its box

`pre-wrap` breaks at whitespace only, so one long token ran straight out: **3544px measured inside a 300px column**. Nothing clipped it, so the page widened and the composer went off-screen. Long tokens now break (same measurement: 300px), the transcript clips rather than widens, and so does the body.

## The freeze, the random failure and the missed taps were one cause

The app was too busy to respond:

- a refresh asked for sessions and statuses **once per distinct directory**, though the bridge answers for every session it knows when asked without one
- nine guaranteed 404s per cycle for endpoints the bridge does not implement
- six freshly built arrays handed to React per refresh whose contents had not changed
- two callbacks declared inline, defeating the memo on every message and re-parsing all of their markdown

Measured on the same session over a comparable window:

| | before | after |
|---|---|---|
| requests | 126 / 8s | 45 / 12s |
| long tasks | 9 (896ms total) | 1 (132ms) |
| transcript DOM mutations while polling | — | 0 across 14s |

Controls also opt out of double-tap-to-zoom, which was holding every tap back until a second one had been ruled out.

## Around a failed load

The model list is fetched only when the session changes, so one transient failure left the picker disabled and marked in warning for as long as the session stayed open. It is retried when the transcript arrives — occasionally, not every poll, because some failures are permanent (Codex will not list models for a conversation another client holds open). A refresh racing an open could also drop the session being opened, which is why the list came back with nothing selected. Opening now retries once, quietly, before reporting anything.

## Checks

`tsc` clean, 73 bridge tests, 9 web suites, production build OK. Verified in-browser at mobile size against a live Codex bridge.