### PR TITLE
feat(core): introduce normalized AgentRun model

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -57,6 +57,7 @@ jobs:
           npm run test:profiles
           npm run test:markdown
           npm run test:attachments
+          npm run test:agent-runs
         working-directory: web
 
       - name: Build web app

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -60,6 +60,7 @@ jobs:
           npm run test:profiles
           npm run test:markdown
           npm run test:attachments
+          npm run test:agent-runs
           npm run test:platform
         working-directory: web
 

--- a/web/package.json
+++ b/web/package.json
@@ -83,7 +83,10 @@
     },
     "linux": {
       "target": [
-        "AppImage",
+        {
+          "target": "AppImage",
+          "arch": ["x64"]
+        },
         {
           "target": "deb",
           "arch": ["x64"]

--- a/web/package.json
+++ b/web/package.json
@@ -34,6 +34,7 @@
     "test:markdown": "node --experimental-strip-types src/markdown-directives.test.mjs",
     "test:config": "node --experimental-strip-types src/server-config.test.mjs",
     "test:attachments": "node --experimental-strip-types src/attachments.test.mjs",
+    "test:agent-runs": "node --experimental-strip-types src/agent-runs.test.mjs",
     "test:platform": "node src/platform-regression.test.mjs",
     "test:desktop": "npm run build:electron && node --test electron/*.test.mjs",
     "test:desktop:menu": "npm run build:electron && electron scripts/menu-smoke.mjs"
@@ -82,10 +83,7 @@
     },
     "linux": {
       "target": [
-        {
-          "target": "AppImage",
-          "arch": ["x64"]
-        },
+        "AppImage",
         {
           "target": "deb",
           "arch": ["x64"]

--- a/web/src/agent-runs.test.mjs
+++ b/web/src/agent-runs.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict'
+import { normalizeAgentRunStatus, toAgentRun } from './agentRuns.ts'
+
+const session = (overrides = {}) => ({
+  id: 'session-1',
+  title: 'Fix issue #131',
+  directory: '/work/harness-remote',
+  updated: 1_723_456_789_000,
+  status: 'idle',
+  files: 0,
+  additions: 0,
+  deletions: 0,
+  ...overrides
+})
+
+assert.equal(normalizeAgentRunStatus('idle'), 'idle')
+assert.equal(normalizeAgentRunStatus('busy'), 'working')
+assert.equal(normalizeAgentRunStatus('retry'), 'retrying')
+assert.equal(normalizeAgentRunStatus('waiting'), 'waiting')
+assert.equal(normalizeAgentRunStatus('BUSY'), 'working', 'status normalization should be case-insensitive')
+assert.equal(normalizeAgentRunStatus('unknown-backend-state'), 'idle', 'unknown states must fail safe')
+
+const openCodeRun = toAgentRun(session({ status: 'busy' }), 'opencode')
+assert.deepEqual(openCodeRun, {
+  id: 'opencode:session-1',
+  backend: 'opencode',
+  sessionId: 'session-1',
+  title: 'Fix issue #131',
+  directory: '/work/harness-remote',
+  status: 'working',
+  updatedAt: 1_723_456_789_000
+})
+
+const codexRun = toAgentRun(session({ id: 'codex-session', status: 'waiting' }), 'codex', {
+  machineId: 'workstation',
+  projectId: 'harness-remote',
+  startedAt: 1_723_456_000_000
+})
+assert.equal(codexRun.backend, 'codex')
+assert.equal(codexRun.sessionId, 'codex-session')
+assert.equal(codexRun.status, 'waiting')
+assert.equal(codexRun.attention, undefined, 'waiting on agent/subagent work is not user attention')
+assert.equal(codexRun.machineId, 'workstation')
+assert.equal(codexRun.projectId, 'harness-remote')
+assert.equal(codexRun.startedAt, 1_723_456_000_000)
+
+const questionRun = toAgentRun(session(), 'opencode', {
+  questions: [
+    { id: 'question-other', sessionID: 'another-session' },
+    { id: 'question-1', sessionID: 'session-1' }
+  ]
+})
+assert.deepEqual(questionRun.attention, { reason: 'question', requestId: 'question-1' })
+
+const permissionRun = toAgentRun(session(), 'opencode', {
+  questions: [{ id: 'question-1', sessionID: 'session-1' }],
+  permissions: [{ id: 'permission-1', sessionID: 'session-1' }]
+})
+assert.deepEqual(
+  permissionRun.attention,
+  { reason: 'permission', requestId: 'permission-1' },
+  'permissions should take precedence when more than one actionable signal exists'
+)
+
+const failedRun = toAgentRun(session({ status: 'idle' }), 'claude', { terminalStatus: 'failed' })
+assert.equal(failedRun.status, 'failed')
+assert.deepEqual(failedRun.attention, { reason: 'failure' })
+
+const completedRun = toAgentRun(session({ status: 'busy' }), 'pi', { terminalStatus: 'completed' })
+assert.equal(completedRun.status, 'completed')
+assert.deepEqual(completedRun.attention, { reason: 'completion' })
+
+const stoppedRun = toAgentRun(session({ status: 'busy' }), 'omp', { terminalStatus: 'stopped' })
+assert.equal(stoppedRun.status, 'stopped')
+assert.equal(stoppedRun.attention, undefined)
+
+console.log('agent run normalization tests passed')

--- a/web/src/agent-runs.test.mjs
+++ b/web/src/agent-runs.test.mjs
@@ -20,6 +20,19 @@ assert.equal(normalizeAgentRunStatus('waiting'), 'waiting')
 assert.equal(normalizeAgentRunStatus('BUSY'), 'working', 'status normalization should be case-insensitive')
 assert.equal(normalizeAgentRunStatus('unknown-backend-state'), 'idle', 'unknown states must fail safe')
 
+// These words already fall through the unknown branch above, so they name a decision rather than
+// add behaviour: terminal states come only from the explicit terminalStatus signal. An earlier
+// revision mapped them directly, which would have promoted a harness reporting a transient `error`
+// to a terminal failed run — visible in a future Inbox as finished, with no way back to working.
+// Without a case that says so, restoring those aliases would pass the suite.
+for (const word of ['error', 'failure', 'done', 'success', 'completed', 'cancelled', 'aborted']) {
+  assert.equal(
+    normalizeAgentRunStatus(word),
+    'idle',
+    `a harness reporting "${word}" must not be read as a terminal run`
+  )
+}
+
 const openCodeRun = toAgentRun(session({ status: 'busy' }), 'opencode')
 assert.deepEqual(openCodeRun, {
   id: 'opencode:session-1',

--- a/web/src/agentRuns.ts
+++ b/web/src/agentRuns.ts
@@ -1,0 +1,111 @@
+import type { BackendKind, PermissionRequest, QuestionRequest, SessionView } from "./types"
+
+export type AgentRunStatus =
+  | "idle"
+  | "working"
+  | "waiting"
+  | "retrying"
+  | "completed"
+  | "failed"
+  | "stopped"
+
+export type AgentAttention =
+  | { reason: "permission"; requestId: string }
+  | { reason: "question"; requestId: string }
+  | { reason: "failure" }
+  | { reason: "completion" }
+
+export type AgentRun = {
+  id: string
+  backend: BackendKind
+  sessionId: string
+  title: string
+  directory: string
+  status: AgentRunStatus
+  attention?: AgentAttention
+  projectId?: string
+  machineId?: string
+  startedAt?: number
+  updatedAt?: number
+}
+
+export type AgentRunSignals = {
+  questions?: readonly Pick<QuestionRequest, "id" | "sessionID">[]
+  permissions?: readonly Pick<PermissionRequest, "id" | "sessionID">[]
+  terminalStatus?: Extract<AgentRunStatus, "completed" | "failed" | "stopped">
+  projectId?: string
+  machineId?: string
+  startedAt?: number
+}
+
+const WORKING_STATUSES = new Set(["busy", "working", "running"])
+const RETRYING_STATUSES = new Set(["retry", "retrying"])
+const WAITING_STATUSES = new Set(["waiting"])
+const COMPLETED_STATUSES = new Set(["completed", "complete", "done", "success", "succeeded"])
+const FAILED_STATUSES = new Set(["failed", "failure", "error"])
+const STOPPED_STATUSES = new Set(["stopped", "cancelled", "canceled", "aborted"])
+
+/**
+ * Normalize the status vocabulary exposed by individual harnesses into the operational states used
+ * by the control-plane layer. The currently supported session list uses idle/busy/retry/waiting;
+ * the additional aliases keep the boundary tolerant of richer lifecycle data without teaching UI
+ * consumers about backend-specific words later.
+ */
+export function normalizeAgentRunStatus(status: string, terminalStatus?: AgentRunSignals["terminalStatus"]): AgentRunStatus {
+  if (terminalStatus) return terminalStatus
+
+  const normalized = status.trim().toLowerCase()
+  if (WORKING_STATUSES.has(normalized)) return "working"
+  if (RETRYING_STATUSES.has(normalized)) return "retrying"
+  if (WAITING_STATUSES.has(normalized)) return "waiting"
+  if (COMPLETED_STATUSES.has(normalized)) return "completed"
+  if (FAILED_STATUSES.has(normalized)) return "failed"
+  if (STOPPED_STATUSES.has(normalized)) return "stopped"
+  return "idle"
+}
+
+function attentionFor(
+  sessionId: string,
+  status: AgentRunStatus,
+  signals: AgentRunSignals
+): AgentAttention | undefined {
+  const permission = signals.permissions?.find((request) => request.sessionID === sessionId)
+  if (permission) return { reason: "permission", requestId: permission.id }
+
+  const question = signals.questions?.find((request) => request.sessionID === sessionId)
+  if (question) return { reason: "question", requestId: question.id }
+
+  if (status === "failed") return { reason: "failure" }
+  if (status === "completed") return { reason: "completion" }
+  return undefined
+}
+
+/**
+ * Convert an existing session into the backend-agnostic representation consumed by cross-agent
+ * operational views. This deliberately retains backend/session identity: AgentRun is a projection,
+ * not a replacement for the underlying session and its harness-specific capabilities.
+ */
+export function toAgentRun(
+  session: SessionView,
+  backend: BackendKind,
+  signals: AgentRunSignals = {}
+): AgentRun {
+  const status = normalizeAgentRunStatus(session.status, signals.terminalStatus)
+  const run: AgentRun = {
+    id: `${backend}:${session.id}`,
+    backend,
+    sessionId: session.id,
+    title: session.title,
+    directory: session.directory,
+    status,
+    updatedAt: session.updated
+  }
+
+  const attention = attentionFor(session.id, status, signals)
+  if (attention) run.attention = attention
+  if (signals.projectId) run.projectId = signals.projectId
+  if (signals.machineId) run.machineId = signals.machineId
+  if (signals.startedAt !== undefined) run.startedAt = signals.startedAt
+
+  return run
+}

--- a/web/src/agentRuns.ts
+++ b/web/src/agentRuns.ts
@@ -41,15 +41,12 @@ export type AgentRunSignals = {
 const WORKING_STATUSES = new Set(["busy", "working", "running"])
 const RETRYING_STATUSES = new Set(["retry", "retrying"])
 const WAITING_STATUSES = new Set(["waiting"])
-const COMPLETED_STATUSES = new Set(["completed", "complete", "done", "success", "succeeded"])
-const FAILED_STATUSES = new Set(["failed", "failure", "error"])
-const STOPPED_STATUSES = new Set(["stopped", "cancelled", "canceled", "aborted"])
 
 /**
- * Normalize the status vocabulary exposed by individual harnesses into the operational states used
- * by the control-plane layer. The currently supported session list uses idle/busy/retry/waiting;
- * the additional aliases keep the boundary tolerant of richer lifecycle data without teaching UI
- * consumers about backend-specific words later.
+ * Normalize the status vocabulary exposed by currently supported harnesses into the operational
+ * states used by the control-plane layer. Terminal states are deliberately supplied only through
+ * the explicit terminalStatus signal: inferring them from raw harness words such as "error" or
+ * "done" could turn transient or backend-specific states into false terminal runs in the Inbox.
  */
 export function normalizeAgentRunStatus(status: string, terminalStatus?: AgentRunSignals["terminalStatus"]): AgentRunStatus {
   if (terminalStatus) return terminalStatus
@@ -58,9 +55,6 @@ export function normalizeAgentRunStatus(status: string, terminalStatus?: AgentRu
   if (WORKING_STATUSES.has(normalized)) return "working"
   if (RETRYING_STATUSES.has(normalized)) return "retrying"
   if (WAITING_STATUSES.has(normalized)) return "waiting"
-  if (COMPLETED_STATUSES.has(normalized)) return "completed"
-  if (FAILED_STATUSES.has(normalized)) return "failed"
-  if (STOPPED_STATUSES.has(normalized)) return "stopped"
   return "idle"
 }
 


### PR DESCRIPTION
## Summary

Introduces the backend-agnostic `AgentRun` projection planned in #131, without changing the existing session UI.

### What changed

- add `AgentRunStatus`, `AgentAttention`, `AgentRun` and `AgentRunSignals`
- normalize current harness session states (`idle`, `busy`, `retry`, `waiting`) into operational states
- retain the backend + session identity needed to open/control the underlying session
- surface actionable question/permission attention with the original request id
- support explicit future terminal signals (`completed`, `failed`, `stopped`) without inventing them from current harness data
- reserve optional project/machine/start metadata for the later control-plane phases
- add normalization coverage across OpenCode and ACP-backed harness examples
- run the new suite in PR checks

## Design notes

`AgentRun` is deliberately a projection rather than a replacement for `SessionView`. Backend-specific details and capabilities remain on the existing session path.

`waiting` is normalized as an operational state but is not treated as user attention: waiting for internal/subagent work does not itself require intervention.

When multiple actionable signals exist, permission takes precedence over question so a future Inbox can surface the most immediately blocking action. The request id is retained so that Inbox can later become actionable without reshaping this model.

## Validation

The PR workflow runs:

- TypeScript build/type-check
- the new `test:agent-runs` suite
- all existing web regression suites
- bridge tests
- debug APK build

Closes #131.