### PR TITLE
feat(tasks): add finish-work result and safe finalization primitives

### DIFF
--- a/bridge/src/http-policy.js
+++ b/bridge/src/http-policy.js
@@ -36,6 +36,21 @@ export function matchesCredentials(request, config) {
   return received.length === expected.length && timingSafeEqual(received, expected)
 }
 
+export function authenticateDaemonRequest(request, response, config) {
+  applyCorsHeaders(request, response, config)
+  if (request.method === "OPTIONS") {
+    response.writeHead(allowedOrigin(request, config) ? 204 : 403)
+    response.end()
+    return false
+  }
+  if (!matchesCredentials(request, config)) {
+    response.writeHead(401, { "WWW-Authenticate": 'Basic realm="Harness Remote Daemon"' })
+    response.end()
+    return false
+  }
+  return true
+}
+
 export function writeJSON(response, status, body) {
   response.writeHead(status, { "Content-Type": "application/json; charset=utf-8", "Cache-Control": "no-store" })
   response.end(JSON.stringify(body))

--- a/bridge/src/machine-daemon.js
+++ b/bridge/src/machine-daemon.js
@@ -3,6 +3,7 @@ import { MachineRegistry, trackAgentHostLifecycle } from "./machine-registry.js"
 import { trackManagedHostLifecycle } from "./opencode-host.js"
 import { discoverProjects } from "./project-catalog.js"
 import { createBridgeServer } from "./server.js"
+import { createTaskFinishServer } from "./task-finish-server.js"
 import { createTaskLaunchServer } from "./task-launch-server.js"
 import { TaskLauncher } from "./task-launcher.js"
 import { TaskRunController } from "./task-run-controller.js"
@@ -78,6 +79,7 @@ export function createMachineDaemonServer({
   createServer = createBridgeServer,
   createRouter = createAgentRoutingServer,
   createLaunchServer = createTaskLaunchServer,
+  createFinishServer = createTaskFinishServer,
   taskStore,
   projectCatalog,
   worktreeManager,
@@ -107,5 +109,6 @@ export function createMachineDaemonServer({
     projectCatalog: projects,
     worktreeManager: worktrees
   })
-  return createLaunchServer({ innerServer, config, taskRunController: runs })
+  const launchServer = createLaunchServer({ innerServer, config, taskRunController: runs })
+  return createFinishServer({ innerServer: launchServer, config, taskStore: tasks, worktreeManager: worktrees })
 }

--- a/bridge/src/machine-daemon.js
+++ b/bridge/src/machine-daemon.js
@@ -17,38 +17,20 @@ export class MachineDaemon {
   }
 
   registerAcpHost({ id, label, backend = id, capabilities = {}, agent, managed = true }) {
-    this.registry.registerHost({
-      id,
-      label,
-      backend,
-      transport: "acp",
-      managed,
-      state: "configured",
-      capabilities
-    })
+    this.registry.registerHost({ id, label, backend, transport: "acp", managed, state: "configured", capabilities })
     const tracked = trackAgentHostLifecycle(agent, this.registry, id)
     this.hosts.set(id, { id, kind: "acp", host: tracked, eager: false })
     return tracked
   }
 
   registerManagedHttpHost({ id, label, backend = id, capabilities = {}, host, managed = true }) {
-    this.registry.registerHost({
-      id,
-      label,
-      backend,
-      transport: "http",
-      managed,
-      state: "configured",
-      capabilities
-    })
+    this.registry.registerHost({ id, label, backend, transport: "http", managed, state: "configured", capabilities })
     const tracked = trackManagedHostLifecycle(host, this.registry, id)
     this.hosts.set(id, { id, kind: "http", host: tracked, eager: true })
     return tracked
   }
 
-  hostEntry(id) {
-    return this.hosts.get(id)
-  }
+  hostEntry(id) { return this.hosts.get(id) }
 
   async startManagedHosts() {
     const eager = [...this.hosts.values()].filter((entry) => entry.eager)
@@ -58,9 +40,7 @@ export class MachineDaemon {
       : { id: entry.id, status: "unavailable", error: settled[index].reason })
   }
 
-  snapshot() {
-    return this.registry.snapshot()
-  }
+  snapshot() { return this.registry.snapshot() }
 
   close() {
     for (const entry of this.hosts.values()) {
@@ -86,12 +66,7 @@ export function createMachineDaemonServer({
   taskLauncher,
   taskRunController
 }) {
-  const bridgeServer = createServer({
-    config,
-    acp: primaryAcp,
-    machineRegistry: daemon.registry,
-    serviceOptions
-  })
+  const bridgeServer = createServer({ config, acp: primaryAcp, machineRegistry: daemon.registry, serviceOptions })
   const machineID = daemon.snapshot().machine.id
   const roots = config.roots?.length ? config.roots : [process.cwd()]
   const stateDirectory = config.stateDirectory ?? process.cwd()
@@ -100,15 +75,7 @@ export function createMachineDaemonServer({
   const worktrees = worktreeManager ?? new WorktreeManager({ stateDirectory })
   const launcher = taskLauncher ?? new TaskLauncher({ daemon })
   const runs = taskRunController ?? new TaskRunController({ taskStore: tasks, taskLauncher: launcher })
-  const innerServer = createRouter({
-    daemon,
-    config,
-    primaryAgentID,
-    bridgeServer,
-    taskStore: tasks,
-    projectCatalog: projects,
-    worktreeManager: worktrees
-  })
+  const innerServer = createRouter({ daemon, config, primaryAgentID, bridgeServer, taskStore: tasks, projectCatalog: projects, worktreeManager: worktrees })
   const launchServer = createLaunchServer({ innerServer, config, taskRunController: runs })
-  return createFinishServer({ innerServer: launchServer, config, taskStore: tasks, worktreeManager: worktrees })
+  return createFinishServer({ innerServer: launchServer, config, taskStore: tasks, worktreeManager: worktrees, taskRunController: runs })
 }

--- a/bridge/src/task-finish-server.js
+++ b/bridge/src/task-finish-server.js
@@ -1,32 +1,18 @@
 import http from "node:http"
-import { allowedOrigin, applyCorsHeaders, matchesCredentials, writeJSON } from "./http-policy.js"
+import { authenticateDaemonRequest, writeJSON } from "./http-policy.js"
 import { inspectTaskWork } from "./task-finish.js"
 
 const resultRoute = /^\/v1\/tasks\/([^/]+)\/result$/
 const finishRoute = /^\/v1\/tasks\/([^/]+)\/finish$/
 
-function authenticate(request, response, config) {
-  applyCorsHeaders(request, response, config)
-  if (request.method === "OPTIONS") {
-    response.writeHead(allowedOrigin(request, config) ? 204 : 403)
-    response.end()
-    return false
-  }
-  if (!matchesCredentials(request, config)) {
-    response.writeHead(401, { "WWW-Authenticate": 'Basic realm="Harness Remote Daemon"' })
-    response.end()
-    return false
-  }
-  return true
-}
-
 function status(error) {
   if (error?.code === "unknown_task") return 404
+  if (error?.code === "agent_unavailable") return 503
   if (["task_active", "worktree_dirty", "invalid_worktree", "worktree_outside_state", "worktree_missing"].includes(error?.code)) return 409
   return 500
 }
 
-export function createTaskFinishServer({ innerServer, config, taskStore, worktreeManager, createServer = http.createServer }) {
+export function createTaskFinishServer({ innerServer, config, taskStore, worktreeManager, taskRunController, createServer = http.createServer }) {
   return createServer(async (request, response) => {
     const pathname = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`).pathname
     const resultMatch = resultRoute.exec(pathname)
@@ -37,9 +23,17 @@ export function createTaskFinishServer({ innerServer, config, taskStore, worktre
       innerServer.emit("request", request, response)
       return
     }
-    if (!authenticate(request, response, config)) return
+    if (!authenticateDaemonRequest(request, response, config)) return
 
     try {
+      if (taskRunController) {
+        await taskRunController.reconciliation
+        if (taskRunController.reconciliationError) {
+          const error = new Error("Task state is unavailable")
+          error.code = "agent_unavailable"
+          throw error
+        }
+      }
       const taskID = decodeURIComponent((resultMatch ?? finishMatch)[1])
       const task = await taskStore.get(taskID)
       if (!task) {

--- a/bridge/src/task-finish-server.js
+++ b/bridge/src/task-finish-server.js
@@ -1,0 +1,72 @@
+import http from "node:http"
+import { allowedOrigin, applyCorsHeaders, matchesCredentials, writeJSON } from "./http-policy.js"
+import { inspectTaskWork } from "./task-finish.js"
+
+const resultRoute = /^\/v1\/tasks\/([^/]+)\/result$/
+const finishRoute = /^\/v1\/tasks\/([^/]+)\/finish$/
+
+function authenticate(request, response, config) {
+  applyCorsHeaders(request, response, config)
+  if (request.method === "OPTIONS") {
+    response.writeHead(allowedOrigin(request, config) ? 204 : 403)
+    response.end()
+    return false
+  }
+  if (!matchesCredentials(request, config)) {
+    response.writeHead(401, { "WWW-Authenticate": 'Basic realm="Harness Remote Daemon"' })
+    response.end()
+    return false
+  }
+  return true
+}
+
+function status(error) {
+  if (error?.code === "unknown_task") return 404
+  if (["task_active", "worktree_dirty", "invalid_worktree", "worktree_outside_state", "worktree_missing"].includes(error?.code)) return 409
+  return 500
+}
+
+export function createTaskFinishServer({ innerServer, config, taskStore, worktreeManager, createServer = http.createServer }) {
+  return createServer(async (request, response) => {
+    const pathname = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`).pathname
+    const resultMatch = resultRoute.exec(pathname)
+    const finishMatch = finishRoute.exec(pathname)
+    const inspect = resultMatch && request.method === "GET"
+    const finish = finishMatch && request.method === "POST"
+    if (!inspect && !finish) {
+      innerServer.emit("request", request, response)
+      return
+    }
+    if (!authenticate(request, response, config)) return
+
+    try {
+      const taskID = decodeURIComponent((resultMatch ?? finishMatch)[1])
+      const task = await taskStore.get(taskID)
+      if (!task) {
+        const error = new Error(`Unknown task: ${taskID}`)
+        error.code = "unknown_task"
+        throw error
+      }
+      if (task.workspace?.mode !== "worktree") {
+        const result = { managed: false, dirty: false, changeCount: 0 }
+        writeJSON(response, 200, finish ? { task, result, cleanup: { removed: false, branchDeleted: false } } : result)
+        return
+      }
+      if (finish && ["starting", "running"].includes(task.status)) {
+        const error = new Error("An active task cannot be finished")
+        error.code = "task_active"
+        throw error
+      }
+      const result = await inspectTaskWork(task.workspace, worktreeManager)
+      if (!finish) {
+        writeJSON(response, 200, result)
+        return
+      }
+      const cleanup = await worktreeManager.cleanup(task.workspace)
+      const updated = await taskStore.clearWorkspace(taskID)
+      writeJSON(response, 200, { task: updated, result, cleanup })
+    } catch (error) {
+      writeJSON(response, status(error), { error: error instanceof Error ? error.message : String(error), ...(error?.code ? { code: error.code } : {}) })
+    }
+  })
+}

--- a/bridge/src/task-finish.js
+++ b/bridge/src/task-finish.js
@@ -1,0 +1,25 @@
+function output(result) {
+  return String(result?.stdout ?? "").trim()
+}
+
+export async function inspectTaskWork(workspace, worktreeManager) {
+  const status = await worktreeManager.inspect(workspace)
+  const sourceHead = output(await worktreeManager.runGit(["-C", workspace.source, "rev-parse", "HEAD"]))
+  const branchHead = output(await worktreeManager.runGit(["-C", workspace.source, "rev-parse", workspace.branch]))
+  const counts = output(await worktreeManager.runGit([
+    "-C", workspace.source, "rev-list", "--left-right", "--count", `${sourceHead}...${branchHead}`
+  ])).split(/\s+/).map((value) => Number.parseInt(value, 10))
+  const commitsBehind = Number.isFinite(counts[0]) ? counts[0] : 0
+  const commitsAhead = Number.isFinite(counts[1]) ? counts[1] : 0
+
+  return {
+    ...status,
+    branch: workspace.branch,
+    source: workspace.source,
+    sourceHead,
+    branchHead,
+    commitsAhead,
+    commitsBehind,
+    mergedIntoSource: commitsAhead === 0
+  }
+}

--- a/bridge/src/task-finish.js
+++ b/bridge/src/task-finish.js
@@ -5,7 +5,14 @@ function output(result) {
 export async function inspectTaskWork(workspace, worktreeManager) {
   const status = await worktreeManager.inspect(workspace)
   const sourceHead = output(await worktreeManager.runGit(["-C", workspace.source, "rev-parse", "HEAD"]))
-  const branchHead = output(await worktreeManager.runGit(["-C", workspace.source, "rev-parse", workspace.branch]))
+  let branchHead
+  let branchMissing = false
+  try {
+    branchHead = output(await worktreeManager.runGit(["-C", workspace.source, "rev-parse", workspace.branch]))
+  } catch {
+    branchMissing = true
+    branchHead = output(await worktreeManager.runGit(["-C", workspace.path, "rev-parse", "HEAD"]))
+  }
   const counts = output(await worktreeManager.runGit([
     "-C", workspace.source, "rev-list", "--left-right", "--count", `${sourceHead}...${branchHead}`
   ])).split(/\s+/).map((value) => Number.parseInt(value, 10))
@@ -15,6 +22,7 @@ export async function inspectTaskWork(workspace, worktreeManager) {
   return {
     ...status,
     branch: workspace.branch,
+    branchMissing,
     source: workspace.source,
     sourceHead,
     branchHead,

--- a/bridge/src/task-launch-server.js
+++ b/bridge/src/task-launch-server.js
@@ -1,5 +1,5 @@
 import http from "node:http"
-import { allowedOrigin, applyCorsHeaders, matchesCredentials, writeJSON } from "./http-policy.js"
+import { authenticateDaemonRequest, writeJSON } from "./http-policy.js"
 
 const TASK_LAUNCH_ROUTE = /^\/v1\/tasks\/([^/]+)\/launch$/
 const TASK_WORKTREE_ROUTE = /^\/v1\/tasks\/([^/]+)\/worktree$/
@@ -18,21 +18,6 @@ const LAUNCH_STATUS = new Map([
   ["worktree_missing", 409]
 ])
 
-function authenticate(request, response, config) {
-  applyCorsHeaders(request, response, config)
-  if (request.method === "OPTIONS") {
-    response.writeHead(allowedOrigin(request, config) ? 204 : 403)
-    response.end()
-    return false
-  }
-  if (!matchesCredentials(request, config)) {
-    response.writeHead(401, { "WWW-Authenticate": 'Basic realm="Harness Remote Daemon"' })
-    response.end()
-    return false
-  }
-  return true
-}
-
 export function launchStatus(error) {
   return LAUNCH_STATUS.get(error?.code) ?? 500
 }
@@ -50,7 +35,7 @@ export function createTaskLaunchServer({ innerServer, config, taskRunController,
       return
     }
 
-    if (!authenticate(request, response, config)) return
+    if (!authenticateDaemonRequest(request, response, config)) return
     try {
       if (launchMatch) {
         if (request.method !== "POST") {

--- a/bridge/src/task-result-placeholder.tmp
+++ b/bridge/src/task-result-placeholder.tmp
@@ -1,0 +1,1 @@
+placeholder

--- a/bridge/src/task-result-placeholder.tmp
+++ b/bridge/src/task-result-placeholder.tmp
@@ -1,1 +1,0 @@
-placeholder

--- a/bridge/test/machine-daemon.test.js
+++ b/bridge/test/machine-daemon.test.js
@@ -77,24 +77,8 @@ test("eager managed hosts start concurrently rather than serially", async () => 
   const firstGate = new Promise((resolve) => { releaseFirst = resolve })
   const secondGate = new Promise((resolve) => { releaseSecond = resolve })
 
-  daemon.registerManagedHttpHost({
-    id: "first",
-    host: new FakeHttpHost({
-      startImpl: async () => {
-        firstStarted = true
-        await firstGate
-      }
-    })
-  })
-  daemon.registerManagedHttpHost({
-    id: "second",
-    host: new FakeHttpHost({
-      startImpl: async () => {
-        secondStarted = true
-        await secondGate
-      }
-    })
-  })
+  daemon.registerManagedHttpHost({ id: "first", host: new FakeHttpHost({ startImpl: async () => { firstStarted = true; await firstGate } }) })
+  daemon.registerManagedHttpHost({ id: "second", host: new FakeHttpHost({ startImpl: async () => { secondStarted = true; await secondGate } }) })
 
   const starting = daemon.startManagedHosts()
   await new Promise((resolve) => setImmediate(resolve))
@@ -104,21 +88,16 @@ test("eager managed hosts start concurrently rather than serially", async () => 
   releaseFirst()
   releaseSecond()
   const result = await starting
-  assert.deepEqual(result.map(({ id, status }) => [id, status]), [
-    ["first", "available"],
-    ["second", "available"]
-  ])
+  assert.deepEqual(result.map(({ id, status }) => [id, status]), [["first", "available"], ["second", "available"]])
 })
 
 test("one host failure does not erase or stop the other host", async () => {
   const daemon = new MachineDaemon({ id: "machine_test", name: "workstation" })
   const acp = new FakeAcp()
   const openCode = new FakeHttpHost()
-
   daemon.registerAcpHost({ id: "claude", label: "Claude Code", agent: acp })
   daemon.registerManagedHttpHost({ id: "opencode", label: "OpenCode", host: openCode })
   await acp.start()
-
   openCode.emit("unavailable", new Error("OpenCode crashed"))
   const snapshot = daemon.snapshot()
   assert.equal(snapshot.agents.find((host) => host.id === "claude").state, "available")
@@ -131,17 +110,15 @@ test("failed eager startup is isolated and reported in the machine snapshot", as
   const acp = new FakeAcp()
   const openCode = new FakeHttpHost()
   openCode.shouldFail = true
-
   daemon.registerAcpHost({ id: "codex", agent: acp })
   daemon.registerManagedHttpHost({ id: "opencode", host: openCode })
-
   const result = await daemon.startManagedHosts()
   assert.equal(result[0].status, "unavailable")
   assert.equal(daemon.snapshot().agents.find((host) => host.id === "opencode").state, "unavailable")
   assert.equal(daemon.snapshot().agents.find((host) => host.id === "codex").state, "configured")
 })
 
-test("machine server wires the shared registry, agent router, and task launch wrapper", () => {
+test("machine server wires the shared registry, agent router, task launch, and finish wrappers", () => {
   const daemon = new MachineDaemon({ id: "machine_test", name: "workstation" })
   const acp = new FakeAcp()
   const openCode = new FakeHttpHost()
@@ -151,30 +128,24 @@ test("machine server wires the shared registry, agent router, and task launch wr
   let bridgeOptions
   let routerOptions
   let launchOptions
+  let finishOptions
   const bridgeServer = { marker: "bridge" }
   const routedServer = { marker: "router" }
   const launchServer = { marker: "launch" }
+  const finishServer = { marker: "finish" }
   const value = createMachineDaemonServer({
     daemon,
     config: { backend: "pi", port: 4097 },
     primaryAcp: acp,
     primaryAgentID: "pi",
     serviceOptions: { snapshotDirectory: "/tmp/test" },
-    createServer: (options) => {
-      bridgeOptions = options
-      return bridgeServer
-    },
-    createRouter: (options) => {
-      routerOptions = options
-      return routedServer
-    },
-    createLaunchServer: (options) => {
-      launchOptions = options
-      return launchServer
-    }
+    createServer: (options) => { bridgeOptions = options; return bridgeServer },
+    createRouter: (options) => { routerOptions = options; return routedServer },
+    createLaunchServer: (options) => { launchOptions = options; return launchServer },
+    createFinishServer: (options) => { finishOptions = options; return finishServer }
   })
 
-  assert.equal(value, launchServer)
+  assert.equal(value, finishServer)
   assert.equal(bridgeOptions.machineRegistry, daemon.registry)
   assert.equal(bridgeOptions.acp, acp)
   assert.equal(routerOptions.daemon, daemon)
@@ -182,6 +153,9 @@ test("machine server wires the shared registry, agent router, and task launch wr
   assert.equal(routerOptions.primaryAgentID, "pi")
   assert.equal(launchOptions.innerServer, routedServer)
   assert.equal(typeof launchOptions.taskRunController.launch, "function")
+  assert.equal(finishOptions.innerServer, launchServer)
+  assert.equal(finishOptions.taskStore, routerOptions.taskStore)
+  assert.equal(finishOptions.worktreeManager, routerOptions.worktreeManager)
   assert.deepEqual(bridgeOptions.machineRegistry.snapshot().agents.map((host) => host.id), ["pi", "opencode"])
 })
 
@@ -201,7 +175,6 @@ test("daemon shutdown closes ACP and terminates managed HTTP hosts", () => {
   const openCode = new FakeHttpHost()
   daemon.registerAcpHost({ id: "codex", agent: acp })
   daemon.registerManagedHttpHost({ id: "opencode", host: openCode })
-
   daemon.close()
   assert.equal(acp.closed, true)
   assert.deepEqual(openCode.stopped, ["SIGTERM"])

--- a/bridge/test/task-finish.test.js
+++ b/bridge/test/task-finish.test.js
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import test from "node:test"
+import { createTaskFinishServer } from "../src/task-finish-server.js"
+import { inspectTaskWork } from "../src/task-finish.js"
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  return server.address().port
+}
+
+async function close(server) {
+  await new Promise((resolve) => server.close(resolve))
+}
+
+const workspace = { mode: "worktree", path: "/state/worktrees/t", branch: "task/t", source: "/repo" }
+
+function manager({ dirty = false } = {}) {
+  return {
+    async inspect() { return { managed: true, dirty, changeCount: dirty ? 1 : 0 } },
+    async runGit(args) {
+      if (args.includes("rev-list")) return { stdout: "2\t3\n" }
+      if (args.at(-1) === "HEAD") return { stdout: "source-head\n" }
+      return { stdout: "branch-head\n" }
+    },
+    async cleanup() { return { removed: true, branchDeleted: false } }
+  }
+}
+
+test("result inspection reports branch divergence without mutating work", async () => {
+  const result = await inspectTaskWork(workspace, manager())
+  assert.equal(result.commitsBehind, 2)
+  assert.equal(result.commitsAhead, 3)
+  assert.equal(result.mergedIntoSource, false)
+  assert.equal(result.sourceHead, "source-head")
+  assert.equal(result.branchHead, "branch-head")
+})
+
+test("finish releases an inactive clean worktree and preserves its result", async () => {
+  const innerServer = new EventEmitter()
+  let cleared = false
+  const task = { id: "t", status: "completed", workspace, project: { path: "/repo" } }
+  const server = createTaskFinishServer({
+    innerServer,
+    config: { username: "", password: "", corsOrigins: [] },
+    taskStore: {
+      async get() { return task },
+      async clearWorkspace() { cleared = true; return { ...task, workspace: { mode: "project", path: "/repo" } } }
+    },
+    worktreeManager: manager()
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/tasks/t/finish`, { method: "POST" })
+    assert.equal(response.status, 200)
+    const body = await response.json()
+    assert.equal(body.result.commitsAhead, 3)
+    assert.equal(body.cleanup.branchDeleted, false)
+    assert.equal(body.task.workspace.mode, "project")
+    assert.equal(cleared, true)
+  } finally {
+    await close(server)
+  }
+})
+
+test("finish refuses an active task before touching Git", async () => {
+  const innerServer = new EventEmitter()
+  let inspected = false
+  const worktreeManager = manager()
+  worktreeManager.inspect = async () => { inspected = true; return { managed: true, dirty: false, changeCount: 0 } }
+  const server = createTaskFinishServer({
+    innerServer,
+    config: { username: "", password: "", corsOrigins: [] },
+    taskStore: { async get() { return { id: "t", status: "running", workspace } } },
+    worktreeManager
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/tasks/t/finish`, { method: "POST" })
+    assert.equal(response.status, 409)
+    assert.equal((await response.json()).code, "task_active")
+    assert.equal(inspected, false)
+  } finally {
+    await close(server)
+  }
+})

--- a/bridge/test/task-finish.test.js
+++ b/bridge/test/task-finish.test.js
@@ -18,11 +18,16 @@ async function close(server) {
 
 const workspace = { mode: "worktree", path: "/state/worktrees/t", branch: "task/t", source: "/repo" }
 
-function manager({ dirty = false } = {}) {
+function manager({ dirty = false, branchMissing = false } = {}) {
   return {
     async inspect() { return { managed: true, dirty, changeCount: dirty ? 1 : 0 } },
     async runGit(args) {
       if (args.includes("rev-list")) return { stdout: "2\t3\n" }
+      if (args.at(-1) === workspace.branch) {
+        if (branchMissing) throw new Error("branch missing")
+        return { stdout: "branch-head\n" }
+      }
+      if (args.at(-1) === "HEAD" && args[1] === workspace.path) return { stdout: "branch-head\n" }
       if (args.at(-1) === "HEAD") return { stdout: "source-head\n" }
       return { stdout: "branch-head\n" }
     },
@@ -35,8 +40,17 @@ test("result inspection reports branch divergence without mutating work", async 
   assert.equal(result.commitsBehind, 2)
   assert.equal(result.commitsAhead, 3)
   assert.equal(result.mergedIntoSource, false)
+  assert.equal(result.branchMissing, false)
   assert.equal(result.sourceHead, "source-head")
   assert.equal(result.branchHead, "branch-head")
+})
+
+test("result inspection falls back to the worktree head when the branch ref is missing", async () => {
+  const result = await inspectTaskWork(workspace, manager({ branchMissing: true }))
+  assert.equal(result.branchMissing, true)
+  assert.equal(result.branchHead, "branch-head")
+  assert.equal(result.commitsAhead, 3)
+  assert.equal(result.mergedIntoSource, false)
 })
 
 test("finish releases an inactive clean worktree and preserves its result", async () => {
@@ -61,6 +75,32 @@ test("finish releases an inactive clean worktree and preserves its result", asyn
     assert.equal(body.cleanup.branchDeleted, false)
     assert.equal(body.task.workspace.mode, "project")
     assert.equal(cleared, true)
+  } finally {
+    await close(server)
+  }
+})
+
+test("finish waits for restart reconciliation before deciding whether a task is active", async () => {
+  const innerServer = new EventEmitter()
+  const task = { id: "t", status: "running", workspace, project: { path: "/repo" } }
+  const taskRunController = {
+    reconciliationError: null,
+    reconciliation: Promise.resolve().then(() => { task.status = "failed" })
+  }
+  const server = createTaskFinishServer({
+    innerServer,
+    config: { username: "", password: "", corsOrigins: [] },
+    taskStore: {
+      async get() { return task },
+      async clearWorkspace() { return { ...task, workspace: { mode: "project", path: "/repo" } } }
+    },
+    worktreeManager: manager(),
+    taskRunController
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/tasks/t/finish`, { method: "POST" })
+    assert.equal(response.status, 200)
   } finally {
     await close(server)
   }


### PR DESCRIPTION
## Summary

Backend-only follow-up for #163 and the task lifecycle started in #145.

- Add `GET /v1/tasks/:id/result` for normalized Git result inspection.
- Report dirty/change count, task/source heads, commits ahead/behind, and whether task commits are already represented by the source checkout.
- Add `POST /v1/tasks/:id/finish` as an explicit lifecycle action separate from agent-run completion.
- Refuse finish while a task is active.
- Reuse safe worktree cleanup so dirty work is never deleted and unmerged committed branches are preserved.
- Restore the task workspace binding to the project after successful finish.
- Make non-worktree finish a clear no-op.
- Add regressions for divergence reporting, successful finish, and active-task refusal.

No UI/UX changes, no PR creation, and no GitHub-specific runtime coupling.

Advances #163 and #145.