### PR TITLE
feat(daemon): run ACP and OpenCode under one machine daemon

### DIFF
--- a/bridge/package.json
+++ b/bridge/package.json
@@ -4,10 +4,12 @@
   "private": true,
   "type": "module",
   "bin": {
-    "harness-remote-bridge": "./src/cli.js"
+    "harness-remote-bridge": "./src/cli.js",
+    "harness-remote-daemon": "./src/daemon-cli.js"
   },
   "scripts": {
     "start": "node src/cli.js",
+    "daemon": "node src/daemon-cli.js",
     "test": "node --test"
   },
   "engines": {

--- a/bridge/src/daemon-cli.js
+++ b/bridge/src/daemon-cli.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+import path from "node:path"
+import { AcpClient } from "./acp-client.js"
+import { parseConfig, usage as bridgeUsage } from "./config.js"
+import { harnessProfile } from "./harness-profiles.js"
+import { loadMachineIdentity } from "./machine-registry.js"
+import { MachineDaemon, createMachineDaemonServer } from "./machine-daemon.js"
+import { ManagedOpenCodeHost } from "./opencode-host.js"
+
+function requireValue(args, index, option) {
+  const value = args[index + 1]
+  if (!value || value.startsWith("--")) throw new Error(`${option} requires a value`)
+  return value
+}
+
+function parsePort(value, option) {
+  const port = Number(value)
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) throw new Error(`${option} must be an integer between 1 and 65535`)
+  return port
+}
+
+export function parseDaemonOptions(args, environment = process.env) {
+  const bridgeArgs = []
+  const options = {
+    openCode: true,
+    openCodeCommand: environment.HARNESS_REMOTE_OPENCODE_COMMAND ?? "opencode",
+    openCodePort: parsePort(environment.HARNESS_REMOTE_OPENCODE_PORT ?? "4096", "--opencode-port")
+  }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const option = args[index]
+    if (option === "--no-opencode") {
+      options.openCode = false
+      continue
+    }
+    if (option === "--opencode-command") {
+      options.openCodeCommand = requireValue(args, index, option)
+      index += 1
+      continue
+    }
+    if (option === "--opencode-port") {
+      options.openCodePort = parsePort(requireValue(args, index, option), option)
+      index += 1
+      continue
+    }
+    bridgeArgs.push(option)
+    if (["--backend", "--host", "--port", "--username", "--password", "--acp-command", "--acp-arg", "--root", "--cors", "--state-dir"].includes(option)) {
+      bridgeArgs.push(requireValue(args, index, option))
+      index += 1
+    }
+  }
+
+  return { config: parseConfig(bridgeArgs, environment), ...options }
+}
+
+export function daemonUsage() {
+  return `${bridgeUsage()}\n\nMulti-host daemon options:\n  --opencode-command <path>  OpenCode executable (default: opencode)\n  --opencode-port <port>     Managed OpenCode port (default: 4096)\n  --no-opencode              Start only the primary ACP host`
+}
+
+async function main() {
+  let parsed
+  try {
+    parsed = parseDaemonOptions(process.argv.slice(2))
+  } catch (error) {
+    process.stderr.write(`${error.message}\n\n${daemonUsage()}\n`)
+    process.exitCode = 1
+    return
+  }
+
+  const { config, openCode, openCodeCommand, openCodePort } = parsed
+  if (config.help) {
+    process.stdout.write(`${daemonUsage()}\n`)
+    return
+  }
+
+  if (openCode && openCodePort === config.port) {
+    throw new Error(`OpenCode port ${openCodePort} conflicts with the Harness daemon port`)
+  }
+
+  const identity = await loadMachineIdentity(config.stateDirectory)
+  const daemon = new MachineDaemon(identity)
+  const profile = harnessProfile(config.backend)
+  const acp = new AcpClient({
+    command: config.acpCommand,
+    args: config.acpArgs,
+    permissionMode: profile.permissionMode,
+    preferredAuthMethod: profile.authMethod
+  })
+
+  daemon.registerAcpHost({
+    id: profile.id,
+    label: profile.label,
+    backend: profile.id,
+    capabilities: profile.capabilities,
+    agent: acp
+  })
+
+  if (openCode) {
+    const managedOpenCode = new ManagedOpenCodeHost({
+      command: openCodeCommand,
+      host: config.host,
+      port: openCodePort,
+      username: config.username,
+      password: config.password
+    })
+    daemon.registerManagedHttpHost({
+      id: "opencode",
+      label: "OpenCode",
+      backend: "opencode",
+      capabilities: { sessions: true },
+      host: managedOpenCode
+    })
+  }
+
+  const server = createMachineDaemonServer({
+    daemon,
+    config,
+    primaryAcp: acp,
+    serviceOptions: {
+      snapshotDirectory: path.join(config.stateDirectory, profile.id),
+      historyLoader: profile.historyLoader,
+      preserveListedTimestamps: profile.preserveListedTimestamps,
+      reloadOnHistoryRefresh: profile.reloadOnHistoryRefresh
+    }
+  })
+
+  acp.on("stderr", (line) => process.stderr.write(`[${profile.id}] ${line}`))
+  acp.on("exit", (error) => process.stderr.write(`[${profile.id}] ${error.message}\n`))
+
+  const managedResults = await daemon.startManagedHosts()
+  for (const result of managedResults) {
+    if (result.status === "available") process.stdout.write(`[${result.id}] available\n`)
+    else process.stderr.write(`[${result.id}] unavailable: ${result.error?.message ?? "startup failed"}\n`)
+  }
+
+  server.listen(config.port, config.host, () => {
+    process.stdout.write(`Harness daemon listening on http://${config.host}:${config.port}\n`)
+    process.stdout.write(`Machine: ${identity.name} (${identity.id})\n`)
+    for (const host of daemon.snapshot().agents) {
+      process.stdout.write(`${host.state === "available" ? "✓" : "•"} ${host.label} [${host.transport}] ${host.state}\n`)
+    }
+  })
+
+  let shuttingDown = false
+  const shutdown = () => {
+    if (shuttingDown) return
+    shuttingDown = true
+    daemon.close()
+    server.close(() => process.exit(0))
+    setTimeout(() => process.exit(1), 5_000).unref()
+  }
+  process.on("SIGINT", shutdown)
+  process.on("SIGTERM", shutdown)
+}
+
+if (process.argv[1]?.endsWith("daemon-cli.js")) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`)
+    process.exitCode = 1
+  })
+}

--- a/bridge/src/daemon-cli.js
+++ b/bridge/src/daemon-cli.js
@@ -3,6 +3,7 @@ import path from "node:path"
 import { AcpClient } from "./acp-client.js"
 import { parseConfig, usage as bridgeUsage } from "./config.js"
 import { harnessProfile } from "./harness-profiles.js"
+import { canListen } from "./launcher.js"
 import { loadMachineIdentity } from "./machine-registry.js"
 import { MachineDaemon, createMachineDaemonServer } from "./machine-daemon.js"
 import { ManagedOpenCodeHost } from "./opencode-host.js"
@@ -24,6 +25,7 @@ export function parseDaemonOptions(args, environment = process.env) {
   const options = {
     openCode: true,
     openCodeCommand: environment.HARNESS_REMOTE_OPENCODE_COMMAND ?? "opencode",
+    openCodeHost: environment.HARNESS_REMOTE_OPENCODE_HOST ?? "127.0.0.1",
     openCodePort: parsePort(environment.HARNESS_REMOTE_OPENCODE_PORT ?? "4096", "--opencode-port")
   }
 
@@ -35,6 +37,11 @@ export function parseDaemonOptions(args, environment = process.env) {
     }
     if (option === "--opencode-command") {
       options.openCodeCommand = requireValue(args, index, option)
+      index += 1
+      continue
+    }
+    if (option === "--opencode-host") {
+      options.openCodeHost = requireValue(args, index, option)
       index += 1
       continue
     }
@@ -54,7 +61,12 @@ export function parseDaemonOptions(args, environment = process.env) {
 }
 
 export function daemonUsage() {
-  return `${bridgeUsage()}\n\nMulti-host daemon options:\n  --opencode-command <path>  OpenCode executable (default: opencode)\n  --opencode-port <port>     Managed OpenCode port (default: 4096)\n  --no-opencode              Start only the primary ACP host`
+  return `${bridgeUsage()}\n\nMulti-host daemon options:\n  --opencode-command <path>  OpenCode executable (default: opencode)\n  --opencode-host <host>     Managed OpenCode bind host (default: 127.0.0.1)\n  --opencode-port <port>     Managed OpenCode port (default: 4096)\n  --no-opencode              Start only the primary ACP host`
+}
+
+export async function ensureOpenCodePortAvailable({ port, host, canListenImpl = canListen }) {
+  if (await canListenImpl(port, host)) return
+  throw new Error(`OpenCode port ${port} is already in use on ${host}. Is OpenCode already running? Use --opencode-port to choose another.`)
 }
 
 async function main() {
@@ -67,15 +79,16 @@ async function main() {
     return
   }
 
-  const { config, openCode, openCodeCommand, openCodePort } = parsed
+  const { config, openCode, openCodeCommand, openCodeHost, openCodePort } = parsed
   if (config.help) {
     process.stdout.write(`${daemonUsage()}\n`)
     return
   }
 
-  if (openCode && openCodePort === config.port) {
-    throw new Error(`OpenCode port ${openCodePort} conflicts with the Harness daemon port`)
+  if (openCode && openCodeHost === config.host && openCodePort === config.port) {
+    throw new Error(`OpenCode port ${openCodePort} conflicts with the Harness daemon on ${openCodeHost}`)
   }
+  if (openCode) await ensureOpenCodePortAvailable({ port: openCodePort, host: openCodeHost })
 
   const identity = await loadMachineIdentity(config.stateDirectory)
   const daemon = new MachineDaemon(identity)
@@ -98,7 +111,7 @@ async function main() {
   if (openCode) {
     const managedOpenCode = new ManagedOpenCodeHost({
       command: openCodeCommand,
-      host: config.host,
+      host: openCodeHost,
       port: openCodePort,
       username: config.username,
       password: config.password
@@ -127,19 +140,20 @@ async function main() {
   acp.on("stderr", (line) => process.stderr.write(`[${profile.id}] ${line}`))
   acp.on("exit", (error) => process.stderr.write(`[${profile.id}] ${error.message}\n`))
 
+  server.listen(config.port, config.host, () => {
+    process.stdout.write(`Harness daemon listening on http://${config.host}:${config.port}\n`)
+    process.stdout.write(`Machine: ${identity.name} (${identity.id})\n`)
+    if (openCode) process.stdout.write(`Managed OpenCode endpoint: http://${openCodeHost}:${openCodePort}\n`)
+    for (const host of daemon.snapshot().agents) {
+      process.stdout.write(`${host.state === "available" ? "✓" : "•"} ${host.label} [${host.transport}] ${host.state}\n`)
+    }
+  })
+
   const managedResults = await daemon.startManagedHosts()
   for (const result of managedResults) {
     if (result.status === "available") process.stdout.write(`[${result.id}] available\n`)
     else process.stderr.write(`[${result.id}] unavailable: ${result.error?.message ?? "startup failed"}\n`)
   }
