### PR TITLE
fix(web): raise message and session action menus above the composer

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2582,7 +2582,7 @@ a:focus-visible,
 
 .message-context-menu {
   position: fixed;
-  z-index: 20;
+  z-index: var(--z-menu);
   display: grid;
   min-width: 14rem;
   gap: 1px;
@@ -2662,7 +2662,7 @@ a:focus-visible,
   position: absolute;
   top: calc(100% + var(--space-1));
   right: 0;
-  z-index: 20;
+  z-index: var(--z-menu);
   display: grid;
   min-width: 14rem;
   gap: 1px;

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -523,7 +523,7 @@ assert.match(
 )
 assert.match(app, /session-actions-menu/, 'the header actions menu should have its own styles')
 assert.match(styles, /\.session-actions-menu\s*\{[\s\S]*?position:\s*absolute/, 'the header actions menu must overlay the conversation rather than push its layout')
-assert.match(styles, /\.session-actions-menu\s*\{[\s\S]*?z-index:\s*20/, 'the header actions menu must stack above the message list')
+assert.match(styles, /\.session-actions-menu\s*\{[\s\S]*?z-index:\s*var\(--z-menu\)/, 'the header actions menu must stack above the message list')
 assert.match(app, /mobile-session-appbar[\s\S]*?mobile-back-button[\s\S]*?SessionActionsMenu/, 'mobile detail should use one contextual row for back, identity, and session actions')
 assert.match(app, /isDesktop && selectedSession && sessionHeaderActions\.length > 0/, 'on desktop the header actions menu should remain beside the session heading')
 assert.match(styles, /\.mobile-appbar \{[\s\S]*?display:\s*flex/, 'the mobile contextual app bar should keep its controls on one row')


### PR DESCRIPTION
## What

Raise the message context menu (long-press on a phone, right-click on desktop) above the composer.

The composer stacks at `z-index: var(--z-sticky)` (20) — `position: fixed` floating over the transcript on mobile, `position: relative` below the transcript on desktop. The message context menu hardcoded `z-index: 20` and, being rendered earlier in the DOM, lost the tie: whenever the menu opened over the bottom of the transcript (mobile bottom sheet, or a right-click near the composer on desktop), its top items ("Copy text" / "Copy Markdown") were covered by the input box and taps/clicks landed on the composer instead of the menu.

## Changes

- `web/src/styles.css`
  - `.message-context-menu`: `z-index: 20` → `z-index: var(--z-menu)` (30), so it stacks above the composer and every sticky element
  - `.session-actions-menu`: same change for consistency — the header actions dropdown was on the same hardcoded value
- `web/src/ui-regression.test.mjs`: update the assertion that pinned the literal `z-index: 20`

## Verification

- `npm run test:ui` — UI regression tests pass
- `npm run build` — tsc + vite production build pass
- Manual check on a phone-width window and on desktop: the message menu now renders above the composer in both layouts; the header "⋮" menu is unchanged

Fixes #124
