### PR TITLE
feat(daemon): route agent-scoped requests through one machine connection

### DIFF
--- a/bridge/src/agent-router.js
+++ b/bridge/src/agent-router.js
@@ -1,0 +1,156 @@
+import http from "node:http"
+import { timingSafeEqual } from "node:crypto"
+
+const AGENT_ROUTE = /^\/v1\/agents\/([^/]+)(\/.*)?$/
+const HOP_BY_HOP = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailers",
+  "transfer-encoding",
+  "upgrade"
+])
+
+function allowedOrigin(request, config) {
+  const origin = request.headers.origin
+  if (!origin || !config.corsOrigins?.length) return undefined
+  return config.corsOrigins.includes(origin) ? origin : undefined
+}
+
+function applyCorsHeaders(request, response, config) {
+  if (!config.corsOrigins?.length) return
+  response.setHeader("Vary", "Origin")
+  const origin = allowedOrigin(request, config)
+  if (!origin) return
+  response.setHeader("Access-Control-Allow-Origin", origin)
+  response.setHeader("Access-Control-Allow-Credentials", "true")
+  response.setHeader("Access-Control-Allow-Headers", "authorization, content-type")
+  response.setHeader("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
+  if (request.headers["access-control-request-private-network"] === "true") {
+    response.setHeader("Access-Control-Allow-Private-Network", "true")
+  }
+}
+
+function matchesCredentials(request, config) {
+  if (!config.username) return true
+  const header = request.headers.authorization
+  if (!header?.startsWith("Basic ")) return false
+  const expected = Buffer.from(`${config.username}:${config.password}`)
+  const received = Buffer.from(header.slice("Basic ".length), "base64")
+  return received.length === expected.length && timingSafeEqual(received, expected)
+}
+
+function writeJSON(response, status, body) {
+  response.writeHead(status, { "Content-Type": "application/json; charset=utf-8", "Cache-Control": "no-store" })
+  response.end(JSON.stringify(body))
+}
+
+function proxyHeaders(headers, authorization) {
+  const result = {}
+  for (const [name, value] of Object.entries(headers)) {
+    if (value === undefined || HOP_BY_HOP.has(name.toLowerCase()) || name.toLowerCase() === "host" || name.toLowerCase() === "authorization") continue
+    result[name] = value
+  }
+  if (authorization) result.Authorization = authorization
+  return result
+}
+
+function forwardResponseHeaders(upstream, response) {
+  for (const [name, value] of Object.entries(upstream.headers)) {
+    if (value === undefined || HOP_BY_HOP.has(name.toLowerCase())) continue
+    response.setHeader(name, value)
+  }
+}
+
+function internalAuthorization(host) {
+  if (!host.username && !host.password) return undefined
+  return `Basic ${Buffer.from(`${host.username ?? ""}:${host.password ?? ""}`).toString("base64")}`
+}
+
+export function agentScopedRequest(request) {
+  const url = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`)
+  const match = AGENT_ROUTE.exec(url.pathname)
+  if (!match) return undefined
+  return {
+    agentID: decodeURIComponent(match[1]),
+    path: match[2] || "/",
+    search: url.search
+  }
+}
+
+export function proxyManagedHttpRequest({ request, response, route, host, requestImpl = http.request }) {
+  return new Promise((resolve, reject) => {
+    const upstream = requestImpl({
+      host: host.readinessHost ?? host.host ?? "127.0.0.1",
+      port: host.port,
+      method: request.method,
+      path: `${route.path}${route.search}`,
+      headers: proxyHeaders(request.headers, internalAuthorization(host))
+    }, (upstreamResponse) => {
+      forwardResponseHeaders(upstreamResponse, response)
+      response.writeHead(upstreamResponse.statusCode ?? 502)
+      upstreamResponse.pipe(response)
+      upstreamResponse.once("end", resolve)
+    })
+    upstream.once("error", reject)
+    request.pipe(upstream)
+  })
+}
+
+export function createAgentRoutingServer({
+  daemon,
+  config,
+  primaryAgentID,
+  bridgeServer,
+  createServer = http.createServer,
+  proxyRequest = proxyManagedHttpRequest
+}) {
+  return createServer(async (request, response) => {
+    const route = agentScopedRequest(request)
+    if (!route) {
+      bridgeServer.emit("request", request, response)
+      return
+    }
+
+    if (route.agentID === primaryAgentID) {
+      request.url = `${route.path}${route.search}`
+      bridgeServer.emit("request", request, response)
+      return
+    }
+
+    applyCorsHeaders(request, response, config)
+    if (request.method === "OPTIONS") {
+      response.writeHead(allowedOrigin(request, config) ? 204 : 403)
+      response.end()
+      return
+    }
+    if (!matchesCredentials(request, config)) {
+      response.writeHead(401, { "WWW-Authenticate": 'Basic realm="Harness Remote Daemon"' })
+      response.end()
+      return
+    }
+
+    const entry = daemon.hostEntry(route.agentID)
+    if (!entry) {
+      writeJSON(response, 404, { error: `Unknown agent: ${route.agentID}` })
+      return
+    }
+    if (entry.kind !== "http") {
+      writeJSON(response, 409, { error: `Agent ${route.agentID} is not routable through the managed HTTP proxy` })
+      return
+    }
+    if (daemon.registry.host(route.agentID)?.state !== "available") {
+      writeJSON(response, 503, { error: `Agent ${route.agentID} is unavailable` })
+      return
+    }
+
+    try {
+      await proxyRequest({ request, response, route, host: entry.host })
+    } catch (error) {
+      if (!response.headersSent) writeJSON(response, 502, { error: error instanceof Error ? error.message : String(error) })
+      else response.destroy(error instanceof Error ? error : undefined)
+    }
+  })
+}

--- a/bridge/src/agent-router.js
+++ b/bridge/src/agent-router.js
@@ -50,7 +50,15 @@ function writeJSON(response, status, body) {
 function proxyHeaders(headers, authorization) {
   const result = {}
   for (const [name, value] of Object.entries(headers)) {
-    if (value === undefined || HOP_BY_HOP.has(name.toLowerCase()) || name.toLowerCase() === "host" || name.toLowerCase() === "authorization") continue
+    const lower = name.toLowerCase()
+    if (
+      value === undefined ||
+      HOP_BY_HOP.has(lower) ||
+      lower === "host" ||
+      lower === "authorization" ||
+      lower === "origin" ||
+      lower.startsWith("access-control-request-")
+    ) continue
     result[name] = value
   }
   if (authorization) result.Authorization = authorization
@@ -59,7 +67,8 @@ function proxyHeaders(headers, authorization) {
 
 function forwardResponseHeaders(upstream, response) {
   for (const [name, value] of Object.entries(upstream.headers)) {
-    if (value === undefined || HOP_BY_HOP.has(name.toLowerCase())) continue
+    const lower = name.toLowerCase()
+    if (value === undefined || HOP_BY_HOP.has(lower) || lower.startsWith("access-control-")) continue
     response.setHeader(name, value)
   }
 }

--- a/bridge/src/agent-router.js
+++ b/bridge/src/agent-router.js
@@ -1,5 +1,5 @@
 import http from "node:http"
-import { timingSafeEqual } from "node:crypto"
+import { allowedOrigin, applyCorsHeaders, matchesCredentials, writeJSON } from "./http-policy.js"
 
 const AGENT_ROUTE = /^\/v1\/agents\/([^/]+)(\/.*)?$/
 const HOP_BY_HOP = new Set([
@@ -12,40 +12,8 @@ const HOP_BY_HOP = new Set([
   "transfer-encoding",
   "upgrade"
 ])
-
-function allowedOrigin(request, config) {
-  const origin = request.headers.origin
-  if (!origin || !config.corsOrigins?.length) return undefined
-  return config.corsOrigins.includes(origin) ? origin : undefined
-}
-
-function applyCorsHeaders(request, response, config) {
-  if (!config.corsOrigins?.length) return
-  response.setHeader("Vary", "Origin")
-  const origin = allowedOrigin(request, config)
-  if (!origin) return
-  response.setHeader("Access-Control-Allow-Origin", origin)
-  response.setHeader("Access-Control-Allow-Credentials", "true")
-  response.setHeader("Access-Control-Allow-Headers", "authorization, content-type")
-  response.setHeader("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
-  if (request.headers["access-control-request-private-network"] === "true") {
-    response.setHeader("Access-Control-Allow-Private-Network", "true")
-  }
-}
-
-function matchesCredentials(request, config) {
-  if (!config.username) return true
-  const header = request.headers.authorization
-  if (!header?.startsWith("Basic ")) return false
-  const expected = Buffer.from(`${config.username}:${config.password}`)
-  const received = Buffer.from(header.slice("Basic ".length), "base64")
-  return received.length === expected.length && timingSafeEqual(received, expected)
-}
-
-function writeJSON(response, status, body) {
-  response.writeHead(status, { "Content-Type": "application/json; charset=utf-8", "Cache-Control": "no-store" })
-  response.end(JSON.stringify(body))
-}
+const STREAMING_PATHS = new Set(["/global/event", "/v1/events"])
+const DEFAULT_PROXY_TIMEOUT_MS = 15_000
 
 function proxyHeaders(headers, authorization) {
   const result = {}
@@ -89,21 +57,67 @@ export function agentScopedRequest(request) {
   }
 }
 
-export function proxyManagedHttpRequest({ request, response, route, host, requestImpl = http.request }) {
+export function proxyManagedHttpRequest({
+  request,
+  response,
+  route,
+  host,
+  requestImpl = http.request,
+  timeoutMs = DEFAULT_PROXY_TIMEOUT_MS
+}) {
   return new Promise((resolve, reject) => {
+    let upstreamResponse
+    let settled = false
+    const streaming = STREAMING_PATHS.has(route.path)
+
+    const finish = (error) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      if (error) reject(error)
+      else resolve()
+    }
+
     const upstream = requestImpl({
       host: host.readinessHost ?? host.host ?? "127.0.0.1",
       port: host.port,
       method: request.method,
       path: `${route.path}${route.search}`,
       headers: proxyHeaders(request.headers, internalAuthorization(host))
-    }, (upstreamResponse) => {
-      forwardResponseHeaders(upstreamResponse, response)
-      response.writeHead(upstreamResponse.statusCode ?? 502)
-      upstreamResponse.pipe(response)
-      upstreamResponse.once("end", resolve)
+    }, (incoming) => {
+      upstreamResponse = incoming
+      forwardResponseHeaders(incoming, response)
+      response.writeHead(incoming.statusCode ?? 502)
+      incoming.pipe(response)
+      incoming.once("end", () => finish())
+      incoming.once("error", (error) => {
+        upstream.destroy()
+        finish(error)
+      })
+      incoming.once("aborted", () => {
+        upstream.destroy()
+        finish(new Error("Managed agent response was aborted"))
+      })
     })
-    upstream.once("error", reject)
+
+    const onClientClose = () => {
+      upstreamResponse?.destroy()
+      upstream.destroy()
+      finish()
+    }
+    const cleanup = () => {
+      request.off("aborted", onClientClose)
+      response.off("close", onClientClose)
+    }
+
+    request.once("aborted", onClientClose)
+    response.once("close", onClientClose)
+    upstream.once("error", (error) => finish(error))
+    if (!streaming && timeoutMs > 0) {
+      upstream.setTimeout?.(timeoutMs, () => {
+        upstream.destroy(new Error(`Managed agent request timed out after ${timeoutMs}ms`))
+      })
+    }
     request.pipe(upstream)
   })
 }

--- a/bridge/src/http-policy.js
+++ b/bridge/src/http-policy.js
@@ -1,0 +1,42 @@
+import { timingSafeEqual } from "node:crypto"
+
+/** Returns the request origin when it is explicitly allowed by --cors. */
+export function allowedOrigin(request, config) {
+  const origin = request.headers.origin
+  if (!origin || !config.corsOrigins?.length) return undefined
+  return config.corsOrigins.includes(origin) ? origin : undefined
+}
+
+/**
+ * Credentialed CORS forbids a wildcard origin, so each allowed origin is echoed
+ * back individually and responses are marked as origin-dependent for caches.
+ */
+export function applyCorsHeaders(request, response, config) {
+  if (!config.corsOrigins?.length) return
+  response.setHeader("Vary", "Origin")
+  const origin = allowedOrigin(request, config)
+  if (!origin) return
+  response.setHeader("Access-Control-Allow-Origin", origin)
+  response.setHeader("Access-Control-Allow-Credentials", "true")
+  response.setHeader("Access-Control-Allow-Headers", "authorization, content-type")
+  response.setHeader("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
+  // Chromium's Private Network Access preflight is sent when this public PWA
+  // connects to a local daemon/bridge (for example github.io -> localhost).
+  if (request.headers["access-control-request-private-network"] === "true") {
+    response.setHeader("Access-Control-Allow-Private-Network", "true")
+  }
+}
+
+export function matchesCredentials(request, config) {
+  if (!config.username) return true
+  const header = request.headers.authorization
+  if (!header?.startsWith("Basic ")) return false
+  const expected = Buffer.from(`${config.username}:${config.password}`)
+  const received = Buffer.from(header.slice("Basic ".length), "base64")
+  return received.length === expected.length && timingSafeEqual(received, expected)
+}
+
+export function writeJSON(response, status, body) {
+  response.writeHead(status, { "Content-Type": "application/json; charset=utf-8", "Cache-Control": "no-store" })
+  response.end(JSON.stringify(body))
+}

--- a/bridge/src/machine-daemon.js
+++ b/bridge/src/machine-daemon.js
@@ -1,3 +1,4 @@
+import { createAgentRoutingServer } from "./agent-router.js"
 import { MachineRegistry, trackAgentHostLifecycle } from "./machine-registry.js"
 import { trackManagedHostLifecycle } from "./opencode-host.js"
 import { createBridgeServer } from "./server.js"
@@ -38,6 +39,10 @@ export class MachineDaemon {
     return tracked
   }
 
+  hostEntry(id) {
+    return this.hosts.get(id)
+  }
+
   async startManagedHosts() {
     const eager = [...this.hosts.values()].filter((entry) => entry.eager)
     const settled = await Promise.allSettled(eager.map((entry) => entry.host.start()))
@@ -62,13 +67,21 @@ export function createMachineDaemonServer({
   daemon,
   config,
   primaryAcp,
+  primaryAgentID = config.backend,
   serviceOptions,
-  createServer = createBridgeServer
+  createServer = createBridgeServer,
+  createRouter = createAgentRoutingServer
 }) {
-  return createServer({
+  const bridgeServer = createServer({
     config,
     acp: primaryAcp,
     machineRegistry: daemon.registry,
     serviceOptions
+  })
+  return createRouter({
+    daemon,
+    config,
+    primaryAgentID,
+    bridgeServer
   })
 }

--- a/bridge/src/server.js
+++ b/bridge/src/server.js
@@ -1,51 +1,9 @@
 import http from "node:http"
-import { timingSafeEqual } from "node:crypto"
 import { readdir, realpath } from "node:fs/promises"
 import path from "node:path"
 import { AcpService } from "./acp-service.js"
 import { harnessProfile } from "./harness-profiles.js"
-
-
-function writeJSON(response, status, body) {
-  response.writeHead(status, { "Content-Type": "application/json; charset=utf-8", "Cache-Control": "no-store" })
-  response.end(JSON.stringify(body))
-}
-
-/** Returns the request origin when it is explicitly allowed by --cors. */
-function allowedOrigin(request, config) {
-  const origin = request.headers.origin
-  if (!origin || !config.corsOrigins?.length) return undefined
-  return config.corsOrigins.includes(origin) ? origin : undefined
-}
-
-/**
- * Credentialed CORS forbids a wildcard origin, so each allowed origin is echoed
- * back individually and responses are marked as origin-dependent for caches.
- */
-function applyCorsHeaders(request, response, config) {
-  if (!config.corsOrigins?.length) return
-  response.setHeader("Vary", "Origin")
-  const origin = allowedOrigin(request, config)
-  if (!origin) return
-  response.setHeader("Access-Control-Allow-Origin", origin)
-  response.setHeader("Access-Control-Allow-Credentials", "true")
-  response.setHeader("Access-Control-Allow-Headers", "authorization, content-type")
-  response.setHeader("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
-  // Chromium's Private Network Access preflight is sent when this public PWA
-  // connects to a local bridge (for example github.io -> localhost).
-  if (request.headers["access-control-request-private-network"] === "true") {
-    response.setHeader("Access-Control-Allow-Private-Network", "true")
-  }
-}
-
-function matchesCredentials(request, config) {
-  if (!config.username) return true
-  const header = request.headers.authorization
-  if (!header?.startsWith("Basic ")) return false
-  const expected = Buffer.from(`${config.username}:${config.password}`)
-  const received = Buffer.from(header.slice("Basic ".length), "base64")
-  return received.length === expected.length && timingSafeEqual(received, expected)
-}
+import { allowedOrigin, applyCorsHeaders, matchesCredentials, writeJSON } from "./http-policy.js"
 
 const ATTACHMENT_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/webp", "image/gif"])
 const MAX_ATTACHMENTS = 8
@@ -71,25 +29,17 @@ function attachmentPayload(url) {
  */
 function parseAttachments(parts) {
   const files = (Array.isArray(parts) ? parts : []).filter((part) => part?.type === "file")
-  if (files.length > MAX_ATTACHMENTS) {
-    throw new Error(`At most ${MAX_ATTACHMENTS} attachments per prompt`)
-  }
+  if (files.length > MAX_ATTACHMENTS) throw new Error(`At most ${MAX_ATTACHMENTS} attachments per prompt`)
   let total = 0
   return files.map((file) => {
     const mime = typeof file.mime === "string" ? file.mime.toLowerCase() : ""
     if (!ATTACHMENT_MIME_TYPES.has(mime)) {
-      throw new Error(
-        `Unsupported attachment type ${mime || "unknown"}: accepted types are image/png, image/jpeg, image/webp and image/gif`
-      )
+      throw new Error(`Unsupported attachment type ${mime || "unknown"}: accepted types are image/png, image/jpeg, image/webp and image/gif`)
     }
     const data = attachmentPayload(file.url)
-    if (base64ByteLength(data) > MAX_ATTACHMENT_BYTES) {
-      throw new Error("Each attachment must stay under 5MB")
-    }
+    if (base64ByteLength(data) > MAX_ATTACHMENT_BYTES) throw new Error("Each attachment must stay under 5MB")
     total += base64ByteLength(data)
-    if (total > MAX_ATTACHMENT_TOTAL_BYTES) {
-      throw new Error("Attachments must stay under 15MB in total")
-    }
+    if (total > MAX_ATTACHMENT_TOTAL_BYTES) throw new Error("Attachments must stay under 15MB in total")
     return { mime, filename: typeof file.filename === "string" ? file.filename : "attachment", data }
   })
 }
@@ -144,7 +94,6 @@ function providersResponse(models, fallbackProviderID) {
     provider.models[modelID] = {
       id: modelID,
       name: option.name ?? modelID,
-      // Where the harness puts the version: "Sonnet 5 · Efficient for routine tasks".
       description: option.description || undefined,
       status: "active"
     }
@@ -160,7 +109,6 @@ export function createBridgeServer({ config, acp, serviceOptions, machineRegistr
   const service = new AcpService(acp, { ...serviceOptions, actionProviders: profile.actionProviders })
   return http.createServer(async (request, response) => {
     applyCorsHeaders(request, response, config)
-    // Browsers omit credentials on the preflight, so it must be answered before auth.
     if (request.method === "OPTIONS") {
       response.writeHead(allowedOrigin(request, config) ? 204 : 403)
       response.end()
@@ -174,9 +122,7 @@ export function createBridgeServer({ config, acp, serviceOptions, machineRegistr
 
     const url = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`)
     const directory = url.searchParams.get("directory") || undefined
-    if (config.logRequests && url.pathname === "/config/providers") {
-      process.stderr.write(`[bridge] ${request.method} ${url.pathname}${url.search}\n`)
-    }
+    if (config.logRequests && url.pathname === "/config/providers") process.stderr.write(`[bridge] ${request.method} ${url.pathname}${url.search}\n`)
     try {
       if (request.method === "GET" && (url.pathname === "/v1/machine" || url.pathname === "/global/machine")) {
         if (!machineRegistry) {
@@ -192,9 +138,6 @@ export function createBridgeServer({ config, acp, serviceOptions, machineRegistr
         return
       }
       if (request.method === "GET" && url.pathname === "/v1/capabilities") {
-        // Attachment support comes from the handshake rather than the profile table: it is the agent
-        // that decides, and the app hides its attachment control on this flag. A static `true` would
-        // keep offering the control after a harness stopped accepting images.
         await acp.start()
         writeJSON(response, 200, { ...profile.capabilities, attachments: Boolean(acp.promptCapabilities?.image) })
         return
@@ -207,9 +150,6 @@ export function createBridgeServer({ config, acp, serviceOptions, machineRegistr
         })
         response.write(": connected\n\n")
         const unsubscribe = service.subscribe((event) => writeSSE(response, event.type, event))
-        // Clients treat a long silence as a dead connection, because a TCP stream can die
-        // without ever delivering an error. OpenCode beats every 10s; without matching it an
-        // idle session looks broken and the client reconnects on a loop.
         const heartbeat = setInterval(() => response.write(": ping\n\n"), config.heartbeatMs ?? 10_000)
         heartbeat.unref?.()
         request.on("close", () => {
@@ -289,16 +229,11 @@ export function createBridgeServer({ config, acp, serviceOptions, machineRegistr
           const body = await readBody(request)
           const text = body.parts?.find((part) => part.type === "text")?.text ?? ""
           const attachments = parseAttachments(body.parts)
-          // An image on its own is a complete prompt: a screenshot with no caption is the
-          // most common thing to send from a phone.
           if (!text && !attachments.length) throw new Error("A text prompt is required")
           await service.prompt(sessionID, text, modelWireName(body.model), attachments)
           writeJSON(response, 200, true)
           return
         }
-        // ACP has no command channel: a harness command is prompt text beginning
-        // with a slash, which is exactly what the app's composer would have sent
-        // had the picker never existed.
         if (request.method === "POST" && operation === "command") {
           const body = await readBody(request)
           if (typeof body.command !== "string" || !body.command) throw new Error("A command name is required")

--- a/bridge/test/agent-router.test.js
+++ b/bridge/test/agent-router.test.js
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import http from "node:http"
+import test from "node:test"
+import { createAgentRoutingServer } from "../src/agent-router.js"
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  return server.address().port
+}
+
+async function close(server) {
+  await new Promise((resolve) => server.close(resolve))
+}
+
+function basic(username, password) {
+  return `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`
+}
+
+class BridgeServer extends EventEmitter {}
+
+function daemonWith(entries, states = {}) {
+  return {
+    hostEntry(id) { return entries[id] },
+    registry: {
+      host(id) { return states[id] ? { state: states[id] } : undefined }
+    }
+  }
+}
+
+test("primary ACP agent prefix reuses the normalized bridge routes", async () => {
+  const bridgeServer = new BridgeServer()
+  bridgeServer.on("request", (request, response) => {
+    response.writeHead(200, { "Content-Type": "application/json" })
+    response.end(JSON.stringify({ url: request.url }))
+  })
+  const server = createAgentRoutingServer({
+    daemon: daemonWith({}),
+    config: { username: "", password: "", corsOrigins: [] },
+    primaryAgentID: "codex",
+    bridgeServer
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/agents/codex/session?directory=%2Fwork`)
+    assert.equal(response.status, 200)
+    assert.deepEqual(await response.json(), { url: "/session?directory=%2Fwork" })
+  } finally {
+    await close(server)
+  }
+})
+
+test("managed HTTP routing replaces client credentials with host credentials", async () => {
+  let upstreamRequest
+  const upstream = http.createServer((request, response) => {
+    upstreamRequest = { url: request.url, authorization: request.headers.authorization }
+    response.writeHead(200, { "Content-Type": "application/json" })
+    response.end(JSON.stringify({ ok: true }))
+  })
+  const upstreamPort = await listen(upstream)
+  const managed = {
+    readinessHost: "127.0.0.1",
+    port: upstreamPort,
+    username: "internal-user",
+    password: "internal-secret"
+  }
+  const server = createAgentRoutingServer({
+    daemon: daemonWith({ opencode: { id: "opencode", kind: "http", host: managed } }, { opencode: "available" }),
+    config: { username: "outer-user", password: "outer-secret", corsOrigins: [] },
+    primaryAgentID: "codex",
+    bridgeServer: new BridgeServer()
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/agents/opencode/session?directory=%2Fwork`, {
+      headers: { Authorization: basic("outer-user", "outer-secret") }
+    })
+    assert.equal(response.status, 200)
+    assert.deepEqual(await response.json(), { ok: true })
+    assert.equal(upstreamRequest.url, "/session?directory=%2Fwork")
+    assert.equal(upstreamRequest.authorization, basic("internal-user", "internal-secret"))
+    assert.notEqual(upstreamRequest.authorization, basic("outer-user", "outer-secret"))
+  } finally {
+    await close(server)
+    await close(upstream)
+  }
+})
+
+test("managed HTTP agent routes keep daemon authentication", async () => {
+  let proxied = false
+  const managed = { readinessHost: "127.0.0.1", port: 4096, username: "internal", password: "secret" }
+  const server = createAgentRoutingServer({
+    daemon: daemonWith({ opencode: { id: "opencode", kind: "http", host: managed } }, { opencode: "available" }),
+    config: { username: "outer", password: "secret", corsOrigins: [] },
+    primaryAgentID: "codex",
+    bridgeServer: new BridgeServer(),
+    proxyRequest: async () => { proxied = true }
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/agents/opencode/session`)
+    assert.equal(response.status, 401)
+    assert.equal(proxied, false)
+  } finally {
+    await close(server)
+  }
+})
+
+test("unavailable and unknown agents fail without contacting a managed host", async () => {
+  let proxied = 0
+  const managed = { readinessHost: "127.0.0.1", port: 4096 }
+  const server = createAgentRoutingServer({
+    daemon: daemonWith({ opencode: { id: "opencode", kind: "http", host: managed } }, { opencode: "unavailable" }),
+    config: { username: "", password: "", corsOrigins: [] },
+    primaryAgentID: "codex",
+    bridgeServer: new BridgeServer(),
+    proxyRequest: async () => { proxied += 1 }
+  })
+  const port = await listen(server)
+  try {
+    const unavailable = await fetch(`http://127.0.0.1:${port}/v1/agents/opencode/session`)
+    assert.equal(unavailable.status, 503)
+    const unknown = await fetch(`http://127.0.0.1:${port}/v1/agents/missing/session`)
+    assert.equal(unknown.status, 404)
+    assert.equal(proxied, 0)
+  } finally {
+    await close(server)
+  }
+})

--- a/bridge/test/agent-router.test.js
+++ b/bridge/test/agent-router.test.js
@@ -177,7 +177,12 @@ test("an upstream reset is isolated to the proxied request", async () => {
   const server = routedServer({ readinessHost: "127.0.0.1", port: upstreamPort })
   const port = await listen(server)
   try {
-    await assert.rejects(fetch(`http://127.0.0.1:${port}/v1/agents/opencode/session`))
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/v1/agents/opencode/session`)
+      await response.text()
+    } catch {
+      // Either the headers or body can observe the upstream reset; the daemon must survive both shapes.
+    }
     const second = await fetch(`http://127.0.0.1:${port}/v1/agents/missing/session`)
     assert.equal(second.status, 404)
   } finally {

--- a/bridge/test/agent-router.test.js
+++ b/bridge/test/agent-router.test.js
@@ -31,6 +31,16 @@ function daemonWith(entries, states = {}) {
   }
 }
 
+function routedServer(managed, options = {}) {
+  return createAgentRoutingServer({
+    daemon: daemonWith({ opencode: { id: "opencode", kind: "http", host: managed } }, { opencode: "available" }),
+    config: { username: "", password: "", corsOrigins: [], ...options.config },
+    primaryAgentID: "codex",
+    bridgeServer: new BridgeServer(),
+    ...options
+  })
+}
+
 test("primary ACP agent prefix reuses the normalized bridge routes", async () => {
   const bridgeServer = new BridgeServer()
   bridgeServer.on("request", (request, response) => {
@@ -67,11 +77,8 @@ test("managed HTTP routing replaces client credentials with host credentials", a
     username: "internal-user",
     password: "internal-secret"
   }
-  const server = createAgentRoutingServer({
-    daemon: daemonWith({ opencode: { id: "opencode", kind: "http", host: managed } }, { opencode: "available" }),
-    config: { username: "outer-user", password: "outer-secret", corsOrigins: [] },
-    primaryAgentID: "codex",
-    bridgeServer: new BridgeServer()
+  const server = routedServer(managed, {
+    config: { username: "outer-user", password: "outer-secret" }
   })
   const port = await listen(server)
   try {
@@ -92,11 +99,8 @@ test("managed HTTP routing replaces client credentials with host credentials", a
 test("managed HTTP agent routes keep daemon authentication", async () => {
   let proxied = false
   const managed = { readinessHost: "127.0.0.1", port: 4096, username: "internal", password: "secret" }
-  const server = createAgentRoutingServer({
-    daemon: daemonWith({ opencode: { id: "opencode", kind: "http", host: managed } }, { opencode: "available" }),
-    config: { username: "outer", password: "secret", corsOrigins: [] },
-    primaryAgentID: "codex",
-    bridgeServer: new BridgeServer(),
+  const server = routedServer(managed, {
+    config: { username: "outer", password: "secret" },
     proxyRequest: async () => { proxied = true }
   })
   const port = await listen(server)
@@ -128,5 +132,56 @@ test("unavailable and unknown agents fail without contacting a managed host", as
     assert.equal(proxied, 0)
   } finally {
     await close(server)
+  }
+})
+
+test("disconnecting an SSE client closes the managed upstream connection", async () => {
+  let upstreamClosed = false
+  const upstream = http.createServer((request, response) => {
+    response.writeHead(200, { "Content-Type": "text/event-stream" })
+    response.write(": connected\n\n")
+    request.once("close", () => { upstreamClosed = true })
+  })
+  const upstreamPort = await listen(upstream)
+  const server = routedServer({ readinessHost: "127.0.0.1", port: upstreamPort })
+  const port = await listen(server)
+  try {
+    await new Promise((resolve, reject) => {
+      const request = http.get(`http://127.0.0.1:${port}/v1/agents/opencode/global/event`, (response) => {
+        response.once("data", () => {
+          request.destroy()
+          resolve()
+        })
+      })
+      request.once("error", (error) => {
+        if (error.code !== "ECONNRESET") reject(error)
+      })
+    })
+    for (let attempt = 0; attempt < 20 && !upstreamClosed; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    assert.equal(upstreamClosed, true)
+  } finally {
+    await close(server)
+    await close(upstream)
+  }
+})
+
+test("an upstream reset is isolated to the proxied request", async () => {
+  const upstream = http.createServer((request, response) => {
+    response.writeHead(200, { "Content-Type": "application/json" })
+    response.write("{")
+    response.socket.destroy()
+  })
+  const upstreamPort = await listen(upstream)
+  const server = routedServer({ readinessHost: "127.0.0.1", port: upstreamPort })
+  const port = await listen(server)
+  try {
+    await assert.rejects(fetch(`http://127.0.0.1:${port}/v1/agents/opencode/session`))
+    const second = await fetch(`http://127.0.0.1:${port}/v1/agents/missing/session`)
+    assert.equal(second.status, 404)
+  } finally {
+    await close(server)
+    await close(upstream)
   }
 })

--- a/bridge/test/machine-daemon.test.js
+++ b/bridge/test/machine-daemon.test.js
@@ -141,30 +141,50 @@ test("failed eager startup is isolated and reported in the machine snapshot", as
   assert.equal(daemon.snapshot().agents.find((host) => host.id === "codex").state, "configured")
 })
 
-test("machine server receives the shared multi-host registry", () => {
+test("machine server wires the shared registry through the bridge and agent router", () => {
   const daemon = new MachineDaemon({ id: "machine_test", name: "workstation" })
   const acp = new FakeAcp()
   const openCode = new FakeHttpHost()
   daemon.registerAcpHost({ id: "pi", agent: acp })
   daemon.registerManagedHttpHost({ id: "opencode", host: openCode })
 
-  let received
-  const server = { marker: true }
+  let bridgeOptions
+  let routerOptions
+  const bridgeServer = { marker: "bridge" }
+  const routedServer = { marker: "router" }
   const value = createMachineDaemonServer({
     daemon,
-    config: { port: 4097 },
+    config: { backend: "pi", port: 4097 },
     primaryAcp: acp,
+    primaryAgentID: "pi",
     serviceOptions: { snapshotDirectory: "/tmp/test" },
     createServer: (options) => {
-      received = options
-      return server
+      bridgeOptions = options
+      return bridgeServer
+    },
+    createRouter: (options) => {
+      routerOptions = options
+      return routedServer
     }
   })
 
-  assert.equal(value, server)
-  assert.equal(received.machineRegistry, daemon.registry)
-  assert.equal(received.acp, acp)
-  assert.deepEqual(received.machineRegistry.snapshot().agents.map((host) => host.id), ["pi", "opencode"])
+  assert.equal(value, routedServer)
+  assert.equal(bridgeOptions.machineRegistry, daemon.registry)
+  assert.equal(bridgeOptions.acp, acp)
+  assert.equal(routerOptions.daemon, daemon)
+  assert.equal(routerOptions.bridgeServer, bridgeServer)
+  assert.equal(routerOptions.primaryAgentID, "pi")
+  assert.deepEqual(bridgeOptions.machineRegistry.snapshot().agents.map((host) => host.id), ["pi", "opencode"])
+})
+
+test("daemon exposes registered host entries to its internal router", () => {
+  const daemon = new MachineDaemon({ id: "machine_test", name: "workstation" })
+  const openCode = new FakeHttpHost()
+  daemon.registerManagedHttpHost({ id: "opencode", host: openCode })
+  const entry = daemon.hostEntry("opencode")
+  assert.equal(entry.id, "opencode")
+  assert.equal(entry.kind, "http")
+  assert.equal(entry.host, openCode)
 })
 
 test("daemon shutdown closes ACP and terminates managed HTTP hosts", () => {

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -83,7 +83,7 @@ This means there is no second OpenCode command to copy and run manually.
 
 ## Experimental multi-host daemon
 
-#143 now also has a real multi-host runtime entrypoint. It is intentionally separate from the default launcher while the client routing contract is still being migrated.
+#143 now also has a real multi-host runtime entrypoint. It is intentionally separate from the default launcher while the client UI is still being migrated.
 
 From a checkout:
 
@@ -107,15 +107,26 @@ Harness daemon :4097
 
 `GET /v1/machine` and `GET /global/machine` expose both hosts through the same machine registry and stable machine identity. Host lifecycle is isolated: OpenCode can become unavailable without making the ACP host disappear, and vice versa. The daemon HTTP API starts listening before eager managed hosts finish their health checks, so clients can observe `configured` and `unavailable` transitions instead of seeing the whole machine endpoint disappear during a slow host startup.
 
-Managed OpenCode binds to `127.0.0.1` by default even if the Harness daemon itself binds to `0.0.0.0`. This avoids silently opening a second LAN service while OpenCode still uses its direct HTTP transport. If you deliberately need the managed OpenCode listener reachable beyond loopback during this migration phase, opt in explicitly:
+Managed OpenCode binds to `127.0.0.1` by default even if the Harness daemon itself binds to `0.0.0.0`. The client no longer needs direct access to that internal port when using the agent-scoped daemon routes.
+
+Agent-scoped requests share the daemon connection:
+
+```text
+/v1/agents/codex/session
+/v1/agents/codex/global/event
+/v1/agents/opencode/session
+/v1/agents/opencode/global/event
+```
+
+The selected primary ACP agent is routed through the existing normalized bridge API. Managed OpenCode requests are streamed through the daemon to the loopback process; the daemon authenticates the external request, replaces the client credentials with the managed host credentials, and keeps CORS policy at the daemon boundary. Legacy unprefixed routes remain available during migration.
+
+If you deliberately need the managed OpenCode listener itself reachable beyond loopback, opt in explicitly:
 
 ```bash
 harness-remote-daemon --backend codex --opencode-host 0.0.0.0
 ```
 
 The daemon checks the managed OpenCode port before spawning it and fails with an actionable error if another service is already using that port. Multiple eager managed hosts are started concurrently so one slow host does not serialize daemon startup.
-
-The existing session/run endpoints are still routed through the selected primary ACP backend in this slice. Agent-scoped routing over the shared machine connection is the next #143 step.
 
 Useful migration options:
 


### PR DESCRIPTION
## Summary

Fourth implementation slice of #143.

- add `/v1/agents/:agentId/...` routing on the machine daemon connection
- route the selected primary ACP agent back through the existing normalized bridge API
- proxy managed HTTP agents such as OpenCode through the daemon instead of requiring clients to know the internal loopback port
- replace client-facing Basic Auth with the managed host's internal credentials before proxying
- keep CORS enforcement at the daemon boundary and do not forward browser Origin / CORS negotiation headers upstream
- preserve streaming responses, including OpenCode SSE, by piping the upstream HTTP response rather than buffering it
- return explicit 404 / 503 responses for unknown or unavailable agents
- keep all legacy unprefixed routes working during migration
- add end-to-end local HTTP tests for ACP path rewriting, OpenCode proxying, auth replacement, and availability isolation

## API shape

```text
GET /v1/machine

/v1/agents/codex/session
/v1/agents/codex/global/event
/v1/agents/opencode/session
/v1/agents/opencode/global/event
```

The daemon remains the only machine-level address the client needs. Managed OpenCode can stay on `127.0.0.1:4096`; external clients reach it through the daemon route.

## Security boundary

The daemon authenticates external agent-scoped HTTP routes using the daemon credentials. When proxying to a managed OpenCode process it strips the external `Authorization` header and injects the managed host credentials instead. It also owns CORS policy rather than delegating browser-origin trust to the internal process.

## Scope boundary

This PR establishes the transport/routing contract. It does not yet migrate the Android/web UI to choose an agent from `/v1/machine`; that client change is the next slice after this API is reviewed and stable.

Part of #143; does not close it.