-
-  server.listen(config.port, config.host, () => {
-    process.stdout.write(`Harness daemon listening on http://${config.host}:${config.port}\n`)
-    process.stdout.write(`Machine: ${identity.name} (${identity.id})\n`)
-    for (const host of daemon.snapshot().agents) {
-      process.stdout.write(`${host.state === "available" ? "✓" : "•"} ${host.label} [${host.transport}] ${host.state}\n`)
-    }
-  })
 
   let shuttingDown = false
   const shutdown = () => {

--- a/bridge/src/daemon-cli.js
+++ b/bridge/src/daemon-cli.js
@@ -85,8 +85,8 @@ async function main() {
     return
   }
 
-  if (openCode && openCodeHost === config.host && openCodePort === config.port) {
-    throw new Error(`OpenCode port ${openCodePort} conflicts with the Harness daemon on ${openCodeHost}`)
+  if (openCode && openCodePort === config.port) {
+    throw new Error(`OpenCode port ${openCodePort} conflicts with the Harness daemon port`)
   }
   if (openCode) await ensureOpenCodePortAvailable({ port: openCodePort, host: openCodeHost })
 

--- a/bridge/src/machine-daemon.js
+++ b/bridge/src/machine-daemon.js
@@ -1,0 +1,80 @@
+import { MachineRegistry, trackAgentHostLifecycle } from "./machine-registry.js"
+import { trackManagedHostLifecycle } from "./opencode-host.js"
+import { createBridgeServer } from "./server.js"
+
+export class MachineDaemon {
+  constructor(identity, { registry = new MachineRegistry(identity) } = {}) {
+    this.registry = registry
+    this.hosts = new Map()
+  }
+
+  registerAcpHost({ id, label, backend = id, capabilities = {}, agent, managed = true }) {
+    this.registry.registerHost({
+      id,
+      label,
+      backend,
+      transport: "acp",
+      managed,
+      state: "configured",
+      capabilities
+    })
+    const tracked = trackAgentHostLifecycle(agent, this.registry, id)
+    this.hosts.set(id, { id, kind: "acp", host: tracked, eager: false })
+    return tracked
+  }
+
+  registerManagedHttpHost({ id, label, backend = id, capabilities = {}, host, managed = true }) {
+    this.registry.registerHost({
+      id,
+      label,
+      backend,
+      transport: "http",
+      managed,
+      state: "configured",
+      capabilities
+    })
+    const tracked = trackManagedHostLifecycle(host, this.registry, id)
+    this.hosts.set(id, { id, kind: "http", host: tracked, eager: true })
+    return tracked
+  }
+
+  async startManagedHosts() {
+    const results = []
+    for (const entry of this.hosts.values()) {
+      if (!entry.eager) continue
+      try {
+        await entry.host.start()
+        results.push({ id: entry.id, status: "available" })
+      } catch (error) {
+        results.push({ id: entry.id, status: "unavailable", error })
+      }
+    }
+    return results
+  }
+
+  snapshot() {
+    return this.registry.snapshot()
+  }
+
+  close() {
+    for (const entry of this.hosts.values()) {
+      if (entry.kind === "acp") entry.host.close?.()
+      else entry.host.stop?.("SIGTERM")
+    }
+  }
+}
+
+export function createMachineDaemonServer({
+  daemon,
+  config,
+  primaryAcp,
+  serviceOptions,
+  createServer = createBridgeServer
+}) {
+  return createServer({
+    config,
+    acp: primaryAcp,
+    machineRegistry: daemon.registry,
+    serviceOptions
+  })
+}

--- a/bridge/src/machine-daemon.js
+++ b/bridge/src/machine-daemon.js
@@ -39,17 +39,11 @@ export class MachineDaemon {
   }
 
   async startManagedHosts() {
-    const results = []
-    for (const entry of this.hosts.values()) {
-      if (!entry.eager) continue
-      try {
-        await entry.host.start()
-        results.push({ id: entry.id, status: "available" })
-      } catch (error) {
-        results.push({ id: entry.id, status: "unavailable", error })
-      }
-    }
-    return results
+    const eager = [...this.hosts.values()].filter((entry) => entry.eager)
+    const settled = await Promise.allSettled(eager.map((entry) => entry.host.start()))
+    return eager.map((entry, index) => settled[index].status === "fulfilled"
+      ? { id: entry.id, status: "available" }
+      : { id: entry.id, status: "unavailable", error: settled[index].reason })
   }
 
   snapshot() {

--- a/bridge/test/daemon-cli.test.js
+++ b/bridge/test/daemon-cli.test.js
@@ -1,25 +1,37 @@
 import assert from "node:assert/strict"
 import test from "node:test"
-import { parseDaemonOptions } from "../src/daemon-cli.js"
+import { ensureOpenCodePortAvailable, parseDaemonOptions } from "../src/daemon-cli.js"
 
 const loopbackEnv = {
   HARNESS_REMOTE_HOST: "127.0.0.1",
   HARNESS_REMOTE_BACKEND: "codex"
 }
 
-test("daemon defaults to one ACP primary plus managed OpenCode", () => {
+test("daemon defaults to one ACP primary plus loopback managed OpenCode", () => {
   const parsed = parseDaemonOptions([], loopbackEnv)
   assert.equal(parsed.config.backend, "codex")
   assert.equal(parsed.openCode, true)
   assert.equal(parsed.openCodeCommand, "opencode")
+  assert.equal(parsed.openCodeHost, "127.0.0.1")
   assert.equal(parsed.openCodePort, 4096)
   assert.equal(parsed.config.port, 4097)
+})
+
+test("daemon does not inherit a LAN daemon bind for managed OpenCode", () => {
+  const parsed = parseDaemonOptions(["--host", "0.0.0.0"], {
+    HARNESS_REMOTE_BACKEND: "codex",
+    HARNESS_REMOTE_USERNAME: "harness",
+    HARNESS_REMOTE_PASSWORD: "secret"
+  })
+  assert.equal(parsed.config.host, "0.0.0.0")
+  assert.equal(parsed.openCodeHost, "127.0.0.1")
 })
 
 test("daemon forwards bridge options and consumes OpenCode-specific options", () => {
   const parsed = parseDaemonOptions([
     "--backend", "claude",
     "--port", "4900",
+    "--opencode-host", "127.0.0.2",
     "--opencode-port", "4901",
     "--opencode-command", "/tools/opencode",
     "--root", "/work"
@@ -28,6 +40,7 @@ test("daemon forwards bridge options and consumes OpenCode-specific options", ()
   assert.equal(parsed.config.backend, "claude")
   assert.equal(parsed.config.port, 4900)
   assert.deepEqual(parsed.config.roots, ["/work"])
+  assert.equal(parsed.openCodeHost, "127.0.0.2")
   assert.equal(parsed.openCodePort, 4901)
   assert.equal(parsed.openCodeCommand, "/tools/opencode")
 })
@@ -39,4 +52,20 @@ test("daemon can explicitly disable OpenCode during migration", () => {
 
 test("daemon rejects invalid managed OpenCode ports", () => {
   assert.throws(() => parseDaemonOptions(["--opencode-port", "nope"], loopbackEnv), /integer between 1 and 65535/)
+})
+
+test("daemon preflight rejects an occupied managed OpenCode port with an actionable error", async () => {
+  await assert.rejects(ensureOpenCodePortAvailable({
+    port: 4096,
+    host: "127.0.0.1",
+    canListenImpl: async () => false
+  }), /already in use.*OpenCode already running.*--opencode-port/)
+})
+
+test("daemon preflight accepts a free managed OpenCode port", async () => {
+  await ensureOpenCodePortAvailable({
+    port: 4096,
+    host: "127.0.0.1",
+    canListenImpl: async () => true
+  })
 })

--- a/bridge/test/daemon-cli.test.js
+++ b/bridge/test/daemon-cli.test.js
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { parseDaemonOptions } from "../src/daemon-cli.js"
+
+const loopbackEnv = {
+  HARNESS_REMOTE_HOST: "127.0.0.1",
+  HARNESS_REMOTE_BACKEND: "codex"
+}
+
+test("daemon defaults to one ACP primary plus managed OpenCode", () => {
+  const parsed = parseDaemonOptions([], loopbackEnv)
+  assert.equal(parsed.config.backend, "codex")
+  assert.equal(parsed.openCode, true)
+  assert.equal(parsed.openCodeCommand, "opencode")
+  assert.equal(parsed.openCodePort, 4096)
+  assert.equal(parsed.config.port, 4097)
+})
+
+test("daemon forwards bridge options and consumes OpenCode-specific options", () => {
+  const parsed = parseDaemonOptions([
+    "--backend", "claude",
+    "--port", "4900",
+    "--opencode-port", "4901",
+    "--opencode-command", "/tools/opencode",
+    "--root", "/work"
+  ], loopbackEnv)
+
+  assert.equal(parsed.config.backend, "claude")
+  assert.equal(parsed.config.port, 4900)
+  assert.deepEqual(parsed.config.roots, ["/work"])
+  assert.equal(parsed.openCodePort, 4901)
+  assert.equal(parsed.openCodeCommand, "/tools/opencode")
+})
+
+test("daemon can explicitly disable OpenCode during migration", () => {
+  const parsed = parseDaemonOptions(["--no-opencode"], loopbackEnv)
+  assert.equal(parsed.openCode, false)
+})
+
+test("daemon rejects invalid managed OpenCode ports", () => {
+  assert.throws(() => parseDaemonOptions(["--opencode-port", "nope"], loopbackEnv), /integer between 1 and 65535/)
+})

--- a/bridge/test/machine-daemon.test.js
+++ b/bridge/test/machine-daemon.test.js
@@ -13,9 +13,16 @@ class FakeHttpHost extends EventEmitter {
   processID = 5151
   stopped = []
   shouldFail = false
+  startImpl
+
+  constructor({ startImpl } = {}) {
+    super()
+    this.startImpl = startImpl
+  }
 
   async start() {
     if (this.shouldFail) throw new Error("OpenCode failed")
+    if (this.startImpl) await this.startImpl()
     this.emit("available")
   }
 
@@ -59,6 +66,48 @@ test("one machine daemon represents ACP and OpenCode concurrently", async () => 
     ["opencode", "available"]
   ])
   assert.equal(snapshot.agents.find((host) => host.id === "opencode").processID, 5151)
+})
+
+test("eager managed hosts start concurrently rather than serially", async () => {
+  const daemon = new MachineDaemon({ id: "machine_test", name: "workstation" })
+  let firstStarted = false
+  let secondStarted = false
+  let releaseFirst
+  let releaseSecond
+  const firstGate = new Promise((resolve) => { releaseFirst = resolve })
+  const secondGate = new Promise((resolve) => { releaseSecond = resolve })
+
+  daemon.registerManagedHttpHost({
+    id: "first",
+    host: new FakeHttpHost({
+      startImpl: async () => {
+        firstStarted = true
+        await firstGate
+      }
+    })
+  })
+  daemon.registerManagedHttpHost({
+    id: "second",
+    host: new FakeHttpHost({
+      startImpl: async () => {
+        secondStarted = true
+        await secondGate
+      }
+    })
+  })
+
+  const starting = daemon.startManagedHosts()
+  await new Promise((resolve) => setImmediate(resolve))
+  assert.equal(firstStarted, true)
+  assert.equal(secondStarted, true)
+
+  releaseFirst()
+  releaseSecond()
+  const result = await starting
+  assert.deepEqual(result.map(({ id, status }) => [id, status]), [
+    ["first", "available"],
+    ["second", "available"]
+  ])
 })
 
 test("one host failure does not erase or stop the other host", async () => {

--- a/bridge/test/machine-daemon.test.js
+++ b/bridge/test/machine-daemon.test.js
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import test from "node:test"
+import { MachineDaemon, createMachineDaemonServer } from "../src/machine-daemon.js"
+
+class FakeAcp extends EventEmitter {
+  closed = false
+  async start() {}
+  close() { this.closed = true }
+}
+
+class FakeHttpHost extends EventEmitter {
+  processID = 5151
+  stopped = []
+  shouldFail = false
+
+  async start() {
+    if (this.shouldFail) throw new Error("OpenCode failed")
+    this.emit("available")
+  }
+
+  stop(signal) {
+    this.stopped.push(signal)
+    return true
+  }
+}
+
+test("one machine daemon represents ACP and OpenCode concurrently", async () => {
+  const daemon = new MachineDaemon({ id: "machine_test", name: "workstation" })
+  const acp = new FakeAcp()
+  const openCode = new FakeHttpHost()
+
+  daemon.registerAcpHost({
+    id: "codex",
+    label: "Codex",
+    capabilities: { sessions: true },
+    agent: acp
+  })
+  daemon.registerManagedHttpHost({
+    id: "opencode",
+    label: "OpenCode",
+    capabilities: { sessions: true },
+    host: openCode
+  })
+
+  let snapshot = daemon.snapshot()
+  assert.deepEqual(snapshot.agents.map((host) => [host.id, host.transport, host.state]), [
+    ["codex", "acp", "configured"],
+    ["opencode", "http", "configured"]
+  ])
+
+  const started = await daemon.startManagedHosts()
+  assert.deepEqual(started.map(({ id, status }) => [id, status]), [["opencode", "available"]])
+
+  await acp.start()
+  snapshot = daemon.snapshot()
+  assert.deepEqual(snapshot.agents.map((host) => [host.id, host.state]), [
+    ["codex", "available"],
+    ["opencode", "available"]
+  ])
+  assert.equal(snapshot.agents.find((host) => host.id === "opencode").processID, 5151)
+})
+
+test("one host failure does not erase or stop the other host", async () => {
+  const daemon = new MachineDaemon({ id: "machine_test", name: "workstation" })
+  const acp = new FakeAcp()
+  const openCode = new FakeHttpHost()
+
+  daemon.registerAcpHost({ id: "claude", label: "Claude Code", agent: acp })
+  daemon.registerManagedHttpHost({ id: "opencode", label: "OpenCode", host: openCode })
+  await acp.start()
+
+  openCode.emit("unavailable", new Error("OpenCode crashed"))
+  const snapshot = daemon.snapshot()
+  assert.equal(snapshot.agents.find((host) => host.id === "claude").state, "available")
+  assert.equal(snapshot.agents.find((host) => host.id === "opencode").state, "unavailable")
+  assert.equal(acp.closed, false)
+})
+
+test("failed eager startup is isolated and reported in the machine snapshot", async () => {
+  const daemon = new MachineDaemon({ id: "machine_test", name: "workstation" })
+  const acp = new FakeAcp()
+  const openCode = new FakeHttpHost()
+  openCode.shouldFail = true
+
+  daemon.registerAcpHost({ id: "codex", agent: acp })
+  daemon.registerManagedHttpHost({ id: "opencode", host: openCode })
+
+  const result = await daemon.startManagedHosts()
+  assert.equal(result[0].status, "unavailable")
+  assert.equal(daemon.snapshot().agents.find((host) => host.id === "opencode").state, "unavailable")
+  assert.equal(daemon.snapshot().agents.find((host) => host.id === "codex").state, "configured")
+})
+
+test("machine server receives the shared multi-host registry", () => {
+  const daemon = new MachineDaemon({ id: "machine_test", name: "workstation" })
+  const acp = new FakeAcp()
+  const openCode = new FakeHttpHost()
+  daemon.registerAcpHost({ id: "pi", agent: acp })
+  daemon.registerManagedHttpHost({ id: "opencode", host: openCode })
+
+  let received
+  const server = { marker: true }
+  const value = createMachineDaemonServer({
+    daemon,
+    config: { port: 4097 },
+    primaryAcp: acp,
+    serviceOptions: { snapshotDirectory: "/tmp/test" },
+    createServer: (options) => {
+      received = options
+      return server
+    }
+  })
+
+  assert.equal(value, server)
+  assert.equal(received.machineRegistry, daemon.registry)
+  assert.equal(received.acp, acp)
+  assert.deepEqual(received.machineRegistry.snapshot().agents.map((host) => host.id), ["pi", "opencode"])
+})
+
+test("daemon shutdown closes ACP and terminates managed HTTP hosts", () => {
+  const daemon = new MachineDaemon({ id: "machine_test", name: "workstation" })
+  const acp = new FakeAcp()
+  const openCode = new FakeHttpHost()
+  daemon.registerAcpHost({ id: "codex", agent: acp })
+  daemon.registerManagedHttpHost({ id: "opencode", host: openCode })
+
+  daemon.close()
+  assert.equal(acp.closed, true)
+  assert.deepEqual(openCode.stopped, ["SIGTERM"])
+})

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -102,10 +102,18 @@ The daemon owns one primary ACP host plus a managed OpenCode host by default:
 ```text
 Harness daemon :4097
   ├── Codex / Claude / OMP / PI via ACP
-  └── OpenCode :4096 via managed HTTP
+  └── OpenCode 127.0.0.1:4096 via managed HTTP
 ```
 
-`GET /v1/machine` and `GET /global/machine` expose both hosts through the same machine registry and stable machine identity. Host lifecycle is isolated: OpenCode can become unavailable without making the ACP host disappear, and vice versa.
+`GET /v1/machine` and `GET /global/machine` expose both hosts through the same machine registry and stable machine identity. Host lifecycle is isolated: OpenCode can become unavailable without making the ACP host disappear, and vice versa. The daemon HTTP API starts listening before eager managed hosts finish their health checks, so clients can observe `configured` and `unavailable` transitions instead of seeing the whole machine endpoint disappear during a slow host startup.
+
+Managed OpenCode binds to `127.0.0.1` by default even if the Harness daemon itself binds to `0.0.0.0`. This avoids silently opening a second LAN service while OpenCode still uses its direct HTTP transport. If you deliberately need the managed OpenCode listener reachable beyond loopback during this migration phase, opt in explicitly:
+
+```bash
+harness-remote-daemon --backend codex --opencode-host 0.0.0.0
+```
+
+The daemon checks the managed OpenCode port before spawning it and fails with an actionable error if another service is already using that port. Multiple eager managed hosts are started concurrently so one slow host does not serialize daemon startup.
 
 The existing session/run endpoints are still routed through the selected primary ACP backend in this slice. Agent-scoped routing over the shared machine connection is the next #143 step.
 
@@ -114,10 +122,11 @@ Useful migration options:
 ```bash
 harness-remote-daemon --backend claude --opencode-port 4901
 harness-remote-daemon --backend codex --opencode-command /custom/opencode
+harness-remote-daemon --backend codex --opencode-host 127.0.0.2
 harness-remote-daemon --backend omp --no-opencode
 ```
 
-For non-loopback binding, the existing bridge security rule still applies: username and password are required.
+For non-loopback daemon binding, the existing bridge security rule still applies: username and password are required. The managed OpenCode listener remains loopback-only unless `--opencode-host` is supplied explicitly.
 
 ## Advanced/manual setup
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -81,6 +81,44 @@ will start `opencode serve` itself, pass the generated credentials through `OPEN
 
 This means there is no second OpenCode command to copy and run manually.
 
+## Experimental multi-host daemon
+
+#143 now also has a real multi-host runtime entrypoint. It is intentionally separate from the default launcher while the client routing contract is still being migrated.
+
+From a checkout:
+
+```bash
+npm run daemon -- --backend codex --host 127.0.0.1
+```
+
+or, when the repository package is installed:
+
+```bash
+harness-remote-daemon --backend codex --host 127.0.0.1
+```
+
+The daemon owns one primary ACP host plus a managed OpenCode host by default:
+
+```text
+Harness daemon :4097
+  ├── Codex / Claude / OMP / PI via ACP
+  └── OpenCode :4096 via managed HTTP
+```
+
+`GET /v1/machine` and `GET /global/machine` expose both hosts through the same machine registry and stable machine identity. Host lifecycle is isolated: OpenCode can become unavailable without making the ACP host disappear, and vice versa.
+
+The existing session/run endpoints are still routed through the selected primary ACP backend in this slice. Agent-scoped routing over the shared machine connection is the next #143 step.
+
+Useful migration options:
+
+```bash
+harness-remote-daemon --backend claude --opencode-port 4901
+harness-remote-daemon --backend codex --opencode-command /custom/opencode
+harness-remote-daemon --backend omp --no-opencode
+```
+
+For non-loopback binding, the existing bridge security rule still applies: username and password are required.
+
 ## Advanced/manual setup
 
 The existing backend-specific bridge commands remain supported. Use them when you need custom adapter commands, unusual networking, browser CORS configuration, or other advanced settings documented in the main README.

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "private": true,
   "type": "module",
   "bin": {
-    "harness-remote": "./bridge/src/launcher.js"
+    "harness-remote": "./bridge/src/launcher.js",
+    "harness-remote-daemon": "./bridge/src/daemon-cli.js"
   },
   "scripts": {
     "start": "node bridge/src/launcher.js",
+    "daemon": "node bridge/src/daemon-cli.js",
     "test": "npm --prefix bridge test"
   },
   "engines": {


### PR DESCRIPTION
## Summary

Third implementation slice of #143.

- add a `MachineDaemon` runtime that owns one shared `MachineRegistry`
- register ACP and managed HTTP hosts under the same stable machine identity
- supervise OpenCode eagerly while keeping the primary ACP host lazy/compatible with the existing bridge behavior
- isolate host failures so one unavailable agent does not erase or stop the other
- pass the shared multi-host registry into the existing HTTP server, so `/v1/machine` and `/global/machine` expose both hosts
- add a real `harness-remote-daemon` entrypoint with one primary ACP host plus managed OpenCode
- expose the daemon command from both the bridge package and repository root
- start multiple eager managed hosts concurrently rather than serially
- start the daemon HTTP API before eager hosts finish readiness, so host state remains observable during startup failures/timeouts
- bind managed OpenCode to loopback by default, with explicit `--opencode-host` opt-in for wider exposure
- preflight the OpenCode port before spawning and fail with an actionable collision message
- add tests for concurrent heterogeneous hosts, startup failure isolation, bind safety, port preflight, shared server registry, shutdown, and daemon option parsing
- document the experimental multi-host path and its current routing limitation

## User-visible shape

```text
Harness daemon :4097
  ├── primary ACP host (Codex / Claude / OMP / PI)
  └── managed OpenCode 127.0.0.1:4096
```

A single machine query now sees both host records and their independent lifecycle states.

From a checkout:

```bash
npm run daemon -- --backend codex --host 127.0.0.1
```

Managed OpenCode stays on loopback even when the daemon binds to `0.0.0.0`. During this migration phase, wider OpenCode exposure is explicit:

```bash
harness-remote-daemon --backend codex --host 0.0.0.0 --opencode-host 0.0.0.0
```

## Review hardening

Claude identified four daemon-boundary issues, all addressed in this head:

- no implicit second LAN listener for OpenCode
- machine API listens before eager-host readiness completes
- eager managed hosts start concurrently
- occupied OpenCode ports are detected before process spawn

## Scope boundary

Session/run endpoints still use the selected primary ACP backend in this slice. OpenCode remains a direct HTTP protocol transport. The next #143 slice will introduce agent-scoped routing over the machine daemon instead of pretending that registry convergence alone is full transport convergence.

## #143 acceptance progress

This slice is intended to satisfy the first daemon acceptance milestone in executable form: one Harness daemon process can represent/manage at least two supported agent hosts concurrently, with isolated lifecycle state and one machine registry/API.

Part of #143; does not close it.