### PR TITLE
feat(tasks): prepare isolated Git worktrees for draft tasks

### DIFF
--- a/bridge/src/agent-router.js
+++ b/bridge/src/agent-router.js
@@ -2,6 +2,7 @@ import http from "node:http"
 import { allowedOrigin, applyCorsHeaders, matchesCredentials, writeJSON } from "./http-policy.js"
 
 const AGENT_ROUTE = /^\/v1\/agents\/([^/]+)(\/.*)?$/
+const TASK_WORKTREE_ROUTE = /^\/v1\/tasks\/([^/]+)\/worktree$/
 const MACHINE_ROUTES = new Set(["/v1/projects", "/v1/tasks"])
 const HOP_BY_HOP = new Set([
   "connection",
@@ -154,12 +155,14 @@ export function createAgentRoutingServer({
   bridgeServer,
   taskStore,
   projectCatalog,
+  worktreeManager,
   createServer = http.createServer,
   proxyRequest = proxyManagedHttpRequest
 }) {
   return createServer(async (request, response) => {
     const requestURL = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`)
-    if (MACHINE_ROUTES.has(requestURL.pathname)) {
+    const worktreeMatch = TASK_WORKTREE_ROUTE.exec(requestURL.pathname)
+    if (MACHINE_ROUTES.has(requestURL.pathname) || worktreeMatch) {
       if (!authenticateMachineRequest(request, response, config)) return
       try {
         if (request.method === "GET" && requestURL.pathname === "/v1/projects") {
@@ -192,7 +195,25 @@ export function createAgentRoutingServer({
           writeJSON(response, 201, await taskStore.create({ project, agentId: agentID, prompt }))
           return
         }
-        response.writeHead(405, { Allow: requestURL.pathname === "/v1/tasks" ? "GET, POST, OPTIONS" : "GET, OPTIONS" })
+        if (request.method === "POST" && worktreeMatch) {
+          const taskID = decodeURIComponent(worktreeMatch[1])
+          const task = await taskStore.get(taskID)
+          if (!task) {
+            writeJSON(response, 404, { error: `Unknown task: ${taskID}` })
+            return
+          }
+          const workspace = await worktreeManager.prepare(task)
+          try {
+            const updated = await taskStore.setWorkspace(taskID, workspace)
+            writeJSON(response, 200, updated)
+          } catch (error) {
+            await worktreeManager.rollback(workspace)
+            throw error
+          }
+          return
+        }
+        const allow = worktreeMatch ? "POST, OPTIONS" : requestURL.pathname === "/v1/tasks" ? "GET, POST, OPTIONS" : "GET, OPTIONS"
+        response.writeHead(405, { Allow: allow })
         response.end()
       } catch (error) {
         writeJSON(response, 500, { error: error instanceof Error ? error.message : String(error) })

--- a/bridge/src/machine-daemon.js
+++ b/bridge/src/machine-daemon.js
@@ -4,6 +4,7 @@ import { trackManagedHostLifecycle } from "./opencode-host.js"
 import { discoverProjects } from "./project-catalog.js"
 import { createBridgeServer } from "./server.js"
 import { TaskStore } from "./task-store.js"
+import { WorktreeManager } from "./worktree-manager.js"
 
 export class MachineDaemon {
   constructor(identity, { registry = new MachineRegistry(identity) } = {}) {
@@ -74,7 +75,8 @@ export function createMachineDaemonServer({
   createServer = createBridgeServer,
   createRouter = createAgentRoutingServer,
   taskStore,
-  projectCatalog
+  projectCatalog,
+  worktreeManager
 }) {
   const bridgeServer = createServer({
     config,
@@ -84,14 +86,17 @@ export function createMachineDaemonServer({
   })
   const machineID = daemon.snapshot().machine.id
   const roots = config.roots?.length ? config.roots : [process.cwd()]
-  const tasks = taskStore ?? new TaskStore({ machineID, stateDirectory: config.stateDirectory ?? process.cwd() })
+  const stateDirectory = config.stateDirectory ?? process.cwd()
+  const tasks = taskStore ?? new TaskStore({ machineID, stateDirectory })
   const projects = projectCatalog ?? (() => discoverProjects({ machineID, roots }))
+  const worktrees = worktreeManager ?? new WorktreeManager({ stateDirectory })
   return createRouter({
     daemon,
     config,
     primaryAgentID,
     bridgeServer,
     taskStore: tasks,
-    projectCatalog: projects
+    projectCatalog: projects,
+    worktreeManager: worktrees
   })
 }

--- a/bridge/src/task-store.js
+++ b/bridge/src/task-store.js
@@ -84,7 +84,7 @@ export class TaskStore {
   async setWorkspace(taskID, workspace) {
     await this.load()
     const index = this.tasks.findIndex((task) => task.id === taskID)
-    if (index < 0) return undefined
+    if (index < 0) throw new Error(`Unknown task: ${taskID}`)
     const task = this.tasks[index]
     if (task.status !== "draft") throw new Error("Only draft tasks can change workspace")
     const updated = { ...task, workspace: structuredClone(workspace), updatedAt: this.clock() }

--- a/bridge/src/task-store.js
+++ b/bridge/src/task-store.js
@@ -52,6 +52,12 @@ export class TaskStore {
     return this.tasks.map((task) => structuredClone(task))
   }
 
+  async get(taskID) {
+    await this.load()
+    const task = this.tasks.find((candidate) => candidate.id === taskID)
+    return task ? structuredClone(task) : undefined
+  }
+
   async create({ project, agentId, prompt }) {
     await this.load()
     const text = typeof prompt === "string" ? prompt.trim() : ""
@@ -73,5 +79,17 @@ export class TaskStore {
     this.tasks.push(task)
     await this.persist()
     return structuredClone(task)
+  }
+
+  async setWorkspace(taskID, workspace) {
+    await this.load()
+    const index = this.tasks.findIndex((task) => task.id === taskID)
+    if (index < 0) return undefined
+    const task = this.tasks[index]
+    if (task.status !== "draft") throw new Error("Only draft tasks can change workspace")
+    const updated = { ...task, workspace: structuredClone(workspace), updatedAt: this.clock() }
+    this.tasks[index] = updated
+    await this.persist()
+    return structuredClone(updated)
   }
 }

--- a/bridge/src/worktree-manager.js
+++ b/bridge/src/worktree-manager.js
@@ -1,6 +1,10 @@
 import { createHash } from "node:crypto"
+import { execFile } from "node:child_process"
 import { lstat, mkdir } from "node:fs/promises"
 import path from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
 
 function taskKey(taskID) {
   return createHash("sha256").update(taskID).digest("hex").slice(0, 12)
@@ -16,8 +20,12 @@ async function exists(candidate) {
   }
 }
 
+async function defaultRunGit(args) {
+  return execFileAsync("git", args, { maxBuffer: 1024 * 1024 })
+}
+
 export class WorktreeManager {
-  constructor({ stateDirectory, runGit }) {
+  constructor({ stateDirectory, runGit = defaultRunGit }) {
     this.stateDirectory = stateDirectory
     this.runGit = runGit
   }
@@ -26,7 +34,6 @@ export class WorktreeManager {
     if (task?.status !== "draft") throw new Error("Only draft tasks can prepare a workspace")
     if (task?.project?.kind !== "git") throw new Error("Worktree isolation requires a Git project")
     if (task?.workspace?.mode === "worktree") return structuredClone(task.workspace)
-    if (typeof this.runGit !== "function") throw new Error("Git runner is not configured")
 
     const key = taskKey(task.id)
     const branch = `task/${key}`

--- a/bridge/src/worktree-manager.js
+++ b/bridge/src/worktree-manager.js
@@ -1,0 +1,42 @@
+import { createHash } from "node:crypto"
+import { lstat, mkdir } from "node:fs/promises"
+import path from "node:path"
+
+function taskKey(taskID) {
+  return createHash("sha256").update(taskID).digest("hex").slice(0, 12)
+}
+
+async function exists(candidate) {
+  try {
+    await lstat(candidate)
+    return true
+  } catch (error) {
+    if (error?.code === "ENOENT") return false
+    throw error
+  }
+}
+
+export class WorktreeManager {
+  constructor({ stateDirectory, runGit }) {
+    this.stateDirectory = stateDirectory
+    this.runGit = runGit
+  }
+
+  async prepare(task) {
+    if (task?.status !== "draft") throw new Error("Only draft tasks can prepare a workspace")
+    if (task?.project?.kind !== "git") throw new Error("Worktree isolation requires a Git project")
+    if (task?.workspace?.mode === "worktree") return structuredClone(task.workspace)
+    if (typeof this.runGit !== "function") throw new Error("Git runner is not configured")
+
+    const key = taskKey(task.id)
+    const branch = `task/${key}`
+    const worktreePath = path.join(this.stateDirectory, "worktrees", key)
+    if (await exists(worktreePath)) throw new Error(`Worktree path already exists: ${worktreePath}`)
+
+    await this.runGit(["-C", task.project.path, "rev-parse", "--show-toplevel"])
+    await mkdir(path.dirname(worktreePath), { recursive: true })
+    await this.runGit(["-C", task.project.path, "worktree", "add", "-b", branch, worktreePath, "HEAD"])
+
+    return { mode: "worktree", path: worktreePath, branch, source: task.project.path }
+  }
+}

--- a/bridge/src/worktree-manager.js
+++ b/bridge/src/worktree-manager.js
@@ -5,6 +5,7 @@ import path from "node:path"
 import { promisify } from "node:util"
 
 const execFileAsync = promisify(execFile)
+const DEFAULT_GIT_TIMEOUT_MS = 30_000
 
 function taskKey(taskID) {
   return createHash("sha256").update(taskID).digest("hex").slice(0, 12)
@@ -21,7 +22,14 @@ async function exists(candidate) {
 }
 
 async function defaultRunGit(args) {
-  return execFileAsync("git", args, { maxBuffer: 1024 * 1024 })
+  try {
+    return await execFileAsync("git", args, { maxBuffer: 1024 * 1024, timeout: DEFAULT_GIT_TIMEOUT_MS })
+  } catch (error) {
+    if (error?.killed || error?.signal === "SIGTERM") {
+      throw new Error(`Git operation timed out after ${DEFAULT_GIT_TIMEOUT_MS}ms`)
+    }
+    throw error
+  }
 }
 
 export class WorktreeManager {
@@ -42,7 +50,7 @@ export class WorktreeManager {
 
     await this.runGit(["-C", task.project.path, "rev-parse", "--show-toplevel"])
     await mkdir(path.dirname(worktreePath), { recursive: true })
-    await this.runGit(["-C", task.project.path, "worktree", "add", "-b", branch, worktreePath, "HEAD"])
+    await this.runGit(["-C", task.project.path, "worktree", "add", "-B", branch, worktreePath, "HEAD"])
 
     return { mode: "worktree", path: worktreePath, branch, source: task.project.path }
   }
@@ -57,7 +65,7 @@ export class WorktreeManager {
     try {
       await this.runGit(["-C", workspace.source, "branch", "-D", workspace.branch])
     } catch {
-      // The worktree is already detached from the project; a leftover branch is safe to keep.
+      // A later prepare() uses -B, so a leftover task-scoped branch cannot wedge retries.
     }
   }
 }

--- a/bridge/src/worktree-manager.js
+++ b/bridge/src/worktree-manager.js
@@ -46,4 +46,18 @@ export class WorktreeManager {
 
     return { mode: "worktree", path: worktreePath, branch, source: task.project.path }
   }
+
+  async rollback(workspace) {
+    if (workspace?.mode !== "worktree" || !workspace.path || !workspace.branch || !workspace.source) return
+    try {
+      await this.runGit(["-C", workspace.source, "worktree", "remove", "--force", workspace.path])
+    } catch {
+      return
+    }
+    try {
+      await this.runGit(["-C", workspace.source, "branch", "-D", workspace.branch])
+    } catch {
+      // The worktree is already detached from the project; a leftover branch is safe to keep.
+    }
+  }
 }

--- a/bridge/test/task-routes.test.js
+++ b/bridge/test/task-routes.test.js
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import test from "node:test"
+import { createAgentRoutingServer } from "../src/agent-router.js"
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  return server.address().port
+}
+
+async function close(server) {
+  await new Promise((resolve) => server.close(resolve))
+}
+
+class BridgeServer extends EventEmitter {}
+
+function daemon() {
+  return {
+    registry: { host: () => ({ state: "available" }) },
+    hostEntry: () => undefined
+  }
+}
+
+test("worktree route prepares then persists the workspace on the task", async () => {
+  const task = {
+    id: "task-1",
+    status: "draft",
+    project: { name: "repo", path: "/repo", kind: "git" },
+    workspace: { mode: "project", path: "/repo" }
+  }
+  const workspace = { mode: "worktree", path: "/state/worktrees/a", branch: "task/a", source: "/repo" }
+  const calls = []
+  const taskStore = {
+    async get(id) { calls.push(["get", id]); return task },
+    async setWorkspace(id, value) { calls.push(["set", id, value]); return { ...task, workspace: value } }
+  }
+  const worktreeManager = {
+    async prepare(value) { calls.push(["prepare", value.id]); return workspace },
+    async rollback() { calls.push(["rollback"]) }
+  }
+  const server = createAgentRoutingServer({
+    daemon: daemon(),
+    config: { username: "", password: "", corsOrigins: [] },
+    primaryAgentID: "codex",
+    bridgeServer: new BridgeServer(),
+    taskStore,
+    projectCatalog: async () => [],
+    worktreeManager
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/tasks/task-1/worktree`, { method: "POST" })
+    assert.equal(response.status, 200)
+    assert.deepEqual((await response.json()).workspace, workspace)
+    assert.deepEqual(calls, [
+      ["get", "task-1"],
+      ["prepare", "task-1"],
+      ["set", "task-1", workspace]
+    ])
+  } finally {
+    await close(server)
+  }
+})
+
+test("worktree route rolls back a fresh workspace when task persistence fails", async () => {
+  const task = { id: "task-1", status: "draft", project: { path: "/repo", kind: "git" }, workspace: { mode: "project", path: "/repo" } }
+  const workspace = { mode: "worktree", path: "/state/worktrees/a", branch: "task/a", source: "/repo" }
+  let rolledBack
+  const server = createAgentRoutingServer({
+    daemon: daemon(),
+    config: { username: "", password: "", corsOrigins: [] },
+    primaryAgentID: "codex",
+    bridgeServer: new BridgeServer(),
+    taskStore: {
+      async get() { return task },
+      async setWorkspace() { throw new Error("disk full") }
+    },
+    projectCatalog: async () => [],
+    worktreeManager: {
+      async prepare() { return workspace },
+      async rollback(value) { rolledBack = value }
+    }
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/tasks/task-1/worktree`, { method: "POST" })
+    assert.equal(response.status, 500)
+    assert.equal((await response.json()).error, "disk full")
+    assert.deepEqual(rolledBack, workspace)
+  } finally {
+    await close(server)
+  }
+})
+
+test("unknown tasks do not create worktrees", async () => {
+  let prepared = false
+  const server = createAgentRoutingServer({
+    daemon: daemon(),
+    config: { username: "", password: "", corsOrigins: [] },
+    primaryAgentID: "codex",
+    bridgeServer: new BridgeServer(),
+    taskStore: { async get() { return undefined } },
+    projectCatalog: async () => [],
+    worktreeManager: { async prepare() { prepared = true } }
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/tasks/missing/worktree`, { method: "POST" })
+    assert.equal(response.status, 404)
+    assert.equal(prepared, false)
+  } finally {
+    await close(server)
+  }
+})

--- a/bridge/test/task-store.test.js
+++ b/bridge/test/task-store.test.js
@@ -90,3 +90,16 @@ test("malformed task state is preserved before starting a fresh machine-scoped s
     await rm(stateDirectory, { recursive: true, force: true })
   }
 })
