### PR TITLE
feat(tasks): expose backend-neutral Git review summary

### DIFF
--- a/bridge/src/task-finish-server.js
+++ b/bridge/src/task-finish-server.js
@@ -1,8 +1,10 @@
 import http from "node:http"
 import { authenticateDaemonRequest, writeJSON } from "./http-policy.js"
 import { inspectTaskWork } from "./task-finish.js"
+import { inspectTaskDiff } from "./task-review.js"
 
 const resultRoute = /^\/v1\/tasks\/([^/]+)\/result$/
+const diffRoute = /^\/v1\/tasks\/([^/]+)\/diff$/
 const finishRoute = /^\/v1\/tasks\/([^/]+)\/finish$/
 
 function status(error) {
@@ -16,10 +18,12 @@ export function createTaskFinishServer({ innerServer, config, taskStore, worktre
   return createServer(async (request, response) => {
     const pathname = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`).pathname
     const resultMatch = resultRoute.exec(pathname)
+    const diffMatch = diffRoute.exec(pathname)
     const finishMatch = finishRoute.exec(pathname)
     const inspect = resultMatch && request.method === "GET"
+    const inspectDiff = diffMatch && request.method === "GET"
     const finish = finishMatch && request.method === "POST"
-    if (!inspect && !finish) {
+    if (!inspect && !inspectDiff && !finish) {
       innerServer.emit("request", request, response)
       return
     }
@@ -34,7 +38,7 @@ export function createTaskFinishServer({ innerServer, config, taskStore, worktre
           throw error
         }
       }
-      const taskID = decodeURIComponent((resultMatch ?? finishMatch)[1])
+      const taskID = decodeURIComponent((resultMatch ?? diffMatch ?? finishMatch)[1])
       const task = await taskStore.get(taskID)
       if (!task) {
         const error = new Error(`Unknown task: ${taskID}`)
@@ -42,8 +46,27 @@ export function createTaskFinishServer({ innerServer, config, taskStore, worktre
         throw error
       }
       if (task.workspace?.mode !== "worktree") {
+        if (inspectDiff) {
+          writeJSON(response, 200, {
+            managed: false,
+            source: task.project?.path ?? task.workspace?.path ?? null,
+            sourceHead: null,
+            branch: null,
+            dirty: false,
+            fileCount: 0,
+            additions: 0,
+            deletions: 0,
+            hasUnknownLineCounts: false,
+            files: []
+          })
+          return
+        }
         const result = { managed: false, dirty: false, changeCount: 0 }
         writeJSON(response, 200, finish ? { task, result, cleanup: { removed: false, branchDeleted: false } } : result)
+        return
+      }
+      if (inspectDiff) {
+        writeJSON(response, 200, await inspectTaskDiff(task.workspace, worktreeManager))
         return
       }
       if (finish && ["starting", "running"].includes(task.status)) {

--- a/bridge/src/task-review.js
+++ b/bridge/src/task-review.js
@@ -1,0 +1,51 @@
+function text(result) {
+  return String(result?.stdout ?? "")
+}
+
+function count(value) {
+  if (value === "-") return null
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+export function parseNumstat(output) {
+  return output.split(/\r?\n/).filter(Boolean).flatMap((line) => {
+    const [additions, deletions, ...pathParts] = line.split("\t")
+    const path = pathParts.join("\t")
+    if (!path) return []
+    return [{ path, additions: count(additions), deletions: count(deletions), untracked: false }]
+  })
+}
+
+export async function inspectTaskDiff(workspace, worktreeManager) {
+  const status = await worktreeManager.inspect(workspace)
+  const sourceHead = text(await worktreeManager.runGit(["-C", workspace.source, "rev-parse", "HEAD"])).trim()
+  const tracked = parseNumstat(text(await worktreeManager.runGit([
+    "-C", workspace.path, "diff", "--numstat", sourceHead, "--"
+  ])))
+  const trackedPaths = new Set(tracked.map((file) => file.path))
+  const untracked = text(await worktreeManager.runGit([
+    "-C", workspace.path, "ls-files", "--others", "--exclude-standard"
+  ])).split(/\r?\n/).filter(Boolean).filter((path) => !trackedPaths.has(path)).map((path) => ({
+    path,
+    additions: null,
+    deletions: null,
+    untracked: true
+  }))
+  const files = [...tracked, ...untracked].sort((left, right) => left.path.localeCompare(right.path))
+  const knownAdditions = files.reduce((total, file) => total + (file.additions ?? 0), 0)
+  const knownDeletions = files.reduce((total, file) => total + (file.deletions ?? 0), 0)
+
+  return {
+    managed: status.managed,
+    source: workspace.source,
+    sourceHead,
+    branch: workspace.branch,
+    dirty: status.dirty,
+    fileCount: files.length,
+    additions: knownAdditions,
+    deletions: knownDeletions,
+    hasUnknownLineCounts: files.some((file) => file.additions === null || file.deletions === null),
+    files
+  }
+}

--- a/bridge/src/task-review.js
+++ b/bridge/src/task-review.js
@@ -8,10 +8,18 @@ function count(value) {
   return Number.isFinite(parsed) ? parsed : null
 }
 
+function records(output) {
+  return output.includes("\0") ? output.split("\0").filter(Boolean) : output.split(/\r?\n/).filter(Boolean)
+}
+
 export function parseNumstat(output) {
-  return output.split(/\r?\n/).filter(Boolean).flatMap((line) => {
-    const [additions, deletions, ...pathParts] = line.split("\t")
-    const path = pathParts.join("\t")
+  return records(output).flatMap((record) => {
+    const firstTab = record.indexOf("\t")
+    const secondTab = firstTab < 0 ? -1 : record.indexOf("\t", firstTab + 1)
+    if (firstTab < 0 || secondTab < 0) return []
+    const additions = record.slice(0, firstTab)
+    const deletions = record.slice(firstTab + 1, secondTab)
+    const path = record.slice(secondTab + 1)
     if (!path) return []
     return [{ path, additions: count(additions), deletions: count(deletions), untracked: false }]
   })
@@ -21,12 +29,12 @@ export async function inspectTaskDiff(workspace, worktreeManager) {
   const status = await worktreeManager.inspect(workspace)
   const sourceHead = text(await worktreeManager.runGit(["-C", workspace.source, "rev-parse", "HEAD"])).trim()
   const tracked = parseNumstat(text(await worktreeManager.runGit([
-    "-C", workspace.path, "diff", "--numstat", sourceHead, "--"
+    "-C", workspace.path, "diff", "--no-renames", "--numstat", "-z", sourceHead, "--"
   ])))
   const trackedPaths = new Set(tracked.map((file) => file.path))
   const untracked = text(await worktreeManager.runGit([
-    "-C", workspace.path, "ls-files", "--others", "--exclude-standard"
-  ])).split(/\r?\n/).filter(Boolean).filter((path) => !trackedPaths.has(path)).map((path) => ({
+    "-C", workspace.path, "ls-files", "-z", "--others", "--exclude-standard"
+  ])).split("\0").filter(Boolean).filter((path) => !trackedPaths.has(path)).map((path) => ({
     path,
     additions: null,
     deletions: null,

--- a/bridge/test/task-review.test.js
+++ b/bridge/test/task-review.test.js
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import test from "node:test"
+import { createTaskFinishServer } from "../src/task-finish-server.js"
+import { inspectTaskDiff, parseNumstat } from "../src/task-review.js"
+
+const workspace = { mode: "worktree", path: "/state/worktrees/t", branch: "task/t", source: "/repo" }
+
+function manager() {
+  return {
+    async inspect() { return { managed: true, dirty: true, changeCount: 3 } },
+    async runGit(args) {
+      if (args.includes("rev-parse")) return { stdout: "source-head\n" }
+      if (args.includes("--numstat")) return { stdout: "4\t1\tsrc/a.js\n-\t-\tassets/logo.png\n" }
+      if (args.includes("--others")) return { stdout: "notes.txt\n" }
+      throw new Error(`Unexpected git args: ${args.join(" ")}`)
+    }
+  }
+}
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  return server.address().port
+}
+
+async function close(server) {
+  await new Promise((resolve) => server.close(resolve))
+}
+
+test("numstat parser preserves binary files with unknown line counts", () => {
+  assert.deepEqual(parseNumstat("4\t1\tsrc/a.js\n-\t-\tassets/logo.png\n"), [
+    { path: "src/a.js", additions: 4, deletions: 1, untracked: false },
+    { path: "assets/logo.png", additions: null, deletions: null, untracked: false }
+  ])
+})
+
+test("review inspection combines committed/tracked changes with untracked files without mutation", async () => {
+  const calls = []
+  const worktreeManager = manager()
+  const runGit = worktreeManager.runGit
+  worktreeManager.runGit = async (args) => {
+    calls.push(args)
+    return runGit(args)
+  }
+  const result = await inspectTaskDiff(workspace, worktreeManager)
+  assert.equal(result.sourceHead, "source-head")
+  assert.equal(result.fileCount, 3)
+  assert.equal(result.additions, 4)
+  assert.equal(result.deletions, 1)
+  assert.equal(result.hasUnknownLineCounts, true)
+  assert.deepEqual(result.files.map((file) => file.path), ["assets/logo.png", "notes.txt", "src/a.js"])
+  assert.equal(result.files.find((file) => file.path === "notes.txt").untracked, true)
+  assert.ok(calls.every((args) => !args.includes("add") && !args.includes("commit") && !args.includes("checkout")))
+})
+
+test("diff route returns a no-op review result for project workspaces", async () => {
+  const innerServer = new EventEmitter()
+  const server = createTaskFinishServer({
+    innerServer,
+    config: { username: "", password: "", corsOrigins: [] },
+    taskStore: {
+      async get() {
+        return { id: "t", status: "completed", project: { path: "/repo" }, workspace: { mode: "project", path: "/repo" } }
+      }
+    },
+    worktreeManager: manager()
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/tasks/t/diff`)
+    assert.equal(response.status, 200)
+    const body = await response.json()
+    assert.equal(body.managed, false)
+    assert.equal(body.fileCount, 0)
+    assert.deepEqual(body.files, [])
+  } finally {
+    await close(server)
+  }
+})
+
+test("diff route remains available as a point-in-time view for active worktree tasks", async () => {
+  const innerServer = new EventEmitter()
+  const server = createTaskFinishServer({
+    innerServer,
+    config: { username: "", password: "", corsOrigins: [] },
+    taskStore: { async get() { return { id: "t", status: "running", workspace } } },
+    worktreeManager: manager()
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/tasks/t/diff`)
+    assert.equal(response.status, 200)
+    assert.equal((await response.json()).fileCount, 3)
+  } finally {
+    await close(server)
+  }
+})

--- a/bridge/test/task-review.test.js
+++ b/bridge/test/task-review.test.js
@@ -8,11 +8,11 @@ const workspace = { mode: "worktree", path: "/state/worktrees/t", branch: "task/
 
 function manager() {
   return {
-    async inspect() { return { managed: true, dirty: true, changeCount: 3 } },
+    async inspect() { return { managed: true, dirty: true, changeCount: 4 } },
     async runGit(args) {
       if (args.includes("rev-parse")) return { stdout: "source-head\n" }
-      if (args.includes("--numstat")) return { stdout: "4\t1\tsrc/a.js\n-\t-\tassets/logo.png\n" }
-      if (args.includes("--others")) return { stdout: "notes.txt\n" }
+      if (args.includes("--numstat")) return { stdout: "4\t1\tsrc/a.js\0-\t-\tassets/logo.png\00\t3\told.txt\04\t0\tnew.txt\0" }
+      if (args.includes("--others")) return { stdout: "perché.md\0notes\twith-tab.txt\0" }
       throw new Error(`Unexpected git args: ${args.join(" ")}`)
     }
   }
@@ -30,14 +30,15 @@ async function close(server) {
   await new Promise((resolve) => server.close(resolve))
 }
 
-test("numstat parser preserves binary files with unknown line counts", () => {
-  assert.deepEqual(parseNumstat("4\t1\tsrc/a.js\n-\t-\tassets/logo.png\n"), [
+test("numstat parser preserves binary files and literal tabs with NUL records", () => {
+  assert.deepEqual(parseNumstat("4\t1\tsrc/a.js\0-\t-\tassets/logo.png\01\t0\tnotes\twith-tab.txt\0"), [
     { path: "src/a.js", additions: 4, deletions: 1, untracked: false },
-    { path: "assets/logo.png", additions: null, deletions: null, untracked: false }
+    { path: "assets/logo.png", additions: null, deletions: null, untracked: false },
+    { path: "notes\twith-tab.txt", additions: 1, deletions: 0, untracked: false }
   ])
 })
 
-test("review inspection combines committed/tracked changes with untracked files without mutation", async () => {
+test("review inspection disables rename folding and preserves unicode/untracked paths", async () => {
   const calls = []
   const worktreeManager = manager()
   const runGit = worktreeManager.runGit
@@ -47,12 +48,19 @@ test("review inspection combines committed/tracked changes with untracked files 
   }
   const result = await inspectTaskDiff(workspace, worktreeManager)
   assert.equal(result.sourceHead, "source-head")
-  assert.equal(result.fileCount, 3)
-  assert.equal(result.additions, 4)
-  assert.equal(result.deletions, 1)
+  assert.equal(result.fileCount, 6)
+  assert.equal(result.additions, 8)
+  assert.equal(result.deletions, 4)
   assert.equal(result.hasUnknownLineCounts, true)
-  assert.deepEqual(result.files.map((file) => file.path), ["assets/logo.png", "notes.txt", "src/a.js"])
-  assert.equal(result.files.find((file) => file.path === "notes.txt").untracked, true)
+  assert.ok(result.files.some((file) => file.path === "perché.md" && file.untracked))
+  assert.ok(result.files.some((file) => file.path === "notes\twith-tab.txt" && file.untracked))
+  assert.ok(result.files.some((file) => file.path === "old.txt"))
+  assert.ok(result.files.some((file) => file.path === "new.txt"))
+  const diffCall = calls.find((args) => args.includes("--numstat"))
+  const untrackedCall = calls.find((args) => args.includes("--others"))
+  assert.ok(diffCall.includes("--no-renames"))
+  assert.ok(diffCall.includes("-z"))
+  assert.ok(untrackedCall.includes("-z"))
   assert.ok(calls.every((args) => !args.includes("add") && !args.includes("commit") && !args.includes("checkout")))
 })
 
@@ -93,7 +101,7 @@ test("diff route remains available as a point-in-time view for active worktree t
   try {
     const response = await fetch(`http://127.0.0.1:${port}/v1/tasks/t/diff`)
     assert.equal(response.status, 200)
-    assert.equal((await response.json()).fileCount, 3)
+    assert.equal((await response.json()).fileCount, 6)
   } finally {
     await close(server)
   }

--- a/bridge/test/task-review.test.js
+++ b/bridge/test/task-review.test.js
@@ -5,14 +5,15 @@ import { createTaskFinishServer } from "../src/task-finish-server.js"
 import { inspectTaskDiff, parseNumstat } from "../src/task-review.js"
 
 const workspace = { mode: "worktree", path: "/state/worktrees/t", branch: "task/t", source: "/repo" }
+const nulRecords = (...records) => `${records.join("\0")}\0`
 
 function manager() {
   return {
     async inspect() { return { managed: true, dirty: true, changeCount: 4 } },
     async runGit(args) {
       if (args.includes("rev-parse")) return { stdout: "source-head\n" }
-      if (args.includes("--numstat")) return { stdout: "4\t1\tsrc/a.js\0-\t-\tassets/logo.png\00\t3\told.txt\04\t0\tnew.txt\0" }
-      if (args.includes("--others")) return { stdout: "perché.md\0notes\twith-tab.txt\0" }
+      if (args.includes("--numstat")) return { stdout: nulRecords("4\t1\tsrc/a.js", "-\t-\tassets/logo.png", "0\t3\told.txt", "4\t0\tnew.txt") }
+      if (args.includes("--others")) return { stdout: nulRecords("perché.md", "notes\twith-tab.txt") }
       throw new Error(`Unexpected git args: ${args.join(" ")}`)
     }
   }
@@ -31,7 +32,7 @@ async function close(server) {
 }
 
 test("numstat parser preserves binary files and literal tabs with NUL records", () => {
-  assert.deepEqual(parseNumstat("4\t1\tsrc/a.js\0-\t-\tassets/logo.png\01\t0\tnotes\twith-tab.txt\0"), [
+  assert.deepEqual(parseNumstat(nulRecords("4\t1\tsrc/a.js", "-\t-\tassets/logo.png", "1\t0\tnotes\twith-tab.txt")), [
     { path: "src/a.js", additions: 4, deletions: 1, untracked: false },
     { path: "assets/logo.png", additions: null, deletions: null, untracked: false },
     { path: "notes\twith-tab.txt", additions: 1, deletions: 0, untracked: false }


### PR DESCRIPTION
Superseded by #172, which carries the backend-neutral task diff/review summary together with the task-first client and integration fixes.

Closing this PR so review and eventual merge happen through one consolidated path only.