### PR TITLE
feat(tasks): choose the model when starting a task

### DIFF
--- a/bridge/src/agent-router.js
+++ b/bridge/src/agent-router.js
@@ -1,5 +1,6 @@
 import http from "node:http"
 import { allowedOrigin, applyCorsHeaders, matchesCredentials, writeJSON } from "./http-policy.js"
+import { normalizeTaskModel } from "./task-model.js"
 
 const AGENT_ROUTE = /^\/v1\/agents\/([^/]+)(\/.*)?$/
 const TASK_WORKTREE_ROUTE = /^\/v1\/tasks\/([^/]+)\/worktree$/
@@ -219,7 +220,8 @@ export function createAgentRoutingServer({
             writeJSON(response, 400, { error: "A task prompt is required" })
             return
           }
-          writeJSON(response, 201, await taskStore.create({ project, agentId: agentID, prompt }))
+          const model = normalizeTaskModel(body.model)
+          writeJSON(response, 201, await taskStore.create({ project, agentId: agentID, prompt, model }))
           return
         }
         if (request.method === "POST" && worktreeMatch) {

--- a/bridge/src/task-launcher.js
+++ b/bridge/src/task-launcher.js
@@ -1,4 +1,5 @@
 import { taskLaunchError } from "./task-errors.js"
+import { promptModelBody, sessionModelBody } from "./task-model.js"
 
 function basicAuthorization(username, password) {
   if (!username && !password) return undefined
@@ -60,7 +61,7 @@ export class TaskLauncher {
           "Content-Type": "application/json",
           ...(authorization ? { Authorization: authorization } : {})
         },
-        body: JSON.stringify({ title: `Task ${task.id.slice(0, 8)}` })
+        body: JSON.stringify({ title: `Task ${task.id.slice(0, 8)}`, model: sessionModelBody(task.model) })
       })
       const session = await responseJSON(response, `Creating ${task.agentId} session`)
       if (!session?.id) throw new Error(`Agent ${task.agentId} did not return a session id`)
@@ -96,7 +97,11 @@ export class TaskLauncher {
           // Authorization belongs to the ephemeral createSession() result only.
           ...(run.authorization ? { Authorization: run.authorization } : {})
         },
-        body: JSON.stringify({ parts: [{ type: "text", text: task.prompt }] })
+        body: JSON.stringify({
+          parts: [{ type: "text", text: task.prompt }],
+          model: promptModelBody(task.model),
+          variant: task.model?.variant || undefined
+        })
       })
       if (!response.ok) throw new Error(`Starting ${task.agentId} task failed with HTTP ${response.status}`)
     }

--- a/bridge/src/task-model.js
+++ b/bridge/src/task-model.js
@@ -1,0 +1,26 @@
+/**
+ * A task's model selection, in the shape the client already speaks and the agents already accept.
+ * Kept separate from the task store so the daemon has one place that decides what a valid selection
+ * is, rather than each route trimming strings its own way.
+ */
+export function normalizeTaskModel(value) {
+  if (!value || typeof value !== "object") return null
+  const providerID = typeof value.providerID === "string" ? value.providerID.trim() : ""
+  const modelID = typeof value.modelID === "string" ? value.modelID.trim() : ""
+  if (!providerID || !modelID) return null
+  const variant = typeof value.variant === "string" ? value.variant.trim() : ""
+  return variant ? { providerID, modelID, variant } : { providerID, modelID }
+}
+
+/** `POST /session` names the model id `id`; `POST /session/:id/prompt_async` names it `modelID`. */
+export function sessionModelBody(model) {
+  if (!model) return undefined
+  return model.variant
+    ? { providerID: model.providerID, id: model.modelID, variant: model.variant }
+    : { providerID: model.providerID, id: model.modelID }
+}
+
+export function promptModelBody(model) {
+  if (!model) return undefined
+  return { providerID: model.providerID, modelID: model.modelID }
+}

--- a/bridge/src/task-store.js
+++ b/bridge/src/task-store.js
@@ -64,7 +64,7 @@ export class TaskStore {
     return task ? structuredClone(task) : undefined
   }
 
