### PR TITLE
feat(daemon): manage OpenCode as a supervised host

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -113,7 +113,10 @@ jobs:
           fi
         working-directory: web
 
+      # Pull-request APKs are disposable test builds. Icon generation is cosmetic and depends on an
+      # on-demand npx install, so it must not block verification of unrelated application changes.
       - name: Generate Android app icon assets
+        continue-on-error: true
         run: npx @capacitor/assets generate --android --assetPath public --iconBackgroundColor '#FFFFFF' --iconBackgroundColorDark '#FFFFFF'
         working-directory: web
 

--- a/bridge/src/launcher.js
+++ b/bridge/src/launcher.js
@@ -6,6 +6,7 @@ import { networkInterfaces } from "node:os"
 import path from "node:path"
 import { spawn } from "node:child_process"
 import { fileURLToPath } from "node:url"
+import { ManagedOpenCodeHost } from "./opencode-host.js"
 
 const BACKEND_EXECUTABLES = {
   omp: ["omp"],
@@ -15,7 +16,6 @@ const BACKEND_EXECUTABLES = {
   opencode: ["opencode"]
 }
 
-const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"])
 const VIRTUAL_INTERFACE = /^(docker|br-|veth|virbr|tun|tap|utun)/i
 
 function optionValue(args, name) {
@@ -139,11 +139,13 @@ export function lanAddresses(interfaces = networkInterfaces()) {
 }
 
 export function launcherUsage() {
-  return `Usage: harness-remote [options]\n\nQuick start options:\n  --backend <name>       Select omp, pi, claude, codex, or opencode (auto-detected when unambiguous)\n  --host <host>          Bind host (quick-start default: 0.0.0.0)\n  --port <port>          Preferred port (quick-start default: first free port from 4097)\n  --username <username>  Override generated Basic Auth username\n  --password <password>  Override generated Basic Auth password\n  --help                 Show this help\n\nAll other options are forwarded to harness-remote-bridge for ACP-backed agents.`
+  return `Usage: harness-remote [options]\n\nQuick start options:\n  --backend <name>       Select omp, pi, claude, codex, or opencode (auto-detected when unambiguous)\n  --host <host>          Bind host (quick-start default: 0.0.0.0)\n  --port <port>          Preferred port (OpenCode default: 4096; ACP default: 4097)\n  --username <username>  Override generated Basic Auth username\n  --password <password>  Override generated Basic Auth password\n  --help                 Show this help\n\nOpenCode is started and supervised directly. Other options are forwarded to harness-remote-bridge for ACP-backed agents.`
 }
 
-function openCodeGuidance({ host, port, username, password }) {
-  return `OpenCode was found on PATH. OpenCode connects directly to Harness Remote and does not use the ACP bridge.\n\nStart it directly:\n\n  OPENCODE_SERVER_USERNAME=${username} OPENCODE_SERVER_PASSWORD=${password} opencode serve --hostname ${host} --port ${port}\n\nThen select the OpenCode backend in Harness Remote and use the address/credentials above.`
+export async function startManagedOpenCode({ host, port, username, password, command = "opencode", Host = ManagedOpenCodeHost } = {}) {
+  const managed = new Host({ command, host, port, username, password })
+  await managed.start()
+  return managed
 }
 
 async function main() {
@@ -192,7 +194,24 @@ async function main() {
   process.stdout.write(`Password: ${password}\n`)
 
   if (backend === "opencode") {
-    process.stdout.write(`\n${openCodeGuidance({ host, port, username, password })}\n`)
+    process.stdout.write("\nStarting managed OpenCode host...\n")
+    const managed = await startManagedOpenCode({ host, port, username, password })
+    process.stdout.write(`OpenCode is ready on ${host}:${port}. Keep this process running while Harness Remote is connected.\n`)
+
+    let shuttingDown = false
+    const shutdown = () => {
+      if (shuttingDown) return
+      shuttingDown = true
+      managed.stop()
+    }
+    managed.on("unavailable", (error) => {
+      if (!shuttingDown) {
+        process.stderr.write(`${error.message}\n`)
+        process.exitCode = 1
+      }
+    })
+    process.on("SIGINT", shutdown)
+    process.on("SIGTERM", shutdown)
     return
   }
 

--- a/bridge/src/launcher.js
+++ b/bridge/src/launcher.js
@@ -148,6 +148,22 @@ export async function startManagedOpenCode({ host, port, username, password, com
   return managed
 }
 
+export function createManagedShutdown(managed, processObject = process) {
+  let signalCount = 0
+  let exitCode = 0
+  return (signal) => {
+    signalCount += 1
+    if (signalCount === 1) {
+      exitCode = signal === "SIGINT" ? 130 : 143
+      processObject.exitCode = exitCode
+      managed.stop("SIGTERM")
+      return
+    }
+    managed.stop("SIGKILL")
+    processObject.exit(exitCode || 1)
+  }
+}
+
 async function main() {
   const args = process.argv.slice(2)
   if (hasOption(args, "--help")) {
@@ -199,10 +215,10 @@ async function main() {
     process.stdout.write(`OpenCode is ready on ${host}:${port}. Keep this process running while Harness Remote is connected.\n`)
 
     let shuttingDown = false
-    const shutdown = () => {
-      if (shuttingDown) return
+    const shutdown = createManagedShutdown(managed)
+    const handleSignal = (signal) => {
       shuttingDown = true
-      managed.stop()
+      shutdown(signal)
     }
     managed.on("unavailable", (error) => {
       if (!shuttingDown) {
@@ -210,8 +226,8 @@ async function main() {
         process.exitCode = 1
       }
     })
-    process.on("SIGINT", shutdown)
-    process.on("SIGTERM", shutdown)
+    process.on("SIGINT", () => handleSignal("SIGINT"))
+    process.on("SIGTERM", () => handleSignal("SIGTERM"))
     return
   }
 

--- a/bridge/src/opencode-host.js
+++ b/bridge/src/opencode-host.js
@@ -1,0 +1,126 @@
+import { spawn } from "node:child_process"
+import { EventEmitter } from "node:events"
+import net from "node:net"
+
+const DEFAULT_START_TIMEOUT_MS = 15_000
+
+function waitForPort(host, port, timeoutMs = DEFAULT_START_TIMEOUT_MS) {
+  const deadline = Date.now() + timeoutMs
+  return new Promise((resolve, reject) => {
+    const tryConnect = () => {
+      const socket = net.createConnection({ host, port })
+      socket.once("connect", () => {
+        socket.destroy()
+        resolve()
+      })
+      socket.once("error", () => {
+        socket.destroy()
+        if (Date.now() >= deadline) {
+          reject(new Error(`OpenCode did not become ready on ${host}:${port} within ${timeoutMs}ms`))
+          return
+        }
+        setTimeout(tryConnect, 100).unref?.()
+      })
+    }
+    tryConnect()
+  })
+}
+
+export class ManagedOpenCodeHost extends EventEmitter {
+  constructor({
+    command = "opencode",
+    host = "127.0.0.1",
+    port = 4096,
+    username,
+    password,
+    environment = process.env,
+    spawnProcess = spawn,
+    readinessHost,
+    startTimeoutMs = DEFAULT_START_TIMEOUT_MS,
+    waitUntilReady = waitForPort
+  } = {}) {
+    super()
+    this.command = command
+    this.host = host
+    this.port = port
+    this.username = username
+    this.password = password
+    this.environment = environment
+    this.spawnProcess = spawnProcess
+    this.readinessHost = readinessHost ?? (host === "0.0.0.0" ? "127.0.0.1" : host)
+    this.startTimeoutMs = startTimeoutMs
+    this.waitUntilReady = waitUntilReady
+    this.child = undefined
+    this.starting = undefined
+  }
+
+  get processID() {
+    return Number.isInteger(this.child?.pid) ? this.child.pid : undefined
+  }
+
+  async start() {
+    if (this.child && !this.child.killed) return
+    if (this.starting) return this.starting
+    this.starting = this.#start()
+    try {
+      await this.starting
+    } finally {
+      this.starting = undefined
+    }
+  }
+
+  async #start() {
+    const child = this.spawnProcess(this.command, ["serve", "--hostname", this.host, "--port", String(this.port)], {
+      stdio: "inherit",
+      env: {
+        ...this.environment,
+        OPENCODE_SERVER_USERNAME: this.username,
+        OPENCODE_SERVER_PASSWORD: this.password
+      }
+    })
+    this.child = child
+
+    const exited = new Promise((_, reject) => {
+      child.once("error", (error) => reject(error))
+      child.once("exit", (code, signal) => reject(new Error(
+        `OpenCode exited before becoming ready (${code ?? "unknown"}${signal ? `, ${signal}` : ""})`
+      )))
+    })
+
+    try {
+      await Promise.race([
+        this.waitUntilReady(this.readinessHost, this.port, this.startTimeoutMs),
+        exited
+      ])
+      this.emit("available", { pid: this.processID, host: this.host, port: this.port })
+    } catch (error) {
+      this.stop()
+      throw error
+    }
+
+    child.removeAllListeners("exit")
+    child.removeAllListeners("error")
+    child.once("error", (error) => this.#handleExit(error))
+    child.once("exit", (code, signal) => this.#handleExit(new Error(
+      `OpenCode exited (${code ?? "unknown"}${signal ? `, ${signal}` : ""})`
+    )))
+  }
+
+  stop() {
+    const child = this.child
+    this.child = undefined
+    if (child && !child.killed) child.kill()
+  }
+
+  #handleExit(error) {
+    if (!this.child) return
+    this.child = undefined
+    this.emit("unavailable", error)
+  }
+}
+
+export function trackManagedHostLifecycle(host, registry, hostID) {
+  host.on("available", () => registry.updateHost(hostID, { state: "available", processID: host.processID }))
+  host.on("unavailable", () => registry.updateHost(hostID, { state: "unavailable", processID: undefined }))
+  return host
+}

--- a/bridge/src/opencode-host.js
+++ b/bridge/src/opencode-host.js
@@ -5,6 +5,8 @@ const DEFAULT_START_TIMEOUT_MS = 15_000
 const READINESS_RETRY_MS = 100
 const READINESS_ATTEMPT_MS = 1_000
 
+class OpenCodeCredentialError extends Error {}
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
@@ -30,11 +32,11 @@ export async function waitForOpenCodeHealth({ host, port, username, password, ti
       })
       if (response.status === 200) return
       if (response.status === 401) {
-        throw new Error(`OpenCode health check rejected the generated credentials on ${host}:${port}`)
+        throw new OpenCodeCredentialError(`OpenCode health check rejected the generated credentials on ${host}:${port}`)
       }
       lastError = new Error(`OpenCode health check returned HTTP ${response.status}`)
     } catch (error) {
-      if (error?.message?.includes("rejected the generated credentials")) throw error
+      if (error instanceof OpenCodeCredentialError) throw error
       lastError = error
     } finally {
       clearTimeout(timer)
@@ -86,7 +88,8 @@ export class ManagedOpenCodeHost extends EventEmitter {
   }
 
   get processID() {
-    return Number.isInteger(this.child?.pid) ? this.child.pid : undefined
+    if (!this.child || this.child.exitCode != null || this.child.signalCode != null) return undefined
+    return Number.isInteger(this.child.pid) ? this.child.pid : undefined
   }
 
   async start() {

--- a/bridge/src/opencode-host.js
+++ b/bridge/src/opencode-host.js
@@ -1,29 +1,62 @@
 import { spawn } from "node:child_process"
 import { EventEmitter } from "node:events"
-import net from "node:net"
 
 const DEFAULT_START_TIMEOUT_MS = 15_000
+const READINESS_RETRY_MS = 100
+const READINESS_ATTEMPT_MS = 1_000
 
-function waitForPort(host, port, timeoutMs = DEFAULT_START_TIMEOUT_MS) {
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function httpHost(host) {
+  return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host
+}
+
+async function waitForOpenCodeHealth({ host, port, username, password, timeoutMs = DEFAULT_START_TIMEOUT_MS, fetchImpl = fetch }) {
   const deadline = Date.now() + timeoutMs
-  return new Promise((resolve, reject) => {
-    const tryConnect = () => {
-      const socket = net.createConnection({ host, port })
-      socket.once("connect", () => {
-        socket.destroy()
-        resolve()
+  const authorization = Buffer.from(`${username}:${password}`).toString("base64")
+  const url = `http://${httpHost(host)}:${port}/global/health`
+  let lastError
+
+  while (Date.now() < deadline) {
+    const remaining = Math.max(1, deadline - Date.now())
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), Math.min(READINESS_ATTEMPT_MS, remaining))
+    timer.unref?.()
+    try {
+      const response = await fetchImpl(url, {
+        headers: { Authorization: `Basic ${authorization}` },
+        signal: controller.signal
       })
-      socket.once("error", () => {
-        socket.destroy()
-        if (Date.now() >= deadline) {
-          reject(new Error(`OpenCode did not become ready on ${host}:${port} within ${timeoutMs}ms`))
-          return
-        }
-        setTimeout(tryConnect, 100).unref?.()
-      })
+      if (response.status === 200) return
+      if (response.status === 401) {
+        throw new Error(`OpenCode health check rejected the generated credentials on ${host}:${port}`)
+      }
+      lastError = new Error(`OpenCode health check returned HTTP ${response.status}`)
+    } catch (error) {
+      if (error?.message?.includes("rejected the generated credentials")) throw error
+      lastError = error
+    } finally {
+      clearTimeout(timer)
     }
-    tryConnect()
+
+    if (Date.now() < deadline) await sleep(Math.min(READINESS_RETRY_MS, Math.max(1, deadline - Date.now())))
+  }
+
+  const detail = lastError instanceof Error ? `: ${lastError.message}` : ""
+  throw new Error(`OpenCode did not become healthy on ${host}:${port} within ${timeoutMs}ms${detail}`)
+}
+
+function startTimeout(host, port, timeoutMs) {
+  let timer
+  const promise = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(
+      `OpenCode did not become ready on ${host}:${port} within ${timeoutMs}ms`
+    )), timeoutMs)
+    timer.unref?.()
   })
+  return { promise, cancel: () => clearTimeout(timer) }
 }
 
 export class ManagedOpenCodeHost extends EventEmitter {
@@ -37,7 +70,7 @@ export class ManagedOpenCodeHost extends EventEmitter {
     spawnProcess = spawn,
     readinessHost,
     startTimeoutMs = DEFAULT_START_TIMEOUT_MS,
-    waitUntilReady = waitForPort
+    waitUntilReady = waitForOpenCodeHealth
   } = {}) {
     super()
     this.command = command
@@ -59,7 +92,7 @@ export class ManagedOpenCodeHost extends EventEmitter {
   }
 
   async start() {
-    if (this.child && !this.child.killed) return
+    if (this.child && this.child.exitCode == null && this.child.signalCode == null) return
     if (this.starting) return this.starting
     this.starting = this.#start()
     try {
@@ -86,15 +119,25 @@ export class ManagedOpenCodeHost extends EventEmitter {
         `OpenCode exited before becoming ready (${code ?? "unknown"}${signal ? `, ${signal}` : ""})`
       )))
     })
+    const timeout = startTimeout(this.readinessHost, this.port, this.startTimeoutMs)
 
     try {
       await Promise.race([
-        this.waitUntilReady(this.readinessHost, this.port, this.startTimeoutMs),
-        exited
+        this.waitUntilReady({
+          host: this.readinessHost,
+          port: this.port,
+          username: this.username,
+          password: this.password,
+          timeoutMs: this.startTimeoutMs
+        }),
+        exited,
+        timeout.promise
       ])
+      timeout.cancel()
       this.emit("available", { pid: this.processID, host: this.host, port: this.port })
     } catch (error) {
-      this.stop()
+      timeout.cancel()
+      this.stop("SIGTERM")
       throw error
     }
 
@@ -106,10 +149,10 @@ export class ManagedOpenCodeHost extends EventEmitter {
     )))
   }
 
-  stop() {
+  stop(signal = "SIGTERM") {
     const child = this.child
-    this.child = undefined
-    if (child && !child.killed) child.kill()
+    if (!child || child.exitCode != null || child.signalCode != null) return false
+    return child.kill(signal)
   }
 
   #handleExit(error) {
@@ -120,7 +163,17 @@ export class ManagedOpenCodeHost extends EventEmitter {
 }
 
 export function trackManagedHostLifecycle(host, registry, hostID) {
-  host.on("available", () => registry.updateHost(hostID, { state: "available", processID: host.processID }))
+  const start = host.start.bind(host)
+  host.start = async (...args) => {
+    try {
+      const result = await start(...args)
+      registry.updateHost(hostID, { state: "available", processID: host.processID })
+      return result
+    } catch (error) {
+      registry.updateHost(hostID, { state: "unavailable", processID: undefined })
+      throw error
+    }
+  }
   host.on("unavailable", () => registry.updateHost(hostID, { state: "unavailable", processID: undefined }))
   return host
 }

--- a/bridge/src/opencode-host.js
+++ b/bridge/src/opencode-host.js
@@ -23,7 +23,6 @@ async function waitForOpenCodeHealth({ host, port, username, password, timeoutMs
     const remaining = Math.max(1, deadline - Date.now())
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), Math.min(READINESS_ATTEMPT_MS, remaining))
-    timer.unref?.()
     try {
       const response = await fetchImpl(url, {
         headers: { Authorization: `Basic ${authorization}` },
@@ -54,7 +53,6 @@ function startTimeout(host, port, timeoutMs) {
     timer = setTimeout(() => reject(new Error(
       `OpenCode did not become ready on ${host}:${port} within ${timeoutMs}ms`
     )), timeoutMs)
-    timer.unref?.()
   })
   return { promise, cancel: () => clearTimeout(timer) }
 }

--- a/bridge/src/opencode-host.js
+++ b/bridge/src/opencode-host.js
@@ -13,7 +13,7 @@ function httpHost(host) {
   return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host
 }
 
-async function waitForOpenCodeHealth({ host, port, username, password, timeoutMs = DEFAULT_START_TIMEOUT_MS, fetchImpl = fetch }) {
+export async function waitForOpenCodeHealth({ host, port, username, password, timeoutMs = DEFAULT_START_TIMEOUT_MS, fetchImpl = fetch }) {
   const deadline = Date.now() + timeoutMs
   const authorization = Buffer.from(`${username}:${password}`).toString("base64")
   const url = `http://${httpHost(host)}:${port}/global/health`

--- a/bridge/test/launcher.test.js
+++ b/bridge/test/launcher.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict"
 import path from "node:path"
 import test from "node:test"
-import { bridgeEnvironment, buildBridgeArgs, detectBackends, lanAddresses, resolveBackend, startManagedOpenCode } from "../src/launcher.js"
+import { bridgeEnvironment, buildBridgeArgs, createManagedShutdown, detectBackends, lanAddresses, resolveBackend, startManagedOpenCode } from "../src/launcher.js"
 
 test("detects executable agent files on PATH without running them", () => {
   const pathValue = ["/bin", "/tools"].join(path.delimiter)
@@ -57,6 +57,25 @@ test("delegates OpenCode startup to the managed host", async () => {
     username: "harness",
     password: "secret"
   })
+})
+
+test("escalates a second shutdown signal from SIGTERM to SIGKILL", () => {
+  const signals = []
+  const exits = []
+  const processObject = {
+    exitCode: 0,
+    exit(code) { exits.push(code) }
+  }
+  const shutdown = createManagedShutdown({ stop: (signal) => signals.push(signal) }, processObject)
+
+  shutdown("SIGINT")
+  assert.equal(processObject.exitCode, 130)
+  assert.deepEqual(signals, ["SIGTERM"])
+  assert.deepEqual(exits, [])
+
+  shutdown("SIGINT")
+  assert.deepEqual(signals, ["SIGTERM", "SIGKILL"])
+  assert.deepEqual(exits, [130])
 })
 
 test("uses an explicit backend even when discovery is empty", () => {

--- a/bridge/test/launcher.test.js
+++ b/bridge/test/launcher.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict"
 import path from "node:path"
 import test from "node:test"
-import { bridgeEnvironment, buildBridgeArgs, detectBackends, lanAddresses, resolveBackend } from "../src/launcher.js"
+import { bridgeEnvironment, buildBridgeArgs, detectBackends, lanAddresses, resolveBackend, startManagedOpenCode } from "../src/launcher.js"
 
 test("detects executable agent files on PATH without running them", () => {
   const pathValue = ["/bin", "/tools"].join(path.delimiter)
@@ -24,7 +24,7 @@ test("ignores non-executable PATH entries on Unix", () => {
   }), [])
 })
 
-test("detects OpenCode so its direct HTTP path can be explained", () => {
+test("detects OpenCode as a managed direct-HTTP backend", () => {
   const candidate = path.join("/tools", "opencode")
   assert.deepEqual(detectBackends({
     pathValue: "/tools",
@@ -33,6 +33,30 @@ test("detects OpenCode so its direct HTTP path can be explained", () => {
     access: () => {}
   }), ["opencode"])
   assert.equal(resolveBackend([], ["opencode"]), "opencode")
+})
+
+test("delegates OpenCode startup to the managed host", async () => {
+  let options
+  class FakeHost {
+    constructor(value) { options = value }
+    async start() { this.started = true }
+  }
+  const managed = await startManagedOpenCode({
+    host: "0.0.0.0",
+    port: 4096,
+    username: "harness",
+    password: "secret",
+    command: "/tools/opencode",
+    Host: FakeHost
+  })
+  assert.equal(managed.started, true)
+  assert.deepEqual(options, {
+    command: "/tools/opencode",
+    host: "0.0.0.0",
+    port: 4096,
+    username: "harness",
+    password: "secret"
+  })
 })
 
 test("uses an explicit backend even when discovery is empty", () => {

--- a/bridge/test/opencode-host.test.js
+++ b/bridge/test/opencode-host.test.js
@@ -1,15 +1,25 @@
 import assert from "node:assert/strict"
 import { EventEmitter } from "node:events"
 import test from "node:test"
-import { ManagedOpenCodeHost, trackManagedHostLifecycle } from "../src/opencode-host.js"
+import { ManagedOpenCodeHost, trackManagedHostLifecycle, waitForOpenCodeHealth } from "../src/opencode-host.js"
 import { MachineRegistry } from "../src/machine-registry.js"
 
 class FakeChild extends EventEmitter {
   pid = 4242
-  killed = false
-  kill() {
-    this.killed = true
-    this.emit("exit", 0, "SIGTERM")
+  exitCode = null
+  signalCode = null
+  killSignals = []
+
+  kill(signal = "SIGTERM") {
+    this.killSignals.push(signal)
+    if (signal === "SIGKILL") this.signalCode = signal
+    return true
+  }
+
+  exit(code = 0, signal = null) {
+    this.exitCode = code
+    this.signalCode = signal
+    this.emit("exit", code, signal)
   }
 }
 
@@ -26,9 +36,11 @@ test("starts OpenCode without placing credentials on argv", async () => {
       invocation = { command, args, options }
       return child
     },
-    waitUntilReady: async (readyHost, port) => {
+    waitUntilReady: async ({ host: readyHost, port, username, password }) => {
       assert.equal(readyHost, "127.0.0.1")
       assert.equal(port, 4096)
+      assert.equal(username, "harness")
+      assert.equal(password, "secret")
     }
   })
 
@@ -40,6 +52,49 @@ test("starts OpenCode without placing credentials on argv", async () => {
   assert.equal(invocation.options.env.OPENCODE_SERVER_USERNAME, "harness")
   assert.equal(invocation.options.env.OPENCODE_SERVER_PASSWORD, "secret")
   assert.equal(host.processID, 4242)
+})
+
+test("health readiness verifies the generated credentials", async () => {
+  let request
+  await waitForOpenCodeHealth({
+    host: "127.0.0.1",
+    port: 4096,
+    username: "harness",
+    password: "secret",
+    timeoutMs: 50,
+    fetchImpl: async (url, options) => {
+      request = { url, options }
+      return { status: 200 }
+    }
+  })
+
+  assert.equal(request.url, "http://127.0.0.1:4096/global/health")
+  assert.equal(request.options.headers.Authorization, `Basic ${Buffer.from("harness:secret").toString("base64")}`)
+})
+
+test("health readiness rejects an authentication mismatch immediately", async () => {
+  await assert.rejects(waitForOpenCodeHealth({
+    host: "127.0.0.1",
+    port: 4096,
+    username: "harness",
+    password: "secret",
+    timeoutMs: 1_000,
+    fetchImpl: async () => ({ status: 401 })
+  }), /rejected the generated credentials/)
+})
+
+test("startup has an authoritative timeout even if readiness never settles", async () => {
+  const child = new FakeChild()
+  const host = new ManagedOpenCodeHost({
+    username: "harness",
+    password: "secret",
+    spawnProcess: () => child,
+    startTimeoutMs: 20,
+    waitUntilReady: () => new Promise(() => {})
+  })
+
+  await assert.rejects(host.start(), /within 20ms/)
+  assert.deepEqual(child.killSignals, ["SIGTERM"])
 })
 
 test("updates the machine registry when OpenCode becomes available and exits", async () => {
@@ -59,12 +114,28 @@ test("updates the machine registry when OpenCode becomes available and exits", a
   assert.equal(registry.host("opencode").state, "available")
   assert.equal(registry.host("opencode").processID, 4242)
 
-  child.emit("exit", 1, null)
+  child.exit(1, null)
   assert.equal(registry.host("opencode").state, "unavailable")
   assert.equal(registry.host("opencode").processID, undefined)
 })
 
-test("stops the managed OpenCode child", async () => {
+test("marks the machine registry unavailable when OpenCode startup fails", async () => {
+  const child = new FakeChild()
+  const registry = new MachineRegistry({ id: "machine_test", name: "phone" })
+  registry.registerHost({ id: "opencode", transport: "http", state: "configured" })
+  const host = trackManagedHostLifecycle(new ManagedOpenCodeHost({
+    username: "harness",
+    password: "secret",
+    spawnProcess: () => child,
+    waitUntilReady: async () => { throw new Error("health failed") }
+  }), registry, "opencode")
+
+  await assert.rejects(host.start(), /health failed/)
+  assert.equal(registry.host("opencode").state, "unavailable")
+  assert.equal(registry.host("opencode").processID, undefined)
+})
+
+test("stops the managed OpenCode child with the requested signal", async () => {
   const child = new FakeChild()
   const host = new ManagedOpenCodeHost({
     username: "harness",
@@ -73,7 +144,7 @@ test("stops the managed OpenCode child", async () => {
     waitUntilReady: async () => {}
   })
   await host.start()
-  host.stop()
-  assert.equal(child.killed, true)
-  assert.equal(host.processID, undefined)
+  host.stop("SIGTERM")
+  host.stop("SIGKILL")
+  assert.deepEqual(child.killSignals, ["SIGTERM", "SIGKILL"])
 })

--- a/bridge/test/opencode-host.test.js
+++ b/bridge/test/opencode-host.test.js
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import test from "node:test"
+import { ManagedOpenCodeHost, trackManagedHostLifecycle } from "../src/opencode-host.js"
+import { MachineRegistry } from "../src/machine-registry.js"
+
+class FakeChild extends EventEmitter {
+  pid = 4242
+  killed = false
+  kill() {
+    this.killed = true
+    this.emit("exit", 0, "SIGTERM")
+  }
+}
+
+test("starts OpenCode without placing credentials on argv", async () => {
+  const child = new FakeChild()
+  let invocation
+  const host = new ManagedOpenCodeHost({
+    host: "0.0.0.0",
+    port: 4096,
+    username: "harness",
+    password: "secret",
+    environment: { PATH: "/bin" },
+    spawnProcess: (command, args, options) => {
+      invocation = { command, args, options }
+      return child
+    },
+    waitUntilReady: async (readyHost, port) => {
+      assert.equal(readyHost, "127.0.0.1")
+      assert.equal(port, 4096)
+    }
+  })
+
+  await host.start()
+
+  assert.equal(invocation.command, "opencode")
+  assert.deepEqual(invocation.args, ["serve", "--hostname", "0.0.0.0", "--port", "4096"])
+  assert.equal(invocation.args.includes("secret"), false)
+  assert.equal(invocation.options.env.OPENCODE_SERVER_USERNAME, "harness")
+  assert.equal(invocation.options.env.OPENCODE_SERVER_PASSWORD, "secret")
+  assert.equal(host.processID, 4242)
+})
+
+test("updates the machine registry when OpenCode becomes available and exits", async () => {
+  const child = new FakeChild()
+  const registry = new MachineRegistry({ id: "machine_test", name: "phone" })
+  registry.registerHost({ id: "opencode", transport: "http", state: "configured" })
+  const host = trackManagedHostLifecycle(new ManagedOpenCodeHost({
+    host: "127.0.0.1",
+    port: 4096,
+    username: "harness",
+    password: "secret",
+    spawnProcess: () => child,
+    waitUntilReady: async () => {}
+  }), registry, "opencode")
+
+  await host.start()
+  assert.equal(registry.host("opencode").state, "available")
+  assert.equal(registry.host("opencode").processID, 4242)
+
+  child.emit("exit", 1, null)
+  assert.equal(registry.host("opencode").state, "unavailable")
+  assert.equal(registry.host("opencode").processID, undefined)
+})
+
+test("stops the managed OpenCode child", async () => {
+  const child = new FakeChild()
+  const host = new ManagedOpenCodeHost({
+    username: "harness",
+    password: "secret",
+    spawnProcess: () => child,
+    waitUntilReady: async () => {}
+  })
+  await host.start()
+  host.stop()
+  assert.equal(child.killed, true)
+  assert.equal(host.processID, undefined)
+})

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,8 +1,6 @@
 # Harness Remote quick start
 
-The shortest setup path is the repository-level `harness-remote` launcher.
-
-Run directly from GitHub:
+The shortest setup path uses the `harness-remote` launcher.
 
 ```bash
 npx github:giuliastro/harness-remote
@@ -27,7 +25,9 @@ When installed as a repository/package binary, the command is:
 harness-remote
 ```
 
-The root package intentionally remains private for now: this documents a real GitHub/repository launch path without claiming that an npm registry package has already been published.
+The root package intentionally remains private for now: this documents a real GitHub/repository launch path without claiming that an npm package has already been published.
+
+The launcher remains intentionally thin while #143 evolves toward the Universal Daemon. ACP-backed agents still use the existing bridge. OpenCode is now started and supervised directly by Harness Remote rather than requiring a second command.
 
 ## What it does
 
@@ -35,11 +35,11 @@ The root package intentionally remains private for now: this documents a real Gi
 - auto-selects the backend when exactly one supported CLI is found;
 - otherwise requires an explicit choice with `--backend`;
 - binds to the LAN by default (`0.0.0.0`) and automatically generates HTTP Basic Auth credentials;
-- generates credentials for loopback quick start too, so local applications/users do not get an unauthenticated server by default;
-- keeps generated credentials out of child-process argv and passes them through environment variables instead;
-- starts ACP-backed agents through the existing bridge from port `4097`;
-- starts and supervises OpenCode directly from port `4096`;
-- chooses the next available port when the default is busy;
+- generates credentials for loopback quick start too;
+- keeps generated credentials out of child-process argv and passes them through environment variables;
+- starts ACP-backed agents from port `4097` and OpenCode from port `4096`, choosing the next available port when the default is busy;
+- for OpenCode, waits for an authenticated `/global/health` response before reporting the host ready;
+- supervises the OpenCode process and escalates a repeated shutdown signal from graceful `SIGTERM` to `SIGKILL`;
 - prints one or more plausible LAN addresses while preferring non-virtual interfaces;
 - forwards advanced bridge options such as `--root`, `--cors`, `--state-dir`, and `--log-requests` for ACP-backed agents.
 
@@ -69,27 +69,18 @@ harness-remote \
 
 ## OpenCode
 
-OpenCode remains a direct-HTTP backend: the Harness Remote client talks to the OpenCode server rather than translating it through ACP.
+OpenCode remains different at the protocol layer: the Harness Remote client connects directly to the OpenCode HTTP server rather than through the ACP bridge.
 
-The launcher now manages that server for you. Running:
+The launcher now owns the process lifecycle, though. Running:
 
 ```bash
-npx github:giuliastro/harness-remote --backend opencode
+harness-remote --backend opencode
 ```
 
-will:
+will start `opencode serve` itself, pass the generated credentials through `OPENCODE_SERVER_USERNAME` and `OPENCODE_SERVER_PASSWORD`, wait for the authenticated health endpoint to succeed, print the connection details, and keep supervising the child process until shutdown.
 
-1. generate or accept Basic Auth credentials;
-2. select an available port starting at `4096`;
-3. start `opencode serve` itself;
-4. pass credentials through `OPENCODE_SERVER_USERNAME` and `OPENCODE_SERVER_PASSWORD`, never through argv;
-5. wait until the server is actually accepting connections before reporting it ready;
-6. keep the OpenCode child process supervised until the launcher is stopped.
-
-There is no second command to copy and paste. Keep the launcher process running and configure the Harness Remote client with the printed address and credentials.
-
-This managed-host primitive is also intended to be reused by the Universal Daemon work in #143, where OpenCode and ACP-backed agents will coexist under one machine-level process manager.
+This means there is no second OpenCode command to copy and run manually.
 
 ## Advanced/manual setup
 
-The existing backend-specific bridge commands and direct `opencode serve` setup remain supported. Use them when you need unusual networking or other advanced settings documented in the main README.
+The existing backend-specific bridge commands remain supported. Use them when you need custom adapter commands, unusual networking, browser CORS configuration, or other advanced settings documented in the main README.

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,22 +1,8 @@
 # Harness Remote quick start
 
-The shortest setup path uses the existing bridge through the new `harness-remote` launcher.
+The shortest setup path is the repository-level `harness-remote` launcher.
 
-## Testing this PR before merge
-
-While PR #148 is still open, the root `package.json` only exists on the feature branch, so the `npx` command must include that branch explicitly:
-
-```bash
-npx github:giuliastro/harness-remote#agent/one-command-startup
-```
-
-For OpenCode on the PR branch:
-
-```bash
-npx github:giuliastro/harness-remote#agent/one-command-startup --backend opencode
-```
-
-After #148 is merged to `main`, the shorter command becomes valid:
+Run directly from GitHub:
 
 ```bash
 npx github:giuliastro/harness-remote
@@ -41,9 +27,7 @@ When installed as a repository/package binary, the command is:
 harness-remote
 ```
 
-The root package intentionally remains private for now: this documents a real GitHub/repository launch path without claiming that an npm package has already been published.
-
-The launcher is intentionally thin: it does **not** implement the future Universal Daemon. For ACP-backed agents it starts the existing bridge; for OpenCode it detects the direct-HTTP path and prints the correct startup command.
+The root package intentionally remains private for now: this documents a real GitHub/repository launch path without claiming that an npm registry package has already been published.
 
 ## What it does
 
@@ -51,9 +35,11 @@ The launcher is intentionally thin: it does **not** implement the future Univers
 - auto-selects the backend when exactly one supported CLI is found;
 - otherwise requires an explicit choice with `--backend`;
 - binds to the LAN by default (`0.0.0.0`) and automatically generates HTTP Basic Auth credentials;
-- generates credentials for loopback quick start too, so local applications/users do not get an unauthenticated bridge by default;
-- keeps generated credentials out of the bridge child-process argv and passes them through environment variables instead;
-- starts ACP-backed agents at port `4097` and OpenCode guidance at port `4096`, choosing the next available port when the default is busy;
+- generates credentials for loopback quick start too, so local applications/users do not get an unauthenticated server by default;
+- keeps generated credentials out of child-process argv and passes them through environment variables instead;
+- starts ACP-backed agents through the existing bridge from port `4097`;
+- starts and supervises OpenCode directly from port `4096`;
+- chooses the next available port when the default is busy;
 - prints one or more plausible LAN addresses while preferring non-virtual interfaces;
 - forwards advanced bridge options such as `--root`, `--cors`, `--state-dir`, and `--log-requests` for ACP-backed agents.
 
@@ -83,16 +69,27 @@ harness-remote \
 
 ## OpenCode
 
-OpenCode remains different in the current architecture: the client connects directly to the OpenCode HTTP server rather than through the ACP bridge.
+OpenCode remains a direct-HTTP backend: the Harness Remote client talks to the OpenCode server rather than translating it through ACP.
 
-If OpenCode is the only supported CLI found on `PATH`, the launcher now recognizes it and prints a ready-to-run authenticated `opencode serve` command plus the address and credentials to use in Harness Remote instead of suggesting an unrelated ACP backend.
-
-You can request the same guidance explicitly with:
+The launcher now manages that server for you. Running:
 
 ```bash
-harness-remote --backend opencode
+npx github:giuliastro/harness-remote --backend opencode
 ```
+
+will:
+
+1. generate or accept Basic Auth credentials;
+2. select an available port starting at `4096`;
+3. start `opencode serve` itself;
+4. pass credentials through `OPENCODE_SERVER_USERNAME` and `OPENCODE_SERVER_PASSWORD`, never through argv;
+5. wait until the server is actually accepting connections before reporting it ready;
+6. keep the OpenCode child process supervised until the launcher is stopped.
+
+There is no second command to copy and paste. Keep the launcher process running and configure the Harness Remote client with the printed address and credentials.
+
+This managed-host primitive is also intended to be reused by the Universal Daemon work in #143, where OpenCode and ACP-backed agents will coexist under one machine-level process manager.
 
 ## Advanced/manual setup
 
-The existing backend-specific bridge commands remain supported. Use them when you need custom adapter commands, unusual networking, browser CORS configuration, or other advanced settings documented in the main README.
+The existing backend-specific bridge commands and direct `opencode serve` setup remain supported. Use them when you need unusual networking or other advanced settings documented in the main README.

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -38,7 +38,7 @@ The launcher remains intentionally thin while #143 evolves toward the Universal 
 - generates credentials for loopback quick start too;
 - keeps generated credentials out of child-process argv and passes them through environment variables;
 - starts ACP-backed agents from port `4097` and OpenCode from port `4096`, choosing the next available port when the default is busy;
-- for OpenCode, waits for an authenticated `/global/health` response before reporting the host ready;
+- for OpenCode, reports readiness only after an authenticated `/global/health` request succeeds with the generated credentials;
 - supervises the OpenCode process and escalates a repeated shutdown signal from graceful `SIGTERM` to `SIGKILL`;
 - prints one or more plausible LAN addresses while preferring non-virtual interfaces;
 - forwards advanced bridge options such as `--root`, `--cors`, `--state-dir`, and `--log-requests` for ACP-backed agents.
@@ -77,7 +77,7 @@ The launcher now owns the process lifecycle, though. Running:
 harness-remote --backend opencode
 ```
 
-will start `opencode serve` itself, pass the generated credentials through `OPENCODE_SERVER_USERNAME` and `OPENCODE_SERVER_PASSWORD`, wait for the authenticated health endpoint to succeed, print the connection details, and keep supervising the child process until shutdown.
+will start `opencode serve` itself, pass the generated credentials through `OPENCODE_SERVER_USERNAME` and `OPENCODE_SERVER_PASSWORD`, verify the authenticated health endpoint, print the connection details, and keep supervising the child process until shutdown.
 
 This means there is no second OpenCode command to copy and run manually.
 


### PR DESCRIPTION
## Summary

Second implementation slice of #143.

- add a reusable `ManagedOpenCodeHost` process supervisor
- start `opencode serve` directly instead of printing a second command
- keep OpenCode credentials out of argv and pass them only through `OPENCODE_SERVER_USERNAME` / `OPENCODE_SERVER_PASSWORD`
- report readiness only after an authenticated `/global/health` check succeeds with the generated credentials
- enforce an authoritative startup timeout even if readiness never settles
- supervise process exit and escalate repeated shutdown signals from `SIGTERM` to `SIGKILL`
- add a registry lifecycle adapter with consistent `configured` / `available` / `unavailable` transitions, including failed startup
- add tests for argv secrecy, authenticated readiness, readiness timeout, registry state transitions, process identity, and shutdown escalation
- refresh quick-start docs now that #148 is merged and OpenCode is actually started by Harness

## User-visible change

Before this PR:

```text
harness-remote --backend opencode
  -> prints another `opencode serve ...` command
```

With this PR:

```text
harness-remote --backend opencode
  -> starts OpenCode
  -> verifies authenticated health
  -> prints connection details
  -> supervises the process
```

The Harness Remote client still talks directly to OpenCode HTTP. This slice changes process ownership and lifecycle, not the client protocol.

## Why

The previous quick-start path exposed an important gap: OpenCode was recognized, but Harness did not actually manage it. #143 needs heterogeneous hosts to be real lifecycle-owned resources before a single daemon can route across them.

`ManagedOpenCodeHost` is deliberately reusable by the upcoming multi-host daemon rather than embedding process logic in the launcher.

## Review hardening

The review identified four lifecycle/readiness gaps, now covered by tests:

- no silent startup hang when a readiness operation never settles
- no false-positive readiness from an unrelated listener on the expected port
- failed starts become `unavailable` just like ACP hosts
- a second Ctrl-C escalates shutdown instead of being ignored

## Next slice in #143

- instantiate multiple managed hosts under one machine daemon
- register OpenCode and ACP-backed hosts together
- expose per-host health/lifecycle from one process
- then route agent-scoped operations through that daemon

Part of #143; does not close it.