### PR TITLE
feat(launcher): auto-start the machine daemon on multi-agent hosts

### DIFF
--- a/bridge/src/launcher.js
+++ b/bridge/src/launcher.js
@@ -16,6 +16,7 @@ const BACKEND_EXECUTABLES = {
   opencode: ["opencode"]
 }
 
+const ACP_BACKENDS = ["codex", "claude", "omp", "pi"]
 const VIRTUAL_INTERFACE = /^(docker|br-|veth|virbr|tun|tap|utun)/i
 
 function optionValue(args, name) {
@@ -73,6 +74,25 @@ export function resolveBackend(args, detected = detectBackends()) {
   throw new Error("No supported agent CLI was found on PATH. Install/select omp, pi, claude, codex, or opencode, then re-run with --backend if needed.")
 }
 
+/** Choose the low-friction startup shape without executing any discovered CLI. */
+export function resolveLaunchPlan(args, detected = detectBackends()) {
+  const explicit = optionValue(args, "--backend")
+  if (explicit) return { mode: "single", backend: explicit, detected }
+  if (detected.length === 0) {
+    throw new Error("No supported agent CLI was found on PATH. Install/select omp, pi, claude, codex, or opencode, then re-run with --backend if needed.")
+  }
+  if (detected.length === 1) return { mode: "single", backend: detected[0], detected }
+
+  const primary = ACP_BACKENDS.find((backend) => detected.includes(backend))
+  if (!primary) return { mode: "single", backend: detected[0], detected }
+  return {
+    mode: "daemon",
+    backend: primary,
+    detected,
+    openCode: detected.includes("opencode")
+  }
+}
+
 export function generateCredentials() {
   return {
     username: "harness",
@@ -98,6 +118,12 @@ export function buildBridgeArgs(args, { backend, host, port }) {
   if (!hasOption(result, "--backend")) result.push("--backend", backend)
   if (!hasOption(result, "--host")) result.push("--host", host)
   if (!hasOption(result, "--port")) result.push("--port", String(port))
+  return result
+}
+
+export function buildDaemonArgs(args, { backend, host, port, openCode }) {
+  const result = buildBridgeArgs(args, { backend, host, port })
+  if (!openCode && !hasOption(result, "--no-opencode")) result.push("--no-opencode")
   return result
 }
 
@@ -139,7 +165,7 @@ export function lanAddresses(interfaces = networkInterfaces()) {
 }
 
 export function launcherUsage() {
-  return `Usage: harness-remote [options]\n\nQuick start options:\n  --backend <name>       Select omp, pi, claude, codex, or opencode (auto-detected when unambiguous)\n  --host <host>          Bind host (quick-start default: 0.0.0.0)\n  --port <port>          Preferred port (OpenCode default: 4096; ACP default: 4097)\n  --username <username>  Override generated Basic Auth username\n  --password <password>  Override generated Basic Auth password\n  --help                 Show this help\n\nOpenCode is started and supervised directly. Other options are forwarded to harness-remote-bridge for ACP-backed agents.`
+  return `Usage: harness-remote [options]\n\nQuick start options:\n  --backend <name>       Select omp, pi, claude, codex, or opencode (optional; multi-agent machines start the daemon automatically)\n  --host <host>          Bind host (quick-start default: 0.0.0.0)\n  --port <port>          Preferred port (OpenCode single-host default: 4096; daemon/ACP default: 4097)\n  --username <username>  Override generated Basic Auth username\n  --password <password>  Override generated Basic Auth password\n  --help                 Show this help\n\nWith one detected agent, Harness starts the existing single-backend path. With multiple detected agents and at least one ACP backend, it starts the machine daemon automatically; OpenCode is included when installed.`
 }
 
 export async function startManagedOpenCode({ host, port, username, password, command = "opencode", Host = ManagedOpenCodeHost } = {}) {
@@ -164,6 +190,22 @@ export function createManagedShutdown(managed, processObject = process) {
   }
 }
 
+function spawnNodeEntrypoint(entrypoint, args, username, password) {
+  const child = spawn(process.execPath, [entrypoint, ...args], {
+    stdio: "inherit",
+    env: bridgeEnvironment(process.env, username, password)
+  })
+  child.once("error", (error) => {
+    process.stderr.write(`Failed to start Harness runtime: ${error.message}\n`)
+    process.exitCode = 1
+  })
+  child.once("exit", (code, signal) => {
+    if (signal) process.kill(process.pid, signal)
+    else process.exitCode = code ?? 1
+  })
+  return child
+}
+
 async function main() {
   const args = process.argv.slice(2)
   if (hasOption(args, "--help")) {
@@ -171,9 +213,10 @@ async function main() {
     return
   }
 
-  const backend = resolveBackend(args)
+  const plan = resolveLaunchPlan(args)
+  const backend = plan.backend
   const host = optionValue(args, "--host") ?? "0.0.0.0"
-  const defaultPort = backend === "opencode" ? 4096 : 4097
+  const defaultPort = plan.mode === "daemon" ? 4097 : backend === "opencode" ? 4096 : 4097
   const requestedPort = Number(optionValue(args, "--port") ?? defaultPort)
   if (!Number.isInteger(requestedPort) || requestedPort < 1 || requestedPort > 65_535) {
     throw new Error("--port must be an integer between 1 and 65535")
@@ -199,7 +242,12 @@ async function main() {
   const addresses = host === "0.0.0.0" ? lanAddresses() : [host]
 
   process.stdout.write("Harness Remote quick start\n")
-  process.stdout.write(`Backend: ${backend}\n`)
+  if (plan.mode === "daemon") {
+    process.stdout.write(`Detected agents: ${plan.detected.join(", ")}\n`)
+    process.stdout.write(`Machine daemon primary: ${backend}\n`)
+  } else {
+    process.stdout.write(`Backend: ${backend}\n`)
+  }
   process.stdout.write(`Port: ${port}\n`)
   if (addresses.length) {
     for (const address of addresses) process.stdout.write(`Connect to: http://${address}:${port}\n`)
@@ -208,6 +256,14 @@ async function main() {
   }
   process.stdout.write(`Username: ${username}\n`)
   process.stdout.write(`Password: ${password}\n`)
+
+  if (plan.mode === "daemon") {
+    const daemonArgs = buildDaemonArgs(args, { backend, host, port, openCode: plan.openCode })
+    process.stdout.write("\nStarting machine daemon...\n")
+    const daemonPath = fileURLToPath(new URL("./daemon-cli.js", import.meta.url))
+    spawnNodeEntrypoint(daemonPath, daemonArgs, username, password)
+    return
+  }
 
   if (backend === "opencode") {
     process.stdout.write("\nStarting managed OpenCode host...\n")
@@ -235,18 +291,7 @@ async function main() {
   process.stdout.write("\nStarting existing bridge...\n")
 
   const cliPath = fileURLToPath(new URL("./cli.js", import.meta.url))
-  const child = spawn(process.execPath, [cliPath, ...bridgeArgs], {
-    stdio: "inherit",
-    env: bridgeEnvironment(process.env, username, password)
-  })
-  child.once("error", (error) => {
-    process.stderr.write(`Failed to start bridge: ${error.message}\n`)
-    process.exitCode = 1
-  })
-  child.once("exit", (code, signal) => {
-    if (signal) process.kill(process.pid, signal)
-    else process.exitCode = code ?? 1
-  })
+  spawnNodeEntrypoint(cliPath, bridgeArgs, username, password)
 }
 
 function isDirectInvocation() {

--- a/bridge/src/launcher.js
+++ b/bridge/src/launcher.js
@@ -16,6 +16,8 @@ const BACKEND_EXECUTABLES = {
   opencode: ["opencode"]
 }
 
+// This is product policy, not alphabetical order: prefer the broadest/most-tested ACP path first.
+// Reordering this changes the default primary on every multi-agent machine.
 const ACP_BACKENDS = ["codex", "claude", "omp", "pi"]
 const VIRTUAL_INTERFACE = /^(docker|br-|veth|virbr|tun|tap|utun)/i
 
@@ -77,13 +79,29 @@ export function resolveBackend(args, detected = detectBackends()) {
 /** Choose the low-friction startup shape without executing any discovered CLI. */
 export function resolveLaunchPlan(args, detected = detectBackends()) {
   const explicit = optionValue(args, "--backend")
-  if (explicit) return { mode: "single", backend: explicit, detected }
+  const forceSingle = hasOption(args, "--single")
+
   if (detected.length === 0) {
+    if (explicit) return { mode: "single", backend: explicit, detected }
     throw new Error("No supported agent CLI was found on PATH. Install/select omp, pi, claude, codex, or opencode, then re-run with --backend if needed.")
   }
-  if (detected.length === 1) return { mode: "single", backend: detected[0], detected }
 
-  const primary = ACP_BACKENDS.find((backend) => detected.includes(backend))
+  if (forceSingle) {
+    const backend = explicit ?? (detected.length === 1 ? detected[0] : null)
+    if (!backend) {
+      throw new Error(`--single requires --backend when multiple supported agent CLIs are installed (${detected.join(", ")}).`)
+    }
+    return { mode: "single", backend, detected }
+  }
+
+  if (detected.length === 1) return { mode: "single", backend: explicit ?? detected[0], detected }
+
+  if (explicit === "opencode") return { mode: "single", backend: explicit, detected }
+  if (explicit && !ACP_BACKENDS.includes(explicit)) {
+    throw new Error(`Unsupported ACP backend '${explicit}' for machine-daemon startup.`)
+  }
+
+  const primary = explicit ?? ACP_BACKENDS.find((backend) => detected.includes(backend))
   if (!primary) return { mode: "single", backend: detected[0], detected }
   return {
     mode: "daemon",
@@ -112,17 +130,25 @@ function stripOptionWithValue(args, option) {
   return result
 }
 
+function stripFlag(args, option) {
+  return args.filter((value) => value !== option)
+}
+
 export function buildBridgeArgs(args, { backend, host, port }) {
   let result = stripOptionWithValue(args, "--username")
   result = stripOptionWithValue(result, "--password")
+  result = stripFlag(result, "--single")
   if (!hasOption(result, "--backend")) result.push("--backend", backend)
   if (!hasOption(result, "--host")) result.push("--host", host)
   if (!hasOption(result, "--port")) result.push("--port", String(port))
   return result
 }
 
-export function buildDaemonArgs(args, { backend, host, port, openCode }) {
+export function buildDaemonArgs(args, { backend, host, port, openCode, openCodePort }) {
   const result = buildBridgeArgs(args, { backend, host, port })
+  if (openCode && openCodePort && !hasOption(result, "--opencode-port")) {
+    result.push("--opencode-port", String(openCodePort))
+  }
   if (!openCode && !hasOption(result, "--no-opencode")) result.push("--no-opencode")
   return result
 }
@@ -144,10 +170,12 @@ export function canListen(port, host) {
   })
 }
 
-export async function findAvailablePort(startPort = 4097, host = "0.0.0.0", attempts = 20) {
+export async function findAvailablePort(startPort = 4097, host = "0.0.0.0", attempts = 20, excludedPorts = []) {
+  const excluded = new Set(excludedPorts)
   for (let offset = 0; offset < attempts; offset += 1) {
     const port = startPort + offset
     if (port > 65_535) break
+    if (excluded.has(port)) continue
     if (await canListen(port, host)) return port
   }
   throw new Error(`No available port found from ${startPort} through ${Math.min(65_535, startPort + attempts - 1)}.`)
@@ -165,7 +193,7 @@ export function lanAddresses(interfaces = networkInterfaces()) {
 }
 
 export function launcherUsage() {
-  return `Usage: harness-remote [options]\n\nQuick start options:\n  --backend <name>       Select omp, pi, claude, codex, or opencode (optional; multi-agent machines start the daemon automatically)\n  --host <host>          Bind host (quick-start default: 0.0.0.0)\n  --port <port>          Preferred port (OpenCode single-host default: 4096; daemon/ACP default: 4097)\n  --username <username>  Override generated Basic Auth username\n  --password <password>  Override generated Basic Auth password\n  --help                 Show this help\n\nWith one detected agent, Harness starts the existing single-backend path. With multiple detected agents and at least one ACP backend, it starts the machine daemon automatically; OpenCode is included when installed.`
+  return `Usage: harness-remote [options]\n\nQuick start options:\n  --backend <name>       Select omp, pi, claude, codex, or opencode (on multi-agent machines, selects the daemon primary)\n  --single               Force the legacy single-backend path instead of the machine daemon\n  --host <host>          Bind host (quick-start default: 0.0.0.0)\n  --port <port>          Preferred port (OpenCode single-host default: 4096; daemon/ACP default: 4097)\n  --username <username>  Override generated Basic Auth username\n  --password <password>  Override generated Basic Auth password\n  --help                 Show this help\n\nWith one detected agent, Harness starts the existing single-backend path. With multiple detected agents and at least one ACP backend, it starts the machine daemon automatically; OpenCode is included when installed and receives a free loopback port automatically.`
 }
 
 export async function startManagedOpenCode({ host, port, username, password, command = "opencode", Host = ManagedOpenCodeHost } = {}) {
@@ -232,6 +260,22 @@ async function main() {
     port = await findAvailablePort(requestedPort, host)
   }
 
+  let openCodePort
+  if (plan.mode === "daemon" && plan.openCode) {
+    const explicitOpenCodePort = optionValue(args, "--opencode-port")
+    if (explicitOpenCodePort) {
+      openCodePort = Number(explicitOpenCodePort)
+      if (!Number.isInteger(openCodePort) || openCodePort < 1 || openCodePort > 65_535) {
+        throw new Error("--opencode-port must be an integer between 1 and 65535")
+      }
+      if (openCodePort === port || !(await canListen(openCodePort, "127.0.0.1"))) {
+        throw new Error(`OpenCode port ${openCodePort} is not available. Choose another --opencode-port or omit it for automatic selection.`)
+      }
+    } else {
+      openCodePort = await findAvailablePort(4096, "127.0.0.1", 20, [port])
+    }
+  }
+
   let username = optionValue(args, "--username")
   let password = optionValue(args, "--password")
   if (Boolean(username) !== Boolean(password)) {
@@ -245,6 +289,7 @@ async function main() {
   if (plan.mode === "daemon") {
     process.stdout.write(`Detected agents: ${plan.detected.join(", ")}\n`)
     process.stdout.write(`Machine daemon primary: ${backend}\n`)
+    if (openCodePort) process.stdout.write(`Managed OpenCode port: ${openCodePort}\n`)
   } else {
     process.stdout.write(`Backend: ${backend}\n`)
   }
@@ -258,7 +303,7 @@ async function main() {
   process.stdout.write(`Password: ${password}\n`)
 
   if (plan.mode === "daemon") {
-    const daemonArgs = buildDaemonArgs(args, { backend, host, port, openCode: plan.openCode })
+    const daemonArgs = buildDaemonArgs(args, { backend, host, port, openCode: plan.openCode, openCodePort })
     process.stdout.write("\nStarting machine daemon...\n")
     const daemonPath = fileURLToPath(new URL("./daemon-cli.js", import.meta.url))
     spawnNodeEntrypoint(daemonPath, daemonArgs, username, password)

--- a/bridge/test/launcher.test.js
+++ b/bridge/test/launcher.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict"
 import path from "node:path"
 import test from "node:test"
-import { bridgeEnvironment, buildBridgeArgs, createManagedShutdown, detectBackends, lanAddresses, resolveBackend, startManagedOpenCode } from "../src/launcher.js"
+import { bridgeEnvironment, buildBridgeArgs, buildDaemonArgs, createManagedShutdown, detectBackends, lanAddresses, resolveBackend, resolveLaunchPlan, startManagedOpenCode } from "../src/launcher.js"
 
 test("detects executable agent files on PATH without running them", () => {
   const pathValue = ["/bin", "/tools"].join(path.delimiter)
@@ -80,18 +80,42 @@ test("escalates a second shutdown signal from SIGTERM to SIGKILL", () => {
 
 test("uses an explicit backend even when discovery is empty", () => {
   assert.equal(resolveBackend(["--backend", "claude"], []), "claude")
+  assert.deepEqual(resolveLaunchPlan(["--backend", "claude"], ["codex", "opencode"]), {
+    mode: "single",
+    backend: "claude",
+    detected: ["codex", "opencode"]
+  })
 })
 
 test("auto-selects exactly one detected backend", () => {
   assert.equal(resolveBackend([], ["omp"]), "omp")
+  assert.deepEqual(resolveLaunchPlan([], ["omp"]), { mode: "single", backend: "omp", detected: ["omp"] })
 })
 
-test("requires an explicit choice when multiple backends are detected", () => {
+test("starts the machine daemon automatically when multiple agents are detected", () => {
+  assert.deepEqual(resolveLaunchPlan([], ["claude", "codex", "opencode"]), {
+    mode: "daemon",
+    backend: "codex",
+    detected: ["claude", "codex", "opencode"],
+    openCode: true
+  })
+})
+
+test("starts a daemon without OpenCode when multiple ACP agents are detected", () => {
+  assert.deepEqual(resolveLaunchPlan([], ["omp", "claude"]), {
+    mode: "daemon",
+    backend: "claude",
+    detected: ["omp", "claude"],
+    openCode: false
+  })
+})
+
+test("keeps the legacy resolver strict for callers that still require one backend", () => {
   assert.throws(() => resolveBackend([], ["codex", "claude"]), /Multiple supported agent CLIs were found on PATH/)
 })
 
 test("requires an installed or explicit backend when discovery finds none", () => {
-  assert.throws(() => resolveBackend([], []), /No supported agent CLI was found on PATH/)
+  assert.throws(() => resolveLaunchPlan([], []), /No supported agent CLI was found on PATH/)
 })
 
 test("injects quick-start defaults but never places credentials on child argv", () => {
@@ -116,6 +140,28 @@ test("injects quick-start defaults but never places credentials on child argv", 
   assert.equal(environment.HARNESS_REMOTE_USERNAME, "harness")
   assert.equal(environment.HARNESS_REMOTE_PASSWORD, "secret")
   assert.equal(environment.PATH, "/bin")
+})
+
+test("builds daemon argv with the selected primary and disables absent OpenCode", () => {
+  assert.deepEqual(buildDaemonArgs(["--root", "/work"], {
+    backend: "codex",
+    host: "0.0.0.0",
+    port: 4097,
+    openCode: false
+  }), [
+    "--root", "/work",
+    "--backend", "codex",
+    "--host", "0.0.0.0",
+    "--port", "4097",
+    "--no-opencode"
+  ])
+
+  assert.deepEqual(buildDaemonArgs([], {
+    backend: "claude",
+    host: "0.0.0.0",
+    port: 4097,
+    openCode: true
+  }), ["--backend", "claude", "--host", "0.0.0.0", "--port", "4097"])
 })
 
 test("does not override explicit backend, host, or port", () => {

--- a/bridge/test/launcher.test.js
+++ b/bridge/test/launcher.test.js
@@ -6,85 +6,45 @@ import { bridgeEnvironment, buildBridgeArgs, buildDaemonArgs, createManagedShutd
 test("detects executable agent files on PATH without running them", () => {
   const pathValue = ["/bin", "/tools"].join(path.delimiter)
   const existing = new Set([path.join("/tools", "codex")])
-  assert.deepEqual(detectBackends({
-    pathValue,
-    platform: "linux",
-    exists: (candidate) => existing.has(candidate),
-    access: () => {}
-  }), ["codex"])
+  assert.deepEqual(detectBackends({ pathValue, platform: "linux", exists: (candidate) => existing.has(candidate), access: () => {} }), ["codex"])
 })
 
 test("ignores non-executable PATH entries on Unix", () => {
   const candidate = path.join("/tools", "claude")
-  assert.deepEqual(detectBackends({
-    pathValue: "/tools",
-    platform: "linux",
-    exists: (value) => value === candidate,
-    access: () => { throw new Error("not executable") }
-  }), [])
+  assert.deepEqual(detectBackends({ pathValue: "/tools", platform: "linux", exists: (value) => value === candidate, access: () => { throw new Error("not executable") } }), [])
 })
 
 test("detects OpenCode as a managed direct-HTTP backend", () => {
   const candidate = path.join("/tools", "opencode")
-  assert.deepEqual(detectBackends({
-    pathValue: "/tools",
-    platform: "linux",
-    exists: (value) => value === candidate,
-    access: () => {}
-  }), ["opencode"])
+  assert.deepEqual(detectBackends({ pathValue: "/tools", platform: "linux", exists: (value) => value === candidate, access: () => {} }), ["opencode"])
   assert.equal(resolveBackend([], ["opencode"]), "opencode")
 })
 
 test("delegates OpenCode startup to the managed host", async () => {
   let options
-  class FakeHost {
-    constructor(value) { options = value }
-    async start() { this.started = true }
-  }
-  const managed = await startManagedOpenCode({
-    host: "0.0.0.0",
-    port: 4096,
-    username: "harness",
-    password: "secret",
-    command: "/tools/opencode",
-    Host: FakeHost
-  })
+  class FakeHost { constructor(value) { options = value } async start() { this.started = true } }
+  const managed = await startManagedOpenCode({ host: "0.0.0.0", port: 4096, username: "harness", password: "secret", command: "/tools/opencode", Host: FakeHost })
   assert.equal(managed.started, true)
-  assert.deepEqual(options, {
-    command: "/tools/opencode",
-    host: "0.0.0.0",
-    port: 4096,
-    username: "harness",
-    password: "secret"
-  })
+  assert.deepEqual(options, { command: "/tools/opencode", host: "0.0.0.0", port: 4096, username: "harness", password: "secret" })
 })
 
 test("escalates a second shutdown signal from SIGTERM to SIGKILL", () => {
   const signals = []
   const exits = []
-  const processObject = {
-    exitCode: 0,
-    exit(code) { exits.push(code) }
-  }
+  const processObject = { exitCode: 0, exit(code) { exits.push(code) } }
   const shutdown = createManagedShutdown({ stop: (signal) => signals.push(signal) }, processObject)
-
   shutdown("SIGINT")
   assert.equal(processObject.exitCode, 130)
   assert.deepEqual(signals, ["SIGTERM"])
   assert.deepEqual(exits, [])
-
   shutdown("SIGINT")
   assert.deepEqual(signals, ["SIGTERM", "SIGKILL"])
   assert.deepEqual(exits, [130])
 })
 
-test("uses an explicit backend even when discovery is empty", () => {
+test("uses an explicit backend on a fresh environment with no detected CLI", () => {
   assert.equal(resolveBackend(["--backend", "claude"], []), "claude")
-  assert.deepEqual(resolveLaunchPlan(["--backend", "claude"], ["codex", "opencode"]), {
-    mode: "single",
-    backend: "claude",
-    detected: ["codex", "opencode"]
-  })
+  assert.deepEqual(resolveLaunchPlan(["--backend", "claude"], []), { mode: "single", backend: "claude", detected: [] })
 })
 
 test("auto-selects exactly one detected backend", () => {
@@ -93,21 +53,24 @@ test("auto-selects exactly one detected backend", () => {
 })
 
 test("starts the machine daemon automatically when multiple agents are detected", () => {
-  assert.deepEqual(resolveLaunchPlan([], ["claude", "codex", "opencode"]), {
-    mode: "daemon",
-    backend: "codex",
-    detected: ["claude", "codex", "opencode"],
-    openCode: true
-  })
+  assert.deepEqual(resolveLaunchPlan([], ["claude", "codex", "opencode"]), { mode: "daemon", backend: "codex", detected: ["claude", "codex", "opencode"], openCode: true })
+})
+
+test("uses --backend to select the daemon primary", () => {
+  assert.deepEqual(resolveLaunchPlan(["--backend", "claude"], ["codex", "claude", "opencode"]), { mode: "daemon", backend: "claude", detected: ["codex", "claude", "opencode"], openCode: true })
+})
+
+test("uses --single as the daemon opt-out", () => {
+  assert.deepEqual(resolveLaunchPlan(["--single", "--backend", "claude"], ["codex", "claude", "opencode"]), { mode: "single", backend: "claude", detected: ["codex", "claude", "opencode"] })
+  assert.throws(() => resolveLaunchPlan(["--single"], ["codex", "claude"]), /--single requires --backend/)
+})
+
+test("keeps explicit OpenCode on the single-host path", () => {
+  assert.deepEqual(resolveLaunchPlan(["--backend", "opencode"], ["codex", "opencode"]), { mode: "single", backend: "opencode", detected: ["codex", "opencode"] })
 })
 
 test("starts a daemon without OpenCode when multiple ACP agents are detected", () => {
-  assert.deepEqual(resolveLaunchPlan([], ["omp", "claude"]), {
-    mode: "daemon",
-    backend: "claude",
-    detected: ["omp", "claude"],
-    openCode: false
-  })
+  assert.deepEqual(resolveLaunchPlan([], ["omp", "claude"]), { mode: "daemon", backend: "claude", detected: ["omp", "claude"], openCode: false })
 })
 
 test("keeps the legacy resolver strict for callers that still require one backend", () => {
@@ -118,71 +81,34 @@ test("requires an installed or explicit backend when discovery finds none", () =
   assert.throws(() => resolveLaunchPlan([], []), /No supported agent CLI was found on PATH/)
 })
 
-test("injects quick-start defaults but never places credentials on child argv", () => {
-  const argv = buildBridgeArgs([
-    "--root", "/work",
-    "--username", "harness",
-    "--password", "secret"
-  ], {
-    backend: "codex",
-    host: "0.0.0.0",
-    port: 4098
-  })
-  assert.deepEqual(argv, [
-    "--root", "/work",
-    "--backend", "codex",
-    "--host", "0.0.0.0",
-    "--port", "4098"
-  ])
+test("injects quick-start defaults but never places credentials or launcher-only flags on child argv", () => {
+  const argv = buildBridgeArgs(["--root", "/work", "--single", "--username", "harness", "--password", "secret"], { backend: "codex", host: "0.0.0.0", port: 4098 })
+  assert.deepEqual(argv, ["--root", "/work", "--backend", "codex", "--host", "0.0.0.0", "--port", "4098"])
   assert.equal(argv.includes("secret"), false)
-
   const environment = bridgeEnvironment({ PATH: "/bin" }, "harness", "secret")
   assert.equal(environment.HARNESS_REMOTE_USERNAME, "harness")
   assert.equal(environment.HARNESS_REMOTE_PASSWORD, "secret")
   assert.equal(environment.PATH, "/bin")
 })
 
-test("builds daemon argv with the selected primary and disables absent OpenCode", () => {
-  assert.deepEqual(buildDaemonArgs(["--root", "/work"], {
-    backend: "codex",
-    host: "0.0.0.0",
-    port: 4097,
-    openCode: false
-  }), [
-    "--root", "/work",
-    "--backend", "codex",
-    "--host", "0.0.0.0",
-    "--port", "4097",
-    "--no-opencode"
-  ])
+test("builds daemon argv with selected primary and managed OpenCode port", () => {
+  assert.deepEqual(buildDaemonArgs(["--root", "/work"], { backend: "codex", host: "0.0.0.0", port: 4097, openCode: false }), ["--root", "/work", "--backend", "codex", "--host", "0.0.0.0", "--port", "4097", "--no-opencode"])
+  assert.deepEqual(buildDaemonArgs([], { backend: "claude", host: "0.0.0.0", port: 4097, openCode: true, openCodePort: 4098 }), ["--backend", "claude", "--host", "0.0.0.0", "--port", "4097", "--opencode-port", "4098"])
+})
 
-  assert.deepEqual(buildDaemonArgs([], {
-    backend: "claude",
-    host: "0.0.0.0",
-    port: 4097,
-    openCode: true
-  }), ["--backend", "claude", "--host", "0.0.0.0", "--port", "4097"])
+test("does not override an explicit managed OpenCode port", () => {
+  assert.deepEqual(buildDaemonArgs(["--opencode-port", "4901"], { backend: "codex", host: "0.0.0.0", port: 4097, openCode: true, openCodePort: 4098 }), ["--opencode-port", "4901", "--backend", "codex", "--host", "0.0.0.0", "--port", "4097"])
 })
 
 test("does not override explicit backend, host, or port", () => {
   const explicit = ["--backend", "pi", "--host", "127.0.0.1", "--port", "5000"]
-  assert.deepEqual(buildBridgeArgs(explicit, {
-    backend: "codex",
-    host: "0.0.0.0",
-    port: 4098
-  }), explicit)
+  assert.deepEqual(buildBridgeArgs(explicit, { backend: "codex", host: "0.0.0.0", port: 4098 }), explicit)
 })
 
 test("prefers physical LAN addresses over obvious virtual interfaces", () => {
-  assert.deepEqual(lanAddresses({
-    docker0: [{ family: "IPv4", internal: false, address: "172.17.0.1" }],
-    wlan0: [{ family: "IPv4", internal: false, address: "192.168.1.42" }],
-    lo: [{ family: "IPv4", internal: true, address: "127.0.0.1" }]
-  }), ["192.168.1.42"])
+  assert.deepEqual(lanAddresses({ docker0: [{ family: "IPv4", internal: false, address: "172.17.0.1" }], wlan0: [{ family: "IPv4", internal: false, address: "192.168.1.42" }], lo: [{ family: "IPv4", internal: true, address: "127.0.0.1" }] }), ["192.168.1.42"])
 })
 
 test("falls back to virtual candidates when no physical-looking address exists", () => {
-  assert.deepEqual(lanAddresses({
-    docker0: [{ family: "IPv4", internal: false, address: "172.17.0.1" }]
-  }), ["172.17.0.1"])
+  assert.deepEqual(lanAddresses({ docker0: [{ family: "IPv4", internal: false, address: "172.17.0.1" }] }), ["172.17.0.1"])
 })

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -28,7 +28,9 @@ The launcher inspects `PATH` without executing discovered agent binaries and cho
 - with exactly one supported CLI, it preserves the existing single-backend startup path;
 - with multiple supported CLIs and at least one ACP-backed agent, it starts the machine daemon automatically;
 - the daemon selects one detected ACP backend as its primary host and includes managed OpenCode when OpenCode is installed;
-- an explicit `--backend` keeps the existing single-backend behavior for users who want to force one agent;
+- `--backend <name>` selects the ACP primary on a multi-agent machine;
+- `--single --backend <name>` explicitly opts out of the daemon and forces the legacy single-backend path;
+- if managed OpenCode is included, the launcher chooses a free loopback port automatically instead of assuming 4096 is unused;
 - credentials are generated automatically and kept out of child-process argv;
 - the LAN address and credentials to enter in the client are printed before startup continues.
 
@@ -40,7 +42,7 @@ For example, on a workstation with Codex, Claude Code and OpenCode installed, th
 harness-remote
 ```
 
-starts one machine daemon instead of failing and asking you to choose a backend. The launcher reports the CLIs it detected, selects an ACP primary, manages OpenCode on loopback, and exposes the machine through one authenticated daemon connection.
+starts one machine daemon instead of failing and asking you to choose a backend. The launcher reports the CLIs it detected, selects an ACP primary, finds a free loopback port for managed OpenCode, and exposes the machine through one authenticated daemon connection.
 
 The current automatic multi-host shape is deliberately precise:
 
@@ -52,18 +54,24 @@ Harness daemon :4097
 
 Other detected ACP CLIs are reported by discovery but are not all instantiated concurrently by this startup slice yet. The daemon API and client are already agent-scoped, so adding more ACP host instances does not require another client transport change.
 
-## Force a single backend
+## Choose the daemon primary or force one backend
 
-The backward-compatible explicit path remains available:
+On a multi-agent machine, choose the daemon's ACP primary with:
 
 ```bash
 harness-remote --backend codex --root ~/dev
 ```
 
-For loopback-only use:
+To deliberately use the old single-agent runtime instead:
 
 ```bash
-harness-remote --backend omp --host 127.0.0.1
+harness-remote --single --backend codex --root ~/dev
+```
+
+For loopback-only single-agent use:
+
+```bash
+harness-remote --single --backend omp --host 127.0.0.1
 ```
 
 For a fixed LAN port and your own credentials:
@@ -75,6 +83,8 @@ harness-remote \
   --username harness \
   --password 'choose-a-strong-password'
 ```
+
+If OpenCode is present on a multi-agent machine, an existing process already using `127.0.0.1:4096` does not break startup: Harness scans forward for a free managed OpenCode port and passes it to the daemon. You can still choose one explicitly with `--opencode-port`.
 
 ## OpenCode
 
@@ -88,7 +98,7 @@ When the automatic machine daemon path is selected, OpenCode instead stays on it
 
 ## Machine daemon
 
-The daemon can still be started explicitly when you want to choose its primary ACP backend or advanced options:
+The daemon can still be started explicitly when you want advanced options:
 
 ```bash
 npm run daemon -- --backend codex --host 127.0.0.1

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -6,12 +6,6 @@ The shortest setup path uses the `harness-remote` launcher.
 npx github:giuliastro/harness-remote
 ```
 
-If more than one supported agent CLI is installed, select one explicitly:
-
-```bash
-npx github:giuliastro/harness-remote --backend codex
-```
-
 From a local checkout the equivalent path is:
 
 ```bash
@@ -27,23 +21,40 @@ harness-remote
 
 The root package intentionally remains private for now: this documents a real GitHub/repository launch path without claiming that an npm package has already been published.
 
-The launcher remains intentionally thin while #143 evolves toward the Universal Daemon. ACP-backed agents still use the existing bridge. OpenCode is now started and supervised directly by Harness Remote rather than requiring a second command.
+## What the one command does
 
-## What it does
+The launcher inspects `PATH` without executing discovered agent binaries and chooses the least-friction compatible runtime:
 
-- finds executable `omp`, `pi`, `claude`, `codex`, and `opencode` entries on `PATH` without running them;
-- auto-selects the backend when exactly one supported CLI is found;
-- otherwise requires an explicit choice with `--backend`;
-- binds to the LAN by default (`0.0.0.0`) and automatically generates HTTP Basic Auth credentials;
-- generates credentials for loopback quick start too;
-- keeps generated credentials out of child-process argv and passes them through environment variables;
-- starts ACP-backed agents from port `4097` and OpenCode from port `4096`, choosing the next available port when the default is busy;
-- for OpenCode, reports readiness only after an authenticated `/global/health` request succeeds with the generated credentials;
-- supervises the OpenCode process and escalates a repeated shutdown signal from graceful `SIGTERM` to `SIGKILL`;
-- prints one or more plausible LAN addresses while preferring non-virtual interfaces;
-- forwards advanced bridge options such as `--root`, `--cors`, `--state-dir`, and `--log-requests` for ACP-backed agents.
+- with exactly one supported CLI, it preserves the existing single-backend startup path;
+- with multiple supported CLIs and at least one ACP-backed agent, it starts the machine daemon automatically;
+- the daemon selects one detected ACP backend as its primary host and includes managed OpenCode when OpenCode is installed;
+- an explicit `--backend` keeps the existing single-backend behavior for users who want to force one agent;
+- credentials are generated automatically and kept out of child-process argv;
+- the LAN address and credentials to enter in the client are printed before startup continues.
 
-Example with an installed binary when several agent CLIs are present:
+The supported CLI names are `omp`, `pi`, `claude`, `codex`, and `opencode`.
+
+For example, on a workstation with Codex, Claude Code and OpenCode installed, the plain command:
+
+```bash
+harness-remote
+```
+
+starts one machine daemon instead of failing and asking you to choose a backend. The launcher reports the CLIs it detected, selects an ACP primary, manages OpenCode on loopback, and exposes the machine through one authenticated daemon connection.
+
+The current automatic multi-host shape is deliberately precise:
+
+```text
+Harness daemon :4097
+  ├── one detected ACP primary (Codex / Claude / OMP / PI)
+  └── OpenCode, when installed, as a managed loopback HTTP host
+```
+
+Other detected ACP CLIs are reported by discovery but are not all instantiated concurrently by this startup slice yet. The daemon API and client are already agent-scoped, so adding more ACP host instances does not require another client transport change.
+
+## Force a single backend
+
+The backward-compatible explicit path remains available:
 
 ```bash
 harness-remote --backend codex --root ~/dev
@@ -54,8 +65,6 @@ For loopback-only use:
 ```bash
 harness-remote --backend omp --host 127.0.0.1
 ```
-
-The launcher still generates credentials and prints them for this loopback path.
 
 For a fixed LAN port and your own credentials:
 
@@ -69,45 +78,29 @@ harness-remote \
 
 ## OpenCode
 
-OpenCode remains different at the protocol layer: the Harness Remote client connects directly to the OpenCode HTTP server rather than through the ACP bridge.
-
-The launcher now owns the process lifecycle, though. Running:
+When OpenCode is the only selected backend, Harness Remote starts `opencode serve` itself, passes credentials through `OPENCODE_SERVER_USERNAME` and `OPENCODE_SERVER_PASSWORD`, verifies the authenticated health endpoint, prints connection details, and supervises the child process until shutdown.
 
 ```bash
 harness-remote --backend opencode
 ```
 
-will start `opencode serve` itself, pass the generated credentials through `OPENCODE_SERVER_USERNAME` and `OPENCODE_SERVER_PASSWORD`, verify the authenticated health endpoint, print the connection details, and keep supervising the child process until shutdown.
+When the automatic machine daemon path is selected, OpenCode instead stays on its managed loopback listener and the client reaches it through the daemon's agent-scoped proxy. The phone/web/desktop client therefore does not need direct access to the internal OpenCode port.
 
-This means there is no second OpenCode command to copy and run manually.
+## Machine daemon
 
-## Experimental multi-host daemon
-
-#143 now also has a real multi-host runtime entrypoint. It is intentionally separate from the default launcher while the client UI is still being migrated.
-
-From a checkout:
+The daemon can still be started explicitly when you want to choose its primary ACP backend or advanced options:
 
 ```bash
 npm run daemon -- --backend codex --host 127.0.0.1
 ```
 
-or, when the repository package is installed:
+or:
 
 ```bash
 harness-remote-daemon --backend codex --host 127.0.0.1
 ```
 
-The daemon owns one primary ACP host plus a managed OpenCode host by default:
-
-```text
-Harness daemon :4097
-  ├── Codex / Claude / OMP / PI via ACP
-  └── OpenCode 127.0.0.1:4096 via managed HTTP
-```
-
-`GET /v1/machine` and `GET /global/machine` expose both hosts through the same machine registry and stable machine identity. Host lifecycle is isolated: OpenCode can become unavailable without making the ACP host disappear, and vice versa. The daemon HTTP API starts listening before eager managed hosts finish their health checks, so clients can observe `configured` and `unavailable` transitions instead of seeing the whole machine endpoint disappear during a slow host startup.
-
-Managed OpenCode binds to `127.0.0.1` by default even if the Harness daemon itself binds to `0.0.0.0`. The client no longer needs direct access to that internal port when using the agent-scoped daemon routes.
+`GET /v1/machine` and `GET /global/machine` expose the shared machine registry and stable machine identity. Host lifecycle is isolated: an unavailable managed host does not make the machine disappear.
 
 Agent-scoped requests share the daemon connection:
 
@@ -118,17 +111,15 @@ Agent-scoped requests share the daemon connection:
 /v1/agents/opencode/global/event
 ```
 
-The selected primary ACP agent is routed through the existing normalized bridge API. Managed OpenCode requests are streamed through the daemon to the loopback process; the daemon authenticates the external request, replaces the client credentials with the managed host credentials, and keeps CORS policy at the daemon boundary. Legacy unprefixed routes remain available during migration.
+The selected primary ACP agent is routed through the normalized bridge API. Managed OpenCode requests are streamed through the daemon to the loopback process; external credentials are authenticated at the daemon boundary and replaced with the managed host credentials for the internal request. Legacy unprefixed routes remain available during migration.
 
-If you deliberately need the managed OpenCode listener itself reachable beyond loopback, opt in explicitly:
+Managed OpenCode binds to `127.0.0.1` by default even when the daemon binds to `0.0.0.0`. Wider exposure is explicit:
 
 ```bash
 harness-remote-daemon --backend codex --opencode-host 0.0.0.0
 ```
 
-The daemon checks the managed OpenCode port before spawning it and fails with an actionable error if another service is already using that port. Multiple eager managed hosts are started concurrently so one slow host does not serialize daemon startup.
-
-Useful migration options:
+Useful daemon options:
 
 ```bash
 harness-remote-daemon --backend claude --opencode-port 4901
@@ -137,8 +128,8 @@ harness-remote-daemon --backend codex --opencode-host 127.0.0.2
 harness-remote-daemon --backend omp --no-opencode
 ```
 
-For non-loopback daemon binding, the existing bridge security rule still applies: username and password are required. The managed OpenCode listener remains loopback-only unless `--opencode-host` is supplied explicitly.
+For non-loopback daemon binding, the existing security rule still applies: username and password are required. The managed OpenCode listener remains loopback-only unless `--opencode-host` is supplied explicitly.
 
 ## Advanced/manual setup
 
-The existing backend-specific bridge commands remain supported. Use them when you need custom adapter commands, unusual networking, browser CORS configuration, or other advanced settings documented in the main README.
+The existing backend-specific bridge commands remain supported. Use them when you need custom adapter commands, unusual networking, browser CORS configuration, or other advanced settings documented in `REFERENCE.md`.


### PR DESCRIPTION
## Summary

Final low-friction startup slice of #143.

- keep the existing single-backend quick-start behavior when exactly one supported CLI is detected
- when multiple supported CLIs are present and at least one ACP backend is available, start the machine daemon automatically instead of failing and asking the user to choose
- `--backend` selects the daemon primary on a multi-agent machine, consistently with what the same flag means to the daemon itself
- `--single` is the explicit opt-out back to the legacy single-backend path, and is stripped from child argv as a launcher-only flag
- assign managed OpenCode a free loopback port automatically, excluding the daemon's own, so an OpenCode already running on 4096 does not abort the zero-config path
- validate an explicit `--opencode-port` for availability instead of discovering the conflict after startup
- reuse generated credentials and the existing LAN/port selection path without putting secrets on child argv
- add regression coverage for launch-plan selection, flag precedence, daemon argv construction and port assignment
- update quick-start documentation to describe the automatic daemon path and its current primary-ACP + OpenCode scope accurately

## User-visible change

Before:

```text
harness-remote
  -> detects codex + claude + opencode
  -> exits: choose --backend
```

Now:

```text
harness-remote
  -> detects codex + claude + opencode
  -> starts the machine daemon automatically
  -> selects an ACP primary and prints it
  -> manages OpenCode on a free loopback port
  -> prints one machine address + generated credentials
```

Both overrides remain available:

```bash
harness-remote --backend claude      # daemon, with claude as primary
harness-remote --single --backend codex   # legacy single-backend path
```

## Scope boundary

This does not pretend every detected ACP CLI is instantiated concurrently yet. The automatic daemon path owns one detected ACP primary plus managed OpenCode when present. Other detected ACP CLIs are discovery information for now; the machine API and client transport are already agent-scoped for future expansion.

The `ACP_BACKENDS` order encodes which primary a multi-agent machine gets by default, and now says so in the source — reordering it silently changes that default on every such machine.

Part of #143.