-  async create({ project, agentId, prompt }) {
+  async create({ project, agentId, prompt, model = null }) {
     await this.load()
     const text = typeof prompt === "string" ? prompt.trim() : ""
     if (!text) throw new Error("A task prompt is required")
@@ -76,6 +76,9 @@ export class TaskStore {
       project: { name: project.name, path: project.path, kind: project.kind },
       agentId,
       prompt: text,
+      // Null rather than absent: a task that was launched on the agent's default is a different
+      // fact from a task saved before models could be chosen, and a relaunch must reproduce it.
+      model,
       status: "draft",
       workspace: { mode: "project", path: project.path },
       run: null,

--- a/bridge/test/task-model.test.js
+++ b/bridge/test/task-model.test.js
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { normalizeTaskModel, promptModelBody, sessionModelBody } from "../src/task-model.js"
+import { TaskLauncher } from "../src/task-launcher.js"
+
+test("a model selection is accepted only when it names both a provider and a model", () => {
+  assert.deepEqual(normalizeTaskModel({ providerID: "anthropic", modelID: "claude-opus-5" }), {
+    providerID: "anthropic",
+    modelID: "claude-opus-5"
+  })
+  assert.deepEqual(normalizeTaskModel({ providerID: " anthropic ", modelID: " claude-opus-5 ", variant: " thinking " }), {
+    providerID: "anthropic",
+    modelID: "claude-opus-5",
+    variant: "thinking"
+  })
+  // A task with half a selection would launch on the agent default while claiming otherwise.
+  assert.equal(normalizeTaskModel({ providerID: "anthropic" }), null)
+  assert.equal(normalizeTaskModel({ modelID: "claude-opus-5" }), null)
+  assert.equal(normalizeTaskModel({ providerID: "  ", modelID: "  " }), null)
+  assert.equal(normalizeTaskModel(undefined), null)
+  assert.equal(normalizeTaskModel("anthropic/claude-opus-5"), null)
+})
+
+// The two endpoints disagree about what the model id is called, which is why this lives in one
+// place rather than being spelled out at each call site.
+test("session creation and prompting use the field names each endpoint expects", () => {
+  const model = { providerID: "anthropic", modelID: "claude-opus-5", variant: "thinking" }
+  assert.deepEqual(sessionModelBody(model), { providerID: "anthropic", id: "claude-opus-5", variant: "thinking" })
+  assert.deepEqual(promptModelBody(model), { providerID: "anthropic", modelID: "claude-opus-5" })
+  assert.equal(sessionModelBody(null), undefined)
+  assert.equal(promptModelBody(null), undefined)
+})
+
+function httpDaemon(calls) {
+  return {
+    hostEntry: () => ({ kind: "http", host: { start: async () => {}, host: "127.0.0.1", port: 4096 } }),
+    registry: { host: () => ({ state: "available" }) },
+    calls
+  }
+}
+
+function launcher(calls) {
+  return new TaskLauncher({
+    daemon: httpDaemon(calls),
+    fetchImpl: async (url, options) => {
+      calls.push({ url, body: JSON.parse(options.body) })
+      return { ok: true, status: 200, json: async () => ({ id: "session-1" }) }
+    }
+  })
+}
+
+test("the chosen model reaches both the session and the prompt", async () => {
+  const calls = []
+  const task = {
+    id: "task-abcdef01",
+    agentId: "opencode",
+    prompt: "do the work",
+    model: { providerID: "anthropic", modelID: "claude-opus-5", variant: "thinking" },
+    workspace: { mode: "worktree", path: "/state/worktrees/task", branch: "task/x", source: "/repo" }
+  }
+  const run = await launcher(calls).createSession(task)
+  await launcher(calls).startPrompt(task, { ...run, base: "http://127.0.0.1:4096" })
+
+  const session = calls.find((call) => call.url.includes("/session?"))
+  assert.deepEqual(session.body.model, { providerID: "anthropic", id: "claude-opus-5", variant: "thinking" })
+
+  const prompt = calls.find((call) => call.url.includes("/prompt_async"))
+  assert.deepEqual(prompt.body.model, { providerID: "anthropic", modelID: "claude-opus-5" })
+  assert.equal(prompt.body.variant, "thinking")
+})
+
+// A task saved before models could be chosen, or one deliberately left on the agent default, must
+// send no model at all rather than an empty object the agent would have to interpret.
+test("a task without a model sends nothing rather than an empty selection", async () => {
+  const calls = []
+  const task = {
+    id: "task-abcdef01",
+    agentId: "opencode",
+    prompt: "do the work",
+    model: null,
+    workspace: { mode: "worktree", path: "/state/worktrees/task", branch: "task/x", source: "/repo" }
+  }
+  const run = await launcher(calls).createSession(task)
+  await launcher(calls).startPrompt(task, { ...run, base: "http://127.0.0.1:4096" })
+  assert.ok(calls.every((call) => !("model" in call.body) || call.body.model === undefined))
+  assert.ok(calls.every((call) => call.body.variant === undefined))
+})

--- a/bridge/test/task-store.test.js
+++ b/bridge/test/task-store.test.js
@@ -23,6 +23,8 @@ test("persists machine-scoped draft tasks with project, agent and workspace iden
       project: { name: "repo", path: "/work/repo", kind: "git" },
       agentId: "codex",
       prompt: "Fix issue #145",
+      // Explicitly null: launching on the agent default is a recorded choice, not a missing field.
+      model: null,
       status: "draft",
       workspace: { mode: "project", path: "/work/repo" },
       run: null,

--- a/docs/HARNESS_3_ROADMAP.md
+++ b/docs/HARNESS_3_ROADMAP.md
@@ -129,18 +129,66 @@ Fleet control
 
 The daemon now provides stable machine identity, multiple agent-host representation, project/task foundations and fleet-safe ownership boundaries. Machine-scoped identifiers should continue to be designed so a second or third machine can be added without redefining the model.
 
+### Task, run and session are different layers
+
+A **session** is a backend-native conversation/execution context. It is transient execution state owned largely by the underlying harness.
+
+A **task** is Harness-owned durable work. It should survive and organize the backend execution beneath it:
+
+```text
+Task
+├── goal / prompt
+├── placement
+│   ├── machine
+│   ├── project
+│   ├── agent
+│   └── workspace/worktree
+├── runConfig
+│   ├── model / variant
+│   ├── agent or sub-agent mode
+│   ├── attachments / initial context
+│   └── future capability-specific run options
+├── run history
+│   └── one or more backend sessions/runs
+├── result / diff / checks / review state
+└── finish state
+```
+
+The distinction is intentional:
+
+- a session answers **“what is this harness process/conversation doing now?”**;
+- a task answers **“what work did the user ask Harness to accomplish, where and how should it run, what happened, and is it finished?”**.
+
+Task placement and task execution configuration are separate concerns. `machine/project/agent/workspace` answers **where** work runs; `runConfig` answers **how** the selected agent should run it.
+
+`runConfig` must be capability-aware rather than pretending every backend exposes the same controls. A choice should only be offered when the target agent can honour it, and persisted choices should make relaunch/retry reproducible.
+
+The long-term product direction is **Task-first, not Session-first**. Direct session creation remains available while it provides functionality, backend compatibility or a quick unmanaged interaction that Tasks do not yet cover. It should be demoted only after Task creation is a practical functional superset of the useful direct-session configuration for supported agents.
+
+The intended relationship is:
+
+```text
+Task → Run → backend Session
+```
+
+not:
+
+```text
+Task = Session + extra dropdowns
+```
+
 ## 6. Current implementation status
 
-As of August 13, 2026:
+As of August 14, 2026:
 
 - ✅ **#147 — One-command startup** is complete.
 - ✅ **#143 — Universal Daemon** is complete as an implementation milestone. Its architecture and mechanics are well covered by tests, but a real ACP-backed harness still needs to be run end to end before heterogeneous daemon compatibility is described as validated.
-- 🟡 **#145 — Create work** has most backend foundations complete: project discovery, normalized tasks, isolated worktrees, agent launch, persisted task/run linkage, restart reconciliation, safe cleanup, result inspection and explicit finish semantics. The major remaining closure gap is the task-first client UX.
+- 🟡 **#145 — Create work** now has a working Android/OpenCode task path and most backend foundations complete: project discovery, normalized tasks, isolated worktrees, agent launch, persisted task/run linkage, restart reconciliation, safe cleanup, result inspection and explicit finish semantics. Task/run configuration parity remains incomplete; #173 tracks the structural gap and #176 is the first model-selection slice.
 - ✅ **#163 — Finish-work result and safe finalization primitives** is complete through #164.
 - ⏳ Full review/tests/PR lifecycle remains ahead.
-- ⏳ **#146 — Multi-machine Fleet** remains the next major differentiating product milestone after the task workflow is exposed cleanly to users and fleet demand is validated.
+- ⏳ **#146 — Multi-machine Fleet** remains the next major differentiating product milestone after Task creation is reliable enough to be the primary unit of work and fleet demand is validated.
 
-The important distinction is that task/worktree/finish support now exists as **backend/API capability**, but the product should not claim a complete task-first workflow until the client exposes it end to end.
+The product should not claim a complete Task-first workflow merely because Task launch works. Before direct Session creation is demoted, Task creation must preserve the meaningful per-run choices users already rely on.
 
 ## 7. Execution sequencing
 
@@ -161,36 +209,35 @@ One-command startup and the Universal Daemon established the adoption/runtime ba
 
 The architecture/mechanics are implemented, but real heterogeneous multi-host validation still requires at least one reachable ACP-backed harness environment. Test doubles are evidence for the architecture, not proof of real harness compatibility.
 
-#### Current — finish #145 as a product workflow
+#### Current — finish #145 as a Task-first product workflow
 
-The backend loop already supports:
+The backend loop supports:
 
 ```text
 project → task → isolated worktree → agent → run → result → finish
 ```
 
-The immediate product gap is exposing that loop cleanly in the client:
+That loop describes lifecycle and placement but is not sufficient by itself. Task creation also needs an explicit, capability-aware execution configuration:
+
+```text
+Task = goal + placement + runConfig + lifecycle
+```
+
+The immediate product work is therefore:
 
 - choose a known project;
-- enter a task;
-- choose an agent;
+- enter a task goal;
+- choose/resolve the target agent and machine;
+- configure the run using the options the selected agent actually supports;
 - prepare/start the isolated task;
 - open the resulting run/session;
 - inspect the result and finish safely.
 
+#173 is the structural parity issue. Model/variant selection is the first slice; sub-agent/agent mode, attachments/initial context and future backend-supported run options should travel through the same `runConfig` channel instead of being added as unrelated Task fields.
+
 Several tasks should eventually be usable concurrently in separate worktrees. Explicit agent selection is enough initially. `Auto` routing remains later.
 
-#### Finish-work expansion — review / tests / PR
-
-The first backend finish primitives are complete, but the competitive loop is not:
-
-```text
-run → diff → tests/checks → review → PR → CI visibility → finish
-```
-
-Next slices should add these incrementally without coupling the core task model to one forge too early.
-
-#### Later — Multi-machine Fleet (#146)
+#### Next differentiating milestone — Multi-machine Fleet (#146)
 
 Before implementation becomes the largest roadmap investment, validate demand cheaply with existing users/contributors:
 
@@ -206,10 +253,21 @@ Initial placement can be explicit:
 Task       Fix issue #200
 Machine    Workstation
 Agent      Codex
+Model      agent-supported choice/default
 Workspace  New worktree
 ```
 
 Automatic machine selection comes later.
+
+#### Finish-work expansion — review / tests / PR
+
+The first backend finish primitives are complete, but the competitive loop is not:
+
+```text
+run → diff → tests/checks → review → PR → CI visibility → finish
+```
+
+These should continue incrementally after the Task contract is sound and alongside/after the first Fleet milestone, without coupling the core task model to one forge too early.
 
 #### Later — Coordinate
 
@@ -296,7 +354,8 @@ Do not prioritize:
 - smart routing before reliable task launch;
 - a hosted cloud backend before local value is excellent;
 - a greenfield rewrite without implementation evidence;
-- multi-machine implementation before demand is validated.
+- multi-machine implementation before demand is validated;
+- adding session features to Tasks one field at a time without a coherent `runConfig` contract.
 
 ## 11. Validation gates
 
@@ -305,6 +364,12 @@ The roadmap should remain falsifiable.
 Before the multi-agent daemon is described as validated:
 
 - run at least one real ACP-backed harness end to end against it. Test doubles validate architecture and mechanics; they are not evidence of real harness compatibility.
+
+Before direct `New Session` is demoted from the normal workflow:
+
+- Task creation must be a practical functional superset of the useful direct-session configuration for supported agents;
+- at minimum, capability-aware run configuration must preserve the choices users depend on rather than silently falling back to backend defaults;
+- legacy/direct session workflows must remain available where the daemon or backend cannot yet satisfy the Task contract.
 
 Before #146 becomes the largest build:
 
@@ -328,11 +393,13 @@ PRIMARY
   ↓
 #143  Universal Daemon
   ↓
-#145  Expose task launch + worktree + result/finish as an end-to-end client workflow
+#145  Reliable Task-first workflow
   ↓
-       Diff / tests / review / PR / CI lifecycle
+#173  Capability-aware runConfig / direct-session parity
   ↓
 #146  Multi-machine Fleet (after demand validation)
+  ↓
+       Diff / tests / review / PR / CI lifecycle
   ↓
        Auto machine + agent routing / orchestration
 
@@ -341,8 +408,16 @@ SECONDARY / NON-BLOCKING
 #141 Track B ─────────→ ACP permission policy
 ```
 
+This ordering does **not** require every possible session knob before Fleet. It requires the Task model to have the correct extensible contract and the important currently-used choices to work, so Fleet is built on the durable unit of work rather than on a temporary launch wrapper.
+
 ## 13. Success test
 
 Harness is succeeding when users describe it as **the place they run and manage agent work**, not merely the app they use to remote into one coding session.
 
 The strongest product test is not whether Harness supports the most agents. It is whether one workflow remains useful as the user changes agents, projects and machines while local execution stays under their control.
+
+A useful product-level test is:
+
+> Would a normal user choose `New Task` for essentially all meaningful coding work, and use direct `New Session` only for a quick unmanaged interaction or legacy compatibility?
+
+When the answer is yes across supported agents, Session has become an execution detail rather than the primary unit of work.

--- a/web/src/components/task-launch-dialog.tsx
+++ b/web/src/components/task-launch-dialog.tsx
@@ -3,8 +3,9 @@ import { CloseIcon, FolderIcon, LoadingIcon, PlayIcon, ServerIcon } from "../Ico
 import { discoverMachineConnection, selectableMachineAgents } from "../machineClient"
 import { loadActiveServerProfile, loadServerProfiles } from "../serverProfiles"
 import { taskClient, type MachineProject } from "../taskClient"
+import { api } from "../api"
 import type { Translator } from "../i18n"
-import type { MachineSnapshot, ServerConfig } from "../types"
+import type { MachineSnapshot, ModelOption, ServerConfig } from "../types"
 
 /**
  * Which agent a task runs on is not a choice yet: the launched session has to open in the existing
@@ -29,6 +30,8 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
   const [machine, setMachine] = useState<MachineSnapshot | null>(null)
   const [projects, setProjects] = useState<MachineProject[]>([])
   const [projectId, setProjectId] = useState("")
+  const [models, setModels] = useState<ModelOption[]>([])
+  const [modelIndex, setModelIndex] = useState(-1)
   const [prompt, setPrompt] = useState("")
   const [isolated, setIsolated] = useState(true)
   const [loading, setLoading] = useState(true)
@@ -53,6 +56,14 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
         if (cancelled) return
         const active = activeProfileAgent(connection.machine, config)
         if (!active) throw new Error(t('task.agentUnavailable', { agent: config.agentId ?? config.backend }))
+        // Models are an agent-scoped question, and not every agent answers it: ACP harnesses have
+        // no model listing, so a failure here means "no choice to offer", not a broken dialog.
+        const offered = await api
+          .listModels({ ...connection.config, agentId: active.id })
+          .catch(() => [] as ModelOption[])
+        if (cancelled) return
+        setModels(offered)
+        setModelIndex(offered.findIndex((option) => option.isDefault))
         setTaskConfig(connection.config)
         setMachine(connection.machine)
         setProjects(knownProjects)
@@ -71,7 +82,13 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
     setStarting(true)
     setError(null)
     try {
-      let task = await taskClient.createTask(taskConfig, { projectId, agentId: agent.id, prompt: prompt.trim() })
+      const model = models[modelIndex]
+      let task = await taskClient.createTask(taskConfig, {
+        projectId,
+        agentId: agent.id,
+        prompt: prompt.trim(),
+        model: model && { providerID: model.providerID, modelID: model.modelID, variant: model.variant }
+      })
       if (isolated && selectedProject?.kind === "git") task = await taskClient.prepareWorktree(taskConfig, task.id)
       await taskClient.launch(taskConfig, task.id)
       onLaunched()
@@ -125,6 +142,20 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
                   {projects.map((project) => <option key={project.id} value={project.id}>{project.name} — {project.path}</option>)}
                 </select>
               </label>
+
+              {models.length > 0 && (
+                <label className="field">
+                  <span>{t('task.model')}</span>
+                  <select value={String(modelIndex)} onChange={(event) => setModelIndex(Number(event.target.value))}>
+                    <option value="-1">{t('task.modelDefault')}</option>
+                    {models.map((option, index) => (
+                      <option key={`${option.providerID}/${option.modelID}/${option.variant ?? ""}`} value={String(index)}>
+                        {option.providerName} — {option.modelName}{option.variant ? ` (${option.variant})` : ""}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
 
               <label className="field">
                 <span>{t('task.label')}</span>

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -236,6 +236,8 @@ type TranslationKey =
   | 'task.starting'
   | 'task.subtitle'
   | 'task.project'
+  | 'task.model'
+  | 'task.modelDefault'
   | 'task.label'
   | 'task.agent'
   | 'task.machine'
@@ -323,6 +325,8 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'task.starting': 'Starting…',
     'task.subtitle': 'Start agent work on {machine}.',
     'task.project': 'Project',
+    'task.model': 'Model',
+    'task.modelDefault': 'Agent default',
     'task.label': 'Task',
     'task.agent': 'Agent',
     'task.machine': 'Machine',
@@ -637,6 +641,8 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'task.starting': 'Avvio…',
     'task.subtitle': 'Avvia un lavoro con un agente su {machine}.',
     'task.project': 'Progetto',
+    'task.model': 'Modello',
+    'task.modelDefault': 'Predefinito dell’agente',
     'task.label': 'Task',
     'task.agent': 'Agente',
     'task.machine': 'Macchina',
@@ -951,6 +957,8 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'task.starting': '正在啟動…',
     'task.subtitle': '在 {machine} 上開始代理工作。',
     'task.project': '專案',
+    'task.model': '模型',
+    'task.modelDefault': '代理預設',
     'task.label': '任務',
     'task.agent': '代理',
     'task.machine': '機器',
@@ -1217,6 +1225,8 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'task.starting': '正在启动…',
     'task.subtitle': '在 {machine} 上启动代理工作。',
     'task.project': '项目',
+    'task.model': '模型',
+    'task.modelDefault': '代理默认',
     'task.label': '任务',
     'task.agent': '代理',
     'task.machine': '机器',

--- a/web/src/task-client-regression.test.mjs
+++ b/web/src/task-client-regression.test.mjs
@@ -50,6 +50,15 @@ assert.equal(
   'both creation actions need a short label; the compact action drops its label entirely'
 )
 
+// A task started on the wrong model is a task that has to be thrown away, so the choice belongs
+// where the task is created — offered only when the agent has models to offer, since ACP harnesses
+// have no listing and would otherwise show an empty control.
+assert.ok(dialog.includes("t('task.model')"), 'the task dialog must offer a model')
+assert.ok(dialog.includes('models.length > 0 &&'), 'the model field must be absent when the agent has no models to list')
+assert.ok(dialog.includes("t('task.modelDefault')"), 'leaving the agent default must stay an explicit choice')
+assert.ok(dialog.includes('.catch(() => [] as ModelOption[])'), 'an agent without a model listing must not break the dialog')
+assert.ok(client.includes('model?: ModelSelection'), 'the task client must carry the selection to the daemon')
+
 // The endpoint serving sessions is often not the one serving the task APIs.
 assert.ok(dialog.includes('discoverMachineConnection(config)'), 'the Task dialog must resolve the machine endpoint separately from the session endpoint')
 assert.ok(dialog.includes('taskClient.listProjects(connection.config)'), 'project discovery must use the resolved daemon endpoint')

--- a/web/src/taskClient.ts
+++ b/web/src/taskClient.ts
@@ -2,7 +2,7 @@ import { Capacitor, CapacitorHttp } from "@capacitor/core"
 import { desktopRequestResult, isDesktopPlatform } from "./desktopBridge"
 import { unwrapPayload } from "./machinePayload"
 import { authHeader, hasCredentials, machineBaseUrl } from "./serverConfig"
-import type { ServerConfig } from "./types"
+import type { ModelSelection, ServerConfig } from "./types"
 
 export type MachineProject = {
   id: string
@@ -149,7 +149,7 @@ export const taskClient = {
     return requireArray<MachineTask>(payload, "tasks", "/v1/tasks")
   },
 
-  async createTask(config: ServerConfig, input: { projectId: string; agentId: string; prompt: string }): Promise<MachineTask> {
+  async createTask(config: ServerConfig, input: { projectId: string; agentId: string; prompt: string; model?: ModelSelection }): Promise<MachineTask> {
     return machineRequest<MachineTask>(config, "/v1/tasks", { method: "POST", body: input })
   },
 


### PR DESCRIPTION
Stacked on #172. Found by using the task workflow from the Android build: a task asks for a goal and starts immediately, so it runs on whatever the agent defaults to — on a real repository, usually the wrong one, with no remedy but throwing the run away.

## The selection travels the whole way

| Step | Change |
|---|---|
| `POST /v1/tasks` | accepts an optional `model`, normalized at the edge |
| `TaskStore.create` | persists it, `null` when absent |
| `TaskLauncher.createSession` | `{ title, model: { providerID, id, variant } }` |
| `TaskLauncher.startPrompt` | `{ parts, model: { providerID, modelID }, variant }` |
| Task dialog | lists the agent's models, defaults to the agent's own default |

The two endpoints disagree about what the model id is called — `POST /session` wants `id`, `prompt_async` wants `modelID` — so `task-model.js` owns that difference rather than each call site spelling it out.

A selection naming only half of itself is refused rather than half-applied. A task that claims a model and silently uses the default is worse than one that never claimed anything.

`model: null` is stored explicitly rather than omitted: "left on the agent default" is a recorded choice a relaunch can reproduce, and it is a different fact from a task saved before models could be chosen at all.

## Agents without a model listing

The listing is agent-scoped, and ACP harnesses publish none. A failure there means there is no choice to offer, so the field is absent rather than empty — the dialog stays two fields for anyone who does not need a third. Nothing about the existing launch path changes when no model is chosen: both bodies omit `model` entirely rather than sending an empty object the agent would have to interpret.

## Not fixed here

Variant travels with the model, because the session path already treats them as one selection. **Sub-agent and attachments remain unavailable to tasks.** That is not an oversight of this PR — see #173: the roadmap describes the task loop as a sequence of places work passes through (`project → task → worktree → agent → run`), which answers *where* work runs and never *how a run is configured*. Every per-run setting the session surface has will be missing from tasks until the model gains an explicit run-configuration concept. Model is the first one that hurts, not the last one missing.

## Verification

- 193 bridge tests, including four new ones: normalization refuses half a selection, the two endpoints get the field names each expects, the selection reaches both calls, and a task without a model sends no model at all.
- Web build, type-check and all twelve regression suites.
- `task-store.test.js` updated for the new persisted shape — the `deepEqual` there is deliberate, so a field added to a task is a decision someone has to confirm.
