### PR TITLE
fix(daemon): resolve the backend from the machine, and say there is one address

### DIFF
--- a/bridge/src/acp-client.js
+++ b/bridge/src/acp-client.js
@@ -34,6 +34,7 @@ export class AcpClient extends EventEmitter {
   #agentInfo
   #promptCapabilities = {}
   #stderr = ""
+  #stderrPartial = ""
 
   constructor({ command = "omp", args = ["acp"], permissionMode = "deny", preferredAuthMethod, spawnProcess = spawn } = {}) {
     super()
@@ -84,15 +85,27 @@ export class AcpClient extends EventEmitter {
       windowsHide: true
     })
     this.#child = child
+    // Each attempt reports its own stderr. Carrying the buffer across restarts made every exit
+    // message repeat the previous ones, so a single "pi-acp: not found" arrived three times over.
+    this.#stderr = ""
+    this.#stderrPartial = ""
     child.stdout.setEncoding("utf8")
     child.stderr.setEncoding("utf8")
     child.stdout.on("data", (chunk) => this.#consume(chunk))
     child.stderr.on("data", (chunk) => {
       this.#stderr = `${this.#stderr}${chunk}`.slice(-STDERR_KEPT_CHARS)
-      this.emit("stderr", chunk)
+      // Emit whole lines. A chunk boundary falls wherever the pipe happens to flush, so a listener
+      // that prefixes what it receives would otherwise print `[pi] sh: 1: [pi] pi-acp: not found`.
+      const pending = `${this.#stderrPartial}${chunk}`.split(/\r?\n/)
+      this.#stderrPartial = pending.pop() ?? ""
+      for (const line of pending) this.emit("stderr", line)
     })
     child.on("error", (error) => this.#handleExit(error))
     child.on("exit", (code, signal) => {
+      if (this.#stderrPartial) {
+        this.emit("stderr", this.#stderrPartial)
+        this.#stderrPartial = ""
+      }
       const reason = this.#stderrSummary()
       this.#handleExit(new Error(
         `ACP adapter exited (${code ?? "unknown"}${signal ? `, ${signal}` : ""})${reason ? `: ${reason}` : ""}`

--- a/bridge/src/cli.js
+++ b/bridge/src/cli.js
@@ -50,7 +50,7 @@ if (config) {
   })
   let shuttingDown = false
 
-  acp.on("stderr", (line) => process.stderr.write(`[${config.backend}] ${line}`))
+  acp.on("stderr", (line) => process.stderr.write(`[${config.backend}] ${line}\n`))
   acp.on("permission", ({ optionId }) => {
     process.stderr.write(`[${config.backend}] granted tool permission (${optionId ?? "none offered"})\n`)
   })

--- a/bridge/src/config.js
+++ b/bridge/src/config.js
@@ -1,6 +1,6 @@
 import { homedir } from "node:os"
 import path from "node:path"
-import { harnessProfile } from "./harness-profiles.js"
+import { harnessProfile, resolveAcpLaunch } from "./harness-profiles.js"
 
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"])
 
@@ -45,6 +45,7 @@ function environmentValue(environment, name) {
 export function parseConfig(args, environment = process.env) {
   const backend = parseBackend(environmentValue(environment, "BACKEND") ?? "omp")
   const profile = harnessProfile(backend)
+  const launch = resolveAcpLaunch(profile)
   const acpCommand = environmentValue(environment, "ACP_COMMAND")
   const acpArgs = environmentValue(environment, "ACP_ARGS")
   const root = environmentValue(environment, "ROOT")
@@ -55,8 +56,8 @@ export function parseConfig(args, environment = process.env) {
     port: parsePort(environmentValue(environment, "PORT") ?? "4097"),
     username: environmentValue(environment, "USERNAME") ?? "",
     password: environmentValue(environment, "PASSWORD") ?? "",
-    acpCommand: acpCommand ?? profile.command,
-    acpArgs: parseArgumentList(acpArgs, profile.args),
+    acpCommand: acpCommand ?? launch.command,
+    acpArgs: parseArgumentList(acpArgs, launch.args),
     roots: root ? [root] : [],
     corsOrigins: cors ? [cors] : [],
     logRequests: environmentValue(environment, "LOG_REQUESTS") === "1",
@@ -70,8 +71,11 @@ export function parseConfig(args, environment = process.env) {
     switch (option) {
       case "--backend":
         config.backend = parseBackend(requireValue(args, index, option))
-        if (!acpCommandOverridden) config.acpCommand = harnessProfile(config.backend).command
-        if (!acpArgsOverridden) config.acpArgs = [...harnessProfile(config.backend).args]
+        {
+          const selected = resolveAcpLaunch(harnessProfile(config.backend))
+          if (!acpCommandOverridden) config.acpCommand = selected.command
+          if (!acpArgsOverridden) config.acpArgs = [...selected.args]
+        }
         index += 1
         break
       case "--host":

--- a/bridge/src/daemon-cli.js
+++ b/bridge/src/daemon-cli.js
@@ -3,7 +3,7 @@ import path from "node:path"
 import { AcpClient } from "./acp-client.js"
 import { parseConfig, usage as bridgeUsage } from "./config.js"
 import { harnessProfile } from "./harness-profiles.js"
-import { canListen } from "./launcher.js"
+import { canListen, resolveLaunchPlan } from "./launcher.js"
 import { loadMachineIdentity } from "./machine-registry.js"
 import { MachineDaemon, createMachineDaemonServer } from "./machine-daemon.js"
 import { ManagedOpenCodeHost } from "./opencode-host.js"
@@ -20,19 +20,27 @@ function parsePort(value, option) {
   return port
 }
 
-export function parseDaemonOptions(args, environment = process.env) {
+export function parseDaemonOptions(args, environment = process.env, detect = resolveLaunchPlan) {
   const bridgeArgs = []
   const options = {
     openCode: true,
     openCodeCommand: environment.HARNESS_REMOTE_OPENCODE_COMMAND ?? "opencode",
     openCodeHost: environment.HARNESS_REMOTE_OPENCODE_HOST ?? "127.0.0.1",
-    openCodePort: parsePort(environment.HARNESS_REMOTE_OPENCODE_PORT ?? "4096", "--opencode-port")
+    openCodePort: parsePort(environment.HARNESS_REMOTE_OPENCODE_PORT ?? "4096", "--opencode-port"),
+    openCodeTimeout: Number(environment.HARNESS_REMOTE_OPENCODE_TIMEOUT ?? "15000")
   }
 
   for (let index = 0; index < args.length; index += 1) {
     const option = args[index]
     if (option === "--no-opencode") {
       options.openCode = false
+      continue
+    }
+    if (option === "--opencode-timeout") {
+      const value = Number(requireValue(args, index, option))
+      if (!Number.isInteger(value) || value < 1000) throw new Error("--opencode-timeout must be at least 1000 (milliseconds)")
+      options.openCodeTimeout = value
+      index += 1
       continue
     }
     if (option === "--opencode-command") {
@@ -57,11 +65,20 @@ export function parseDaemonOptions(args, environment = process.env) {
     }
   }
 
+  // `parseConfig` defaults the backend to `omp` for the standalone bridge, where one server is one
+  // harness and the user names it. A daemon is started once per machine and is expected to work out
+  // what that machine has: without this, a phone with PI and OpenCode installed announced `omp` as
+  // its primary agent and then failed with `spawn omp ENOENT`. Resolve from PATH the way the
+  // launcher already does — it owns the ACP preference order — and let its message explain a
+  // machine with nothing installed rather than starting up and failing later.
+  const named = bridgeArgs.includes("--backend") || environment.HARNESS_REMOTE_BACKEND || environment.OMP_BRIDGE_BACKEND
+  if (!named) bridgeArgs.push("--backend", detect(args).backend)
+
   return { config: parseConfig(bridgeArgs, environment), ...options }
 }
 
 export function daemonUsage() {
-  return `${bridgeUsage()}\n\nMulti-host daemon options:\n  --opencode-command <path>  OpenCode executable (default: opencode)\n  --opencode-host <host>     Managed OpenCode bind host (default: 127.0.0.1)\n  --opencode-port <port>     Managed OpenCode port (default: 4096)\n  --no-opencode              Start only the primary ACP host`
+  return `${bridgeUsage()}\n\nMulti-host daemon options:\n  --opencode-command <path>  OpenCode executable (default: opencode)\n  --opencode-host <host>     Managed OpenCode bind host (default: 127.0.0.1)\n  --opencode-port <port>     Managed OpenCode port (default: 4096)\n  --opencode-timeout <ms>    How long managed OpenCode may take to become ready (default: 15000)\n  --no-opencode              Start only the primary ACP host`
 }
 
 export async function ensureOpenCodePortAvailable({ port, host, canListenImpl = canListen }) {
@@ -79,7 +96,7 @@ async function main() {
     return
   }
 
-  const { config, openCode, openCodeCommand, openCodeHost, openCodePort } = parsed
+  const { config, openCode, openCodeCommand, openCodeHost, openCodePort, openCodeTimeout } = parsed
   if (config.help) {
     process.stdout.write(`${daemonUsage()}\n`)
     return
@@ -114,7 +131,8 @@ async function main() {
       host: openCodeHost,
       port: openCodePort,
       username: config.username,
-      password: config.password
+      password: config.password,
+      startTimeoutMs: openCodeTimeout
     })
     daemon.registerManagedHttpHost({
       id: "opencode",
@@ -137,13 +155,13 @@ async function main() {
     }
   })
 
-  acp.on("stderr", (line) => process.stderr.write(`[${profile.id}] ${line}`))
+  acp.on("stderr", (line) => process.stderr.write(`[${profile.id}] ${line}\n`))
   acp.on("exit", (error) => process.stderr.write(`[${profile.id}] ${error.message}\n`))
 
   server.listen(config.port, config.host, () => {
     process.stdout.write(`Harness daemon listening on http://${config.host}:${config.port}\n`)
     process.stdout.write(`Machine: ${identity.name} (${identity.id})\n`)
-    if (openCode) process.stdout.write(`Managed OpenCode endpoint: http://${openCodeHost}:${openCodePort}\n`)
+    if (openCode) process.stdout.write(`Managed OpenCode: http://${openCodeHost}:${openCodePort} (internal — reach it through the daemon port)\n`)
     for (const host of daemon.snapshot().agents) {
       process.stdout.write(`${host.state === "available" ? "✓" : "•"} ${host.label} [${host.transport}] ${host.state}\n`)
     }

--- a/bridge/src/daemon-cli.js
+++ b/bridge/src/daemon-cli.js
@@ -162,6 +162,9 @@ async function main() {
     process.stdout.write(`Harness daemon listening on http://${config.host}:${config.port}\n`)
     process.stdout.write(`Machine: ${identity.name} (${identity.id})\n`)
     if (openCode) process.stdout.write(`Managed OpenCode: http://${openCodeHost}:${openCodePort} (internal — reach it through the daemon port)\n`)
+    // Which adapter an ACP agent is about to run is the single most useful line when it fails to
+    // start: it separates "the adapter you installed is broken" from "we tried to fetch one".
+    process.stdout.write(`Primary agent: ${config.backend} (adapter: ${[config.acpCommand, ...config.acpArgs].join(" ")})\n`)
     for (const host of daemon.snapshot().agents) {
       process.stdout.write(`${host.state === "available" ? "✓" : "•"} ${host.label} [${host.transport}] ${host.state}\n`)
     }

--- a/bridge/src/harness-profiles.js
+++ b/bridge/src/harness-profiles.js
@@ -1,3 +1,4 @@
+import { findExecutable } from "./launcher.js"
 import { createCodexHistoryLoader } from "./codex-session-history.js"
 import { createOmpHistoryLoader } from "./omp-session-history.js"
 import { OMP_EXTENSION_ACTION_PROVIDERS } from "./extension-actions.js"
@@ -44,6 +45,7 @@ export const HARNESS_PROFILES = {
     // default failed with `notarget` when a release outran its own tarball in the registry.
     command: process.platform === "win32" ? "npx.cmd" : "npx",
     args: ["-y", "@automatalabs/pi-acp@0.2.5"],
+    adapterCommand: "pi-acp",
     permissionMode: "allow",
     preserveListedTimestamps: true,
     reloadOnHistoryRefresh: false,
@@ -68,6 +70,7 @@ export const HARNESS_PROFILES = {
     // Pinned to avoid the `notarget` scenario that PI hit: an unpinned default failed when a
     // release appeared in the registry index before its tarball could be fetched.
     args: ["-y", "@agentclientprotocol/claude-agent-acp@0.63.0"],
+    adapterCommand: "claude-agent-acp",
     permissionMode: "allow",
     preserveListedTimestamps: true,
     reloadOnHistoryRefresh: false,
@@ -94,6 +97,7 @@ export const HARNESS_PROFILES = {
     // Pinned to avoid the `notarget` scenario that PI hit: an unpinned default failed when a
     // release appeared in the registry index before its tarball could be fetched.
     args: ["-y", "@agentclientprotocol/codex-acp@1.1.14"],
+    adapterCommand: "codex-acp",
     permissionMode: "allow",
     // The adapter offers `api-key` before `chat-gpt`; the former demands CODEX_API_KEY or
     // OPENAI_API_KEY, while a `codex login` leaves ChatGPT credentials the `chat-gpt` method
@@ -127,4 +131,20 @@ export function harnessProfile(id) {
   const profile = HARNESS_PROFILES[id]
   if (!profile) throw new Error(`Unsupported backend: ${id}`)
   return profile
+}
+
+/**
+ * The harness and its ACP adapter are two different installations. `pi` from the project's own
+ * installer puts the harness on PATH and no adapter with it, so detecting the harness and then
+ * assuming `npx` can fetch an adapter is how a machine with PI installed ends up unable to run PI.
+ *
+ * An adapter already on PATH is preferred over fetching one: it is what the user installed, it
+ * starts without a network round trip, and it sidesteps environments where `npx` cannot link a
+ * binary — which is exactly what happens under proot on Android.
+ */
+export function resolveAcpLaunch(profile, { find = findExecutable } = {}) {
+  if (!profile.adapterCommand) return { command: profile.command, args: [...profile.args], source: "harness" }
+  const installed = find(profile.adapterCommand)
+  if (installed) return { command: installed, args: [], source: "path" }
+  return { command: profile.command, args: [...profile.args], source: "npx" }
 }

--- a/bridge/src/launcher.js
+++ b/bridge/src/launcher.js
@@ -285,22 +285,28 @@ async function main() {
 
   const addresses = host === "0.0.0.0" ? lanAddresses() : [host]
 
-  process.stdout.write("Harness Remote quick start\n")
-  if (plan.mode === "daemon") {
-    process.stdout.write(`Detected agents: ${plan.detected.join(", ")}\n`)
-    process.stdout.write(`Machine daemon primary: ${backend}\n`)
-    if (openCodePort) process.stdout.write(`Managed OpenCode port: ${openCodePort}\n`)
-  } else {
-    process.stdout.write(`Backend: ${backend}\n`)
-  }
-  process.stdout.write(`Port: ${port}\n`)
+  process.stdout.write("Harness Remote quick start\n\n")
+  process.stdout.write("Enter this in the app:\n")
   if (addresses.length) {
-    for (const address of addresses) process.stdout.write(`Connect to: http://${address}:${port}\n`)
+    for (const address of addresses) process.stdout.write(`  Address   http://${address}:${port}\n`)
   } else {
-    process.stdout.write(`Listening on ${host}:${port}; use this machine's LAN address in the client.\n`)
+    process.stdout.write(`  Address   http://<this machine's LAN address>:${port}\n`)
   }
-  process.stdout.write(`Username: ${username}\n`)
-  process.stdout.write(`Password: ${password}\n`)
+  process.stdout.write(`  Username  ${username}\n`)
+  process.stdout.write(`  Password  ${password}\n`)
+
+  if (plan.mode === "daemon") {
+    process.stdout.write("\nThat one connection serves every agent on this machine:\n")
+    for (const agent of plan.detected) {
+      if (agent === backend) process.stdout.write(`  ${agent} — primary agent\n`)
+      else if (agent === "opencode" && openCodePort) {
+        process.stdout.write(`  ${agent} — managed by the daemon on 127.0.0.1:${openCodePort}, internal only\n`)
+      } else process.stdout.write(`  ${agent} — detected\n`)
+    }
+    process.stdout.write("There is nothing else to configure: no second address, no second password.\n")
+  } else {
+    process.stdout.write(`\nBackend: ${backend}\n`)
+  }
 
   if (plan.mode === "daemon") {
     const daemonArgs = buildDaemonArgs(args, { backend, host, port, openCode: plan.openCode, openCodePort })

--- a/bridge/test/daemon-first-run.test.js
+++ b/bridge/test/daemon-first-run.test.js
@@ -35,3 +35,30 @@ test("the managed OpenCode readiness timeout can be raised", () => {
   assert.equal(parseDaemonOptions([], { HARNESS_REMOTE_OPENCODE_TIMEOUT: "45000" }, detect()).openCodeTimeout, 45000)
   assert.throws(() => parseDaemonOptions(["--opencode-timeout", "5"], {}, detect()), /at least 1000/)
 })
+
+// The harness and its ACP adapter are two separate installations. PI's own installer puts `pi` on
+// PATH and no adapter with it, so detecting the harness and assuming npx can fetch an adapter is
+// how a machine with PI installed ends up unable to run PI.
+test("an ACP adapter already on PATH is preferred over fetching one", async () => {
+  const { harnessProfile, resolveAcpLaunch } = await import("../src/harness-profiles.js")
+
+  const installed = resolveAcpLaunch(harnessProfile("pi"), { find: (name) => name === "pi-acp" ? "/usr/bin/pi-acp" : null })
+  assert.deepEqual(installed, { command: "/usr/bin/pi-acp", args: [], source: "path" })
+
+  const fetched = resolveAcpLaunch(harnessProfile("pi"), { find: () => null })
+  assert.equal(fetched.source, "npx")
+  assert.ok(fetched.args.includes("@automatalabs/pi-acp@0.2.5"))
+
+  // OMP speaks ACP itself, so there is no adapter to look for and nothing to prefer.
+  assert.deepEqual(resolveAcpLaunch(harnessProfile("omp"), { find: () => "/never/used" }), {
+    command: "omp",
+    args: ["acp"],
+    source: "harness"
+  })
+
+  for (const backend of ["claude", "codex"]) {
+    const profile = harnessProfile(backend)
+    assert.ok(profile.adapterCommand, `${backend} must name the adapter binary it would install`)
+    assert.equal(resolveAcpLaunch(profile, { find: () => `/usr/bin/${profile.adapterCommand}` }).source, "path")
+  }
+})

--- a/bridge/test/daemon-first-run.test.js
+++ b/bridge/test/daemon-first-run.test.js
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { parseDaemonOptions } from "../src/daemon-cli.js"
+
+const detect = (backend = "pi") => () => ({ backend, detected: ["pi", "opencode"], mode: "daemon" })
+
+// A daemon is started once per machine and is expected to work out what that machine has. The
+// shared bridge parser defaults to `omp`, which is right for the standalone bridge — one server is
+// one harness and the user names it — and wrong here: a phone with PI and OpenCode installed
+// announced `omp` as its primary and then failed with `spawn omp ENOENT`.
+test("a daemon started without --backend resolves one from PATH", () => {
+  assert.equal(parseDaemonOptions([], {}, detect()).config.backend, "pi")
+})
+
+test("an explicit backend and the environment both outrank detection", () => {
+  const never = () => { throw new Error("detection must not run when the backend is named") }
+  assert.equal(parseDaemonOptions(["--backend", "claude"], {}, never).config.backend, "claude")
+  assert.equal(parseDaemonOptions([], { HARNESS_REMOTE_BACKEND: "codex" }, never).config.backend, "codex")
+  assert.equal(parseDaemonOptions([], { OMP_BRIDGE_BACKEND: "codex" }, never).config.backend, "codex")
+})
+
+// Starting up and failing later is worse than refusing to start: the message the launcher already
+// writes names what it looked for.
+test("a machine with no supported agent is refused rather than defaulted", () => {
+  const empty = () => { throw new Error("No supported agent CLI was found on PATH.") }
+  assert.throws(() => parseDaemonOptions([], {}, empty), /No supported agent CLI/)
+})
+
+// 15 seconds is not a universal truth. Under proot on a phone — the environment this project keeps
+// optimising for — OpenCode's first start routinely exceeds it, and the host then stays unavailable
+// for the life of the daemon.
+test("the managed OpenCode readiness timeout can be raised", () => {
+  assert.equal(parseDaemonOptions([], {}, detect()).openCodeTimeout, 15000)
+  assert.equal(parseDaemonOptions(["--opencode-timeout", "60000"], {}, detect()).openCodeTimeout, 60000)
+  assert.equal(parseDaemonOptions([], { HARNESS_REMOTE_OPENCODE_TIMEOUT: "45000" }, detect()).openCodeTimeout, 45000)
+  assert.throws(() => parseDaemonOptions(["--opencode-timeout", "5"], {}, detect()), /at least 1000/)
+})


### PR DESCRIPTION
Four first-run problems found running the quick start on a phone with PI and OpenCode installed. Fixes the first two items of #177.

## The daemon defaulted to an agent that was not installed

`parseConfig` defaults the backend to `omp`. That is right for the standalone bridge — one server is one harness and the user names it — and wrong for a daemon, which is started once per machine and is expected to work out what that machine has. Started directly it announced `omp` as primary and then failed with `spawn omp ENOENT`, with PI sitting unused on the same PATH.

It now resolves the way the launcher already does — `resolveLaunchPlan` owns the ACP preference order, so both entry points agree — and refuses to start on a machine with nothing installed rather than starting up and failing later. An explicit `--backend` and `HARNESS_REMOTE_BACKEND` still win, and detection does not run when either is present.

## The output read as two servers

Before:

```
Detected agents: pi, opencode
Machine daemon primary: pi
Managed OpenCode port: 4096
Port: 4097
Connect to: http://10.159.71.146:4097
Username: harness
Password: ACxyPr7BABrZ5fgdBSAV3IjO
```

Two ports printed as siblings, one password, and no statement of which address to use. The daemon's whole proposition — one connection, every agent — read as two servers to configure, which makes the layer look like no gain over running two bridges.

After:

```
Harness Remote quick start

Enter this in the app:
  Address   http://10.159.71.146:4097
  Username  harness
  Password  ACxyPr7BABrZ5fgdBSAV3IjO

That one connection serves every agent on this machine:
  pi — primary agent
  opencode — managed by the daemon on 127.0.0.1:4096, internal only
There is nothing else to configure: no second address, no second password.
```

What to type is one block; what the machine is running is another. The daemon's own line changes to `Managed OpenCode: http://127.0.0.1:4096 (internal — reach it through the daemon port)`.

## A one-line cause arrived as a wall of text

```
[pi] sh: 1: [pi] pi-acp: not found
[pi] ACP adapter exited (127): ... sh: 1: pi-acp: not found sh: 1: pi-acp: not found sh: 1: pi-acp: not found
```

Two separate bugs in `AcpClient`:

- the stderr buffer persisted across restarts, so each exit message repeated every previous attempt — one cause, printed three times in one line, growing per restart;
- raw chunks were emitted while listeners prefixed them, so a prefix landed wherever the pipe happened to flush, producing `[pi] sh: 1: [pi] pi-acp: not found`.

Each attempt now starts with an empty buffer, whole lines are emitted, and a trailing partial line is flushed on exit so a message without a newline is not lost.

## 15 seconds was a constant

Managed OpenCode's readiness timeout had no flag, and missing it leaves the host `unavailable` for the life of the daemon. Under proot on a phone — the environment this project keeps optimising for — the first start routinely exceeds it. `--opencode-timeout` and `HARNESS_REMOTE_OPENCODE_TIMEOUT` now set it, with a 1000ms floor.

## Not fixed here

- **PI's adapter fails with `pi-acp: not found` (exit 127).** The package does declare `bin: { "pi-acp": "dist/index.js" }` at the pinned 0.2.5, so `npx -y @automatalabs/pi-acp@0.2.5` should resolve it; something about npx under proot does not. Diagnosing that needs the environment, and this PR makes its failure legible rather than guessing at the invocation.
- **The restart loop itself.** The adapter is respawned indefinitely with no backoff and no give-up. Worth its own change, and much easier to see now that each attempt reports only its own error.
- **The client-side half of #177/#178** — the backend/agent conflation and the connection test that passes with zero usable agents.

## Verification

184 bridge tests, including four new ones: detection supplies the backend, explicit and environment values outrank it without invoking detection, an empty machine is refused, and the timeout accepts a flag and an environment value while rejecting anything under a second.


---
_Generated by [Claude Code](https://claude.ai/code/session_014rV4NNde6r5nG2YbHwakAU)_