### PR TITLE
feat(web): let soft keyboards enter new lines in the composer

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -125,6 +125,15 @@ function defaultSidebarWidth(): number {
  *  to say the one the user's keyboard actually has. */
 const IS_APPLE = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform || navigator.userAgent)
 
+/** Touch-primary devices have no Shift key on the soft keyboard, so the composer's
+ *  "Enter sends, Shift+Enter for a new line" model must flip there: Enter inserts a new line,
+ *  Ctrl/Cmd+Enter sends, and the send button covers soft-keyboard-only devices. Desktop and
+ *  any device with a fine pointer (including hybrid laptops whose primary pointer is a mouse)
+ *  keep the physical-keyboard behaviour untouched. */
+const SOFT_KEYBOARD_DEVICE =
+  isAndroidPlatform(Capacitor.getPlatform()) ||
+  (typeof window !== "undefined" && window.matchMedia("(pointer: coarse)").matches)
+
 function shortcut(key: string): string {
   return IS_APPLE ? `⌘${key}` : `Ctrl+${key}`
 }
@@ -4924,7 +4933,7 @@ function App() {
               value={composer}
               onChange={(event) => setComposer(event.target.value)}
               placeholder={t('detail.composerPlaceholder')}
-              enterKeyHint="send"
+              enterKeyHint={SOFT_KEYBOARD_DEVICE ? "enter" : "send"}
               autoCapitalize="sentences"
               autoCorrect="on"
               onFocus={() => {
@@ -4937,7 +4946,17 @@ function App() {
                 window.addEventListener("resize", onResize, { once: true })
               }}
               onKeyDown={(event) => {
-                if (event.key === "Enter" && !event.shiftKey) {
+                if (event.key !== "Enter") return
+                if (SOFT_KEYBOARD_DEVICE) {
+                  // The soft keyboard has no Shift key, so Enter inserts a new line by default
+                  // and Ctrl/Cmd+Enter (hardware keyboards) sends.
+                  if (event.ctrlKey || event.metaKey) {
+                    event.preventDefault()
+                    send().catch(() => undefined)
+                  }
+                  return
+                }
+                if (!event.shiftKey) {
                   event.preventDefault()
                   send().catch(() => undefined)
                 }
@@ -5295,7 +5314,9 @@ function App() {
                 <li><strong>Interact:</strong> {isDesktop
                   ? "Read and reply in the conversation beside it"
                   : "Open a session and chat in the Detail view"}</li>
-                <li><strong>Quick Input:</strong> Press Enter to send, Shift+Enter for new lines</li>
+                <li><strong>Quick Input:</strong> {SOFT_KEYBOARD_DEVICE
+                  ? `Enter for new lines, ${shortcut("Enter")} to send`
+                  : "Press Enter to send, Shift+Enter for new lines"}</li>
                 <li><strong>Slash Commands:</strong> Text starting with <code>/</code> is sent as a command</li>
               </ul>
 

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -294,11 +294,16 @@ for (const cls of ['.harness-badge', '.harness-omp', '.harness-pi', '.brand-serv
 }
 assert.match(styles, /\.brand-server[\s\S]*?text-overflow: ellipsis/, 'a long address must truncate rather than push the badge off screen')
 
-// Mobile keyboard: an address is not a sentence, a port is a number, and Enter sends.
+// Mobile keyboard: an address is not a sentence, a port is a number, and a soft keyboard has
+// no Shift key — so the composer flips on touch-primary devices: Enter inserts a new line,
+// Ctrl/Cmd+Enter sends, the send button covers soft-keyboard-only devices. Fine pointers keep
+// Enter sends / Shift+Enter new line, untouched for every user with a physical keyboard.
 assert.ok(app.includes('inputMode="url"') && app.includes('autoCapitalize="none"'), 'the host field must not be autocapitalised or autocorrected')
 assert.ok(app.includes('inputMode="numeric"'), 'the port field should raise a numeric keypad')
 assert.ok(app.includes('autoComplete="username"') && app.includes('autoComplete="current-password"'), 'credentials should be offerable by a password manager')
-assert.ok(app.includes('enterKeyHint="send"'), "the composer's action key should say send")
+assert.ok(app.includes('enterKeyHint={SOFT_KEYBOARD_DEVICE ? "enter" : "send"}'), "the composer's action key should say send on a fine pointer and new line on a soft keyboard")
+assert.ok(app.includes('if (event.ctrlKey || event.metaKey)'), 'a soft keyboard must send with Ctrl/Cmd+Enter and newline with plain Enter')
+assert.ok(app.includes('if (!event.shiftKey)'), 'a fine pointer must keep Enter sends / Shift+Enter new line')
 
 // A session card showed a full absolute path over three lines, a third of its height.
 assert.ok(app.includes('function shortDirectory'), 'the card should shorten the directory it shows')


### PR DESCRIPTION
### Problem

Touch-primary devices have no Shift key on the soft keyboard, so
the composer's "Enter sends, Shift+Enter for new line" model left
no way to insert a new line — and `enterKeyHint="send"` relabeled
the key to "send".

### Change

- Add a `SOFT_KEYBOARD_DEVICE` flag: native Android
  (`Capacitor.getPlatform() === "android"`) or coarse-pointer
  devices (`matchMedia("(pointer: coarse)")`).
- On touch devices the composer's Enter now inserts a new line
  (`enterKeyHint="enter"`), and Ctrl/Cmd+Enter sends. The existing
  send button remains the fallback for soft-keyboard-only devices.
- Desktop and fine-pointer devices are untouched: Enter sends,
  Shift+Enter inserts a new line, exactly as before. No behaviour
  change for any user with a physical keyboard.
- Help text now states the touch-device keys.

### Files

- `web/src/App.tsx` — detection flag, composer `enterKeyHint` and
  keydown handling, help text
- `web/src/ui-regression.test.mjs` — updated assertion

### Verification

- `npm run build` (type-check + bundle) and `npm run test:ui` pass.
- UI-only change; no harness interaction.
- Not verified on a real device: this workstation has no Android
  SDK, so the on-keyboard "newline" label needs the CI-built APK
  or a local SDK to confirm (CONTRIBUTING.md:31).

### Not changed

- Desktop Enter/Shift+Enter behaviour.
- Search inputs (`enterKeyHint="search"`), settings dialogs
  (`enterKeyHint="done"`), the single-line question input.

Fixes #128