+
+test("setWorkspace fails loudly if the task disappeared before persistence", async () => {
+  const stateDirectory = await mkdtemp(path.join(os.tmpdir(), "harness-task-missing-"))
+  try {
+    const store = new TaskStore({ machineID: "machine-1", stateDirectory })
+    await assert.rejects(
+      () => store.setWorkspace("missing", { mode: "worktree", path: "/tmp/worktree" }),
+      /Unknown task: missing/
+    )
+  } finally {
+    await rm(stateDirectory, { recursive: true, force: true })
+  }
+})

--- a/bridge/test/worktree-manager.test.js
+++ b/bridge/test/worktree-manager.test.js
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict"
+import { mkdtemp, rm } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import test from "node:test"
+import { WorktreeManager } from "../src/worktree-manager.js"
+
+function draft(overrides = {}) {
+  return {
+    id: "task-123",
+    status: "draft",
+    project: { kind: "git", path: "/repo" },
+    workspace: { mode: "project", path: "/repo" },
+    ...overrides
+  }
+}
+
+test("prepares a deterministic isolated worktree without mutating the primary checkout", async () => {
+  const stateDirectory = await mkdtemp(path.join(os.tmpdir(), "harness-worktree-"))
+  const calls = []
+  try {
+    const manager = new WorktreeManager({ stateDirectory, runGit: async (args) => { calls.push(args); return { stdout: "/repo\n" } } })
+    const workspace = await manager.prepare(draft())
+    assert.equal(workspace.mode, "worktree")
+    assert.equal(workspace.source, "/repo")
+    assert.equal(workspace.path.startsWith(path.join(stateDirectory, "worktrees")), true)
+    assert.match(workspace.branch, /^task\/[0-9a-f]{12}$/)
+    assert.deepEqual(calls[0], ["-C", "/repo", "rev-parse", "--show-toplevel"])
+    assert.deepEqual(calls[1], ["-C", "/repo", "worktree", "add", "-b", workspace.branch, workspace.path, "HEAD"])
+  } finally {
+    await rm(stateDirectory, { recursive: true, force: true })
+  }
+})
+
+test("rejects non-Git tasks before invoking Git", async () => {
+  let calls = 0
+  const manager = new WorktreeManager({ stateDirectory: "/state", runGit: async () => { calls += 1 } })
+  await assert.rejects(() => manager.prepare(draft({ project: { kind: "directory", path: "/repo" } })), /requires a Git project/)
+  assert.equal(calls, 0)
+})
+
+test("an already prepared worktree is idempotent", async () => {
+  const workspace = { mode: "worktree", path: "/state/worktrees/a", branch: "task/a", source: "/repo" }
+  const manager = new WorktreeManager({ stateDirectory: "/state", runGit: async () => { throw new Error("should not run") } })
+  assert.deepEqual(await manager.prepare(draft({ workspace })), workspace)
+})
+
+test("rollback removes only a just-prepared worktree and its branch", async () => {
+  const calls = []
+  const manager = new WorktreeManager({ stateDirectory: "/state", runGit: async (args) => { calls.push(args) } })
+  await manager.rollback({ mode: "worktree", path: "/state/worktrees/a", branch: "task/a", source: "/repo" })
+  assert.deepEqual(calls, [
+    ["-C", "/repo", "worktree", "remove", "--force", "/state/worktrees/a"],
+    ["-C", "/repo", "branch", "-D", "task/a"]
+  ])
+})

