### PR TITLE
fix(bridge): deduplicate divergent OMP history semantically

### DIFF
--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -59,13 +59,19 @@ function semanticMessagePart(part) {
   return semantic
 }
 
+function semanticMessageSignature(message) {
+  return JSON.stringify({
+    role: message?.info?.role,
+    parts: (message?.parts ?? []).map(semanticMessagePart)
+  })
+}
+
 function semanticHistorySignature(messages) {
   return JSON.stringify(messages.map((message) => ({
     role: message?.info?.role,
     parts: (message?.parts ?? []).map(semanticMessagePart)
   })))
 }
-
 
 function mergeReplay(previous, replayed) {
   if (previous.length === 0) return replayed
@@ -100,19 +106,20 @@ function mergeReplay(previous, replayed) {
   return [...merged, ...previous.slice(leftIndex), ...replayed.slice(rightIndex)]
 }
 
-function mergeExternalHistory(persisted, cached) {
+export function mergeExternalHistory(persisted, cached) {
   const persistedIDs = new Set(persisted.map((message) => message.info.id))
-  const persistedBySignature = new Map()
+  const remainingBySignature = new Map()
   for (const message of persisted) {
-    const signature = messageSignature(message)
-    const times = persistedBySignature.get(signature) ?? []
-    times.push(message.info.time.created)
-    persistedBySignature.set(signature, times)
+    const signature = semanticMessageSignature(message)
+    remainingBySignature.set(signature, (remainingBySignature.get(signature) ?? 0) + 1)
   }
   const cachedOnly = cached.filter((message) => {
     if (persistedIDs.has(message.info.id)) return false
-    const duplicateTimes = persistedBySignature.get(messageSignature(message)) ?? []
-    return !duplicateTimes.some((created) => Math.abs(created - message.info.time.created) < 30_000)
+    const signature = semanticMessageSignature(message)
+    const remaining = remainingBySignature.get(signature) ?? 0
+    if (remaining === 0) return true
+    remainingBySignature.set(signature, remaining - 1)
+    return false
   })
   return [...persisted, ...cachedOnly].sort((left, right) => left.info.time.created - right.info.time.created)
 }
@@ -203,7 +210,6 @@ export class AcpService {
     this.#actionProviders = actionProviders
     acp.on("notification", (notification) => this.#handleNotification(notification))
   }
-
 
   subscribe(listener) {
     this.#listeners.add(listener)

--- a/bridge/test/external-history-dedup.test.js
+++ b/bridge/test/external-history-dedup.test.js
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { mergeExternalHistory } from "../src/acp-service.js"
+
+function message(id, text, created, extras = {}) {
+  return {
+    info: { id, role: "user", sessionID: "session-1", time: { created } },
+    parts: [{ id: `${id}:text`, messageID: id, type: "text", text, ...extras }]
+  }
+}
+
+test("deduplicates replayed messages even when ids and timestamps differ", () => {
+  const persisted = [message("persisted-1", "same prompt", 1_000)]
+  const cached = [message("replayed-1", "same prompt", 120_000)]
+
+  assert.deepEqual(
+    mergeExternalHistory(persisted, cached).map((item) => item.info.id),
+    ["persisted-1"]
+  )
+})
+
+test("preserves legitimate repeated prompts by matching semantic occurrences one-for-one", () => {
+  const persisted = [message("persisted-1", "repeat me", 1_000)]
+  const cached = [
+    message("replayed-1", "repeat me", 120_000),
+    message("actual-repeat", "repeat me", 180_000)
+  ]
+
+  assert.deepEqual(
+    mergeExternalHistory(persisted, cached).map((item) => item.info.id),
+    ["persisted-1", "actual-repeat"]
+  )
+})
+
+test("semantic matching ignores transient part ids but keeps meaningful part differences", () => {
+  const persisted = [message("persisted-1", "same prompt", 1_000)]
+  const replayed = message("replayed-1", "same prompt", 120_000)
+  replayed.parts[0].id = "different-part-id"
+  replayed.parts[0].messageID = "different-message-id"
+
+  assert.equal(mergeExternalHistory(persisted, [replayed]).length, 1)
+
+  const distinct = message("distinct", "same prompt", 180_000, { type: "reasoning" })
+  assert.equal(mergeExternalHistory(persisted, [distinct]).length, 2)
+})


### PR DESCRIPTION
## What changed

Fixes external OMP history merging so replayed messages are deduplicated by stable semantic content instead of requiring either the same generated message ID or a timestamp within 30 seconds.

The merge now counts persisted semantic occurrences and consumes cached matches one-for-one. This means a replay of the same logical message is removed even when OMP minted a fresh ID and timestamp, while a genuinely repeated prompt with identical text is still preserved as a second occurrence.

## Root cause

OMP can mint fresh `messageId` values on `session/load`, while persisted JSONL history retains its original IDs and timestamps. The previous `mergeExternalHistory()` fallback only considered equal text/role within a 30-second timestamp window, so divergent bridge loads could retain both copies.

## Tests

Adds focused coverage for:

- same semantic message with different IDs and widely different timestamps
- legitimate repeated identical prompts
- ignoring transient part/message IDs while preserving meaningful semantic differences

Local execution was not available in this environment because the runtime cannot reach GitHub to clone the repository; the branch diff was verified through the GitHub connector and CI should provide the full repository validation.

Fixes #122