### PR TITLE
feat(web): expose task-first launch workflow

### DIFF
--- a/web/electron/machine-task-transport.test.mjs
+++ b/web/electron/machine-task-transport.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import { after, test } from 'node:test'
+
+const { executeDesktopRequest } = await import('../dist-electron/electron/request-transport.js')
+
+const seen = []
+const server = createServer((request, response) => {
+  seen.push(request.url)
+  response.setHeader('content-type', 'application/json')
+  response.end(JSON.stringify({ url: request.url }))
+})
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+const port = server.address().port
+const profile = {
+  id: 'daemon-agent-profile',
+  backend: 'codex',
+  host: '127.0.0.1',
+  port,
+  username: 'harness',
+  password: 'secret',
+  agentId: 'codex'
+}
+
+after(async () => {
+  await new Promise((resolve) => server.close(resolve))
+})
+
+test('machine task and project endpoints bypass the saved agent scope', async () => {
+  const paths = [
+    '/v1/projects',
+    '/v1/tasks',
+    '/v1/tasks/task-1/worktree',
+    '/v1/tasks/task-1/launch',
+    '/v1/tasks/task-1/result',
+    '/v1/tasks/task-1/finish'
+  ]
+  for (const path of paths) {
+    const result = await executeDesktopRequest(profile, { path })
+    assert.equal(result.response.data.url, path)
+  }
+  assert.deepEqual(seen, paths)
+})
+
+test('ordinary backend paths remain agent-scoped', async () => {
+  const result = await executeDesktopRequest(profile, { path: '/session' })
+  assert.equal(result.response.data.url, '/v1/agents/codex/session')
+})

--- a/web/electron/request-transport.ts
+++ b/web/electron/request-transport.ts
@@ -69,6 +69,15 @@ function validPath(path: unknown): path is string {
     && !/[\\\u0000-\u001f\u007f]/.test(path)
 }
 