--- a/bridge/test/worktree-manager.test.js
+++ b/bridge/test/worktree-manager.test.js
@@ -26,7 +26,7 @@ test("prepares a deterministic isolated worktree without mutating the primary ch
     assert.equal(workspace.path.startsWith(path.join(stateDirectory, "worktrees")), true)
     assert.match(workspace.branch, /^task\/[0-9a-f]{12}$/)
     assert.deepEqual(calls[0], ["-C", "/repo", "rev-parse", "--show-toplevel"])
-    assert.deepEqual(calls[1], ["-C", "/repo", "worktree", "add", "-b", workspace.branch, workspace.path, "HEAD"])
+    assert.deepEqual(calls[1], ["-C", "/repo", "worktree", "add", "-B", workspace.branch, workspace.path, "HEAD"])
   } finally {
     await rm(stateDirectory, { recursive: true, force: true })
   }
@@ -53,4 +53,16 @@ test("rollback removes only a just-prepared worktree and its branch", async () =
     ["-C", "/repo", "worktree", "remove", "--force", "/state/worktrees/a"],
     ["-C", "/repo", "branch", "-D", "task/a"]
   ])
+})
+
+test("prepare uses a resettable task branch so rollback leftovers do not wedge retries", async () => {
+  const stateDirectory = await mkdtemp(path.join(os.tmpdir(), "harness-worktree-retry-"))
+  const calls = []
+  try {
+    const manager = new WorktreeManager({ stateDirectory, runGit: async (args) => { calls.push(args); return { stdout: "/repo\n" } } })
+    await manager.prepare(draft())
+    assert.equal(calls[1].includes("-B"), true)
+  } finally {
+    await rm(stateDirectory, { recursive: true, force: true })
+  }
 })


### PR DESCRIPTION
## Summary

Second implementation slice of #145.

- add a WorktreeManager that creates deterministic isolated Git worktrees for draft tasks
- keep the user's primary checkout untouched by creating the workspace from HEAD
- expose `POST /v1/tasks/:taskId/worktree` on the machine daemon
- persist the prepared workspace on the Task only after Git succeeds
- roll back a just-created worktree if Task persistence fails before any agent is launched
- reject non-Git projects, non-draft tasks, unknown tasks, and path collisions explicitly
- keep cleanup after launch out of scope so user work is never deleted implicitly
- add regression coverage for deterministic naming, idempotence, rollback, route ordering, and unknown-task handling

## Scope boundary

This PR prepares the isolated workspace but does not launch the selected agent yet. Agent launch and task/run linkage are the next #145 slice.

Part of #145.