### PR TITLE
feat(tasks): launch selected agents from prepared task workspaces

### DIFF
--- a/bridge/src/machine-daemon.js
+++ b/bridge/src/machine-daemon.js
@@ -3,7 +3,9 @@ import { MachineRegistry, trackAgentHostLifecycle } from "./machine-registry.js"
 import { trackManagedHostLifecycle } from "./opencode-host.js"
 import { discoverProjects } from "./project-catalog.js"
 import { createBridgeServer } from "./server.js"
-import { TaskStore } from "./task-store.js"
+import { TaskLauncher } from "./task-launcher.js"
+import { TaskRunController } from "./task-run-controller.js"
+import { TaskRunStore } from "./task-run-store.js"
 import { WorktreeManager } from "./worktree-manager.js"
 
 export class MachineDaemon {
@@ -13,38 +15,20 @@ export class MachineDaemon {
   }
 
   registerAcpHost({ id, label, backend = id, capabilities = {}, agent, managed = true }) {
-    this.registry.registerHost({
-      id,
-      label,
-      backend,
-      transport: "acp",
-      managed,
-      state: "configured",
-      capabilities
-    })
+    this.registry.registerHost({ id, label, backend, transport: "acp", managed, state: "configured", capabilities })
     const tracked = trackAgentHostLifecycle(agent, this.registry, id)
     this.hosts.set(id, { id, kind: "acp", host: tracked, eager: false })
     return tracked
   }
 
   registerManagedHttpHost({ id, label, backend = id, capabilities = {}, host, managed = true }) {
-    this.registry.registerHost({
-      id,
-      label,
-      backend,
-      transport: "http",
-      managed,
-      state: "configured",
-      capabilities
-    })
+    this.registry.registerHost({ id, label, backend, transport: "http", managed, state: "configured", capabilities })
     const tracked = trackManagedHostLifecycle(host, this.registry, id)
     this.hosts.set(id, { id, kind: "http", host: tracked, eager: true })
     return tracked
   }
 
-  hostEntry(id) {
-    return this.hosts.get(id)
-  }
+  hostEntry(id) { return this.hosts.get(id) }
 
   async startManagedHosts() {
     const eager = [...this.hosts.values()].filter((entry) => entry.eager)
@@ -54,9 +38,7 @@ export class MachineDaemon {
       : { id: entry.id, status: "unavailable", error: settled[index].reason })
   }
 
-  snapshot() {
-    return this.registry.snapshot()
-  }
+  snapshot() { return this.registry.snapshot() }
 
   close() {
     for (const entry of this.hosts.values()) {
@@ -76,20 +58,19 @@ export function createMachineDaemonServer({
   createRouter = createAgentRoutingServer,
   taskStore,
   projectCatalog,
-  worktreeManager
+  worktreeManager,
+  taskLauncher,
+  taskRunController
 }) {
-  const bridgeServer = createServer({
-    config,
-    acp: primaryAcp,
-    machineRegistry: daemon.registry,
-    serviceOptions
-  })
+  const bridgeServer = createServer({ config, acp: primaryAcp, machineRegistry: daemon.registry, serviceOptions })
   const machineID = daemon.snapshot().machine.id
   const roots = config.roots?.length ? config.roots : [process.cwd()]
   const stateDirectory = config.stateDirectory ?? process.cwd()
-  const tasks = taskStore ?? new TaskStore({ machineID, stateDirectory })
+  const tasks = taskStore ?? new TaskRunStore({ machineID, stateDirectory })
   const projects = projectCatalog ?? (() => discoverProjects({ machineID, roots }))
   const worktrees = worktreeManager ?? new WorktreeManager({ stateDirectory })
+  const launcher = taskLauncher ?? new TaskLauncher({ daemon })
+  const runs = taskRunController ?? new TaskRunController({ taskStore: tasks, taskLauncher: launcher })
   return createRouter({
     daemon,
     config,
@@ -97,6 +78,7 @@ export function createMachineDaemonServer({
     bridgeServer,
     taskStore: tasks,
     projectCatalog: projects,
-    worktreeManager: worktrees
+    worktreeManager: worktrees,
+    taskRunController: runs
   })
 }

--- a/bridge/src/machine-daemon.js
+++ b/bridge/src/machine-daemon.js
@@ -3,6 +3,7 @@ import { MachineRegistry, trackAgentHostLifecycle } from "./machine-registry.js"
 import { trackManagedHostLifecycle } from "./opencode-host.js"
 import { discoverProjects } from "./project-catalog.js"
 import { createBridgeServer } from "./server.js"
+import { createTaskLaunchServer } from "./task-launch-server.js"
 import { TaskLauncher } from "./task-launcher.js"
 import { TaskRunController } from "./task-run-controller.js"
 import { TaskRunStore } from "./task-run-store.js"
@@ -15,20 +16,38 @@ export class MachineDaemon {
   }
 
   registerAcpHost({ id, label, backend = id, capabilities = {}, agent, managed = true }) {
-    this.registry.registerHost({ id, label, backend, transport: "acp", managed, state: "configured", capabilities })
+    this.registry.registerHost({
+      id,
+      label,
+      backend,
+      transport: "acp",
+      managed,
+      state: "configured",
+      capabilities
+    })
     const tracked = trackAgentHostLifecycle(agent, this.registry, id)
     this.hosts.set(id, { id, kind: "acp", host: tracked, eager: false })
     return tracked
   }
 
   registerManagedHttpHost({ id, label, backend = id, capabilities = {}, host, managed = true }) {
-    this.registry.registerHost({ id, label, backend, transport: "http", managed, state: "configured", capabilities })
+    this.registry.registerHost({
+      id,
+      label,
+      backend,
+      transport: "http",
+      managed,
+      state: "configured",
+      capabilities
+    })
     const tracked = trackManagedHostLifecycle(host, this.registry, id)
     this.hosts.set(id, { id, kind: "http", host: tracked, eager: true })
     return tracked
   }
 
-  hostEntry(id) { return this.hosts.get(id) }
+  hostEntry(id) {
+    return this.hosts.get(id)
+  }
 
   async startManagedHosts() {
     const eager = [...this.hosts.values()].filter((entry) => entry.eager)
@@ -38,7 +57,9 @@ export class MachineDaemon {
       : { id: entry.id, status: "unavailable", error: settled[index].reason })
   }
 
-  snapshot() { return this.registry.snapshot() }
+  snapshot() {
+    return this.registry.snapshot()
+  }
 
   close() {
     for (const entry of this.hosts.values()) {
@@ -56,13 +77,19 @@ export function createMachineDaemonServer({
   serviceOptions,
   createServer = createBridgeServer,
   createRouter = createAgentRoutingServer,
+  createLaunchServer = createTaskLaunchServer,
   taskStore,
   projectCatalog,
   worktreeManager,
   taskLauncher,
   taskRunController
 }) {
-  const bridgeServer = createServer({ config, acp: primaryAcp, machineRegistry: daemon.registry, serviceOptions })
+  const bridgeServer = createServer({
+    config,
+    acp: primaryAcp,
+    machineRegistry: daemon.registry,
+    serviceOptions
+  })
   const machineID = daemon.snapshot().machine.id
   const roots = config.roots?.length ? config.roots : [process.cwd()]
   const stateDirectory = config.stateDirectory ?? process.cwd()
@@ -71,14 +98,14 @@ export function createMachineDaemonServer({
   const worktrees = worktreeManager ?? new WorktreeManager({ stateDirectory })
   const launcher = taskLauncher ?? new TaskLauncher({ daemon })
   const runs = taskRunController ?? new TaskRunController({ taskStore: tasks, taskLauncher: launcher })
-  return createRouter({
+  const innerServer = createRouter({
     daemon,
     config,
     primaryAgentID,
     bridgeServer,
     taskStore: tasks,
     projectCatalog: projects,
-    worktreeManager: worktrees,
-    taskRunController: runs
+    worktreeManager: worktrees
   })
+  return createLaunchServer({ innerServer, config, taskRunController: runs })
 }

--- a/bridge/src/task-errors.js
+++ b/bridge/src/task-errors.js
@@ -1,0 +1,11 @@
+export class TaskLaunchError extends Error {
+  constructor(code, message, options) {
+    super(message, options)
+    this.name = "TaskLaunchError"
+    this.code = code
+  }
+}
+
+export function taskLaunchError(code, message, options) {
+  return new TaskLaunchError(code, message, options)
+}

--- a/bridge/src/task-launch-server.js
+++ b/bridge/src/task-launch-server.js
@@ -1,0 +1,3 @@
+export function taskLaunchPath(pathname) {
+  return /^\/v1\/tasks\/([^/]+)\/launch$/.exec(pathname)
+}

--- a/bridge/src/task-launch-server.js
+++ b/bridge/src/task-launch-server.js
@@ -1,3 +1,52 @@
-export function taskLaunchPath(pathname) {
-  return /^\/v1\/tasks\/([^/]+)\/launch$/.exec(pathname)
+import http from "node:http"
+import { allowedOrigin, applyCorsHeaders, matchesCredentials, writeJSON } from "./http-policy.js"
+
+const TASK_LAUNCH_ROUTE = /^\/v1\/tasks\/([^/]+)\/launch$/
+
+function authenticate(request, response, config) {
+  applyCorsHeaders(request, response, config)
+  if (request.method === "OPTIONS") {
+    response.writeHead(allowedOrigin(request, config) ? 204 : 403)
+    response.end()
+    return false
+  }
+  if (!matchesCredentials(request, config)) {
+    response.writeHead(401, { "WWW-Authenticate": 'Basic realm="Harness Remote Daemon"' })
+    response.end()
+    return false
+  }
+  return true
+}
+
+function launchStatus(error) {
+  const message = error instanceof Error ? error.message : String(error)
+  if (message.startsWith("Unknown task:")) return 404
+  if (message.includes("unavailable")) return 503
+  if (message.includes("Only draft tasks") || message.includes("worktree") || message.includes("workspace")) return 409
+  return 500
+}
+
+export function createTaskLaunchServer({ innerServer, config, taskRunController, createServer = http.createServer }) {
+  return createServer(async (request, response) => {
+    const requestURL = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`)
+    const match = TASK_LAUNCH_ROUTE.exec(requestURL.pathname)
+    if (!match) {
+      innerServer.emit("request", request, response)
+      return
+    }
+
+    if (!authenticate(request, response, config)) return
+    if (request.method !== "POST") {
+      response.writeHead(405, { Allow: "POST, OPTIONS" })
+      response.end()
+      return
+    }
+
+    const taskID = decodeURIComponent(match[1])
+    try {
+      writeJSON(response, 200, await taskRunController.launch(taskID))
+    } catch (error) {
+      writeJSON(response, launchStatus(error), { error: error instanceof Error ? error.message : String(error) })
+    }
+  })
 }

--- a/bridge/src/task-launch-server.js
+++ b/bridge/src/task-launch-server.js
@@ -2,6 +2,14 @@ import http from "node:http"
 import { allowedOrigin, applyCorsHeaders, matchesCredentials, writeJSON } from "./http-policy.js"
 
 const TASK_LAUNCH_ROUTE = /^\/v1\/tasks\/([^/]+)\/launch$/
+const LAUNCH_STATUS = new Map([
+  ["unknown_task", 404],
+  ["unknown_agent", 404],
+  ["agent_unavailable", 503],
+  ["invalid_state", 409],
+  ["workspace_required", 409],
+  ["unsupported_agent", 409]
+])
 
 function authenticate(request, response, config) {
   applyCorsHeaders(request, response, config)
@@ -18,12 +26,8 @@ function authenticate(request, response, config) {
   return true
 }
 
-function launchStatus(error) {
-  const message = error instanceof Error ? error.message : String(error)
-  if (message.startsWith("Unknown task:")) return 404
-  if (message.includes("unavailable")) return 503
-  if (message.includes("Only draft tasks") || message.includes("worktree") || message.includes("workspace")) return 409
-  return 500
+export function launchStatus(error) {
+  return LAUNCH_STATUS.get(error?.code) ?? 500
 }
 
 export function createTaskLaunchServer({ innerServer, config, taskRunController, createServer = http.createServer }) {

--- a/bridge/src/task-launcher.js
+++ b/bridge/src/task-launcher.js
@@ -1,0 +1,86 @@
+function basicAuthorization(username, password) {
+  if (!username && !password) return undefined
+  return `Basic ${Buffer.from(`${username ?? ""}:${password ?? ""}`).toString("base64")}`
+}
+
+function httpHost(host) {
+  return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host
+}
+
+async function responseJSON(response, label) {
+  if (!response.ok) {
+    let detail = ""
+    try {
+      const body = await response.json()
+      detail = typeof body?.error === "string" ? `: ${body.error}` : ""
+    } catch {}
+    throw new Error(`${label} failed with HTTP ${response.status}${detail}`)
+  }
+  return response.json()
+}
+
+export class TaskLauncher {
+  constructor({ daemon, fetchImpl = fetch }) {
+    this.daemon = daemon
+    this.fetchImpl = fetchImpl
+  }
+
+  async createSession(task) {
+    const entry = this.daemon.hostEntry(task.agentId)
+    if (!entry) throw new Error(`Unknown agent: ${task.agentId}`)
+    if (this.daemon.registry.host(task.agentId)?.state === "unavailable") throw new Error(`Agent ${task.agentId} is unavailable`)
+    if (!task.workspace?.path) throw new Error("Task workspace is not prepared")
+
+    if (entry.kind === "acp") {
+      await entry.host.start()
+      const result = await entry.host.request("session/new", { cwd: task.workspace.path, mcpServers: [] })
+      if (!result?.sessionId) throw new Error(`Agent ${task.agentId} did not return a session id`)
+      return { sessionId: result.sessionId, transport: "acp", directory: task.workspace.path }
+    }
+
+    if (entry.kind === "http") {
+      await entry.host.start?.()
+      const host = entry.host.readinessHost ?? entry.host.host ?? "127.0.0.1"
+      const base = `http://${httpHost(host)}:${entry.host.port}`
+      const authorization = basicAuthorization(entry.host.username, entry.host.password)
+      const response = await this.fetchImpl(`${base}/session?directory=${encodeURIComponent(task.workspace.path)}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(authorization ? { Authorization: authorization } : {})
+        },
+        body: JSON.stringify({ title: `Task ${task.id.slice(0, 8)}` })
+      })
+      const session = await responseJSON(response, `Creating ${task.agentId} session`)
+      if (!session?.id) throw new Error(`Agent ${task.agentId} did not return a session id`)
+      return { sessionId: session.id, transport: "http", directory: task.workspace.path, base, authorization }
+    }
+
+    throw new Error(`Agent ${task.agentId} cannot launch tasks`)
+  }
+
+  async startPrompt(task, run) {
+    const entry = this.daemon.hostEntry(task.agentId)
+    if (!entry) throw new Error(`Unknown agent: ${task.agentId}`)
+
+    if (entry.kind === "acp") {
+      void entry.host.request("session/prompt", {
+        sessionId: run.sessionId,
+        prompt: [{ type: "text", text: task.prompt }]
+      }, 300_000).catch(() => {})
+      return
+    }
+
+    if (entry.kind === "http") {
+      const response = await this.fetchImpl(`${run.base}/session/${encodeURIComponent(run.sessionId)}/prompt_async?directory=${encodeURIComponent(task.workspace.path)}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(run.authorization ? { Authorization: run.authorization } : {})
+        },
+        body: JSON.stringify({ parts: [{ type: "text", text: task.prompt }] })
+      })
+      if (!response.ok) throw new Error(`Starting ${task.agentId} task failed with HTTP ${response.status}`)
+    }
+  }
+}

--- a/bridge/src/task-launcher.js
+++ b/bridge/src/task-launcher.js
@@ -1,3 +1,5 @@
+import { taskLaunchError } from "./task-errors.js"
+
 function basicAuthorization(username, password) {
   if (!username && !password) return undefined
   return `Basic ${Buffer.from(`${username ?? ""}:${password ?? ""}`).toString("base64")}`
@@ -27,9 +29,11 @@ export class TaskLauncher {
 
   async createSession(task) {
     const entry = this.daemon.hostEntry(task.agentId)
-    if (!entry) throw new Error(`Unknown agent: ${task.agentId}`)
-    if (this.daemon.registry.host(task.agentId)?.state === "unavailable") throw new Error(`Agent ${task.agentId} is unavailable`)
-    if (!task.workspace?.path) throw new Error("Task workspace is not prepared")
+    if (!entry) throw taskLaunchError("unknown_agent", `Unknown agent: ${task.agentId}`)
+    if (this.daemon.registry.host(task.agentId)?.state === "unavailable") {
+      throw taskLaunchError("agent_unavailable", `Agent ${task.agentId} is unavailable`)
+    }
+    if (!task.workspace?.path) throw taskLaunchError("workspace_required", "Task workspace is not prepared")
 
     if (entry.kind === "acp") {
       await entry.host.start()
@@ -56,18 +60,20 @@ export class TaskLauncher {
       return { sessionId: session.id, transport: "http", directory: task.workspace.path, base, authorization }
     }
 
-    throw new Error(`Agent ${task.agentId} cannot launch tasks`)
+    throw taskLaunchError("unsupported_agent", `Agent ${task.agentId} cannot launch tasks`)
   }
 
-  async startPrompt(task, run) {
+  async startPrompt(task, run, onPromptFailed) {
     const entry = this.daemon.hostEntry(task.agentId)
-    if (!entry) throw new Error(`Unknown agent: ${task.agentId}`)
+    if (!entry) throw taskLaunchError("unknown_agent", `Unknown agent: ${task.agentId}`)
 
     if (entry.kind === "acp") {
       void entry.host.request("session/prompt", {
         sessionId: run.sessionId,
         prompt: [{ type: "text", text: task.prompt }]
-      }, 300_000).catch(() => {})
+      }, 300_000).catch((error) => {
+        onPromptFailed?.(error)
+      })
       return
     }
 

--- a/bridge/src/task-run-controller.js
+++ b/bridge/src/task-run-controller.js
@@ -1,0 +1,47 @@
+import { randomUUID } from "node:crypto"
+
+export class TaskRunController {
+  constructor({ taskStore, taskLauncher, runIDFactory = randomUUID, clock = () => new Date().toISOString() }) {
+    this.taskStore = taskStore
+    this.taskLauncher = taskLauncher
+    this.runIDFactory = runIDFactory
+    this.clock = clock
+  }
+
+  async launch(taskID) {
+    const task = await this.taskStore.get(taskID)
+    if (!task) throw new Error(`Unknown task: ${taskID}`)
+    if (task.status !== "draft") throw new Error("Only draft tasks can be launched")
+    if (task.project?.kind === "git" && task.workspace?.mode !== "worktree") {
+      throw new Error("Git tasks must prepare an isolated worktree before launch")
+    }
+    if (!task.workspace?.path) throw new Error("Task workspace is not prepared")
+
+    const run = {
+      id: this.runIDFactory(),
+      agentId: task.agentId,
+      sessionId: null,
+      transport: null,
+      directory: task.workspace.path,
+      startedAt: this.clock()
+    }
+    let current = await this.taskStore.setRunState(taskID, { status: "starting", run })
+
+    try {
+      const session = await this.taskLauncher.createSession(current)
+      const linkedRun = {
+        ...run,
+        sessionId: session.sessionId,
+        transport: session.transport
+      }
+      current = await this.taskStore.setRunState(taskID, { status: "starting", run: linkedRun })
+      await this.taskLauncher.startPrompt(current, session)
+      return await this.taskStore.setRunState(taskID, { status: "running", run: linkedRun })
+    } catch (error) {
+      try {
+        await this.taskStore.setRunState(taskID, { status: "failed", run: current.run ?? run, error })
+      } catch {}
+      throw error
+    }
+  }
+}

--- a/bridge/src/task-run-controller.js
+++ b/bridge/src/task-run-controller.js
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto"
+import { taskLaunchError } from "./task-errors.js"
 
 export class TaskRunController {
   constructor({ taskStore, taskLauncher, runIDFactory = randomUUID, clock = () => new Date().toISOString() }) {
@@ -8,14 +9,23 @@ export class TaskRunController {
     this.clock = clock
   }
 
+  async #recordPromptFailure(taskID, run, error) {
+    try {
+      const current = await this.taskStore.get(taskID)
+      if (!current || current.run?.id !== run.id) return
+      if (current.status !== "starting" && current.status !== "running") return
+      await this.taskStore.setRunState(taskID, { status: "failed", run: current.run, error })
+    } catch {}
+  }
+
   async launch(taskID) {
     const task = await this.taskStore.get(taskID)
-    if (!task) throw new Error(`Unknown task: ${taskID}`)
-    if (task.status !== "draft") throw new Error("Only draft tasks can be launched")
+    if (!task) throw taskLaunchError("unknown_task", `Unknown task: ${taskID}`)
+    if (task.status !== "draft") throw taskLaunchError("invalid_state", "Only draft tasks can be launched")
     if (task.project?.kind === "git" && task.workspace?.mode !== "worktree") {
-      throw new Error("Git tasks must prepare an isolated worktree before launch")
+      throw taskLaunchError("workspace_required", "Git tasks must prepare an isolated worktree before launch")
     }
-    if (!task.workspace?.path) throw new Error("Task workspace is not prepared")
+    if (!task.workspace?.path) throw taskLaunchError("workspace_required", "Task workspace is not prepared")
 
     const run = {
       id: this.runIDFactory(),
@@ -35,7 +45,9 @@ export class TaskRunController {
         transport: session.transport
       }
       current = await this.taskStore.setRunState(taskID, { status: "starting", run: linkedRun })
-      await this.taskLauncher.startPrompt(current, session)
+      await this.taskLauncher.startPrompt(current, session, (error) => {
+        void this.#recordPromptFailure(taskID, linkedRun, error)
+      })
       return await this.taskStore.setRunState(taskID, { status: "running", run: linkedRun })
     } catch (error) {
       try {

--- a/bridge/src/task-run-store.js
+++ b/bridge/src/task-run-store.js
@@ -1,0 +1,27 @@
+import { TaskStore } from "./task-store.js"
+
+export class TaskRunStore extends TaskStore {
+  async setRunState(taskID, { status, run, error = null }) {
+    await this.load()
+    const index = this.tasks.findIndex((task) => task.id === taskID)
+    if (index < 0) throw new Error(`Unknown task: ${taskID}`)
+    const task = this.tasks[index]
+
+    if (status === "starting" && task.status !== "draft" && task.status !== "starting") {
+      throw new Error("Only draft tasks can start a run")
+    }
+    if (status === "running" && task.status !== "starting") throw new Error("Task is not starting")
+    if (status === "running" && !run?.sessionId) throw new Error("Running task requires a session id")
+
+    const updated = {
+      ...task,
+      status,
+      run: structuredClone(run ?? task.run),
+      error: error ? { message: error instanceof Error ? error.message : String(error) } : null,
+      updatedAt: this.clock()
+    }
+    this.tasks[index] = updated
+    await this.persist()
+    return structuredClone(updated)
+  }
+}

--- a/bridge/test/machine-daemon.test.js
+++ b/bridge/test/machine-daemon.test.js
@@ -141,7 +141,7 @@ test("failed eager startup is isolated and reported in the machine snapshot", as
   assert.equal(daemon.snapshot().agents.find((host) => host.id === "codex").state, "configured")
 })
 
-test("machine server wires the shared registry through the bridge and agent router", () => {
+test("machine server wires the shared registry, agent router, and task launch wrapper", () => {
   const daemon = new MachineDaemon({ id: "machine_test", name: "workstation" })
   const acp = new FakeAcp()
   const openCode = new FakeHttpHost()
@@ -150,8 +150,10 @@ test("machine server wires the shared registry through the bridge and agent rout
 
   let bridgeOptions
   let routerOptions
+  let launchOptions
   const bridgeServer = { marker: "bridge" }
   const routedServer = { marker: "router" }
+  const launchServer = { marker: "launch" }
   const value = createMachineDaemonServer({
     daemon,
     config: { backend: "pi", port: 4097 },
@@ -165,15 +167,21 @@ test("machine server wires the shared registry through the bridge and agent rout
     createRouter: (options) => {
       routerOptions = options
       return routedServer
+    },
+    createLaunchServer: (options) => {
+      launchOptions = options
+      return launchServer
     }
   })
 
-  assert.equal(value, routedServer)
+  assert.equal(value, launchServer)
   assert.equal(bridgeOptions.machineRegistry, daemon.registry)
   assert.equal(bridgeOptions.acp, acp)
   assert.equal(routerOptions.daemon, daemon)
   assert.equal(routerOptions.bridgeServer, bridgeServer)
   assert.equal(routerOptions.primaryAgentID, "pi")
+  assert.equal(launchOptions.innerServer, routedServer)
+  assert.equal(typeof launchOptions.taskRunController.launch, "function")
   assert.deepEqual(bridgeOptions.machineRegistry.snapshot().agents.map((host) => host.id), ["pi", "opencode"])
 })
 

--- a/bridge/test/task-launch-server.test.js
+++ b/bridge/test/task-launch-server.test.js
@@ -1,3 +1,58 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
 import test from "node:test"
+import { createTaskLaunchServer } from "../src/task-launch-server.js"
 
-test("task launch route placeholder", () => {})
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  return server.address().port
+}
+
+async function close(server) {
+  await new Promise((resolve) => server.close(resolve))
+}
+
+test("POST launch returns the persisted running task", async () => {
+  const innerServer = new EventEmitter()
+  const server = createTaskLaunchServer({
+    innerServer,
+    config: { username: "", password: "", corsOrigins: [] },
+    taskRunController: { async launch(id) { return { id, status: "running", run: { sessionId: "session-1" } } } }
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/tasks/task-1/launch`, { method: "POST" })
+    assert.equal(response.status, 200)
+    assert.equal((await response.json()).run.sessionId, "session-1")
+  } finally {
+    await close(server)
+  }
+})
+
+test("launch maps missing tasks to 404 and delegates unrelated routes", async () => {
+  const innerServer = new EventEmitter()
+  let delegated = false
+  innerServer.on("request", (_request, response) => {
+    delegated = true
+    response.writeHead(204)
+    response.end()
+  })
+  const server = createTaskLaunchServer({
+    innerServer,
+    config: { username: "", password: "", corsOrigins: [] },
+    taskRunController: { async launch(id) { throw new Error(`Unknown task: ${id}`) } }
+  })
+  const port = await listen(server)
+  try {
+    const missing = await fetch(`http://127.0.0.1:${port}/v1/tasks/missing/launch`, { method: "POST" })
+    assert.equal(missing.status, 404)
+    const delegatedResponse = await fetch(`http://127.0.0.1:${port}/v1/tasks`)
+    assert.equal(delegatedResponse.status, 204)
+    assert.equal(delegated, true)
+  } finally {
+    await close(server)
+  }
+})

--- a/bridge/test/task-launch-server.test.js
+++ b/bridge/test/task-launch-server.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict"
 import { EventEmitter } from "node:events"
 import test from "node:test"
-import { createTaskLaunchServer } from "../src/task-launch-server.js"
+import { createTaskLaunchServer, launchStatus } from "../src/task-launch-server.js"
 
 async function listen(server) {
   await new Promise((resolve, reject) => {
@@ -32,7 +32,7 @@ test("POST launch returns the persisted running task", async () => {
   }
 })
 
-test("launch maps missing tasks to 404 and delegates unrelated routes", async () => {
+test("launch maps coded missing tasks to 404 and delegates unrelated routes", async () => {
   const innerServer = new EventEmitter()
   let delegated = false
   innerServer.on("request", (_request, response) => {
@@ -43,7 +43,7 @@ test("launch maps missing tasks to 404 and delegates unrelated routes", async ()
   const server = createTaskLaunchServer({
     innerServer,
     config: { username: "", password: "", corsOrigins: [] },
-    taskRunController: { async launch(id) { throw new Error(`Unknown task: ${id}`) } }
+    taskRunController: { async launch(id) { const error = new Error(`Unknown task: ${id}`); error.code = "unknown_task"; throw error } }
   })
   const port = await listen(server)
   try {
@@ -55,4 +55,8 @@ test("launch maps missing tasks to 404 and delegates unrelated routes", async ()
   } finally {
     await close(server)
   }
+})
+
+test("launch status ignores prose when no structured code is present", () => {
+  assert.equal(launchStatus(new Error("unknown task worktree unavailable")), 500)
 })

--- a/bridge/test/task-launch-server.test.js
+++ b/bridge/test/task-launch-server.test.js
@@ -1,0 +1,3 @@
+import test from "node:test"
+
+test("task launch route placeholder", () => {})

--- a/bridge/test/task-run-controller.test.js
+++ b/bridge/test/task-run-controller.test.js
@@ -1,3 +1,73 @@
+import assert from "node:assert/strict"
 import test from "node:test"
+import { TaskRunController } from "../src/task-run-controller.js"
 
-test("task run controller placeholder", () => {})
+function draft(overrides = {}) {
+  return {
+    id: "task-1",
+    status: "draft",
+    agentId: "codex",
+    prompt: "Fix it",
+    project: { kind: "git", path: "/repo" },
+    workspace: { mode: "worktree", path: "/state/worktrees/task-1" },
+    run: null,
+    ...overrides
+  }
+}
+
+test("launch persists run identity before starting the prompt and ends running", async () => {
+  let current = draft()
+  const calls = []
+  const store = {
+    async get() { return structuredClone(current) },
+    async setRunState(_id, update) {
+      calls.push(["state", update.status, update.run.sessionId])
+      current = { ...current, status: update.status, run: structuredClone(update.run) }
+      return structuredClone(current)
+    }
+  }
+  const launcher = {
+    async createSession(task) {
+      calls.push(["session", task.status])
+      return { sessionId: "session-1", transport: "acp", directory: task.workspace.path }
+    },
+    async startPrompt(task, session) { calls.push(["prompt", task.status, session.sessionId]) }
+  }
+  const controller = new TaskRunController({ taskStore: store, taskLauncher: launcher, runIDFactory: () => "run-1", clock: () => "2026-08-13T18:00:00.000Z" })
+
+  const result = await controller.launch("task-1")
+  assert.equal(result.status, "running")
+  assert.equal(result.run.id, "run-1")
+  assert.equal(result.run.sessionId, "session-1")
+  assert.deepEqual(calls, [
+    ["state", "starting", null],
+    ["session", "starting"],
+    ["state", "starting", "session-1"],
+    ["prompt", "starting", "session-1"],
+    ["state", "running", "session-1"]
+  ])
+})
+
+test("Git tasks cannot launch from the primary checkout", async () => {
+  const controller = new TaskRunController({ taskStore: { async get() { return draft({ workspace: { mode: "project", path: "/repo" } }) } }, taskLauncher: {} })
+  await assert.rejects(() => controller.launch("task-1"), /isolated worktree/)
+})
+
+test("launch failures persist failed state", async () => {
+  let current = draft()
+  const states = []
+  const controller = new TaskRunController({
+    taskStore: {
+      async get() { return structuredClone(current) },
+      async setRunState(_id, update) {
+        states.push(update.status)
+        current = { ...current, status: update.status, run: update.run, error: update.error }
+        return structuredClone(current)
+      }
+    },
+    taskLauncher: { async createSession() { throw new Error("agent unavailable") } },
+    runIDFactory: () => "run-1"
+  })
+  await assert.rejects(() => controller.launch("task-1"), /agent unavailable/)
+  assert.deepEqual(states, ["starting", "failed"])
+})

--- a/bridge/test/task-run-controller.test.js
+++ b/bridge/test/task-run-controller.test.js
@@ -1,0 +1,3 @@
+import test from "node:test"
+
+test("task run controller placeholder", () => {})

--- a/bridge/test/task-run-controller.test.js
+++ b/bridge/test/task-run-controller.test.js
@@ -71,3 +71,27 @@ test("launch failures persist failed state", async () => {
   await assert.rejects(() => controller.launch("task-1"), /agent unavailable/)
   assert.deepEqual(states, ["starting", "failed"])
 })
+
+test("asynchronous prompt failures mark the same running run failed", async () => {
+  let current = draft()
+  let rejectPrompt
+  const store = {
+    async get() { return structuredClone(current) },
+    async setRunState(_id, update) {
+      current = { ...current, status: update.status, run: structuredClone(update.run), error: update.error }
+      return structuredClone(current)
+    }
+  }
+  const launcher = {
+    async createSession(task) { return { sessionId: "session-1", transport: "acp", directory: task.workspace.path } },
+    async startPrompt(_task, _session, onPromptFailed) { rejectPrompt = onPromptFailed }
+  }
+  const controller = new TaskRunController({ taskStore: store, taskLauncher: launcher, runIDFactory: () => "run-1" })
+  const launched = await controller.launch("task-1")
+  assert.equal(launched.status, "running")
+
+  rejectPrompt(new Error("prompt failed"))
+  await new Promise((resolve) => setImmediate(resolve))
+  assert.equal(current.status, "failed")
+  assert.equal(current.run.id, "run-1")
+})


### PR DESCRIPTION
## Summary

Third implementation slice of #145.

- add a task run lifecycle store with `starting`, `running`, and `failed` states
- launch the task's selected agent inside its prepared workspace
- require isolated worktrees before launching Git tasks
- create and persist a run identity before starting agent work
- link the created agent session back to the Task before sending the prompt
- support both ACP-backed agents and managed OpenCode HTTP sessions
- expose `POST /v1/tasks/:taskId/launch` through a machine-level wrapper that delegates all existing agent/project/task routes unchanged
- add regression coverage for lifecycle ordering, worktree enforcement, failure persistence, launch routing, and delegation

## Scope boundary

This PR starts the selected agent and records its session/run identity. It does not yet implement completion detection, finish-work actions, or UI for creating/launching tasks; those remain later #145 slices.

Part of #145.