+function isMachineScopedPath(path: string): boolean {
+  const pathname = path.split("?", 1)[0]
+  return pathname === "/v1/machine"
+    || pathname === "/global/machine"
+    || pathname === "/v1/projects"
+    || pathname === "/v1/tasks"
+    || pathname.startsWith("/v1/tasks/")
+}
+
 function targetURL(profile: DesktopProfile, path: string): URL | null {
   if (!validPath(path)) return null
   let approved: URL
@@ -77,8 +86,7 @@ function targetURL(profile: DesktopProfile, path: string): URL | null {
   } catch {
     return null
   }
-  const machineScoped = path === "/v1/machine" || path === "/global/machine"
-  const scopedPath = machineScoped ? path : agentScopedPath(profile, path)
+  const scopedPath = isMachineScopedPath(path) ? path : agentScopedPath(profile, path)
   let target: URL
   try {
     target = new URL(scopedPath, approved.origin)

--- a/web/src/components/session-list.tsx
+++ b/web/src/components/session-list.tsx
@@ -1,4 +1,4 @@
-import { useState, type PointerEvent as ReactPointerEvent, type RefObject, type ReactNode } from "react"
+import { useEffect, useMemo, useState, type PointerEvent as ReactPointerEvent, type RefObject, type ReactNode } from "react"
 import {
   CloseIcon,
   FolderIcon,
@@ -6,6 +6,7 @@ import {
   LoadingIcon,
   OfflineIcon,
   PencilIcon,
+  PlayIcon,
   PlusIcon,
   RefreshIcon,
   SaveIcon,
@@ -14,6 +15,9 @@ import {
   TrashIcon
 } from "../Icons"
 import type { Translator } from "../i18n"
+import { discoverMachine } from "../machineClient"
+import { loadActiveServerProfile, loadServerProfiles } from "../serverProfiles"
+import { taskCopy } from "../taskCopy"
 import type { HarnessCapabilities, SessionView } from "../types"
 import { TaskLaunchDialog } from "./task-launch-dialog"
 
@@ -45,6 +49,22 @@ export function formatRelativeTime(epoch: number, locale: string): string {
     if (Math.abs(deltaSeconds) >= secondsInUnit) return formatter.format(Math.round(deltaSeconds / secondsInUnit), unit)
   }
   return formatter.format(deltaSeconds, "second")
+}
+
+function useTaskLaunchAvailability(offline: boolean) {
+  const profile = useMemo(() => loadActiveServerProfile(loadServerProfiles()), [])
+  const [state, setState] = useState<"checking" | "available" | "legacy">("checking")
+  useEffect(() => {
+    if (offline) return
+    let cancelled = false
+    void discoverMachine(profile.config).then((machine) => {
+      if (!cancelled) setState(machine ? "available" : "legacy")
+    }).catch(() => {
+      if (!cancelled) setState("legacy")
+    })
+    return () => { cancelled = true }
+  }, [offline, profile])
+  return state
 }
 
 export type SessionRenameState = {
@@ -204,6 +224,9 @@ export function SessionSidebar({
   sessionCardProps: SessionCardProps
 }) {
   const [showTaskLaunch, setShowTaskLaunch] = useState(false)
+  const taskAvailability = useTaskLaunchAvailability(offline)
+  const taskEnabled = !offline && taskAvailability === "available"
+  const taskTitle = offline ? t('sessions.offlineHint') : taskEnabled ? taskCopy(sessionCardProps.language, "newTask") : taskCopy(sessionCardProps.language, "requiresDaemon")
   return (
     <>
       <aside className="desktop-sidebar fade-in" style={{ width, flex: `0 0 ${width}px` }}>
@@ -213,10 +236,10 @@ export function SessionSidebar({
           <button onClick={onRefresh} className="btn-secondary" disabled={refreshing} aria-label={t('sessions.refresh')} title={t('sessions.refresh')}>
             {refreshing ? <LoadingIcon size={16} /> : <RefreshIcon size={16} />}
           </button>
-          <button onClick={() => setShowTaskLaunch(true)} className="btn-primary" disabled={offline} aria-label="New task" title={offline ? t('sessions.offlineHint') : "New task"}>
-            <PlusIcon size={16} /><span className="sidebar-footer-label">Task</span>
+          <button onClick={() => setShowTaskLaunch(true)} className={taskEnabled ? "btn-primary" : "btn-secondary"} disabled={!taskEnabled} aria-label={taskCopy(sessionCardProps.language, "newTask")} title={taskTitle}>
+            <PlayIcon size={16} />
           </button>
-          <button onClick={onNewSession} className="btn-secondary" disabled={creating || offline} aria-label={t('sessions.new')} title={offline ? t('sessions.offlineHint') : t('sessions.new')}>
+          <button onClick={onNewSession} className={taskEnabled ? "btn-secondary" : "btn-primary"} disabled={creating || offline} aria-label={t('sessions.new')} title={offline ? t('sessions.offlineHint') : t('sessions.new')}>
             {creating ? <LoadingIcon size={16} /> : <PlusIcon size={16} />}
           </button>
         </div>
@@ -234,7 +257,7 @@ export function SessionSidebar({
           <button type="button" className="btn-secondary" onClick={onShowSettings} title={t('nav.settings')}><SettingsIcon size={18} /><span className="sidebar-footer-label">{t('nav.settings')}</span></button>
         </div>
       </aside>
-      {showTaskLaunch && <TaskLaunchDialog t={t} onClose={() => setShowTaskLaunch(false)} onLaunched={onRefresh} />}
+      {showTaskLaunch && <TaskLaunchDialog t={t} language={sessionCardProps.language} onClose={() => setShowTaskLaunch(false)} onLaunched={onRefresh} />}
     </>
   )
 }
@@ -283,6 +306,9 @@ export function SessionsPanel({
   sessionCardProps: SessionCardProps
 }) {
   const [showTaskLaunch, setShowTaskLaunch] = useState(false)
+  const taskAvailability = useTaskLaunchAvailability(offline)
+  const taskEnabled = !offline && taskAvailability === "available"
+  const taskTitle = offline ? t('sessions.offlineHint') : taskEnabled ? taskCopy(sessionCardProps.language, "newTask") : taskCopy(sessionCardProps.language, "requiresDaemon")
   return (
     <>
       <section className="panel sessions fade-in">
@@ -297,8 +323,8 @@ export function SessionsPanel({
           </div>
           <div className="inline-actions sessions-header-actions">
             <button onClick={onRefresh} className="btn-secondary" disabled={refreshing}>{refreshing ? <LoadingIcon size={18} /> : <RefreshIcon size={18} />}{t('sessions.refresh')}</button>
-            <button onClick={() => setShowTaskLaunch(true)} className="btn-primary" disabled={offline} title={offline ? t('sessions.offlineHint') : "Start a new task"}><PlusIcon size={18} />New Task</button>
-            <button onClick={onNewSession} className="btn-secondary" disabled={creating || offline} title={offline ? t('sessions.offlineHint') : undefined}>{creating ? <LoadingIcon size={18} /> : <PlusIcon size={18} />}{creating ? t('sessions.creating') : t('sessions.new')}</button>
+            <button onClick={() => setShowTaskLaunch(true)} className={taskEnabled ? "btn-primary" : "btn-secondary"} disabled={!taskEnabled} title={taskTitle}><PlayIcon size={18} />{taskCopy(sessionCardProps.language, "newTask")}</button>
+            <button onClick={onNewSession} className={taskEnabled ? "btn-secondary" : "btn-primary"} disabled={creating || offline} title={offline ? t('sessions.offlineHint') : undefined}>{creating ? <LoadingIcon size={18} /> : <PlusIcon size={18} />}{creating ? t('sessions.creating') : t('sessions.new')}</button>
           </div>
         </div>
         <div className="toolbar"><input placeholder={t('sessions.searchPlaceholder')} value={query} onChange={(event) => onQueryChange(event.target.value)} className="search" /></div>
@@ -311,7 +337,7 @@ export function SessionsPanel({
         {runtimeError && !(offline && filteredSessions.length === 0) && <div className="error fade-in">✗ {runtimeError}</div>}
         {jumpControls}
       </section>
-      {showTaskLaunch && <TaskLaunchDialog t={t} onClose={() => setShowTaskLaunch(false)} onLaunched={onRefresh} />}
+      {showTaskLaunch && <TaskLaunchDialog t={t} language={sessionCardProps.language} onClose={() => setShowTaskLaunch(false)} onLaunched={onRefresh} />}
     </>
   )
 }

--- a/web/src/components/session-list.tsx
+++ b/web/src/components/session-list.tsx
@@ -1,4 +1,4 @@
-import type { PointerEvent as ReactPointerEvent, RefObject, ReactNode } from "react"
+import { useState, type PointerEvent as ReactPointerEvent, type RefObject, type ReactNode } from "react"
 import {
   CloseIcon,
   FolderIcon,
@@ -15,6 +15,7 @@ import {
 } from "../Icons"
 import type { Translator } from "../i18n"
 import type { HarnessCapabilities, SessionView } from "../types"
+import { TaskLaunchDialog } from "./task-launch-dialog"
 
 export function shortDirectory(directory: string): string {
   const segments = directory.split(/[\\/]+/).filter(Boolean)
@@ -202,32 +203,39 @@ export function SessionSidebar({
   jumpControls: ReactNode
   sessionCardProps: SessionCardProps
 }) {
+  const [showTaskLaunch, setShowTaskLaunch] = useState(false)
   return (
-    <aside className="desktop-sidebar fade-in" style={{ width, flex: `0 0 ${width}px` }}>
-      <div className="resize-handle resize-handle--end" onPointerDown={onResize} role="separator" aria-orientation="vertical" aria-label="Resize panels" />
-      <div className="sidebar-toolbar">
-        <div className="search-field"><SearchIcon size={14} /><input ref={searchInputRef} placeholder={t('sessions.searchPlaceholder')} value={query} onChange={(event) => onQueryChange(event.target.value)} className="search" /></div>
-        <button onClick={onRefresh} className="btn-secondary" disabled={refreshing} aria-label={t('sessions.refresh')} title={t('sessions.refresh')}>
-          {refreshing ? <LoadingIcon size={16} /> : <RefreshIcon size={16} />}
-        </button>
-        <button onClick={onNewSession} className="btn-primary" disabled={creating || offline} aria-label={t('sessions.new')} title={offline ? t('sessions.offlineHint') : t('sessions.new')}>
-          {creating ? <LoadingIcon size={16} /> : <PlusIcon size={16} />}
-        </button>
-      </div>
-      <div className="sidebar-sessions" ref={sidebarSessionsRef} onScroll={onScroll}>
-        {groups.length === 0 ? <p className="subtle sidebar-empty">{offline ? t('sessions.offlineHint') : t('sessions.emptyTitle')}</p> : groups.map((group) => (
-          <section key={group.directory} className="sidebar-group">
-            <div className="sidebar-group-label" title={group.directory}><FolderIcon size={12} /><span>{projectLabel(group.directory)}</span><span className="sidebar-group-count">{group.sessions.length}</span></div>
-            {group.sessions.map((session) => <SessionCard key={session.id} session={session} {...sessionCardProps} />)}
-          </section>
-        ))}
-      </div>
-      {jumpControls}
-      <div className="sidebar-footer">
-        <button type="button" className="btn-secondary" onClick={onShowHelp} title={t('nav.help')}><HelpIcon size={18} /><span className="sidebar-footer-label">{t('nav.help')}</span></button>
-        <button type="button" className="btn-secondary" onClick={onShowSettings} title={t('nav.settings')}><SettingsIcon size={18} /><span className="sidebar-footer-label">{t('nav.settings')}</span></button>
-      </div>
-    </aside>
+    <>
+      <aside className="desktop-sidebar fade-in" style={{ width, flex: `0 0 ${width}px` }}>
+        <div className="resize-handle resize-handle--end" onPointerDown={onResize} role="separator" aria-orientation="vertical" aria-label="Resize panels" />
+        <div className="sidebar-toolbar">
+          <div className="search-field"><SearchIcon size={14} /><input ref={searchInputRef} placeholder={t('sessions.searchPlaceholder')} value={query} onChange={(event) => onQueryChange(event.target.value)} className="search" /></div>
+          <button onClick={onRefresh} className="btn-secondary" disabled={refreshing} aria-label={t('sessions.refresh')} title={t('sessions.refresh')}>
+            {refreshing ? <LoadingIcon size={16} /> : <RefreshIcon size={16} />}
+          </button>
+          <button onClick={() => setShowTaskLaunch(true)} className="btn-primary" disabled={offline} aria-label="New task" title={offline ? t('sessions.offlineHint') : "New task"}>
+            <PlusIcon size={16} /><span className="sidebar-footer-label">Task</span>
+          </button>
+          <button onClick={onNewSession} className="btn-secondary" disabled={creating || offline} aria-label={t('sessions.new')} title={offline ? t('sessions.offlineHint') : t('sessions.new')}>
+            {creating ? <LoadingIcon size={16} /> : <PlusIcon size={16} />}
+          </button>
+        </div>
+        <div className="sidebar-sessions" ref={sidebarSessionsRef} onScroll={onScroll}>
+          {groups.length === 0 ? <p className="subtle sidebar-empty">{offline ? t('sessions.offlineHint') : t('sessions.emptyTitle')}</p> : groups.map((group) => (
+            <section key={group.directory} className="sidebar-group">
+              <div className="sidebar-group-label" title={group.directory}><FolderIcon size={12} /><span>{projectLabel(group.directory)}</span><span className="sidebar-group-count">{group.sessions.length}</span></div>
+              {group.sessions.map((session) => <SessionCard key={session.id} session={session} {...sessionCardProps} />)}
+            </section>
+          ))}
+        </div>
+        {jumpControls}
+        <div className="sidebar-footer">
+          <button type="button" className="btn-secondary" onClick={onShowHelp} title={t('nav.help')}><HelpIcon size={18} /><span className="sidebar-footer-label">{t('nav.help')}</span></button>
+          <button type="button" className="btn-secondary" onClick={onShowSettings} title={t('nav.settings')}><SettingsIcon size={18} /><span className="sidebar-footer-label">{t('nav.settings')}</span></button>
+        </div>
+      </aside>
+      {showTaskLaunch && <TaskLaunchDialog t={t} onClose={() => setShowTaskLaunch(false)} onLaunched={onRefresh} />}
+    </>
   )
 }
 
@@ -274,31 +282,36 @@ export function SessionsPanel({
   jumpControls: ReactNode
   sessionCardProps: SessionCardProps
 }) {
+  const [showTaskLaunch, setShowTaskLaunch] = useState(false)
   return (
-    <section className="panel sessions fade-in">
-      <div className="section-heading">
-        <div>
-          <h2>{t('sessions.title')}</h2>
-          <p className="subtle">{t('sessions.summary', { total: sessions.length, active: activeSessions, changed: changedSessions })}</p>
-          {(connectionStatusText || eventStreamText) && <div className="connection-status-row">
-            {connectionStatusText && <p className={`connection-status ${connectionState}`}>{['connecting', 'reconnecting'].includes(connectionState) && <LoadingIcon size={14} />}{connectionStatusText}</p>}
-            {eventStreamText && <p className={`connection-status event-stream ${eventStreamState}`}>{['connecting', 'reconnecting'].includes(eventStreamState) && <LoadingIcon size={14} />}{eventStreamText}</p>}
-          </div>}
+    <>
+      <section className="panel sessions fade-in">
+        <div className="section-heading">
+          <div>
+            <h2>{t('sessions.title')}</h2>
+            <p className="subtle">{t('sessions.summary', { total: sessions.length, active: activeSessions, changed: changedSessions })}</p>
+            {(connectionStatusText || eventStreamText) && <div className="connection-status-row">
+              {connectionStatusText && <p className={`connection-status ${connectionState}`}>{['connecting', 'reconnecting'].includes(connectionState) && <LoadingIcon size={14} />}{connectionStatusText}</p>}
+              {eventStreamText && <p className={`connection-status event-stream ${eventStreamState}`}>{['connecting', 'reconnecting'].includes(eventStreamState) && <LoadingIcon size={14} />}{eventStreamText}</p>}
+            </div>}
+          </div>
+          <div className="inline-actions sessions-header-actions">
+            <button onClick={onRefresh} className="btn-secondary" disabled={refreshing}>{refreshing ? <LoadingIcon size={18} /> : <RefreshIcon size={18} />}{t('sessions.refresh')}</button>
+            <button onClick={() => setShowTaskLaunch(true)} className="btn-primary" disabled={offline} title={offline ? t('sessions.offlineHint') : "Start a new task"}><PlusIcon size={18} />New Task</button>
+            <button onClick={onNewSession} className="btn-secondary" disabled={creating || offline} title={offline ? t('sessions.offlineHint') : undefined}>{creating ? <LoadingIcon size={18} /> : <PlusIcon size={18} />}{creating ? t('sessions.creating') : t('sessions.new')}</button>
+          </div>
         </div>
-        <div className="inline-actions sessions-header-actions">
-          <button onClick={onRefresh} className="btn-secondary" disabled={refreshing}>{refreshing ? <LoadingIcon size={18} /> : <RefreshIcon size={18} />}{t('sessions.refresh')}</button>
-          <button onClick={onNewSession} className="btn-primary" disabled={creating || offline} title={offline ? t('sessions.offlineHint') : undefined}>{creating ? <LoadingIcon size={18} /> : <PlusIcon size={18} />}{creating ? t('sessions.creating') : t('sessions.new')}</button>
+        <div className="toolbar"><input placeholder={t('sessions.searchPlaceholder')} value={query} onChange={(event) => onQueryChange(event.target.value)} className="search" /></div>
+        <div className="session-list">
+          {filteredSessions.length === 0 && offline ? <div className="empty-state"><OfflineIcon size={44} className="icon-empty-state" /><p>{t('sessions.offlineHint')}</p><div className="empty-state-actions"><button type="button" className="btn-primary" onClick={onRefresh} disabled={refreshing}>{refreshing ? <LoadingIcon size={18} /> : <RefreshIcon size={18} />}{t('sessions.retry')}</button><button type="button" className="btn-secondary" onClick={onShowSettings}><SettingsIcon size={18} />{t('nav.settings')}</button></div></div>
+            : filteredSessions.length === 0 && ['connecting', 'reconnecting'].includes(connectionState) ? <div className="empty-state connection-pending"><LoadingIcon size={40} className="icon-empty-state" /><p>{t('sessions.loadingTitle')}</p><p className="subtle">{t('sessions.loadingHint')}</p></div>
+            : filteredSessions.length === 0 ? <div className="empty-state"><FolderIcon size={48} className="icon-empty-state" /><p>{t('sessions.emptyTitle')}</p><p className="subtle">{t('sessions.emptyHint')}</p></div>
+            : filteredSessions.map((session) => <SessionCard key={session.id} session={session} {...sessionCardProps} />)}
         </div>
-      </div>
-      <div className="toolbar"><input placeholder={t('sessions.searchPlaceholder')} value={query} onChange={(event) => onQueryChange(event.target.value)} className="search" /></div>
-      <div className="session-list">
-        {filteredSessions.length === 0 && offline ? <div className="empty-state"><OfflineIcon size={44} className="icon-empty-state" /><p>{t('sessions.offlineHint')}</p><div className="empty-state-actions"><button type="button" className="btn-primary" onClick={onRefresh} disabled={refreshing}>{refreshing ? <LoadingIcon size={18} /> : <RefreshIcon size={18} />}{t('sessions.retry')}</button><button type="button" className="btn-secondary" onClick={onShowSettings}><SettingsIcon size={18} />{t('nav.settings')}</button></div></div>
-          : filteredSessions.length === 0 && ['connecting', 'reconnecting'].includes(connectionState) ? <div className="empty-state connection-pending"><LoadingIcon size={40} className="icon-empty-state" /><p>{t('sessions.loadingTitle')}</p><p className="subtle">{t('sessions.loadingHint')}</p></div>
-          : filteredSessions.length === 0 ? <div className="empty-state"><FolderIcon size={48} className="icon-empty-state" /><p>{t('sessions.emptyTitle')}</p><p className="subtle">{t('sessions.emptyHint')}</p></div>
-          : filteredSessions.map((session) => <SessionCard key={session.id} session={session} {...sessionCardProps} />)}
-      </div>
-      {runtimeError && !(offline && filteredSessions.length === 0) && <div className="error fade-in">✗ {runtimeError}</div>}
-      {jumpControls}
-    </section>
+        {runtimeError && !(offline && filteredSessions.length === 0) && <div className="error fade-in">✗ {runtimeError}</div>}
+        {jumpControls}
+      </section>
+      {showTaskLaunch && <TaskLaunchDialog t={t} onClose={() => setShowTaskLaunch(false)} onLaunched={onRefresh} />}
+    </>
   )
 }

--- a/web/src/components/task-launch-dialog.tsx
+++ b/web/src/components/task-launch-dialog.tsx
@@ -2,12 +2,14 @@ import { useEffect, useMemo, useState } from "react"
 import { CloseIcon, FolderIcon, LoadingIcon, PlusIcon, ServerIcon } from "../Icons"
 import { discoverMachine, selectableMachineAgents } from "../machineClient"
 import { loadActiveServerProfile, loadServerProfiles } from "../serverProfiles"
+import { taskCopy } from "../taskCopy"
 import { taskClient, type MachineProject } from "../taskClient"
 import type { Translator } from "../i18n"
 import type { MachineSnapshot, ServerConfig } from "../types"
 
-export function TaskLaunchDialog({ t, onClose, onLaunched }: {
+export function TaskLaunchDialog({ t, language, onClose, onLaunched }: {
   t: Translator
+  language: string
   onClose: () => void
   onLaunched: () => void
 }) {
@@ -25,8 +27,6 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
 
   const selectedProject = projects.find((project) => project.id === projectId)
   const availableAgents = machine ? selectableMachineAgents(machine) : []
-  // The current sessions surface is scoped to the active saved profile. New machine profiles carry
-  // agentId; migrated legacy profiles do not, so fall back to the profile backend in that case.
   const profileAgent = availableAgents.find((agent) => config.agentId ? agent.id === config.agentId : agent.backend === config.backend)
   const agents = profileAgent ? [profileAgent] : []
   const canStart = Boolean(projectId && agentId && prompt.trim()) && !starting
@@ -38,14 +38,14 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
       setError(null)
       try {
         const discovered = await discoverMachine(config)
-        if (!discovered) throw new Error("Task launch requires a Harness machine daemon.")
+        if (!discovered) throw new Error(taskCopy(language, "requiresDaemon"))
         const knownProjects = await taskClient.listProjects(config)
         if (cancelled) return
         const selectable = selectableMachineAgents(discovered)
         const activeAgent = selectable.find((agent) => config.agentId ? agent.id === config.agentId : agent.backend === config.backend)
         if (!activeAgent) {
           const label = config.agentId ?? config.backend
-          throw new Error(`The active agent ${label} is unavailable on this machine.`)
+          throw new Error(taskCopy(language, "agentUnavailable", { agent: label }))
         }
         setMachine(discovered)
         setProjects(knownProjects)
@@ -58,7 +58,7 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
       }
     })()
     return () => { cancelled = true }
-  }, [config])
+  }, [config, language])
 
   async function start() {
     if (!canStart) return
@@ -77,63 +77,68 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
     }
   }
 
+  const machineName = machine?.machine.name ?? profile.name
+
   return (
     <div className="modal-backdrop" role="presentation" onClick={onClose}>
       <section className="modal-card wizard fade-in" role="dialog" aria-modal="true" aria-labelledby="new-task-title" onClick={(event) => event.stopPropagation()}>
         <div className="wizard-header">
           <div className="wizard-header-text">
-            <h2 id="new-task-title">New Task</h2>
-            <p className="subtle">Start isolated agent work on {machine?.machine.name ?? profile.name}.</p>
+            <h2 id="new-task-title">{taskCopy(language, "newTask")}</h2>
+            <p className="subtle">{taskCopy(language, "subtitle", { machine: machineName })}</p>
           </div>
           <button type="button" className="btn-icon btn-ghost" onClick={onClose} aria-label={t('session.cancel')}><CloseIcon size={16} /></button>
         </div>
 
         <div className="wizard-body">
           {loading ? (
-            <div className="empty-state compact"><LoadingIcon size={26} /><p>Loading machine projects and agents…</p></div>
+            <div className="empty-state compact"><LoadingIcon size={26} /><p>{taskCopy(language, "loading")}</p></div>
+          ) : error ? (
+            <div className="error fade-in">✗ {error}</div>
+          ) : projects.length === 0 ? (
+            <div className="empty-state compact"><FolderIcon size={30} /><p>{taskCopy(language, "noProjects")}</p></div>
           ) : (
             <>
+              <div className="folder-picker-current">
+                <span className="eyebrow">{taskCopy(language, "machine")}</span>
+                <strong><ServerIcon size={15} /> {machineName}</strong>
+              </div>
+
               <label className="field">
-                <span>Project</span>
-                <select value={projectId} onChange={(event) => setProjectId(event.target.value)} disabled={projects.length === 0}>
+                <span>{taskCopy(language, "project")}</span>
+                <select value={projectId} onChange={(event) => setProjectId(event.target.value)}>
                   {projects.map((project) => <option key={project.id} value={project.id}>{project.name} — {project.path}</option>)}
                 </select>
               </label>
 
               <label className="field">
-                <span>Task</span>
-                <textarea value={prompt} onChange={(event) => setPrompt(event.target.value)} placeholder="Describe the work the agent should complete…" rows={5} autoFocus />
-              </label>
-
-              <label className="field">
-                <span>Agent</span>
+                <span>{taskCopy(language, "agent")}</span>
                 <select value={agentId} onChange={(event) => setAgentId(event.target.value)} disabled={agents.length === 0}>
                   {agents.map((agent) => <option key={agent.id} value={agent.id}>{agent.label}</option>)}
                 </select>
               </label>
-              {availableAgents.length > 1 && <p className="subtle">This task stays on the active agent profile so its launched session opens in the existing session workflow. Cross-agent placement arrives with Fleet.</p>}
+              {availableAgents.length > 1 && <p className="subtle">{taskCopy(language, "activeAgent")}</p>}
 
-              <div className="folder-picker-current">
-                <span className="eyebrow">Machine</span>
-                <strong><ServerIcon size={15} /> {machine?.machine.name ?? "Harness daemon"}</strong>
-              </div>
+              <label className="field">
+                <span>{taskCopy(language, "task")}</span>
+                <textarea value={prompt} onChange={(event) => setPrompt(event.target.value)} placeholder={taskCopy(language, "promptPlaceholder")} rows={5} autoFocus />
+              </label>
 
               <label className="field" style={{ flexDirection: "row", alignItems: "center", gap: "0.65rem" }}>
                 <input type="checkbox" checked={isolated} onChange={(event) => setIsolated(event.target.checked)} disabled={selectedProject?.kind !== "git"} />
-                <span><FolderIcon size={14} /> Use a new isolated Git worktree</span>
+                <span><FolderIcon size={14} /> {taskCopy(language, "isolatedWorktree")}</span>
               </label>
-              {selectedProject?.kind !== "git" && <p className="subtle">This project is not a Git repository, so the task will run in the project directory.</p>}
+              {selectedProject?.kind !== "git" && <p className="subtle">{taskCopy(language, "nonGit")}</p>}
             </>
           )}
-          {error && <div className="error fade-in">✗ {error}</div>}
         </div>
 
         <div className="wizard-footer">
           <span className="spacer" />
           <button type="button" className="btn-secondary" onClick={onClose}>{t('session.cancel')}</button>
-          <button type="button" className="btn-primary" disabled={!canStart || loading} onClick={() => void start()}>
+          <button type="button" className="btn-primary" disabled={!canStart || loading || Boolean(error) || projects.length === 0} onClick={() => void start()}>
             {starting ? <LoadingIcon size={15} /> : <PlusIcon size={15} />}
-            {starting ? "Starting…" : "Start Task"}
+            {starting ? taskCopy(language, "starting") : taskCopy(language, "startTask")}
           </button>
         </div>
       </section>

--- a/web/src/components/task-launch-dialog.tsx
+++ b/web/src/components/task-launch-dialog.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useMemo, useState } from "react"
+import { CloseIcon, FolderIcon, LoadingIcon, PlusIcon, ServerIcon } from "../Icons"
+import { discoverMachine, selectableMachineAgents } from "../machineClient"
+import { loadActiveServerProfile, loadServerProfiles } from "../serverProfiles"
+import { taskClient, type MachineProject } from "../taskClient"
+import type { Translator } from "../i18n"
+import type { MachineSnapshot, ServerConfig } from "../types"
+
+export function TaskLaunchDialog({ t, onClose, onLaunched }: {
+  t: Translator
+  onClose: () => void
+  onLaunched: () => void
+}) {
+  const profile = useMemo(() => loadActiveServerProfile(loadServerProfiles()), [])
+  const config: ServerConfig = profile.config
+  const [machine, setMachine] = useState<MachineSnapshot | null>(null)
+  const [projects, setProjects] = useState<MachineProject[]>([])
+  const [projectId, setProjectId] = useState("")
+  const [agentId, setAgentId] = useState("")
+  const [prompt, setPrompt] = useState("")
+  const [isolated, setIsolated] = useState(true)
+  const [loading, setLoading] = useState(true)
+  const [starting, setStarting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const selectedProject = projects.find((project) => project.id === projectId)
+  const agents = machine ? selectableMachineAgents(machine) : []
+  const canStart = Boolean(projectId && agentId && prompt.trim()) && !starting
+
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const discovered = await discoverMachine(config)
+        if (!discovered) throw new Error("Task launch requires a Harness machine daemon.")
+        const knownProjects = await taskClient.listProjects(config)
+        if (cancelled) return
+        setMachine(discovered)
+        setProjects(knownProjects)
+        setProjectId(knownProjects[0]?.id ?? "")
+        const preferred = selectableMachineAgents(discovered).find((agent) => agent.id === config.agentId)
+          ?? selectableMachineAgents(discovered)[0]
+        setAgentId(preferred?.id ?? "")
+      } catch (cause) {
+        if (!cancelled) setError(cause instanceof Error ? cause.message : String(cause))
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => { cancelled = true }
+  }, [config])
+
+  async function start() {
+    if (!canStart) return
+    setStarting(true)
+    setError(null)
+    try {
+      let task = await taskClient.createTask(config, { projectId, agentId, prompt: prompt.trim() })
+      if (isolated && selectedProject?.kind === "git") task = await taskClient.prepareWorktree(config, task.id)
+      await taskClient.launch(config, task.id)
+      onLaunched()
+      onClose()
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause))
+    } finally {
+      setStarting(false)
+    }
+  }
+
+  return (
+    <div className="modal-backdrop" role="presentation" onClick={onClose}>
+      <section className="modal-card wizard fade-in" role="dialog" aria-modal="true" aria-labelledby="new-task-title" onClick={(event) => event.stopPropagation()}>
+        <div className="wizard-header">
+          <div className="wizard-header-text">
+            <h2 id="new-task-title">New Task</h2>
+            <p className="subtle">Start isolated agent work on {machine?.machine.name ?? profile.name}.</p>
+          </div>
+          <button type="button" className="btn-icon btn-ghost" onClick={onClose} aria-label={t('session.cancel')}><CloseIcon size={16} /></button>
+        </div>
+
+        <div className="wizard-body">
+          {loading ? (
+            <div className="empty-state compact"><LoadingIcon size={26} /><p>Loading machine projects and agents…</p></div>
+          ) : (
+            <>
+              <label className="field">
+                <span>Project</span>
+                <select value={projectId} onChange={(event) => setProjectId(event.target.value)} disabled={projects.length === 0}>
+                  {projects.map((project) => <option key={project.id} value={project.id}>{project.name} — {project.path}</option>)}
+                </select>
+              </label>
+
+              <label className="field">
+                <span>Task</span>
+                <textarea value={prompt} onChange={(event) => setPrompt(event.target.value)} placeholder="Describe the work the agent should complete…" rows={5} autoFocus />
+              </label>
+
+              <label className="field">
+                <span>Agent</span>
+                <select value={agentId} onChange={(event) => setAgentId(event.target.value)} disabled={agents.length === 0}>
+                  {agents.map((agent) => <option key={agent.id} value={agent.id}>{agent.label}</option>)}
+                </select>
+              </label>
+
+              <div className="folder-picker-current">
+                <span className="eyebrow">Machine</span>
+                <strong><ServerIcon size={15} /> {machine?.machine.name ?? "Harness daemon"}</strong>
+              </div>
+
+              <label className="field" style={{ flexDirection: "row", alignItems: "center", gap: "0.65rem" }}>
+                <input type="checkbox" checked={isolated} onChange={(event) => setIsolated(event.target.checked)} disabled={selectedProject?.kind !== "git"} />
+                <span><FolderIcon size={14} /> Use a new isolated Git worktree</span>
+              </label>
+              {selectedProject?.kind !== "git" && <p className="subtle">This project is not a Git repository, so the task will run in the project directory.</p>}
+            </>
+          )}
+          {error && <div className="error fade-in">✗ {error}</div>}
+        </div>
+
+        <div className="wizard-footer">
+          <span className="spacer" />
+          <button type="button" className="btn-secondary" onClick={onClose}>{t('session.cancel')}</button>
+          <button type="button" className="btn-primary" disabled={!canStart || loading} onClick={() => void start()}>
+            {starting ? <LoadingIcon size={15} /> : <PlusIcon size={15} />}
+            {starting ? "Starting…" : "Start Task"}
+          </button>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/web/src/components/task-launch-dialog.tsx
+++ b/web/src/components/task-launch-dialog.tsx
@@ -24,7 +24,13 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
   const [error, setError] = useState<string | null>(null)
 
   const selectedProject = projects.find((project) => project.id === projectId)
-  const agents = machine ? selectableMachineAgents(machine) : []
+  const availableAgents = machine ? selectableMachineAgents(machine) : []
+  // The current sessions surface is still scoped to the active saved agent profile. Until the fleet
+  // UI can switch machine/agent context as part of task launch, do not let a task start on an agent
+  // whose resulting session would immediately disappear from the screen that launched it.
+  const agents = config.agentId
+    ? availableAgents.filter((agent) => agent.id === config.agentId)
+    : availableAgents
   const canStart = Boolean(projectId && agentId && prompt.trim()) && !starting
 
   useEffect(() => {
@@ -37,11 +43,13 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
         if (!discovered) throw new Error("Task launch requires a Harness machine daemon.")
         const knownProjects = await taskClient.listProjects(config)
         if (cancelled) return
+        const selectable = selectableMachineAgents(discovered)
+        const profileAgent = config.agentId ? selectable.find((agent) => agent.id === config.agentId) : undefined
+        const preferred = profileAgent ?? selectable[0]
+        if (config.agentId && !profileAgent) throw new Error(`The active agent ${config.agentId} is unavailable on this machine.`)
         setMachine(discovered)
         setProjects(knownProjects)
         setProjectId(knownProjects[0]?.id ?? "")
-        const preferred = selectableMachineAgents(discovered).find((agent) => agent.id === config.agentId)
-          ?? selectableMachineAgents(discovered)[0]
         setAgentId(preferred?.id ?? "")
       } catch (cause) {
         if (!cancelled) setError(cause instanceof Error ? cause.message : String(cause))
@@ -103,6 +111,7 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
                   {agents.map((agent) => <option key={agent.id} value={agent.id}>{agent.label}</option>)}
                 </select>
               </label>
+              {config.agentId && availableAgents.length > 1 && <p className="subtle">This task stays on the active agent profile so its launched session opens in the existing session workflow. Cross-agent placement arrives with Fleet.</p>}
 
               <div className="folder-picker-current">
                 <span className="eyebrow">Machine</span>

--- a/web/src/components/task-launch-dialog.tsx
+++ b/web/src/components/task-launch-dialog.tsx
@@ -25,12 +25,10 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
 
   const selectedProject = projects.find((project) => project.id === projectId)
   const availableAgents = machine ? selectableMachineAgents(machine) : []
-  // The current sessions surface is still scoped to the active saved agent profile. Until the fleet
-  // UI can switch machine/agent context as part of task launch, do not let a task start on an agent
-  // whose resulting session would immediately disappear from the screen that launched it.
-  const agents = config.agentId
-    ? availableAgents.filter((agent) => agent.id === config.agentId)
-    : availableAgents
+  // The current sessions surface is scoped to the active saved profile. New machine profiles carry
+  // agentId; migrated legacy profiles do not, so fall back to the profile backend in that case.
+  const profileAgent = availableAgents.find((agent) => config.agentId ? agent.id === config.agentId : agent.backend === config.backend)
+  const agents = profileAgent ? [profileAgent] : []
   const canStart = Boolean(projectId && agentId && prompt.trim()) && !starting
 
   useEffect(() => {
@@ -44,13 +42,15 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
         const knownProjects = await taskClient.listProjects(config)
         if (cancelled) return
         const selectable = selectableMachineAgents(discovered)
-        const profileAgent = config.agentId ? selectable.find((agent) => agent.id === config.agentId) : undefined
-        const preferred = profileAgent ?? selectable[0]
-        if (config.agentId && !profileAgent) throw new Error(`The active agent ${config.agentId} is unavailable on this machine.`)
+        const activeAgent = selectable.find((agent) => config.agentId ? agent.id === config.agentId : agent.backend === config.backend)
+        if (!activeAgent) {
+          const label = config.agentId ?? config.backend
+          throw new Error(`The active agent ${label} is unavailable on this machine.`)
+        }
         setMachine(discovered)
         setProjects(knownProjects)
         setProjectId(knownProjects[0]?.id ?? "")
-        setAgentId(preferred?.id ?? "")
+        setAgentId(activeAgent.id)
       } catch (cause) {
         if (!cancelled) setError(cause instanceof Error ? cause.message : String(cause))
       } finally {
@@ -111,7 +111,7 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
                   {agents.map((agent) => <option key={agent.id} value={agent.id}>{agent.label}</option>)}
                 </select>
               </label>
-              {config.agentId && availableAgents.length > 1 && <p className="subtle">This task stays on the active agent profile so its launched session opens in the existing session workflow. Cross-agent placement arrives with Fleet.</p>}
+              {availableAgents.length > 1 && <p className="subtle">This task stays on the active agent profile so its launched session opens in the existing session workflow. Cross-agent placement arrives with Fleet.</p>}
 
               <div className="folder-picker-current">
                 <span className="eyebrow">Machine</span>

--- a/web/src/taskClient.ts
+++ b/web/src/taskClient.ts
@@ -1,0 +1,123 @@
+import { Capacitor, CapacitorHttp } from "@capacitor/core"
+import { desktopRequestResult, isDesktopPlatform } from "./desktopBridge"
+import { authHeader, hasCredentials, machineBaseUrl } from "./serverConfig"
+import type { ServerConfig } from "./types"
+
+export type MachineProject = {
+  id: string
+  machineId: string
+  name: string
+  path: string
+  kind: "git" | "directory" | string
+  configured?: boolean
+}
+
+export type TaskWorkspace = {
+  mode: "project" | "worktree" | string
+  path: string
+  branch?: string
+  source?: string
+}
+
+export type MachineTask = {
+  id: string
+  machineId: string
+  projectId: string
+  project: { name: string; path: string; kind: string }
+  agentId: string
+  prompt: string
+  status: string
+  workspace: TaskWorkspace
+  run: null | { id?: string; sessionId?: string; sessionID?: string; status?: string }
+  createdAt: string
+  updatedAt: string
+}
+
+type TaskRequestOptions = {
+  method?: "GET" | "POST"
+  body?: unknown
+}
+
+function requestHeaders(config: ServerConfig, body: boolean): Record<string, string> {
+  const headers: Record<string, string> = { Accept: "application/json" }
+  if (hasCredentials(config)) headers.Authorization = authHeader(config)
+  if (body) headers["Content-Type"] = "application/json"
+  return headers
+}
+
+function responseDetail(value: unknown, fallback: string): string {
+  if (!value) return fallback
+  if (typeof value === "string") {
+    try { return responseDetail(JSON.parse(value), fallback) } catch { return value || fallback }
+  }
+  if (typeof value === "object") {
+    const candidate = value as { error?: unknown; message?: unknown }
+    if (typeof candidate.error === "string") return candidate.error
+    if (typeof candidate.message === "string") return candidate.message
+  }
+  return fallback
+}
+
+async function machineRequest<T>(config: ServerConfig, path: string, options: TaskRequestOptions = {}): Promise<T> {
+  const method = options.method ?? "GET"
+  if (isDesktopPlatform()) {
+    const result = await desktopRequestResult(config, { path, method, body: options.body })
+    if (!result.ok) throw new Error(result.error.message)
+    return result.response.data as T
+  }
+
+  const target = `${machineBaseUrl(config)}${path}`
+  const headers = requestHeaders(config, options.body !== undefined)
+  if (Capacitor.isNativePlatform()) {
+    let response
+    try {
+      response = await CapacitorHttp.request({
+        url: target,
+        method,
+        headers,
+        data: options.body,
+        connectTimeout: 12_000,
+        readTimeout: 30_000
+      })
+    } catch {
+      throw new Error(`Cannot reach ${config.host}:${config.port}.`)
+    }
+    if (response.status >= 400) throw new Error(responseDetail(response.data, `HTTP ${response.status}`))
+    return response.data as T
+  }
+
+  let response: Response
+  try {
+    response = await fetch(target, {
+      method,
+      headers,
+      body: options.body === undefined ? undefined : JSON.stringify(options.body)
+    })
+  } catch {
+    throw new Error(`Cannot reach ${config.host}:${config.port}.`)
+  }
+  if (!response.ok) {
+    let detail = `HTTP ${response.status}`
+    try { detail = responseDetail(await response.text(), detail) } catch { /* keep status */ }
+    throw new Error(detail)
+  }
+  return await response.json() as T
+}
+
+export const taskClient = {
+  async listProjects(config: ServerConfig): Promise<MachineProject[]> {
+    return (await machineRequest<{ projects: MachineProject[] }>(config, "/v1/projects")).projects
+  },
+
+  async createTask(config: ServerConfig, input: { projectId: string; agentId: string; prompt: string }): Promise<MachineTask> {
+    return machineRequest<MachineTask>(config, "/v1/tasks", { method: "POST", body: input })
+  },
+
+  prepareWorktree(config: ServerConfig, taskId: string): Promise<MachineTask> {
+    return machineRequest<MachineTask>(config, `/v1/tasks/${encodeURIComponent(taskId)}/worktree`, { method: "POST", body: {} })
+  },
+
+  launch(config: ServerConfig, taskId: string): Promise<MachineTask> {
+    return machineRequest<MachineTask>(config, `/v1/tasks/${encodeURIComponent(taskId)}/launch`, { method: "POST", body: {} })
+  }
+}

--- a/web/src/taskCopy.ts
+++ b/web/src/taskCopy.ts
@@ -1,0 +1,104 @@
+type TaskCopyKey =
+  | "newTask"
+  | "startTask"
+  | "starting"
+  | "subtitle"
+  | "project"
+  | "task"
+  | "agent"
+  | "machine"
+  | "loading"
+  | "promptPlaceholder"
+  | "isolatedWorktree"
+  | "nonGit"
+  | "activeAgent"
+  | "requiresDaemon"
+  | "noProjects"
+  | "agentUnavailable"
+
+const copy: Record<string, Record<TaskCopyKey, string>> = {
+  en: {
+    newTask: "New Task",
+    startTask: "Start Task",
+    starting: "Starting…",
+    subtitle: "Start agent work on {machine}.",
+    project: "Project",
+    task: "Task",
+    agent: "Agent",
+    machine: "Machine",
+    loading: "Loading machine projects and agents…",
+    promptPlaceholder: "Describe the work the agent should complete…",
+    isolatedWorktree: "Use a new isolated Git worktree",
+    nonGit: "This project is not a Git repository, so the task will run in the project directory.",
+    activeAgent: "This task stays on the active agent profile so its launched session remains in the current session workflow.",
+    requiresDaemon: "Task launch requires the Harness machine daemon.",
+    noProjects: "This machine has no known projects. Configure a project root on the daemon before starting a task.",
+    agentUnavailable: "The active agent {agent} is unavailable on this machine."
+  },
+  it: {
+    newTask: "Nuovo task",
+    startTask: "Avvia task",
+    starting: "Avvio…",
+    subtitle: "Avvia un lavoro con un agente su {machine}.",
+    project: "Progetto",
+    task: "Task",
+    agent: "Agente",
+    machine: "Macchina",
+    loading: "Caricamento di progetti e agenti della macchina…",
+    promptPlaceholder: "Descrivi il lavoro che l’agente deve completare…",
+    isolatedWorktree: "Usa un nuovo worktree Git isolato",
+    nonGit: "Questo progetto non è un repository Git, quindi il task verrà eseguito nella directory del progetto.",
+    activeAgent: "Il task resta sull’agente attivo così la sessione avviata rimane nel flusso delle sessioni corrente.",
+    requiresDaemon: "L’avvio dei task richiede il daemon Harness della macchina.",
+    noProjects: "Questa macchina non ha progetti noti. Configura una root di progetto nel daemon prima di avviare un task.",
+    agentUnavailable: "L’agente attivo {agent} non è disponibile su questa macchina."
+  },
+  "zh-TW": {
+    newTask: "新增任務",
+    startTask: "開始任務",
+    starting: "正在啟動…",
+    subtitle: "在 {machine} 上開始代理工作。",
+    project: "專案",
+    task: "任務",
+    agent: "代理",
+    machine: "機器",
+    loading: "正在載入機器的專案與代理…",
+    promptPlaceholder: "描述代理應完成的工作…",
+    isolatedWorktree: "使用新的隔離 Git worktree",
+    nonGit: "此專案不是 Git 儲存庫，因此任務將在專案目錄中執行。",
+    activeAgent: "此任務會使用目前的代理設定檔，讓啟動的工作階段留在目前的工作流程中。",
+    requiresDaemon: "啟動任務需要 Harness machine daemon。",
+    noProjects: "此機器沒有已知專案。請先在 daemon 設定專案根目錄。",
+    agentUnavailable: "目前的代理 {agent} 在此機器上不可用。"
+  },
+  "zh-CN": {
+    newTask: "新建任务",
+    startTask: "开始任务",
+    starting: "正在启动…",
+    subtitle: "在 {machine} 上启动代理工作。",
+    project: "项目",
+    task: "任务",
+    agent: "代理",
+    machine: "机器",
+    loading: "正在加载机器的项目和代理…",
+    promptPlaceholder: "描述代理应完成的工作…",
+    isolatedWorktree: "使用新的隔离 Git worktree",
+    nonGit: "此项目不是 Git 仓库，因此任务将在项目目录中运行。",
+    activeAgent: "此任务会使用当前代理配置，使启动的会话保留在当前会话流程中。",
+    requiresDaemon: "启动任务需要 Harness machine daemon。",
+    noProjects: "此机器没有已知项目。请先在 daemon 中配置项目根目录。",
+    agentUnavailable: "当前代理 {agent} 在此机器上不可用。"
+  }
+}
+
+function locale(language: string): string {
+  if (language === "zh-TW" || language === "zh-CN") return language
+  if (language.toLowerCase().startsWith("it")) return "it"
+  return "en"
+}
+
+export function taskCopy(language: string, key: TaskCopyKey, vars: Record<string, string> = {}): string {
+  let value = copy[locale(language)]?.[key] ?? copy.en[key]
+  for (const [name, replacement] of Object.entries(vars)) value = value.replace(`{${name}}`, replacement)
+  return value
+}


### PR DESCRIPTION
Superseded by #172, which consolidates the task-first client work, Android/OpenCode integration fixes, UI cleanup, Fleet foundation and task review summary into one reviewable PR.

Closing this PR to avoid parallel review/merge paths. Nothing from this PR should be merged independently.