### PR TITLE
feat(client): select discovered agents from one machine connection

### DIFF
--- a/web/src/components/panels.tsx
+++ b/web/src/components/panels.tsx
@@ -288,8 +288,12 @@ export function ConnectServerWizard({
     try {
       const result = await onTest(discoveryConfig)
       setTestResult(result)
-      if (!result.ok || !onDiscover) return
-      const discovered = await onDiscover(discoveryConfig)
+      if (!result.ok) return
+      const discover = onDiscover ?? (async (candidate: ServerConfig) => {
+        const { discoverMachine } = await import("../machineClient")
+        return discoverMachine(candidate)
+      })
+      const discovered = await discover(discoveryConfig)
       if (!discovered) return
       const available = discovered.agents.filter((agent) => agent.state === "available" || agent.state === "configured")
       const preferred = available.find((agent) => agent.backend === backend) ?? available[0]

--- a/web/src/components/panels.tsx
+++ b/web/src/components/panels.tsx
@@ -19,7 +19,7 @@ import {
   backendSetupCommand
 } from "../backendSetup"
 import type { Translator } from "../i18n"
-import type { BackendKind, FileEntry, ServerConfig } from "../types"
+import type { BackendKind, FileEntry, MachineSnapshot, ServerConfig } from "../types"
 
 /** Breadcrumb pieces for an absolute path, POSIX or Windows, each carrying the path to browse to.
  *  Typing or pasting a deep path and then wanting to step back up one level is the common case, and
@@ -69,13 +69,6 @@ function CopyButton({ text, copyLabel, copiedLabel }: { text: string; copyLabel:
   )
 }
 
-/**
- * Choosing where a new session runs. The old dialog dropped the user into whatever folder the
- * server happened to report and offered a flat list plus a "parent folder" row — no way to see
- * where you were, no way to type a path you already knew, and no shortcut to a project you had
- * opened ten minutes earlier. All three are here now, and the folder that will actually be used is
- * stated in full before the button that uses it.
- */
 export function NewSessionDialog({
   t,
   path,
@@ -231,25 +224,20 @@ export function NewSessionDialog({
 type WizardStep = "harness" | "address" | "credentials"
 const WIZARD_STEPS: WizardStep[] = ["harness", "address", "credentials"]
 
-/**
- * Adding a server used to mean creating a blank profile and then filling in a five-field form with
- * no explanation of what any harness expects, no idea which port is right, and no way to know that
- * something also has to be started on the other machine. The wizard asks the three questions in the
- * order they matter, defaults the port and username from the harness, and shows the finished
- * command to run on the host before asking for credentials that cannot work without it.
- */
 export function ConnectServerWizard({
   t,
   initialName,
   onCancel,
   onSave,
-  onTest
+  onTest,
+  onDiscover
 }: {
   t: Translator
   initialName: string
   onCancel: () => void
   onSave: (name: string, config: ServerConfig) => void
   onTest: (config: ServerConfig) => Promise<{ ok: boolean; message: string }>
+  onDiscover?: (config: ServerConfig) => Promise<MachineSnapshot | null>
 }) {
   const [step, setStep] = useState<WizardStep>("harness")
   const [backend, setBackend] = useState<BackendKind>("opencode")
@@ -260,12 +248,26 @@ export function ConnectServerWizard({
   const [password, setPassword] = useState("")
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<{ ok: boolean; message: string } | null>(null)
+  const [machine, setMachine] = useState<MachineSnapshot | null>(null)
+  const [agentId, setAgentId] = useState("")
 
-  const config: ServerConfig = { backend, host: host.trim(), port, username: username.trim(), password }
+  const selectedAgent = machine?.agents.find((agent) => agent.id === agentId)
+  const selectedBackend = selectedAgent && BACKEND_KINDS.includes(selectedAgent.backend as BackendKind)
+    ? selectedAgent.backend as BackendKind
+    : backend
+  const config: ServerConfig = {
+    backend: selectedBackend,
+    host: host.trim(),
+    port,
+    username: username.trim(),
+    password,
+    agentId: agentId || undefined
+  }
+  const discoveryConfig: ServerConfig = { backend, host: host.trim(), port, username: username.trim(), password }
   const command = backendSetupCommand(backend, { port, username, password })
   const stepIndex = WIZARD_STEPS.indexOf(step)
   const canLeaveAddress = Boolean(host.trim()) && port > 0
-  const canSave = canLeaveAddress && Boolean(username.trim())
+  const canSave = canLeaveAddress && Boolean(username.trim()) && (!machine || Boolean(agentId))
 
   function chooseBackend(next: BackendKind) {
     setBackend(next)
@@ -273,14 +275,27 @@ export function ConnectServerWizard({
     setUsername(backendDefaultUsername(next))
     setName(`${backendDisplayName(next)} server`)
     setTestResult(null)
+    setMachine(null)
+    setAgentId("")
     setStep("address")
   }
 
   async function test() {
     setTesting(true)
     setTestResult(null)
+    setMachine(null)
+    setAgentId("")
     try {
-      setTestResult(await onTest(config))
+      const result = await onTest(discoveryConfig)
+      setTestResult(result)
+      if (!result.ok || !onDiscover) return
+      const discovered = await onDiscover(discoveryConfig)
+      if (!discovered) return
+      const available = discovered.agents.filter((agent) => agent.state === "available" || agent.state === "configured")
+      const preferred = available.find((agent) => agent.backend === backend) ?? available[0]
+      setMachine(discovered)
+      setAgentId(preferred?.id ?? "")
+      if (preferred) setName(`${discovered.machine.name} · ${preferred.label}`)
     } finally {
       setTesting(false)
     }
@@ -305,8 +320,6 @@ export function ConnectServerWizard({
           </button>
         </div>
 
-        {/* The steps double as navigation. A failed test is usually the address or the port rather
-            than the password, and stepping back one screen at a time to check made that a chore. */}
         <ol className="wizard-steps">
           {WIZARD_STEPS.map((candidate, index) => {
             const reachable = candidate !== "credentials" || canLeaveAddress
@@ -405,6 +418,8 @@ export function ConnectServerWizard({
                     onChange={(event) => {
                       setUsername(event.target.value)
                       setTestResult(null)
+                      setMachine(null)
+                      setAgentId("")
                     }}
                     autoCapitalize="none"
                     autoCorrect="off"
@@ -420,6 +435,8 @@ export function ConnectServerWizard({
                     onChange={(event) => {
                       setPassword(event.target.value)
                       setTestResult(null)
+                      setMachine(null)
+                      setAgentId("")
                     }}
                     placeholder={t('settings.passwordPlaceholder')}
                     autoComplete="current-password"
@@ -427,17 +444,39 @@ export function ConnectServerWizard({
                 </label>
               </div>
               <p className="field-hint">{t('connect.credentialsHint')}</p>
+
+              {machine && (
+                <label className="field fade-in">
+                  <span>Agent on {machine.machine.name}</span>
+                  <select
+                    value={agentId}
+                    onChange={(event) => {
+                      const nextID = event.target.value
+                      setAgentId(nextID)
+                      const next = machine.agents.find((agent) => agent.id === nextID)
+                      if (next) setName(`${machine.machine.name} · ${next.label}`)
+                    }}
+                  >
+                    {machine.agents.map((agent) => (
+                      <option
+                        key={agent.id}
+                        value={agent.id}
+                        disabled={agent.state !== "available" && agent.state !== "configured"}
+                      >
+                        {agent.label} · {agent.state}
+                      </option>
+                    ))}
+                  </select>
+                  <small className="field-hint">One machine connection; requests are routed to the selected agent.</small>
+                </label>
+              )}
             </>
           )}
         </div>
 
-        {/* Outside the scrolling body on purpose. Testing the connection is the first thing anyone
-            does on this step, and with a keyboard open the body is only a couple of lines tall — a
-            test button living at the end of it scrolled out of sight and came to rest against the
-            save button, which is the one press you do not want to hit by accident. */}
         {step === "credentials" && (
           <div className="wizard-test">
-            <button type="button" className="btn-secondary" onClick={() => void test()} disabled={testing || !canSave}>
+            <button type="button" className="btn-secondary" onClick={() => void test()} disabled={testing || !canLeaveAddress || !username.trim()}>
               {testing ? <LoadingIcon size={15} /> : <TestIcon size={15} />}
               {testing ? t('settings.testing') : t('settings.test')}
             </button>
@@ -445,6 +484,7 @@ export function ConnectServerWizard({
               <div className={`notice ${testResult.ok ? "success" : "error"} fade-in`}>
                 {testResult.ok ? "✓ " : "✗ "}
                 {testResult.message}
+                {testResult.ok && machine ? ` · ${machine.agents.length} agent${machine.agents.length === 1 ? "" : "s"} discovered` : ""}
               </div>
             )}
           </div>

--- a/web/src/components/panels.tsx
+++ b/web/src/components/panels.tsx
@@ -286,20 +286,30 @@ export function ConnectServerWizard({
     setMachine(null)
     setAgentId("")
     try {
-      const result = await onTest(discoveryConfig)
-      setTestResult(result)
-      if (!result.ok) return
       const discover = onDiscover ?? (async (candidate: ServerConfig) => {
         const { discoverMachine } = await import("../machineClient")
         return discoverMachine(candidate)
       })
-      const discovered = await discover(discoveryConfig)
-      if (!discovered) return
-      const available = discovered.agents.filter((agent) => agent.state === "available" || agent.state === "configured")
-      const preferred = available.find((agent) => agent.backend === backend) ?? available[0]
-      setMachine(discovered)
-      setAgentId(preferred?.id ?? "")
-      if (preferred) setName(`${discovered.machine.name} · ${preferred.label}`)
+
+      let discovered: MachineSnapshot | null = null
+      try {
+        discovered = await discover(discoveryConfig)
+      } catch {
+        // A daemon with bad credentials and an unreachable host will be explained by the ordinary
+        // backend health test below. Legacy servers intentionally return null from discovery.
+      }
+
+      if (discovered) {
+        const available = discovered.agents.filter((agent) => agent.state === "available" || agent.state === "configured")
+        const preferred = available.find((agent) => agent.backend === backend) ?? available[0]
+        setMachine(discovered)
+        setAgentId(preferred?.id ?? "")
+        if (preferred) setName(`${discovered.machine.name} · ${preferred.label}`)
+        setTestResult({ ok: available.length > 0, message: available.length > 0 ? `Connected to ${discovered.machine.name}` : `${discovered.machine.name} has no available agents` })
+        return
+      }
+
+      setTestResult(await onTest(discoveryConfig))
     } finally {
       setTesting(false)
     }

--- a/web/src/components/panels.tsx
+++ b/web/src/components/panels.tsx
@@ -69,6 +69,13 @@ function CopyButton({ text, copyLabel, copiedLabel }: { text: string; copyLabel:
   )
 }
 
+/**
+ * Choosing where a new session runs. The old dialog dropped the user into whatever folder the
+ * server happened to report and offered a flat list plus a "parent folder" row — no way to see
+ * where you were, no way to type a path you already knew, and no shortcut to a project you had
+ * opened ten minutes earlier. All three are here now, and the folder that will actually be used is
+ * stated in full before the button that uses it.
+ */
 export function NewSessionDialog({
   t,
   path,
@@ -224,6 +231,13 @@ export function NewSessionDialog({
 type WizardStep = "harness" | "address" | "credentials"
 const WIZARD_STEPS: WizardStep[] = ["harness", "address", "credentials"]
 
+/**
+ * Adding a server used to mean creating a blank profile and then filling in a five-field form with
+ * no explanation of what any harness expects, no idea which port is right, and no way to know that
+ * something also has to be started on the other machine. The wizard asks the three questions in the
+ * order they matter, defaults the port and username from the harness, and shows the finished
+ * command to run on the host before asking for credentials that cannot work without it.
+ */
 export function ConnectServerWizard({
   t,
   initialName,
@@ -305,7 +319,12 @@ export function ConnectServerWizard({
         setMachine(discovered)
         setAgentId(preferred?.id ?? "")
         if (preferred) setName(`${discovered.machine.name} · ${preferred.label}`)
-        setTestResult({ ok: available.length > 0, message: available.length > 0 ? `Connected to ${discovered.machine.name}` : `${discovered.machine.name} has no available agents` })
+        setTestResult({
+          ok: available.length > 0,
+          message: available.length > 0
+            ? `${t('connection.connected')} · ${discovered.machine.name}`
+            : `${discovered.machine.name} · ${t('detail.unavailable')}`
+        })
         return
       }
 
@@ -334,6 +353,8 @@ export function ConnectServerWizard({
           </button>
         </div>
 
+        {/* The steps double as navigation. A failed test is usually the address or the port rather
+            than the password, and stepping back one screen at a time to check made that a chore. */}
         <ol className="wizard-steps">
           {WIZARD_STEPS.map((candidate, index) => {
             const reachable = candidate !== "credentials" || canLeaveAddress
@@ -461,7 +482,7 @@ export function ConnectServerWizard({
 
               {machine && (
                 <label className="field fade-in">
-                  <span>Agent on {machine.machine.name}</span>
+                  <span>{t('detail.agentTitle')} · {machine.machine.name}</span>
                   <select
                     value={agentId}
                     onChange={(event) => {
@@ -477,17 +498,20 @@ export function ConnectServerWizard({
                         value={agent.id}
                         disabled={agent.state !== "available" && agent.state !== "configured"}
                       >
-                        {agent.label} · {agent.state}
+                        {agent.label}{agent.state === "unavailable" ? ` · ${t('detail.unavailable')}` : ""}
                       </option>
                     ))}
                   </select>
-                  <small className="field-hint">One machine connection; requests are routed to the selected agent.</small>
                 </label>
               )}
             </>
           )}
         </div>
 
+        {/* Outside the scrolling body on purpose. Testing the connection is the first thing anyone
+            does on this step, and with a keyboard open the body is only a couple of lines tall — a
+            test button living at the end of it scrolled out of sight and came to rest against the
+            save button, which is the one press you do not want to hit by accident. */}
         {step === "credentials" && (
           <div className="wizard-test">
             <button type="button" className="btn-secondary" onClick={() => void test()} disabled={testing || !canLeaveAddress || !username.trim()}>
@@ -498,7 +522,6 @@ export function ConnectServerWizard({
               <div className={`notice ${testResult.ok ? "success" : "error"} fade-in`}>
                 {testResult.ok ? "✓ " : "✗ "}
                 {testResult.message}
-                {testResult.ok && machine ? ` · ${machine.agents.length} agent${machine.agents.length === 1 ? "" : "s"} discovered` : ""}
               </div>
             )}
           </div>

--- a/web/src/settings-regression.test.mjs
+++ b/web/src/settings-regression.test.mjs
@@ -5,6 +5,7 @@ const app = readFileSync(new URL('./App.tsx', import.meta.url), 'utf8')
 const i18n = readFileSync(new URL('./i18n.ts', import.meta.url), 'utf8')
 const styles = readFileSync(new URL('./styles.css', import.meta.url), 'utf8')
 const shell = readFileSync(new URL('./components/shell.tsx', import.meta.url), 'utf8')
+const panels = readFileSync(new URL('./components/panels.tsx', import.meta.url), 'utf8')
 
 const testConnection = app.match(/async function testConnection[\s\S]*?async function refreshSessions/)
 assert.ok(testConnection, 'testConnection function should be present')
@@ -31,6 +32,14 @@ assert.ok(app.includes('<option value="codex">Codex CLI (ACP bridge)</option>'),
 assert.ok(app.includes('health.backend && health.backend !== configToTest.backend'), 'Connection tests should reject a bridge for the wrong backend')
 assert.ok(app.includes('https://github.com/giuliastro/harness-remote#'), 'Help should link to the canonical repository')
 assert.equal(app.includes('https://github.com/gervaso-assistant/opencode-remote-android#'), false, 'Help must not link to the obsolete repository owner')
+
+// A daemon-backed connection discovers the machine after the ordinary connection test succeeds.
+// Legacy servers return null from discovery and therefore keep the exact existing save flow.
+assert.ok(panels.includes('await import("../machineClient")'), 'the connection wizard should discover a machine without requiring App-level wiring')
+assert.ok(panels.includes('discoverMachine(candidate)'), 'the wizard should call machine discovery after a successful connection test')
+assert.ok(panels.includes('agentId: agentId || undefined'), 'the selected machine agent should be persisted in the saved server config')
+assert.ok(panels.includes('One machine connection; requests are routed to the selected agent.'), 'the wizard should explain machine-scoped routing when discovery succeeds')
+assert.ok(panels.includes('agent.state !== "available" && agent.state !== "configured"'), 'unavailable machine agents must not be selectable')
 
 // The server picker used to caption itself with a visually-hidden span, but no rule ever hid it: the
 // caption rendered as stray text above the header. Every class the picker and its actions rely on has

--- a/web/src/settings-regression.test.mjs
+++ b/web/src/settings-regression.test.mjs
@@ -33,12 +33,16 @@ assert.ok(app.includes('health.backend && health.backend !== configToTest.backen
 assert.ok(app.includes('https://github.com/giuliastro/harness-remote#'), 'Help should link to the canonical repository')
 assert.equal(app.includes('https://github.com/gervaso-assistant/opencode-remote-android#'), false, 'Help must not link to the obsolete repository owner')
 
-// A daemon-backed connection discovers the machine after the ordinary connection test succeeds.
-// Legacy servers return null from discovery and therefore keep the exact existing save flow.
+// A daemon-backed connection discovers the machine before falling back to the backend-specific
+// health check. Legacy servers return null from discovery and therefore keep the existing save flow.
 assert.ok(panels.includes('await import("../machineClient")'), 'the connection wizard should discover a machine without requiring App-level wiring')
-assert.ok(panels.includes('discoverMachine(candidate)'), 'the wizard should call machine discovery after a successful connection test')
+assert.ok(panels.includes('discoverMachine(candidate)'), 'the wizard should call machine discovery when testing the connection')
 assert.ok(panels.includes('agentId: agentId || undefined'), 'the selected machine agent should be persisted in the saved server config')
-assert.ok(panels.includes('One machine connection; requests are routed to the selected agent.'), 'the wizard should explain machine-scoped routing when discovery succeeds')
+assert.ok(panels.includes("t('detail.agentTitle')"), 'the discovered-agent picker label should use translated UI copy')
+assert.ok(panels.includes("t('detail.unavailable')"), 'unavailable machine hosts should use translated UI copy')
+assert.equal(panels.includes('Agent on '), false, 'the machine picker must not introduce hardcoded English labels')
+assert.equal(panels.includes('agents discovered'), false, 'machine discovery feedback must not introduce hardcoded English copy')
+assert.equal(panels.includes('{agent.label} · {agent.state}'), false, 'protocol host states must not be rendered verbatim')
 assert.ok(panels.includes('agent.state !== "available" && agent.state !== "configured"'), 'unavailable machine agents must not be selectable')
 
 // The server picker used to caption itself with a visually-hidden span, but no rule ever hid it: the


### PR DESCRIPTION
## Summary

Sixth implementation slice of #143.

- keep the existing connection wizard fully compatible with legacy per-harness servers
- probe `GET /v1/machine` first once host and credentials are available, so users do not need to guess the daemon's primary backend
- when a machine daemon is discovered, show its agent hosts in the wizard
- prefer the discovered agent matching the harness the user initially chose, otherwise select the first available host
- prevent unavailable hosts from being selected
- persist the chosen `agentId` in the saved server profile
- derive the saved backend from the selected machine host so the existing client capability layer remains correct
- fall back to the existing backend-specific health test when `/v1/machine` is absent
- reuse the agent-scoped transport introduced by #153 without another App-level routing refactor
- add regression coverage for machine discovery and agent persistence

## User-visible flow

Legacy server:

```text
Choose harness -> host/port -> credentials -> test -> save
```

Machine daemon:

```text
Choose any starting harness -> machine host/port -> credentials -> test
                                                  -> discover /v1/machine
                                                  -> choose Codex / Claude / OpenCode / ...
                                                  -> save one machine-scoped profile
```

The starting harness is only a setup hint for daemon connections; discovery identifies the actual available hosts and the saved backend follows the selected host.

The profile then routes through `/v1/agents/:agentId/...` using the transport contract already merged in #153.

## Compatibility

If `/v1/machine` is absent or the server is a legacy bridge/OpenCode endpoint, discovery returns `null` and the wizard behaves as before.

Part of #143; does not close it.