### PR TITLE
feat(fleet): add resilient multi-machine client foundation

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -83,32 +83,47 @@
     },
     "linux": {
       "target": [
-        "AppImage",
-        "deb"
+        {
+          "target": "AppImage",
+          "arch": ["x64"]
+        },
+        {
+          "target": "deb",
+          "arch": ["x64"]
+        }
       ],
-      "category": "Development",
       "icon": "public/app-icon.png",
+      "category": "Development",
+      "maintainer": "Giulio Ardoino <giuliaccio@gmail.com>",
       "artifactName": "Harness-Remote-${version}-linux-${arch}.${ext}"
-    }
+    },
+    "forceCodeSigning": false,
+    "nsis": {
+      "oneClick": false,
+      "perMachine": false,
+      "allowToChangeInstallationDirectory": true,
+      "deleteAppDataOnUninstall": false
+    },
+    "publish": null
   },
   "dependencies": {
     "@capacitor/android": "^8.3.4",
     "@capacitor/app": "^8.1.1",
     "@capacitor/cli": "^8.3.4",
     "@capacitor/core": "^8.3.4",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
-    "@types/node": "^22.10.2",
-    "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1",
-    "@vitejs/plugin-react": "^4.3.4",
-    "electron": "^33.2.1",
-    "electron-builder": "^25.1.8",
-    "typescript": "~5.6.2",
-    "vite": "^6.0.5"
+    "@types/node": "^26.1.2",
+    "@types/react": "18.3.12",
+    "@types/react-dom": "18.3.1",
+    "@vitejs/plugin-react": "^6.0.2",
+    "electron": "^43.3.0",
+    "electron-builder": "^26.15.3",
+    "typescript": "5.6.3",
+    "vite": "^8.0.14"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -30,7 +30,7 @@
     "test:settings": "node src/settings-regression.test.mjs",
     "test:model": "node src/model-regression.test.mjs",
     "test:events": "node --experimental-strip-types src/opencode-events.test.mjs",
-    "test:profiles": "node --experimental-strip-types src/server-profiles.test.mjs",
+    "test:profiles": "node --experimental-strip-types src/server-profiles.test.mjs && node --experimental-strip-types src/fleet-model.test.mjs",
     "test:markdown": "node --experimental-strip-types src/markdown-directives.test.mjs",
     "test:config": "node --experimental-strip-types src/server-config.test.mjs",
     "test:attachments": "node --experimental-strip-types src/attachments.test.mjs",
@@ -83,47 +83,32 @@
     },
     "linux": {
       "target": [
-        {
-          "target": "AppImage",
-          "arch": ["x64"]
-        },
-        {
-          "target": "deb",
-          "arch": ["x64"]
-        }
+        "AppImage",
+        "deb"
       ],
-      "icon": "public/app-icon.png",
       "category": "Development",
-      "maintainer": "Giulio Ardoino <giuliaccio@gmail.com>",
+      "icon": "public/app-icon.png",
       "artifactName": "Harness-Remote-${version}-linux-${arch}.${ext}"
-    },
-    "forceCodeSigning": false,
-    "nsis": {
-      "oneClick": false,
-      "perMachine": false,
-      "allowToChangeInstallationDirectory": true,
-      "deleteAppDataOnUninstall": false
-    },
-    "publish": null
+    }
   },
   "dependencies": {
     "@capacitor/android": "^8.3.4",
     "@capacitor/app": "^8.1.1",
     "@capacitor/cli": "^8.3.4",
     "@capacitor/core": "^8.3.4",
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
-    "@types/node": "^26.1.2",
-    "@types/react": "18.3.12",
-    "@types/react-dom": "18.3.1",
-    "@vitejs/plugin-react": "^6.0.2",
-    "electron": "^43.3.0",
-    "electron-builder": "^26.15.3",
-    "typescript": "5.6.3",
-    "vite": "^8.0.14"
+    "@types/node": "^22.10.2",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "electron": "^33.2.1",
+    "electron-builder": "^25.1.8",
+    "typescript": "~5.6.2",
+    "vite": "^6.0.5"
   }
 }

--- a/web/src/fleet-model.test.mjs
+++ b/web/src/fleet-model.test.mjs
@@ -24,6 +24,14 @@ function task(machineId, id = "task-1") {
   }
 }
 
