### PR TITLE
fix(web): send the credentials that were typed

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,7 +1,7 @@
 import { Capacitor, CapacitorHttp } from "@capacitor/core"
 import { desktopRequest, isDesktopPlatform } from "./desktopBridge"
 import { streamURL } from "./opencode-events"
-import { baseUrl, isValidServerConfig } from "./serverConfig"
+import { authHeader, baseUrl, hasCredentials, isValidServerConfig } from "./serverConfig"
 import type { AttachmentPart } from "./attachments"
 import type {
   AgentOption,
@@ -27,11 +27,17 @@ import type {
   VcsStatus
 } from "./types"
 
-function authHeader(config: ServerConfig): string {
-  return `Basic ${btoa(`${config.username}:${config.password}`)}`
-}
-
 export { baseUrl, isValidServerConfig }
+
+// A 401 says the server wants credentials, not that the ones given are wrong — and the app can tell
+// the two apart, because it knows whether it sent any. The connection test enables itself without a
+// password, so the common case is a server with Basic Auth and an empty password field, which read
+// as "wrong password" and sent people back to re-check credentials that were correct.
+function unauthorizedDetail(config: ServerConfig): string {
+  return hasCredentials(config)
+    ? "HTTP 401: the server rejected these credentials."
+    : "HTTP 401: this server requires a username and password, and none were sent."
+}
 
 function withDirectory(path: string, directory?: string): string {
   if (!directory) return path
@@ -125,7 +131,7 @@ async function requestWithHeaders<T>(config: ServerConfig, path: string, options
   const headers: Record<string, string> = {
     Accept: "application/json"
   }
-  if (config.username && config.password) {
+  if (hasCredentials(config)) {
     headers.Authorization = authHeader(config)
   }
   if (options.body !== undefined) {
@@ -148,6 +154,7 @@ async function requestWithHeaders<T>(config: ServerConfig, path: string, options
     }
 
     if (response.status >= 400) {
+      if (response.status === 401) throw new Error(responseDetail(response.data) || unauthorizedDetail(config))
       throw new Error(responseDetail(response.data) || `HTTP ${response.status}`)
     }
 
@@ -166,14 +173,14 @@ async function requestWithHeaders<T>(config: ServerConfig, path: string, options
   } catch {
     // Kept short: this text reaches a phone screen. The CORS note only means something in a
     // browser, where it is the usual cause, and nothing at all inside the app.
-    const corsHint = config.username && config.password
+    const corsHint = hasCredentials(config)
       ? " In a browser, Basic Auth also needs the bridge started with --cors for this origin."
       : ""
     throw new Error(`Cannot reach ${config.host}:${config.port}.${corsHint}`)
   }
 
   if (!response.ok) {
-    let detail = `HTTP ${response.status}`
+    let detail = response.status === 401 ? unauthorizedDetail(config) : `HTTP ${response.status}`
     try {
       // A Response body is a one-shot stream. Read it once and let responseDetail
       // parse JSON when applicable, so a plain-text server error remains useful.
@@ -223,7 +230,7 @@ function modelWireName(model?: ModelSelection) {
 export const api = {
   eventStream(config: ServerConfig) {
     const headers: Record<string, string> = {}
-    if (config.username && config.password) headers.Authorization = authHeader(config)
+    if (hasCredentials(config)) headers.Authorization = authHeader(config)
     return { url: streamURL(baseUrl(config), "global"), headers }
   },
 

--- a/web/src/server-config.test.mjs
+++ b/web/src/server-config.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { streamURL } from './opencode-events.ts'
-import { baseUrl, isValidServerConfig } from './serverConfig.ts'
+import { authHeader, baseUrl, hasCredentials, isValidServerConfig } from './serverConfig.ts'
 
 const config = (host, port = 4096) => ({ backend: 'opencode', host, port, username: 'opencode', password: 'secret' })
 
@@ -53,5 +53,56 @@ assert.match(main, /<ErrorBoundary resetKeys=\{SERVER_STORAGE_KEYS\}>/, 'a crash
 
 const boundary = readFileSync(new URL('./ErrorBoundary.tsx', import.meta.url), 'utf8')
 assert.match(boundary, /localStorage\.removeItem\(key\)/, 'recovery must clear the saved server configuration')
+
+// Basic Auth, built from two fields typed on a phone keyboard into inputs that show nothing back.
+const creds = (username, password) => ({ backend: 'opencode', host: 'localhost', port: 4096, username, password })
+
+assert.equal(
+  authHeader(creds('opencode', 'secret')),
+  'Basic b3BlbmNvZGU6c2VjcmV0',
+  'the ordinary case must still produce the standard header'
+)
+
+// The password field is masked and the stored config keeps what was typed, so a space accepted from
+// a keyboard suggestion is invisible in the UI and fatal on the wire. Host and username were already
+// trimmed elsewhere; the credentials were not, in either field.
+assert.equal(
+  authHeader(creds(' opencode ', ' secret ')),
+  authHeader(creds('opencode', 'secret')),
+  'surrounding whitespace must not change the credentials sent'
+)
+
+// `btoa` encodes Latin-1: `à` went out as one byte where curl and every other client send the two
+// UTF-8 bytes the server decodes, so the password silently did not match. Above U+00FF it threw.
+assert.equal(
+  authHeader(creds('opencode', 'pàssword')),
+  'Basic b3BlbmNvZGU6cMOgc3N3b3Jk',
+  'credentials must be encoded as UTF-8 before base64'
+)
+assert.notEqual(
+  authHeader(creds('opencode', 'pàssword')),
+  'Basic b3BlbmNvZGU6cOBzc3dvcmQ=',
+  'the Latin-1 encoding btoa produces on its own must not be what goes on the wire'
+)
+assert.doesNotThrow(() => authHeader(creds('opencode', 'påsswörd☂')), 'a character above U+00FF must not throw')
+
+// The connection test enables itself without a password, so a request can go out unauthenticated
+// against a server that requires Basic Auth. That has to be distinguishable from a wrong password:
+// one is a field left empty, the other is a credential to re-check.
+assert.equal(hasCredentials(creds('opencode', 'secret')), true, 'a complete pair must count as credentials')
+assert.equal(hasCredentials(creds('opencode', '')), false, 'a missing password must not be sent as an empty one')
+assert.equal(hasCredentials(creds('opencode', '   ')), false, 'a password of only spaces is an empty one')
+assert.equal(hasCredentials(creds('', 'secret')), false, 'a password without a username cannot form a header')
+
+const api = readFileSync(new URL('./api.ts', import.meta.url), 'utf8')
+assert.ok(
+  api.includes('function unauthorizedDetail(') && api.includes('and none were sent.'),
+  'a 401 must say whether credentials were sent at all, not just that the request was unauthorized'
+)
+assert.equal(
+  api.includes('config.username && config.password'),
+  false,
+  'credential checks must go through the shared helper, so an untrimmed field cannot pass one check and fail another'
+)
 
 console.log('server config regression tests passed')

--- a/web/src/serverConfig.ts
+++ b/web/src/serverConfig.ts
@@ -19,6 +19,34 @@ export function baseUrl(config: ServerConfig): string {
  * persisted invalid host reproduces that crash on every launch.
  */
 
+/**
+ * Credentials are typed on a phone keyboard into fields that show nothing back — the password one
+ * is masked, and a trailing space accepted from a suggestion is invisible in both. The stored
+ * config keeps whatever was typed; trimming here, at the single point the bytes are built, means a
+ * stray space cannot silently produce a 401 that reads as a wrong password.
+ */
+function credentials(config: ServerConfig): { username: string; password: string } {
+  return { username: config.username.trim(), password: config.password.trim() }
+}
+
+export function hasCredentials(config: ServerConfig): boolean {
+  const { username, password } = credentials(config)
+  return Boolean(username) && Boolean(password)
+}
+
+/**
+ * `btoa` encodes Latin-1, so `à` in a password became one byte where every other client sends the
+ * two UTF-8 bytes the server decodes, and anything above U+00FF threw outright. Encode the pair as
+ * UTF-8 first, then base64 those bytes.
+ */
+export function authHeader(config: ServerConfig): string {
+  const { username, password } = credentials(config)
+  const utf8 = new TextEncoder().encode(`${username}:${password}`)
+  let binary = ""
+  for (const byte of utf8) binary += String.fromCharCode(byte)
+  return `Basic ${btoa(binary)}`
+}
+
 export function isValidServerConfig(config: ServerConfig): boolean {
   if (!config.host.trim() || !Number.isInteger(config.port) || config.port <= 0 || config.port > 65535) return false
   try {


### PR DESCRIPTION
## Summary

- trim the username and password where the Basic Auth header is built, as host and username already were elsewhere
- encode the credentials as UTF-8 before base64, instead of relying on `btoa`'s Latin-1
- tell a 401 with no credentials sent apart from a 401 with credentials rejected
- route every credential check through one helper, so a field cannot pass one test and fail another

## Why

These turned up while debugging a real connection failure against an OpenCode server on a phone. `curl -u` returned 200 with the same username and password the app refused, which is a confusing place to be: the fault looks like the credentials, and the credentials are correct.

**Whitespace.** `authHeader` read `config.username` and `config.password` raw. Host and username are trimmed in `configKey` and `canTestConfig`, so a trailing space passes those checks and then changes the bytes on the wire. The password input is masked and a trailing space in the username field is invisible, so there is nothing on screen to see. Android keyboards add one readily when a suggestion is accepted.

**Encoding.** `btoa` encodes Latin-1: `à` in a password went out as `0xE0` where curl and every other client send the UTF-8 pair `0xC3 0xA0` that the server decodes, so the password silently did not match. A character above U+00FF made `btoa` throw, failing the request with a message about nothing relevant.

**The 401.** `canTestConfig` requires a username but not a password, so the Test button enables itself on a half-filled form and the request goes out with no `Authorization` header at all. The server answers 401, which the app reported as a plain `HTTP 401` — indistinguishable from a rejected password, and it sends you back to re-check credentials that were never sent. The app knows which case it is, because it knows whether it attached the header.

## Notes

`authHeader` and `hasCredentials` live in `serverConfig.ts`, which is already documented as free of Capacitor imports so it can be unit tested directly. `api.ts` no longer builds the header itself, and the four places that tested `config.username && config.password` now call `hasCredentials`, which treats a whitespace-only password as the empty one it is.

Trimming is a deliberate trade: a password whose first or last character is a space stops working. That is the rarer case by some distance, and the sibling fields already made the same choice.

The 401 text is a plain English string, like the `Cannot reach …` message beside it. Those errors are not translated today — they arrive inside the translated `settings.connectionFailed` wrapper — so this adds no new i18n keys.

## Validation

- `npm run build` (`tsc -b && vite build`)
- the ten web suites: `i18n`, `config`, `ui`, `settings`, `model`, `events`, `profiles`, `markdown`, `attachments`, `platform`
- `npm test` in `bridge` — 88 passing

New coverage in `server-config.test.mjs` asserts the ordinary header is unchanged, that surrounding whitespace in either field produces the same header, that `pàssword` encodes to its UTF-8 base64 and explicitly not to the Latin-1 form `btoa` would have produced, that a character above U+00FF no longer throws, and that a whitespace-only password does not count as credentials. A source assertion keeps the raw `config.username && config.password` pattern from coming back.

None of this was the cause of the failure that uncovered it — that was Android freezing the Termux process holding the server — so the fixes are for the traps found on the way, not a reproduction of that incident.