### PR TITLE
feat(daemon): introduce machine identity and agent host registry

### DIFF
--- a/bridge/src/cli.js
+++ b/bridge/src/cli.js
@@ -3,6 +3,7 @@ import path from "node:path"
 import { AcpClient } from "./acp-client.js"
 import { parseConfig, usage } from "./config.js"
 import { harnessProfile } from "./harness-profiles.js"
+import { loadMachineIdentity, MachineRegistry } from "./machine-registry.js"
 import { createBridgeServer } from "./server.js"
 
 let config
@@ -20,10 +21,22 @@ if (config?.help) {
 
 if (config) {
   const profile = harnessProfile(config.backend)
+  const machineIdentity = await loadMachineIdentity(config.stateDirectory)
+  const machineRegistry = new MachineRegistry(machineIdentity)
+  machineRegistry.registerHost({
+    id: profile.id,
+    label: profile.label,
+    backend: profile.id,
+    transport: "acp",
+    state: "configured",
+    capabilities: profile.capabilities
+  })
+
   const acp = new AcpClient({ command: config.acpCommand, args: config.acpArgs, permissionMode: profile.permissionMode, preferredAuthMethod: profile.authMethod })
   const server = createBridgeServer({
     config,
     acp,
+    machineRegistry,
     serviceOptions: {
       snapshotDirectory: path.join(config.stateDirectory, profile.id),
       historyLoader: profile.historyLoader,
@@ -41,11 +54,13 @@ if (config) {
     process.stderr.write(`[${config.backend}] handled agent request: ${message.method}\n`)
   })
   acp.on("exit", (error) => {
+    machineRegistry.updateHost(profile.id, { state: "unavailable" })
     if (!shuttingDown) process.stderr.write(`[${config.backend}] ${error.message}\n`)
   })
 
   server.listen(config.port, config.host, () => {
     process.stdout.write(`${config.backend.toUpperCase()} bridge listening on http://${config.host}:${config.port}\n`)
+    process.stdout.write(`Machine: ${machineIdentity.name} (${machineIdentity.id})\n`)
   })
 
   const shutdown = () => {

--- a/bridge/src/cli.js
+++ b/bridge/src/cli.js
@@ -3,7 +3,7 @@ import path from "node:path"
 import { AcpClient } from "./acp-client.js"
 import { parseConfig, usage } from "./config.js"
 import { harnessProfile } from "./harness-profiles.js"
-import { loadMachineIdentity, MachineRegistry } from "./machine-registry.js"
+import { loadMachineIdentity, MachineRegistry, trackAgentHostLifecycle } from "./machine-registry.js"
 import { createBridgeServer } from "./server.js"
 
 let config
@@ -32,7 +32,11 @@ if (config) {
     capabilities: profile.capabilities
   })
 
-  const acp = new AcpClient({ command: config.acpCommand, args: config.acpArgs, permissionMode: profile.permissionMode, preferredAuthMethod: profile.authMethod })
+  const acp = trackAgentHostLifecycle(
+    new AcpClient({ command: config.acpCommand, args: config.acpArgs, permissionMode: profile.permissionMode, preferredAuthMethod: profile.authMethod }),
+    machineRegistry,
+    profile.id
+  )
   const server = createBridgeServer({
     config,
     acp,
@@ -54,7 +58,6 @@ if (config) {
     process.stderr.write(`[${config.backend}] handled agent request: ${message.method}\n`)
   })
   acp.on("exit", (error) => {
-    machineRegistry.updateHost(profile.id, { state: "unavailable" })
     if (!shuttingDown) process.stderr.write(`[${config.backend}] ${error.message}\n`)
   })
 

--- a/bridge/src/machine-registry.js
+++ b/bridge/src/machine-registry.js
@@ -30,6 +30,9 @@ async function installIdentity(machineFile, identity) {
   const temporary = `${machineFile}.${process.pid}.${randomUUID()}.tmp`
   await writeFile(temporary, `${JSON.stringify(identity, null, 2)}\n`, { mode: 0o600 })
   try {
+    // Hard-linking the complete temp file is an atomic "create if absent" operation. If
+    // another daemon wins the race, use its identity rather than returning two identities
+    // for the same state directory.
     await link(temporary, machineFile)
     return identity
   } catch (error) {
@@ -114,4 +117,24 @@ export class MachineRegistry {
       }))
     }
   }
+}
+
+/**
+ * ACP starts lazily, so lifecycle tracking has to wrap every start attempt rather than only
+ * initial daemon boot. A successful restart restores availability after a prior process exit.
+ */
+export function trackAgentHostLifecycle(agent, registry, hostID) {
+  const start = agent.start.bind(agent)
+  agent.start = async (...args) => {
+    try {
+      const result = await start(...args)
+      registry.updateHost(hostID, { state: "available" })
+      return result
+    } catch (error) {
+      registry.updateHost(hostID, { state: "unavailable" })
+      throw error
+    }
+  }
+  agent.on("exit", () => registry.updateHost(hostID, { state: "unavailable" }))
+  return agent
 }

--- a/bridge/src/machine-registry.js
+++ b/bridge/src/machine-registry.js
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto"
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
+import { link, mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises"
 import { hostname } from "node:os"
 import path from "node:path"
 
@@ -9,13 +9,50 @@ function validIdentity(value) {
   return value && typeof value.id === "string" && value.id.length > 0 && typeof value.name === "string" && value.name.length > 0
 }
 
+async function readIdentity(machineFile) {
+  const parsed = JSON.parse(await readFile(machineFile, "utf8"))
+  return validIdentity(parsed) ? parsed : undefined
+}
+
+async function preserveCorruptIdentity(machineFile, warn) {
+  const corruptFile = `${machineFile}.corrupt-${Date.now()}-${process.pid}`
+  try {
+    await rename(machineFile, corruptFile)
+  } catch (error) {
+    if (error?.code === "ENOENT") return undefined
+    throw error
+  }
+  warn(`Invalid Harness machine identity moved to ${corruptFile}; generating a new identity.`)
+  return corruptFile
+}
+
+async function installIdentity(machineFile, identity) {
+  const temporary = `${machineFile}.${process.pid}.${randomUUID()}.tmp`
+  await writeFile(temporary, `${JSON.stringify(identity, null, 2)}\n`, { mode: 0o600 })
+  try {
+    await link(temporary, machineFile)
+    return identity
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error
+    const existing = await readIdentity(machineFile)
+    if (existing) return existing
+    throw new Error("Concurrent Harness daemon created an invalid machine identity")
+  } finally {
+    await unlink(temporary).catch(() => {})
+  }
+}
+
 export async function loadMachineIdentity(stateDirectory, options = {}) {
   const machineFile = path.join(stateDirectory, IDENTITY_FILE)
+  const warn = options.warn ?? ((message) => process.stderr.write(`[machine] ${message}\n`))
+
   try {
-    const parsed = JSON.parse(await readFile(machineFile, "utf8"))
-    if (validIdentity(parsed)) return parsed
+    const existing = await readIdentity(machineFile)
+    if (existing) return existing
+    await preserveCorruptIdentity(machineFile, warn)
   } catch (error) {
     if (error?.code !== "ENOENT" && !(error instanceof SyntaxError)) throw error
+    if (error instanceof SyntaxError) await preserveCorruptIdentity(machineFile, warn)
   }
 
   const identity = {
@@ -24,10 +61,7 @@ export async function loadMachineIdentity(stateDirectory, options = {}) {
     createdAt: new Date().toISOString()
   }
   await mkdir(stateDirectory, { recursive: true })
-  const temporary = `${machineFile}.${process.pid}.tmp`
-  await writeFile(temporary, `${JSON.stringify(identity, null, 2)}\n`, { mode: 0o600 })
-  await rename(temporary, machineFile)
-  return identity
+  return installIdentity(machineFile, identity)
 }
 
 export class MachineRegistry {

--- a/bridge/src/machine-registry.js
+++ b/bridge/src/machine-registry.js
@@ -1,0 +1,83 @@
+import { randomUUID } from "node:crypto"
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
+import { hostname } from "node:os"
+import path from "node:path"
+
+const IDENTITY_FILE = "machine.json"
+
+function validIdentity(value) {
+  return value && typeof value.id === "string" && value.id.length > 0 && typeof value.name === "string" && value.name.length > 0
+}
+
+export async function loadMachineIdentity(stateDirectory, options = {}) {
+  const machineFile = path.join(stateDirectory, IDENTITY_FILE)
+  try {
+    const parsed = JSON.parse(await readFile(machineFile, "utf8"))
+    if (validIdentity(parsed)) return parsed
+  } catch (error) {
+    if (error?.code !== "ENOENT" && !(error instanceof SyntaxError)) throw error
+  }
+
+  const identity = {
+    id: `machine_${(options.randomUUID ?? randomUUID)()}`,
+    name: (options.hostname ?? hostname)(),
+    createdAt: new Date().toISOString()
+  }
+  await mkdir(stateDirectory, { recursive: true })
+  const temporary = `${machineFile}.${process.pid}.tmp`
+  await writeFile(temporary, `${JSON.stringify(identity, null, 2)}\n`, { mode: 0o600 })
+  await rename(temporary, machineFile)
+  return identity
+}
+
+export class MachineRegistry {
+  constructor(identity) {
+    if (!validIdentity(identity)) throw new Error("MachineRegistry requires a stable machine identity")
+    this.identity = { ...identity }
+    this.hosts = new Map()
+  }
+
+  registerHost(host) {
+    if (!host?.id || typeof host.id !== "string") throw new Error("Agent host requires an id")
+    if (this.hosts.has(host.id)) throw new Error(`Agent host already registered: ${host.id}`)
+    const normalized = {
+      id: host.id,
+      label: host.label ?? host.id,
+      backend: host.backend ?? host.id,
+      transport: host.transport ?? "acp",
+      managed: host.managed !== false,
+      state: host.state ?? "configured",
+      capabilities: host.capabilities ? { ...host.capabilities } : {}
+    }
+    this.hosts.set(normalized.id, normalized)
+    return { ...normalized, capabilities: { ...normalized.capabilities } }
+  }
+
+  updateHost(id, patch) {
+    const current = this.hosts.get(id)
+    if (!current) throw new Error(`Unknown agent host: ${id}`)
+    const next = {
+      ...current,
+      ...patch,
+      id: current.id,
+      capabilities: patch.capabilities ? { ...patch.capabilities } : current.capabilities
+    }
+    this.hosts.set(id, next)
+    return { ...next, capabilities: { ...next.capabilities } }
+  }
+
+  host(id) {
+    const value = this.hosts.get(id)
+    return value ? { ...value, capabilities: { ...value.capabilities } } : undefined
+  }
+
+  snapshot() {
+    return {
+      machine: { ...this.identity },
+      agents: [...this.hosts.values()].map((host) => ({
+        ...host,
+        capabilities: { ...host.capabilities }
+      }))
+    }
+  }
+}

--- a/bridge/src/server.js
+++ b/bridge/src/server.js
@@ -5,7 +5,6 @@ import path from "node:path"
 import { AcpService } from "./acp-service.js"
 import { harnessProfile } from "./harness-profiles.js"
 
-
 function writeJSON(response, status, body) {
   response.writeHead(status, { "Content-Type": "application/json; charset=utf-8", "Cache-Control": "no-store" })
   response.end(JSON.stringify(body))
@@ -31,8 +30,6 @@ function applyCorsHeaders(request, response, config) {
   response.setHeader("Access-Control-Allow-Credentials", "true")
   response.setHeader("Access-Control-Allow-Headers", "authorization, content-type")
   response.setHeader("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
-  // Chromium's Private Network Access preflight is sent when this public PWA
-  // connects to a local bridge (for example github.io -> localhost).
   if (request.headers["access-control-request-private-network"] === "true") {
     response.setHeader("Access-Control-Allow-Private-Network", "true")
   }
@@ -52,7 +49,6 @@ const MAX_ATTACHMENTS = 8
 const MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024
 const MAX_ATTACHMENT_TOTAL_BYTES = 15 * 1024 * 1024
 
-/** base64 carries 3 bytes per 4 characters, so measure it rather than decoding megabytes to count them. */
 function base64ByteLength(value) {
   const padding = value.endsWith("==") ? 2 : value.endsWith("=") ? 1 : 0
   return Math.floor(value.length / 4) * 3 - padding
@@ -64,32 +60,19 @@ function attachmentPayload(url) {
   return match[1]
 }
 
-/**
- * Attachments are validated before the prompt reaches the agent: a mime type the harness
- * cannot read, or a payload large enough to stall the turn, is a client mistake worth
- * naming rather than a failure to discover mid-stream.
- */
 function parseAttachments(parts) {
   const files = (Array.isArray(parts) ? parts : []).filter((part) => part?.type === "file")
-  if (files.length > MAX_ATTACHMENTS) {
-    throw new Error(`At most ${MAX_ATTACHMENTS} attachments per prompt`)
-  }
+  if (files.length > MAX_ATTACHMENTS) throw new Error(`At most ${MAX_ATTACHMENTS} attachments per prompt`)
   let total = 0
   return files.map((file) => {
     const mime = typeof file.mime === "string" ? file.mime.toLowerCase() : ""
     if (!ATTACHMENT_MIME_TYPES.has(mime)) {
-      throw new Error(
-        `Unsupported attachment type ${mime || "unknown"}: accepted types are image/png, image/jpeg, image/webp and image/gif`
-      )
+      throw new Error(`Unsupported attachment type ${mime || "unknown"}: accepted types are image/png, image/jpeg, image/webp and image/gif`)
     }
     const data = attachmentPayload(file.url)
-    if (base64ByteLength(data) > MAX_ATTACHMENT_BYTES) {
-      throw new Error("Each attachment must stay under 5MB")
-    }
+    if (base64ByteLength(data) > MAX_ATTACHMENT_BYTES) throw new Error("Each attachment must stay under 5MB")
     total += base64ByteLength(data)
-    if (total > MAX_ATTACHMENT_TOTAL_BYTES) {
-      throw new Error("Attachments must stay under 15MB in total")
-    }
+    if (total > MAX_ATTACHMENT_TOTAL_BYTES) throw new Error("Attachments must stay under 15MB in total")
     return { mime, filename: typeof file.filename === "string" ? file.filename : "attachment", data }
   })
 }
@@ -122,15 +105,6 @@ function modelWireName(model) {
   return model.providerID && modelID ? `${model.providerID}/${modelID}` : undefined
 }
 
-/**
- * The app's model API is OpenCode's, which names a model `provider/model`. ACP has no such rule:
- * OMP and PI happen to use that shape, while Claude Code's adapter offers bare ids — `sonnet`,
- * `opus[1m]`. Splitting on "/" and requiring both halves silently dropped every one of them, which
- * is why that backend looked like it exposed no models at all.
- *
- * A bare id is presented under the backend's own name instead, so it reads and behaves like the
- * others — `claude/sonnet`. `AcpService.setModel` puts it back to the id the agent knows.
- */
 function providersResponse(models, fallbackProviderID) {
   const providers = new Map()
   const defaults = {}
@@ -144,7 +118,6 @@ function providersResponse(models, fallbackProviderID) {
     provider.models[modelID] = {
       id: modelID,
       name: option.name ?? modelID,
-      // Where the harness puts the version: "Sonnet 5 · Efficient for routine tasks".
       description: option.description || undefined,
       status: "active"
     }
@@ -154,13 +127,12 @@ function providersResponse(models, fallbackProviderID) {
   return { providers: [...providers.values()], default: defaults }
 }
 
-export function createBridgeServer({ config, acp, serviceOptions }) {
+export function createBridgeServer({ config, acp, serviceOptions, machineRegistry }) {
   const backend = config.backend ?? "omp"
   const profile = harnessProfile(backend)
   const service = new AcpService(acp, { ...serviceOptions, actionProviders: profile.actionProviders })
   return http.createServer(async (request, response) => {
     applyCorsHeaders(request, response, config)
-    // Browsers omit credentials on the preflight, so it must be answered before auth.
     if (request.method === "OPTIONS") {
       response.writeHead(allowedOrigin(request, config) ? 204 : 403)
       response.end()
@@ -178,15 +150,20 @@ export function createBridgeServer({ config, acp, serviceOptions }) {
       process.stderr.write(`[bridge] ${request.method} ${url.pathname}${url.search}\n`)
     }
     try {
+      if (request.method === "GET" && (url.pathname === "/v1/machine" || url.pathname === "/global/machine")) {
+        if (!machineRegistry) {
+          writeJSON(response, 503, { error: "Machine registry is not configured" })
+          return
+        }
+        writeJSON(response, 200, machineRegistry.snapshot())
+        return
+      }
       if (request.method === "GET" && (url.pathname === "/v1/health" || url.pathname === "/global/health")) {
         await acp.start()
         writeJSON(response, 200, { healthy: true, backend, version: acp.agentInfo?.version ?? "unknown" })
         return
       }
       if (request.method === "GET" && url.pathname === "/v1/capabilities") {
-        // Attachment support comes from the handshake rather than the profile table: it is the agent
-        // that decides, and the app hides its attachment control on this flag. A static `true` would
-        // keep offering the control after a harness stopped accepting images.
         await acp.start()
         writeJSON(response, 200, { ...profile.capabilities, attachments: Boolean(acp.promptCapabilities?.image) })
         return
@@ -199,9 +176,6 @@ export function createBridgeServer({ config, acp, serviceOptions }) {
         })
         response.write(": connected\n\n")
         const unsubscribe = service.subscribe((event) => writeSSE(response, event.type, event))
-        // Clients treat a long silence as a dead connection, because a TCP stream can die
-        // without ever delivering an error. OpenCode beats every 10s; without matching it an
-        // idle session looks broken and the client reconnects on a loop.
         const heartbeat = setInterval(() => response.write(": ping\n\n"), config.heartbeatMs ?? 10_000)
         heartbeat.unref?.()
         request.on("close", () => {
@@ -281,16 +255,11 @@ export function createBridgeServer({ config, acp, serviceOptions }) {
           const body = await readBody(request)
           const text = body.parts?.find((part) => part.type === "text")?.text ?? ""
           const attachments = parseAttachments(body.parts)
-          // An image on its own is a complete prompt: a screenshot with no caption is the
-          // most common thing to send from a phone.
           if (!text && !attachments.length) throw new Error("A text prompt is required")
           await service.prompt(sessionID, text, modelWireName(body.model), attachments)
           writeJSON(response, 200, true)
           return
         }
-        // ACP has no command channel: a harness command is prompt text beginning
-        // with a slash, which is exactly what the app's composer would have sent
-        // had the picker never existed.
         if (request.method === "POST" && operation === "command") {
           const body = await readBody(request)
           if (typeof body.command !== "string" || !body.command) throw new Error("A command name is required")

--- a/bridge/src/server.js
+++ b/bridge/src/server.js
@@ -5,6 +5,7 @@ import path from "node:path"
 import { AcpService } from "./acp-service.js"
 import { harnessProfile } from "./harness-profiles.js"
 
+
 function writeJSON(response, status, body) {
   response.writeHead(status, { "Content-Type": "application/json; charset=utf-8", "Cache-Control": "no-store" })
   response.end(JSON.stringify(body))
@@ -30,6 +31,8 @@ function applyCorsHeaders(request, response, config) {
   response.setHeader("Access-Control-Allow-Credentials", "true")
   response.setHeader("Access-Control-Allow-Headers", "authorization, content-type")
   response.setHeader("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
+  // Chromium's Private Network Access preflight is sent when this public PWA
+  // connects to a local bridge (for example github.io -> localhost).
   if (request.headers["access-control-request-private-network"] === "true") {
     response.setHeader("Access-Control-Allow-Private-Network", "true")
   }
@@ -49,6 +52,7 @@ const MAX_ATTACHMENTS = 8
 const MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024
 const MAX_ATTACHMENT_TOTAL_BYTES = 15 * 1024 * 1024
 
+/** base64 carries 3 bytes per 4 characters, so measure it rather than decoding megabytes to count them. */
 function base64ByteLength(value) {
   const padding = value.endsWith("==") ? 2 : value.endsWith("=") ? 1 : 0
   return Math.floor(value.length / 4) * 3 - padding
@@ -60,19 +64,32 @@ function attachmentPayload(url) {
   return match[1]
 }
 
+/**
+ * Attachments are validated before the prompt reaches the agent: a mime type the harness
+ * cannot read, or a payload large enough to stall the turn, is a client mistake worth
+ * naming rather than a failure to discover mid-stream.
+ */
 function parseAttachments(parts) {
   const files = (Array.isArray(parts) ? parts : []).filter((part) => part?.type === "file")
-  if (files.length > MAX_ATTACHMENTS) throw new Error(`At most ${MAX_ATTACHMENTS} attachments per prompt`)
+  if (files.length > MAX_ATTACHMENTS) {
+    throw new Error(`At most ${MAX_ATTACHMENTS} attachments per prompt`)
+  }
   let total = 0
   return files.map((file) => {
     const mime = typeof file.mime === "string" ? file.mime.toLowerCase() : ""
     if (!ATTACHMENT_MIME_TYPES.has(mime)) {
-      throw new Error(`Unsupported attachment type ${mime || "unknown"}: accepted types are image/png, image/jpeg, image/webp and image/gif`)
+      throw new Error(
+        `Unsupported attachment type ${mime || "unknown"}: accepted types are image/png, image/jpeg, image/webp and image/gif`
+      )
     }
     const data = attachmentPayload(file.url)
-    if (base64ByteLength(data) > MAX_ATTACHMENT_BYTES) throw new Error("Each attachment must stay under 5MB")
+    if (base64ByteLength(data) > MAX_ATTACHMENT_BYTES) {
+      throw new Error("Each attachment must stay under 5MB")
+    }
     total += base64ByteLength(data)
-    if (total > MAX_ATTACHMENT_TOTAL_BYTES) throw new Error("Attachments must stay under 15MB in total")
+    if (total > MAX_ATTACHMENT_TOTAL_BYTES) {
+      throw new Error("Attachments must stay under 15MB in total")
+    }
     return { mime, filename: typeof file.filename === "string" ? file.filename : "attachment", data }
   })
 }
@@ -105,6 +122,15 @@ function modelWireName(model) {
   return model.providerID && modelID ? `${model.providerID}/${modelID}` : undefined
 }
 
+/**
+ * The app's model API is OpenCode's, which names a model `provider/model`. ACP has no such rule:
+ * OMP and PI happen to use that shape, while Claude Code's adapter offers bare ids — `sonnet`,
+ * `opus[1m]`. Splitting on "/" and requiring both halves silently dropped every one of them, which
+ * is why that backend looked like it exposed no models at all.
+ *
+ * A bare id is presented under the backend's own name instead, so it reads and behaves like the
+ * others — `claude/sonnet`. `AcpService.setModel` puts it back to the id the agent knows.
+ */
 function providersResponse(models, fallbackProviderID) {
   const providers = new Map()
   const defaults = {}
@@ -118,6 +144,7 @@ function providersResponse(models, fallbackProviderID) {
     provider.models[modelID] = {
       id: modelID,
       name: option.name ?? modelID,
+      // Where the harness puts the version: "Sonnet 5 · Efficient for routine tasks".
       description: option.description || undefined,
       status: "active"
     }
@@ -133,6 +160,7 @@ export function createBridgeServer({ config, acp, serviceOptions, machineRegistr
   const service = new AcpService(acp, { ...serviceOptions, actionProviders: profile.actionProviders })
   return http.createServer(async (request, response) => {
     applyCorsHeaders(request, response, config)
+    // Browsers omit credentials on the preflight, so it must be answered before auth.
     if (request.method === "OPTIONS") {
       response.writeHead(allowedOrigin(request, config) ? 204 : 403)
       response.end()
@@ -164,6 +192,9 @@ export function createBridgeServer({ config, acp, serviceOptions, machineRegistr
         return
       }
       if (request.method === "GET" && url.pathname === "/v1/capabilities") {
+        // Attachment support comes from the handshake rather than the profile table: it is the agent
+        // that decides, and the app hides its attachment control on this flag. A static `true` would
+        // keep offering the control after a harness stopped accepting images.
         await acp.start()
         writeJSON(response, 200, { ...profile.capabilities, attachments: Boolean(acp.promptCapabilities?.image) })
         return
@@ -176,6 +207,9 @@ export function createBridgeServer({ config, acp, serviceOptions, machineRegistr
         })
         response.write(": connected\n\n")
         const unsubscribe = service.subscribe((event) => writeSSE(response, event.type, event))
+        // Clients treat a long silence as a dead connection, because a TCP stream can die
+        // without ever delivering an error. OpenCode beats every 10s; without matching it an
+        // idle session looks broken and the client reconnects on a loop.
         const heartbeat = setInterval(() => response.write(": ping\n\n"), config.heartbeatMs ?? 10_000)
         heartbeat.unref?.()
         request.on("close", () => {
@@ -255,11 +289,16 @@ export function createBridgeServer({ config, acp, serviceOptions, machineRegistr
           const body = await readBody(request)
           const text = body.parts?.find((part) => part.type === "text")?.text ?? ""
           const attachments = parseAttachments(body.parts)
+          // An image on its own is a complete prompt: a screenshot with no caption is the
+          // most common thing to send from a phone.
           if (!text && !attachments.length) throw new Error("A text prompt is required")
           await service.prompt(sessionID, text, modelWireName(body.model), attachments)
           writeJSON(response, 200, true)
           return
         }
+        // ACP has no command channel: a harness command is prompt text beginning
+        // with a slash, which is exactly what the app's composer would have sent
+        // had the picker never existed.
         if (request.method === "POST" && operation === "command") {
           const body = await readBody(request)
           if (typeof body.command !== "string" || !body.command) throw new Error("A command name is required")

--- a/bridge/test/machine-registry.test.js
+++ b/bridge/test/machine-registry.test.js
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict"
-import { mkdtemp, rm } from "node:fs/promises"
+import { EventEmitter } from "node:events"
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import test from "node:test"
-import { loadMachineIdentity, MachineRegistry } from "../src/machine-registry.js"
+import { loadMachineIdentity, MachineRegistry, trackAgentHostLifecycle } from "../src/machine-registry.js"
 
 test("persists one stable machine identity across restarts", async (t) => {
   const directory = await mkdtemp(path.join(tmpdir(), "harness-machine-"))
@@ -21,6 +22,39 @@ test("persists one stable machine identity across restarts", async (t) => {
   assert.equal(first.id, "machine_11111111-2222-3333-4444-555555555555")
   assert.equal(first.name, "workstation")
   assert.deepEqual(second, first)
+})
+
+test("preserves a corrupt machine identity before generating a replacement", async (t) => {
+  const directory = await mkdtemp(path.join(tmpdir(), "harness-machine-corrupt-"))
+  t.after(() => rm(directory, { recursive: true, force: true }))
+  await writeFile(path.join(directory, "machine.json"), "{broken json", "utf8")
+  const warnings = []
+
+  const identity = await loadMachineIdentity(directory, {
+    randomUUID: () => "replacement",
+    hostname: () => "workstation",
+    warn: (message) => warnings.push(message)
+  })
+
+  assert.equal(identity.id, "machine_replacement")
+  assert.equal(warnings.length, 1)
+  const files = await readdir(directory)
+  const corrupt = files.find((file) => file.startsWith("machine.json.corrupt-"))
+  assert.ok(corrupt)
+  assert.equal(await readFile(path.join(directory, corrupt), "utf8"), "{broken json")
+})
+
+test("concurrent first starts converge on one machine identity", async (t) => {
+  const directory = await mkdtemp(path.join(tmpdir(), "harness-machine-race-"))
+  t.after(() => rm(directory, { recursive: true, force: true }))
+
+  const [first, second] = await Promise.all([
+    loadMachineIdentity(directory, { randomUUID: () => "first", hostname: () => "workstation" }),
+    loadMachineIdentity(directory, { randomUUID: () => "second", hostname: () => "workstation" })
+  ])
+
+  assert.deepEqual(second, first)
+  assert.deepEqual(JSON.parse(await readFile(path.join(directory, "machine.json"), "utf8")), first)
 })
 
 test("represents multiple heterogeneous agent hosts on one machine", () => {
@@ -64,6 +98,39 @@ test("represents multiple heterogeneous agent hosts on one machine", () => {
       }
     ]
   })
+})
+
+test("tracks host startup, failure, and recovery", async () => {
+  class FakeAgent extends EventEmitter {
+    starts = 0
+    failNext = false
+
+    async start() {
+      this.starts += 1
+      if (this.failNext) {
+        this.failNext = false
+        throw new Error("start failed")
+      }
+    }
+  }
+
+  const registry = new MachineRegistry({ id: "machine_test", name: "workstation" })
+  registry.registerHost({ id: "codex" })
+  const agent = trackAgentHostLifecycle(new FakeAgent(), registry, "codex")
+
+  assert.equal(registry.host("codex").state, "configured")
+  await agent.start()
+  assert.equal(registry.host("codex").state, "available")
+
+  agent.emit("exit", new Error("crashed"))
+  assert.equal(registry.host("codex").state, "unavailable")
+
+  await agent.start()
+  assert.equal(registry.host("codex").state, "available")
+
+  agent.failNext = true
+  await assert.rejects(agent.start(), /start failed/)
+  assert.equal(registry.host("codex").state, "unavailable")
 })
 
 test("rejects duplicate host identities", () => {

--- a/bridge/test/machine-registry.test.js
+++ b/bridge/test/machine-registry.test.js
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import test from "node:test"
+import { loadMachineIdentity, MachineRegistry } from "../src/machine-registry.js"
+
+test("persists one stable machine identity across restarts", async (t) => {
+  const directory = await mkdtemp(path.join(tmpdir(), "harness-machine-"))
+  t.after(() => rm(directory, { recursive: true, force: true }))
+
+  const first = await loadMachineIdentity(directory, {
+    randomUUID: () => "11111111-2222-3333-4444-555555555555",
+    hostname: () => "workstation"
+  })
+  const second = await loadMachineIdentity(directory, {
+    randomUUID: () => "different",
+    hostname: () => "renamed-host"
+  })
+
+  assert.equal(first.id, "machine_11111111-2222-3333-4444-555555555555")
+  assert.equal(first.name, "workstation")
+  assert.deepEqual(second, first)
+})
+
+test("represents multiple heterogeneous agent hosts on one machine", () => {
+  const registry = new MachineRegistry({ id: "machine_test", name: "workstation" })
+  registry.registerHost({
+    id: "codex",
+    label: "Codex CLI",
+    backend: "codex",
+    transport: "acp",
+    capabilities: { sessions: true, models: true }
+  })
+  registry.registerHost({
+    id: "opencode",
+    label: "OpenCode",
+    backend: "opencode",
+    transport: "http",
+    state: "available",
+    capabilities: { sessions: true, permissions: true }
+  })
+
+  assert.deepEqual(registry.snapshot(), {
+    machine: { id: "machine_test", name: "workstation" },
+    agents: [
+      {
+        id: "codex",
+        label: "Codex CLI",
+        backend: "codex",
+        transport: "acp",
+        managed: true,
+        state: "configured",
+        capabilities: { sessions: true, models: true }
+      },
+      {
+        id: "opencode",
+        label: "OpenCode",
+        backend: "opencode",
+        transport: "http",
+        managed: true,
+        state: "available",
+        capabilities: { sessions: true, permissions: true }
+      }
+    ]
+  })
+})
+
+test("rejects duplicate host identities", () => {
+  const registry = new MachineRegistry({ id: "machine_test", name: "workstation" })
+  registry.registerHost({ id: "codex" })
+  assert.throws(() => registry.registerHost({ id: "codex" }), /already registered/)
+})

--- a/bridge/test/machine-server.test.js
+++ b/bridge/test/machine-server.test.js
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import test from "node:test"
+import { MachineRegistry } from "../src/machine-registry.js"
+import { createBridgeServer } from "../src/server.js"
+
+class IdleAcp extends EventEmitter {}
+
+function baseConfig() {
+  return {
+    backend: "omp",
+    host: "127.0.0.1",
+    port: 0,
+    username: "",
+    password: "",
+    roots: [],
+    corsOrigins: [],
+    logRequests: false,
+    heartbeatMs: 10_000
+  }
+}
+
+test("serves a machine-scoped heterogeneous agent registry", async (t) => {
+  const registry = new MachineRegistry({ id: "machine_test", name: "workstation" })
+  registry.registerHost({ id: "omp", label: "Oh My Pi", backend: "omp", transport: "acp" })
+  registry.registerHost({ id: "opencode", label: "OpenCode", backend: "opencode", transport: "http", state: "available" })
+
+  const server = createBridgeServer({
+    config: baseConfig(),
+    acp: new IdleAcp(),
+    machineRegistry: registry,
+    serviceOptions: {}
+  })
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  t.after(() => new Promise((resolve) => server.close(resolve)))
+
+  const address = server.address()
+  assert.ok(address && typeof address === "object")
+  const response = await fetch(`http://127.0.0.1:${address.port}/v1/machine`)
+
+  assert.equal(response.status, 200)
+  assert.deepEqual(await response.json(), registry.snapshot())
+})
+
+test("machine endpoint remains protected by bridge authentication", async (t) => {
+  const registry = new MachineRegistry({ id: "machine_test", name: "workstation" })
+  registry.registerHost({ id: "omp" })
+  const config = { ...baseConfig(), username: "harness", password: "secret" }
+  const server = createBridgeServer({ config, acp: new IdleAcp(), machineRegistry: registry, serviceOptions: {} })
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  t.after(() => new Promise((resolve) => server.close(resolve)))
+
+  const address = server.address()
+  assert.ok(address && typeof address === "object")
+  const unauthorized = await fetch(`http://127.0.0.1:${address.port}/v1/machine`)
+  assert.equal(unauthorized.status, 401)
+
+  const authorization = Buffer.from("harness:secret").toString("base64")
+  const authorized = await fetch(`http://127.0.0.1:${address.port}/v1/machine`, {
+    headers: { Authorization: `Basic ${authorization}` }
+  })
+  assert.equal(authorized.status, 200)
+})


### PR DESCRIPTION
## Summary

This is the first implementation slice of #143.

- add a stable machine identity persisted under the Harness state directory
- preserve corrupt identity files for diagnosis and avoid concurrent first-start identity races
- introduce a backend-neutral `MachineRegistry` that can represent heterogeneous agent hosts on one machine
- register the current legacy ACP backend as the first machine host without changing existing session APIs
- track ACP host lifecycle in both directions (`configured` → `available` → `unavailable` → `available`)
- expose the fleet-safe machine contract through `GET /v1/machine` and `GET /global/machine`
- add unit coverage for stable identity, corruption recovery, concurrent identity creation, heterogeneous hosts, lifecycle recovery, the HTTP machine endpoint, and authentication

## Why

The Universal Daemon needs a machine-scoped contract before process ownership and multi-agent routing are layered on top. This slice deliberately establishes:

```text
Machine
  -> AgentHost[]
```

instead of extending the current implicit `server -> backend` model.

The registry already supports heterogeneous transports (for example ACP and direct HTTP), so OpenCode can become a real host in the next slice without changing the machine API shape.

## Host state contract

- `configured`: registered but not yet successfully started
- `available`: transport/agent completed startup successfully
- `unavailable`: a previously started or attempted host exited/failed

Recovery is observable: a later successful ACP restart returns the host to `available`.

## Compatibility

Existing single-backend bridge/session endpoints remain in place. A legacy bridge process simply appears as a machine with one registered agent host.

## Follow-ups in #143

- move from one legacy host per bridge process to multiple concurrently managed hosts in one daemon
- add OpenCode as a managed/direct-HTTP host rather than launcher guidance
- expose richer host health/process lifecycle through the registry
- route agent-scoped session/run operations through the machine daemon

Part of #143; does not close it.