+function observation(machineId, name = machineId) {
+  return {
+    machine: { machine: { id: machineId, name }, agents: [] },
+    projects: [],
+    tasks: []
+  }
+}
+
 test("groups multiple agent profiles for one daemon into one machine endpoint", () => {
   const profiles = [
     profile("codex", "Workstation Codex", { agentId: "codex" }),
@@ -33,6 +41,24 @@ test("groups multiple agent profiles for one daemon into one machine endpoint", 
   const groups = groupProfilesByMachineEndpoint(profiles)
   assert.equal(groups.size, 2)
   assert.equal(groups.get(machineEndpointKey(baseConfig))?.length, 2)
+})
+
+test("tries alternate profiles for one daemon before declaring the machine unreachable", async () => {
+  const profiles = [
+    profile("stale", "Workstation stale", { agentId: "codex", password: "old" }),
+    profile("valid", "Workstation valid", { backend: "claude", agentId: "claude", password: "new" })
+  ]
+  const attempts = []
+  const fleet = await discoverFleet(profiles, async (config) => {
+    attempts.push(config.password)
+    if (config.password === "old") throw new Error("unauthorized")
+    return observation("machine:workstation", "Workstation")
+  })
+  assert.deepEqual(attempts, ["old", "new"])
+  assert.equal(fleet.length, 1)
+  assert.equal(fleet[0].state, "online")
+  assert.equal(fleet[0].config.password, "new")
+  assert.deepEqual(fleet[0].profileIds, ["stale", "valid"])
 })
 
 test("discovers two machines simultaneously and preserves daemon identity", async () => {
@@ -85,11 +111,7 @@ test("one unreachable machine does not hide reachable machines", async () => {
   ]
   const fleet = await discoverFleet(profiles, async (config) => {
     if (config.host === "laptop.local") throw new Error("offline")
-    return {
-      machine: { machine: { id: "machine:workstation", name: "Workstation" }, agents: [] },
-      projects: [],
-      tasks: []
-    }
+    return observation("machine:workstation", "Workstation")
   })
   assert.equal(fleet.length, 2)
   assert.equal(fleet[0].state, "online")

--- a/web/src/fleet-model.test.mjs
+++ b/web/src/fleet-model.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { discoverFleet, groupProfilesByMachineEndpoint, machineEndpointKey } from "./fleetModel.ts"
+
+const baseConfig = { backend: "codex", host: "workstation.local", port: 4097, username: "harness", password: "secret" }
+
+function profile(id, name, config = {}) {
+  return { id, name, config: { ...baseConfig, ...config } }
+}
+
+test("groups multiple agent profiles for one daemon into one machine endpoint", () => {
+  const profiles = [
+    profile("codex", "Workstation Codex", { agentId: "codex" }),
+    profile("claude", "Workstation Claude", { backend: "claude", agentId: "claude" }),
+    profile("server", "Server", { host: "server.local", agentId: "codex" })
+  ]
+  const groups = groupProfilesByMachineEndpoint(profiles)
+  assert.equal(groups.size, 2)
+  assert.equal(groups.get(machineEndpointKey(baseConfig))?.length, 2)
+})
+
+test("discovers two machines simultaneously and preserves daemon identity", async () => {
+  const profiles = [
+    profile("workstation", "Workstation"),
+    profile("server", "Server", { host: "server.local" })
+  ]
+  const fleet = await discoverFleet(profiles, async (config) => ({
+    machine: {
+      machine: { id: `machine:${config.host}`, name: config.host },
+      agents: [{ id: "codex", label: "Codex", backend: "codex", transport: "acp", managed: true, state: "available", capabilities: {} }]
+    },
+    projects: [{ id: `project:${config.host}`, machineId: `machine:${config.host}`, name: "repo", path: "/repo", kind: "git" }]
+  }))
+  assert.deepEqual(fleet.map((entry) => entry.key).sort(), ["machine:server.local", "machine:workstation.local"])
+  assert.ok(fleet.every((entry) => entry.state === "online"))
+  assert.ok(fleet.every((entry) => entry.projects[0].machineId === entry.key))
+})
+
+test("one unreachable machine does not hide reachable machines", async () => {
+  const profiles = [
+    profile("workstation", "Workstation"),
+    profile("laptop", "Laptop", { host: "laptop.local" })
+  ]
+  const fleet = await discoverFleet(profiles, async (config) => {
+    if (config.host === "laptop.local") throw new Error("offline")
+    return {
+      machine: { machine: { id: "machine:workstation", name: "Workstation" }, agents: [] },
+      projects: []
+    }
+  })
+  assert.equal(fleet.length, 2)
+  assert.equal(fleet[0].state, "online")
+  assert.equal(fleet[0].key, "machine:workstation")
+  assert.equal(fleet[1].state, "unreachable")
+  assert.match(fleet[1].error, /offline/)
+})

--- a/web/src/fleet-model.test.mjs
+++ b/web/src/fleet-model.test.mjs
@@ -1,11 +1,27 @@
 import assert from "node:assert/strict"
 import test from "node:test"
-import { discoverFleet, groupProfilesByMachineEndpoint, machineEndpointKey } from "./fleetModel.ts"
+import { discoverFleet, fleetTaskID, groupProfilesByMachineEndpoint, machineEndpointKey } from "./fleetModel.ts"
 
 const baseConfig = { backend: "codex", host: "workstation.local", port: 4097, username: "harness", password: "secret" }
 
 function profile(id, name, config = {}) {
   return { id, name, config: { ...baseConfig, ...config } }
+}
+
+function task(machineId, id = "task-1") {
+  return {
+    id,
+    machineId,
+    projectId: `project:${machineId}`,
+    project: { name: "repo", path: "/repo", kind: "git" },
+    agentId: "codex",
+    prompt: "Do work",
+    status: "running",
+    workspace: { mode: "worktree", path: "/worktree" },
+    run: { id: "run-1", sessionId: "session-1", status: "running" },
+    createdAt: "2026-08-14T00:00:00Z",
+    updatedAt: "2026-08-14T00:00:00Z"
+  }
 }
 
 test("groups multiple agent profiles for one daemon into one machine endpoint", () => {
@@ -24,16 +40,42 @@ test("discovers two machines simultaneously and preserves daemon identity", asyn
     profile("workstation", "Workstation"),
     profile("server", "Server", { host: "server.local" })
   ]
-  const fleet = await discoverFleet(profiles, async (config) => ({
-    machine: {
-      machine: { id: `machine:${config.host}`, name: config.host },
-      agents: [{ id: "codex", label: "Codex", backend: "codex", transport: "acp", managed: true, state: "available", capabilities: {} }]
-    },
-    projects: [{ id: `project:${config.host}`, machineId: `machine:${config.host}`, name: "repo", path: "/repo", kind: "git" }]
-  }))
+  const fleet = await discoverFleet(profiles, async (config) => {
+    const machineId = `machine:${config.host}`
+    return {
+      machine: {
+        machine: { id: machineId, name: config.host },
+        agents: [{ id: "codex", label: "Codex", backend: "codex", transport: "acp", managed: true, state: "available", capabilities: {} }]
+      },
+      projects: [{ id: `project:${config.host}`, machineId, name: "repo", path: "/repo", kind: "git" }],
+      tasks: [task(machineId)]
+    }
+  })
   assert.deepEqual(fleet.map((entry) => entry.key).sort(), ["machine:server.local", "machine:workstation.local"])
   assert.ok(fleet.every((entry) => entry.state === "online"))
   assert.ok(fleet.every((entry) => entry.projects[0].machineId === entry.key))
+})
+
+test("overlapping local task and run ids remain unambiguous across machines", async () => {
+  const profiles = [
+    profile("workstation", "Workstation"),
+    profile("server", "Server", { host: "server.local" })
+  ]
+  const fleet = await discoverFleet(profiles, async (config) => {
+    const machineId = `machine:${config.host}`
+    return {
+      machine: { machine: { id: machineId, name: config.host }, agents: [] },
+      projects: [],
+      tasks: [task(machineId, "shared-task-id")]
+    }
+  })
+  const taskIds = fleet.flatMap((machine) => machine.tasks.map((candidate) => candidate.fleetId))
+  assert.equal(new Set(taskIds).size, 2)
+  assert.deepEqual(taskIds.sort(), [
+    fleetTaskID("machine:server.local", "shared-task-id"),
+    fleetTaskID("machine:workstation.local", "shared-task-id")
+  ].sort())
+  assert.ok(fleet.every((machine) => machine.tasks[0].run.id === "run-1"))
 })
 
 test("one unreachable machine does not hide reachable machines", async () => {
@@ -45,12 +87,14 @@ test("one unreachable machine does not hide reachable machines", async () => {
     if (config.host === "laptop.local") throw new Error("offline")
     return {
       machine: { machine: { id: "machine:workstation", name: "Workstation" }, agents: [] },
-      projects: []
+      projects: [],
+      tasks: []
     }
   })
   assert.equal(fleet.length, 2)
   assert.equal(fleet[0].state, "online")
   assert.equal(fleet[0].key, "machine:workstation")
   assert.equal(fleet[1].state, "unreachable")
+  assert.equal(fleet[1].tasks.length, 0)
   assert.match(fleet[1].error, /offline/)
 })

--- a/web/src/fleetClient.ts
+++ b/web/src/fleetClient.ts
@@ -7,8 +7,11 @@ export async function loadFleet(profiles: SavedServerProfile[]): Promise<FleetMa
   return discoverFleet(profiles, async (config) => {
     const machine = await discoverMachine(config)
     if (!machine) throw new Error("Harness machine daemon is unavailable")
-    const projects = await taskClient.listProjects(config)
-    return { machine, projects }
+    const [projects, tasks] = await Promise.all([
+      taskClient.listProjects(config),
+      taskClient.listTasks(config)
+    ])
+    return { machine, projects, tasks }
   })
 }
 

--- a/web/src/fleetClient.ts
+++ b/web/src/fleetClient.ts
@@ -1,0 +1,37 @@
+import { discoverMachine } from "./machineClient"
+import { discoverFleet, type FleetMachine } from "./fleetModel"
+import type { SavedServerProfile } from "./serverProfiles"
+import { taskClient, type MachineTask } from "./taskClient"
+
+export async function loadFleet(profiles: SavedServerProfile[]): Promise<FleetMachine[]> {
+  return discoverFleet(profiles, async (config) => {
+    const machine = await discoverMachine(config)
+    if (!machine) throw new Error("Harness machine daemon is unavailable")
+    const projects = await taskClient.listProjects(config)
+    return { machine, projects }
+  })
+}
+
+export async function launchFleetTask(machine: FleetMachine, input: {
+  projectId: string
+  agentId: string
+  prompt: string
+  isolated?: boolean
+}): Promise<MachineTask> {
+  if (machine.state !== "online" || !machine.machine) throw new Error("The selected machine is unreachable")
+  if (!machine.agents.some((agent) => agent.id === input.agentId && (agent.state === "available" || agent.state === "configured"))) {
+    throw new Error(`Agent ${input.agentId} is unavailable on ${machine.machine.name}`)
+  }
+  const project = machine.projects.find((candidate) => candidate.id === input.projectId)
+  if (!project) throw new Error(`Unknown project on ${machine.machine.name}`)
+
+  let task = await taskClient.createTask(machine.config, {
+    projectId: input.projectId,
+    agentId: input.agentId,
+    prompt: input.prompt
+  })
+  if (input.isolated !== false && project.kind === "git") {
+    task = await taskClient.prepareWorktree(machine.config, task.id)
+  }
+  return taskClient.launch(machine.config, task.id)
+}

--- a/web/src/fleetModel.ts
+++ b/web/src/fleetModel.ts
@@ -1,0 +1,86 @@
+import type { SavedServerProfile } from "./serverProfiles"
+import type { MachineSnapshot, ServerConfig } from "./types"
+import type { MachineProject } from "./taskClient"
+
+export type FleetMachine = {
+  key: string
+  profileIds: string[]
+  profileNames: string[]
+  config: ServerConfig
+  state: "online" | "unreachable"
+  machine: MachineSnapshot["machine"] | null
+  agents: MachineSnapshot["agents"]
+  projects: MachineProject[]
+  error?: string
+}
+
+export type FleetObservation = {
+  machine: MachineSnapshot
+  projects: MachineProject[]
+}
+
+export type FleetDiscover = (config: ServerConfig) => Promise<FleetObservation>
+
+/**
+ * Profiles for different agents on the same daemon share one machine endpoint. Fleet discovery must
+ * contact that endpoint once, not turn five saved agent profiles into five fake machines.
+ */
+export function machineEndpointKey(config: ServerConfig): string {
+  const raw = config.host.trim().replace(/\/+$/, "")
+  const normalized = /^https?:\/\//i.test(raw) ? raw.toLowerCase() : `http://${raw.toLowerCase()}`
+  return `${normalized}:${config.port}`
+}
+
+export function groupProfilesByMachineEndpoint(profiles: SavedServerProfile[]): Map<string, SavedServerProfile[]> {
+  const groups = new Map<string, SavedServerProfile[]>()
+  for (const profile of profiles) {
+    if (!profile.config.host.trim() || !profile.config.port) continue
+    const key = machineEndpointKey(profile.config)
+    groups.set(key, [...(groups.get(key) ?? []), profile])
+  }
+  return groups
+}
+
+/**
+ * Discover every configured daemon independently. One dead laptop must produce one unreachable
+ * fleet row, never reject the whole fleet load. Successful daemon identity replaces the endpoint
+ * key as the durable identity users see; the endpoint key remains useful while a machine is down.
+ */
+export async function discoverFleet(profiles: SavedServerProfile[], discover: FleetDiscover): Promise<FleetMachine[]> {
+  const groups = [...groupProfilesByMachineEndpoint(profiles).entries()]
+  const machines = await Promise.all(groups.map(async ([endpoint, machineProfiles]): Promise<FleetMachine> => {
+    const representative = machineProfiles[0]
+    try {
+      const observation = await discover(representative.config)
+      return {
+        key: observation.machine.machine.id,
+        profileIds: machineProfiles.map((profile) => profile.id),
+        profileNames: machineProfiles.map((profile) => profile.name),
+        config: representative.config,
+        state: "online",
+        machine: observation.machine.machine,
+        agents: observation.machine.agents,
+        projects: observation.projects
+      }
+    } catch (cause) {
+      return {
+        key: endpoint,
+        profileIds: machineProfiles.map((profile) => profile.id),
+        profileNames: machineProfiles.map((profile) => profile.name),
+        config: representative.config,
+        state: "unreachable",
+        machine: null,
+        agents: [],
+        projects: [],
+        error: cause instanceof Error ? cause.message : String(cause)
+      }
+    }
+  }))
+
+  return machines.sort((left, right) => {
+    if (left.state !== right.state) return left.state === "online" ? -1 : 1
+    const leftName = left.machine?.name ?? left.profileNames[0] ?? left.key
+    const rightName = right.machine?.name ?? right.profileNames[0] ?? right.key
+    return leftName.localeCompare(rightName)
+  })
+}

--- a/web/src/fleetModel.ts
+++ b/web/src/fleetModel.ts
@@ -1,6 +1,10 @@
 import type { SavedServerProfile } from "./serverProfiles"
 import type { MachineSnapshot, ServerConfig } from "./types"
-import type { MachineProject } from "./taskClient"
+import type { MachineProject, MachineTask } from "./taskClient"
+
+export type FleetTask = MachineTask & {
+  fleetId: string
+}
 
 export type FleetMachine = {
   key: string
@@ -11,12 +15,14 @@ export type FleetMachine = {
   machine: MachineSnapshot["machine"] | null
   agents: MachineSnapshot["agents"]
   projects: MachineProject[]
+  tasks: FleetTask[]
   error?: string
 }
 
 export type FleetObservation = {
   machine: MachineSnapshot
   projects: MachineProject[]
+  tasks: MachineTask[]
 }
 
 export type FleetDiscover = (config: ServerConfig) => Promise<FleetObservation>
@@ -41,6 +47,10 @@ export function groupProfilesByMachineEndpoint(profiles: SavedServerProfile[]): 
   return groups
 }
 
+export function fleetTaskID(machineID: string, taskID: string): string {
+  return `${encodeURIComponent(machineID)}:${encodeURIComponent(taskID)}`
+}
+
 /**
  * Discover every configured daemon independently. One dead laptop must produce one unreachable
  * fleet row, never reject the whole fleet load. Successful daemon identity replaces the endpoint
@@ -52,15 +62,17 @@ export async function discoverFleet(profiles: SavedServerProfile[], discover: Fl
     const representative = machineProfiles[0]
     try {
       const observation = await discover(representative.config)
+      const machineID = observation.machine.machine.id
       return {
-        key: observation.machine.machine.id,
+        key: machineID,
         profileIds: machineProfiles.map((profile) => profile.id),
         profileNames: machineProfiles.map((profile) => profile.name),
         config: representative.config,
         state: "online",
         machine: observation.machine.machine,
         agents: observation.machine.agents,
-        projects: observation.projects
+        projects: observation.projects,
+        tasks: observation.tasks.map((task) => ({ ...task, fleetId: fleetTaskID(machineID, task.id) }))
       }
     } catch (cause) {
       return {
@@ -72,6 +84,7 @@ export async function discoverFleet(profiles: SavedServerProfile[], discover: Fl
         machine: null,
         agents: [],
         projects: [],
+        tasks: [],
         error: cause instanceof Error ? cause.message : String(cause)
       }
     }

--- a/web/src/fleetModel.ts
+++ b/web/src/fleetModel.ts
@@ -29,7 +29,7 @@ export type FleetDiscover = (config: ServerConfig) => Promise<FleetObservation>
 
 /**
  * Profiles for different agents on the same daemon share one machine endpoint. Fleet discovery must
- * contact that endpoint once, not turn five saved agent profiles into five fake machines.
+ * contact that endpoint once logically, not turn five saved agent profiles into five fake machines.
  */
 export function machineEndpointKey(config: ServerConfig): string {
   const raw = config.host.trim().replace(/\/+$/, "")
@@ -51,23 +51,39 @@ export function fleetTaskID(machineID: string, taskID: string): string {
   return `${encodeURIComponent(machineID)}:${encodeURIComponent(taskID)}`
 }
 
+async function discoverThroughProfiles(machineProfiles: SavedServerProfile[], discover: FleetDiscover): Promise<{
+  profile: SavedServerProfile
+  observation: FleetObservation
+}> {
+  let lastError: unknown
+  for (const profile of machineProfiles) {
+    try {
+      return { profile, observation: await discover(profile.config) }
+    } catch (cause) {
+      lastError = cause
+    }
+  }
+  throw lastError ?? new Error("No usable profile is configured for this machine")
+}
+
 /**
  * Discover every configured daemon independently. One dead laptop must produce one unreachable
- * fleet row, never reject the whole fleet load. Successful daemon identity replaces the endpoint
- * key as the durable identity users see; the endpoint key remains useful while a machine is down.
+ * fleet row, never reject the whole fleet load. Several saved agent profiles may point at the same
+ * daemon; if one profile carries stale credentials, alternate profiles for that endpoint are tried
+ * before the physical machine is declared unreachable.
  */
 export async function discoverFleet(profiles: SavedServerProfile[], discover: FleetDiscover): Promise<FleetMachine[]> {
   const groups = [...groupProfilesByMachineEndpoint(profiles).entries()]
   const machines = await Promise.all(groups.map(async ([endpoint, machineProfiles]): Promise<FleetMachine> => {
     const representative = machineProfiles[0]
     try {
-      const observation = await discover(representative.config)
+      const { profile, observation } = await discoverThroughProfiles(machineProfiles, discover)
       const machineID = observation.machine.machine.id
       return {
         key: machineID,
-        profileIds: machineProfiles.map((profile) => profile.id),
-        profileNames: machineProfiles.map((profile) => profile.name),
-        config: representative.config,
+        profileIds: machineProfiles.map((candidate) => candidate.id),
+        profileNames: machineProfiles.map((candidate) => candidate.name),
+        config: profile.config,
         state: "online",
         machine: observation.machine.machine,
         agents: observation.machine.agents,

--- a/web/src/taskClient.ts
+++ b/web/src/taskClient.ts
@@ -109,6 +109,10 @@ export const taskClient = {
     return (await machineRequest<{ projects: MachineProject[] }>(config, "/v1/projects")).projects
   },
 
+  async listTasks(config: ServerConfig): Promise<MachineTask[]> {
+    return (await machineRequest<{ tasks: MachineTask[] }>(config, "/v1/tasks")).tasks
+  },
+
   async createTask(config: ServerConfig, input: { projectId: string; agentId: string; prompt: string }): Promise<MachineTask> {
     return machineRequest<MachineTask>(config, "/v1/tasks", { method: "POST", body: input })
   },


### PR DESCRIPTION
Superseded by #172, which consolidates the Fleet client foundation with the task-first workflow and the integration fixes discovered during Android testing.

Closing this stacked PR to leave a single review path. Nothing from this PR should be merged independently.