### PR TITLE
fix(tests): compare project paths against canonical temporary roots

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -68,6 +68,31 @@ jobs:
         run: npm test
         working-directory: bridge
 
+  # The bridge is the half of this repository that touches the filesystem, and it ships inside the
+  # desktop app for all three platforms — which is where its tests were first run on anything but
+  # Linux, on `main`, after the merge. A test that compared a path against the raw `mkdtemp` result
+  # passed here and failed there, because the temporary directory is a symlink on macOS and an 8.3
+  # alias on Windows. Node and the test suite are cheap; the two extra runners close that window.
+  bridge-platforms:
+    name: Bridge tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Run bridge tests
+        run: npm test
+        working-directory: bridge
+
   apk:
     name: Debug APK
     needs: tests

--- a/bridge/test/project-catalog.test.js
+++ b/bridge/test/project-catalog.test.js
@@ -1,12 +1,24 @@
 import assert from "node:assert/strict"
-import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import test from "node:test"
 import { discoverProjects } from "../src/project-catalog.js"
 
+/**
+ * The catalog reports canonical paths, because a project id has to stay the same however the root
+ * was reached and the boundary check has to compare resolved paths. The temporary directory is not
+ * canonical on two of the three platforms this repository builds for: macOS hands out
+ * `/var/folders/...`, a symlink to `/private/var/folders/...`, and Windows hands out the 8.3 form
+ * `C:\Users\RUNNER~1\...` of `C:\Users\runneradmin\...`. Comparing against the raw `mkdtemp` result
+ * therefore asserted the platform's alias rather than the value under test, and passed only on Linux.
+ */
+async function tempRoot(prefix) {
+  return realpath(await mkdtemp(path.join(os.tmpdir(), prefix)))
+}
+
 test("discovers configured roots and immediate Git projects without recursive scanning", async () => {
-  const root = await mkdtemp(path.join(os.tmpdir(), "harness-projects-"))
+  const root = await tempRoot("harness-projects-")
   try {
     const gitProject = path.join(root, "alpha")
     const plainDirectory = path.join(root, "notes")
@@ -29,7 +41,7 @@ test("discovers configured roots and immediate Git projects without recursive sc
 })
 
 test("project ids remain stable for the same machine and canonical path", async () => {
-  const root = await mkdtemp(path.join(os.tmpdir(), "harness-project-id-"))
+  const root = await tempRoot("harness-project-id-")
   try {
     const first = await discoverProjects({ machineID: "machine-1", roots: [root] })
     const second = await discoverProjects({ machineID: "machine-1", roots: [root] })
@@ -42,7 +54,7 @@ test("project ids remain stable for the same machine and canonical path", async 
 })
 
 test("an unreadable or missing configured root does not hide valid roots", async () => {
-  const root = await mkdtemp(path.join(os.tmpdir(), "harness-project-roots-"))
+  const root = await tempRoot("harness-project-roots-")
   try {
     const projects = await discoverProjects({ machineID: "machine-1", roots: [path.join(root, "missing"), root] })
     assert.equal(projects.length, 1)
@@ -53,8 +65,8 @@ test("an unreadable or missing configured root does not hide valid roots", async
 })
 
 test("symlinked children cannot escape the configured root boundary", async () => {
-  const root = await mkdtemp(path.join(os.tmpdir(), "harness-project-boundary-"))
-  const outside = await mkdtemp(path.join(os.tmpdir(), "harness-project-outside-"))
+  const root = await tempRoot("harness-project-boundary-")
+  const outside = await tempRoot("harness-project-outside-")
   try {
     await mkdir(path.join(outside, ".git"), { recursive: true })
     await symlink(outside, path.join(root, "external"), "dir")


### PR DESCRIPTION
`main` has been red since #159 landed. Every commit after it — #160, `5255f26`, #162 — carries the same failure.

## What fails

The desktop workflow runs the bridge suite on Linux, macOS and Windows. One test fails on the last two:

```
not ok 94 - an unreadable or missing configured root does not hide valid roots
  macOS:   + /private/var/folders/.../harness-project-roots-SQSZrN
           - /var/folders/.../harness-project-roots-SQSZrN
  Windows: + C:\Users\runneradmin\AppData\Local\Temp\harness-project-roots-qngl2V
           - C:\Users\RUNNER~1\AppData\Local\Temp\harness-project-roots-qngl2V
```

`project-catalog.test.js` asserted that a discovered project's path equalled the value `mkdtemp` returned. The catalog reports the **canonical** path, and the temporary directory is not canonical outside Linux: macOS hands out `/var/folders/...`, a symlink to `/private/var/folders/...`, and Windows hands out the 8.3 alias `C:\Users\RUNNER~1\...` of `C:\Users\runneradmin\...`. The assertion was checking the platform's alias, not the behaviour under test, and agreed with it only on Linux — where `/tmp` happens to be a real directory.

## Why the test moved and not the source

Canonicalizing is the correct behaviour and the reason `project-catalog.js` does it:

- a project id must not change with the route taken to reach the root, and
- `insideRoot` compares resolved paths, so a symlinked child cannot escape the configured boundary.

Reporting the raw configured path would break both. So the fix is in the test: every temporary root now goes through one helper that canonicalizes it, and the comment there records why, so the next person writing a path assertion does not have to rediscover it on a red `main`.

## Why pull-request checks did not catch it

`pr-checks.yml` ran the bridge suite on `ubuntu-latest` only. macOS and Windows appeared solely in the desktop workflow, which runs *after* the merge — this class of failure was structurally invisible before merging.

This adds a `bridge-platforms` job running the same suite on macOS and Windows. The bridge has no dependencies (`npm test` is `node --test`), so each runner costs a checkout, a Node setup and the suite — no `npm ci`, no Android SDK, no build.

## Verification

The macOS failure reproduces on Linux by pointing `TMPDIR` at a symlink — same assertion, same shape. After the change:

| | plain `TMPDIR` | symlinked `TMPDIR` |
|---|---|---|
| `bridge` suite | 175/175 | 175/175 |

The symlinked run also confirms no other test in the suite carries the same latent assumption.
