### PR TITLE
docs: put the one command above the argument for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Harness Remote
 
-**Run and supervise AI coding agents across your machines, from anywhere.**
+**Run and supervise AI coding agents on the machines where your code already lives, from anywhere.**
 
-Harness Remote is a **local-first control plane for AI coding agents**. Connect to the machines where your code and credentials already live, then supervise OpenCode, Claude Code, Codex CLI, Oh My Pi and PI from one interface on phone, web or desktop.
+Harness Remote is a **local-first control plane for AI coding agents**. Connect to the machine where your code and credentials already live, then supervise OpenCode, Claude Code, Codex CLI, Oh My Pi and PI from one interface on phone, web or desktop.
 
-**One interface. Multiple agents. Multiple machines. Your infrastructure.**
+**One interface. Multiple agents. Your machines, your credentials, your code.**
 
 > Harness Remote is not another coding agent. It is the control plane above them.
 
@@ -21,6 +21,18 @@ Harness Remote is a **local-first control plane for AI coding agents**. Connect 
 ```
 
 Execution stays on your machines. Repositories stay on your machines. Agent credentials and model access stay on your machines. Harness Remote coordinates and supervises the work remotely.
+
+## Quick start
+
+On the machine where your coding agents are installed:
+
+```bash
+npx github:giuliastro/harness-remote
+```
+
+It detects the supported agents on your `PATH`, picks a free port, generates credentials and prints the address to enter in the client. OpenCode is started and supervised directly; ACP-backed agents run through the local bridge or daemon.
+
+Then install a client from [GitHub Releases](https://github.com/giuliastro/harness-remote/releases/latest), or open the [web app](https://giuliastro.github.io/harness-remote/) and enter the address it printed.
 
 ## What works today
 
@@ -75,18 +87,6 @@ Current screenshots:
     <td><img src="docs/screenshots/detail.jpg" alt="Harness Remote session detail"></td>
   </tr>
 </table>
-
-## Quick start
-
-For the current one-command launcher:
-
-```bash
-npx github:giuliastro/harness-remote
-```
-
-It detects supported local agents and starts the appropriate Harness Remote path. OpenCode can be launched as a managed host; ACP-backed agents use the local bridge/daemon.
-
-For releases and packaged clients, see [GitHub Releases](https://github.com/giuliastro/harness-remote/releases/latest).
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- move the quick start from line 79 to just below the intro, before everything that only matters once someone has decided to try it
- stop claiming multiple machines in the present tense on the first screen
- expand the quick start slightly so it says what the command actually does and where to get a client

## Why

#154 is a big improvement — 630 lines to 105, and the positioning finally matches the strategy. Two things about the ordering undercut it.

**The one command was at the bottom.** The market section of the roadmap calls setup friction disqualifying rather than cosmetic, and names one-command startup as the price of being evaluated at all. The README then put that command below the positioning, the roadmap, the local-first rationale, the client list and two screenshots. Someone deciding whether this is worth ten minutes had to scroll past everything that only pays off after they have decided.

**The headline claimed multi-machine.** "Multiple machines" in bold on line 7, and "across your machines" in the tagline, while the fleet work is an open issue and the client connects to one machine at a time. The "What works today" section immediately below was already careful about this, which made the first screen the only place that overstated. Multi-machine stays in "Where it is going", which is where a claim belongs until it ships — and it is the one claim this product cannot afford to spend before it exists, since it is the differentiator the market review identified.

## Notes

Nothing else moved: same sections, same links, same length. I checked that every relative link in the file resolves against `main`, including the new `REFERENCE.md` and both screenshots.

The quick start now also points at the hosted web app as an alternative to installing a client, since the PWA is deployed from this repository on every merge and is the fastest way for someone to see the thing working.

---
_Generated by [Claude Code](https://claude.ai/code/session_014rV4NNde6r5nG2YbHwakAU)_