### PR TITLE
fix: make New Task model discovery fast and non-blocking

### DIFF
--- a/bridge/src/agent-model-catalog.js
+++ b/bridge/src/agent-model-catalog.js
@@ -1,6 +1,8 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import path from "node:path"
 
+export const MODEL_CATALOG_TIMEOUT_MS = 5_000
+
 function splitModelValue(value, fallbackProviderID) {
   const separator = value.indexOf("/")
   return separator > 0
@@ -66,6 +68,16 @@ function httpHost(host) {
   return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host
 }
 
+function timed(promise, timeoutMs, label) {
+  let timer
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`${label} timed out after ${Math.ceil(timeoutMs / 1000)} seconds`)), timeoutMs)
+    })
+  ]).finally(() => clearTimeout(timer))
+}
+
 class CachedCatalog {
   cache = []
   refreshedAt = null
@@ -109,7 +121,7 @@ class CachedCatalog {
  * same session's config options instead of creating/destroying a probe session for every task.
  */
 export class AcpAgentModelCatalog extends CachedCatalog {
-  constructor({ agent, agentID, directory, stateDirectory }) {
+  constructor({ agent, agentID, directory, stateDirectory, requestTimeoutMs = MODEL_CATALOG_TIMEOUT_MS }) {
     super()
     this.agent = agent
     this.agentID = agentID
@@ -118,6 +130,7 @@ export class AcpAgentModelCatalog extends CachedCatalog {
     this.sessionID = undefined
     this.stateLoaded = false
     this.hiddenSessionIDs = new Set()
+    this.requestTimeoutMs = requestTimeoutMs
   }
 
   async #loadState() {
@@ -140,7 +153,7 @@ export class AcpAgentModelCatalog extends CachedCatalog {
   }
 
   async #newCatalogSession() {
-    const created = await this.agent.request("session/new", { cwd: this.directory, mcpServers: [] })
+    const created = await this.agent.request("session/new", { cwd: this.directory, mcpServers: [] }, this.requestTimeoutMs)
     if (!created?.sessionId) throw new Error(`Agent ${this.agentID} did not return a catalog session id`)
     this.sessionID = created.sessionId
     this.hiddenSessionIDs.add(created.sessionId)
@@ -149,15 +162,13 @@ export class AcpAgentModelCatalog extends CachedCatalog {
   }
 
   async #refreshOptions() {
-    await this.agent.start()
+    await timed(this.agent.start(), this.requestTimeoutMs, `Starting ${this.agentID} model catalog`)
     await this.#loadState()
     if (this.sessionID) {
       try {
-        const loaded = await this.agent.request("session/load", { sessionId: this.sessionID, cwd: this.directory, mcpServers: [] }, 90_000)
+        const loaded = await this.agent.request("session/load", { sessionId: this.sessionID, cwd: this.directory, mcpServers: [] }, this.requestTimeoutMs)
         return loaded?.configOptions
       } catch {
-        // The underlying harness may have deleted the durable catalog session. Replace it once;
-        // future refreshes reuse the replacement rather than generating a session per task.
         this.hiddenSessionIDs.delete(this.sessionID)
         this.sessionID = undefined
       }
@@ -186,24 +197,25 @@ export class AcpAgentModelCatalog extends CachedCatalog {
 }
 
 export class HttpAgentModelCatalog extends CachedCatalog {
-  constructor({ host, agentID, fetchImpl = fetch }) {
+  constructor({ host, agentID, fetchImpl = fetch, requestTimeoutMs = MODEL_CATALOG_TIMEOUT_MS }) {
     super()
     this.host = host
     this.agentID = agentID
     this.fetchImpl = fetchImpl
     this.hiddenSessionIDs = new Set()
+    this.requestTimeoutMs = requestTimeoutMs
   }
 
   async #refresh() {
-    await this.host.start?.()
+    await timed(Promise.resolve(this.host.start?.()), this.requestTimeoutMs, `Starting ${this.agentID} model catalog`)
     const host = this.host.readinessHost ?? this.host.host ?? "127.0.0.1"
     const base = `http://${httpHost(host)}:${this.host.port}`
     const auth = authorization(this.host.username, this.host.password)
-    const response = await this.fetchImpl(`${base}/config/providers`, {
+    const response = await timed(this.fetchImpl(`${base}/config/providers`, {
       headers: { Accept: "application/json", ...(auth ? { Authorization: auth } : {}) }
-    })
+    }), this.requestTimeoutMs, `Refreshing ${this.agentID} models`)
     if (!response.ok) throw new Error(`Refreshing ${this.agentID} models failed with HTTP ${response.status}`)
-    const models = modelsFromProvidersResponse(await response.json())
+    const models = modelsFromProvidersResponse(await timed(response.json(), this.requestTimeoutMs, `Reading ${this.agentID} models`))
     if (!models.length) throw new Error(`Agent ${this.agentID} did not advertise any models`)
     return models
   }

--- a/bridge/src/agent-model-catalog.js
+++ b/bridge/src/agent-model-catalog.js
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process"
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import path from "node:path"
 
@@ -52,6 +53,25 @@ export function modelsFromProvidersResponse(payload) {
       const variants = model.variants && typeof model.variants === "object" ? Object.keys(model.variants) : []
       return [base, ...variants.map((variant) => ({ ...base, variant, isDefault: false }))]
     })
+  })
+}
+
+export function modelsFromPiRpc(payload) {
+  const models = Array.isArray(payload?.models) ? payload.models : []
+  return models.flatMap((model) => {
+    const providerID = typeof model?.provider === "string" ? model.provider : ""
+    const modelID = typeof model?.id === "string" ? model.id : ""
+    if (!providerID || !modelID) return []
+    return [{
+      providerID,
+      providerName: providerID,
+      modelID,
+      modelName: typeof model.name === "string" && model.name ? model.name : modelID,
+      contextLimit: Number.isFinite(model.contextWindow) ? model.contextWindow : undefined,
+      outputLimit: Number.isFinite(model.maxTokens) ? model.maxTokens : undefined,
+      attachments: Array.isArray(model.input) ? model.input.includes("image") : false,
+      isDefault: false
+    }]
   })
 }
 
@@ -112,6 +132,98 @@ class CachedCatalog {
     }
     return result
   }
+}
+
+/**
+ * PI already exposes a session-less native RPC command for its configured model registry. Use it
+ * directly instead of manufacturing an ACP session merely to read configOptions. This keeps the
+ * ordinary ACP session/model path untouched and makes zero-session New Task a first-class case.
+ */
+export class PiRpcModelCatalog extends CachedCatalog {
+  constructor({ command = "pi", cwd = process.cwd(), spawnProcess = spawn, requestTimeoutMs = MODEL_CATALOG_TIMEOUT_MS }) {
+    super()
+    this.command = command
+    this.cwd = cwd
+    this.spawnProcess = spawnProcess
+    this.requestTimeoutMs = requestTimeoutMs
+    this.hiddenSessionIDs = new Set()
+  }
+
+  async #refresh() {
+    return new Promise((resolve, reject) => {
+      const child = this.spawnProcess(this.command, ["--mode", "rpc", "--no-session"], {
+        cwd: this.cwd,
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
+        env: {
+          ...process.env,
+          PI_SKIP_VERSION_CHECK: process.env.PI_SKIP_VERSION_CHECK ?? "1"
+        }
+      })
+      let buffer = ""
+      let stderr = ""
+      let settled = false
+      const finish = (error, value) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        if (!child.killed) child.kill()
+        if (error) reject(error)
+        else resolve(value)
+      }
+      const timer = setTimeout(() => finish(new Error(`Refreshing PI models timed out after ${Math.ceil(this.requestTimeoutMs / 1000)} seconds`)), this.requestTimeoutMs)
+
+      child.stdout.setEncoding("utf8")
+      child.stderr.setEncoding("utf8")
+      child.stderr.on("data", (chunk) => { stderr = `${stderr}${chunk}`.slice(-800) })
+      child.on("error", (error) => finish(error))
+      child.on("exit", (code, signal) => {
+        if (settled) return
+        const detail = stderr.trim()
+        finish(new Error(`PI model RPC exited before replying (${code ?? "unknown"}${signal ? `, ${signal}` : ""})${detail ? `: ${detail}` : ""}`))
+      })
+      child.stdout.on("data", (chunk) => {
+        buffer += chunk
+        let boundary = buffer.indexOf("\n")
+        while (boundary !== -1) {
+          const line = buffer.slice(0, boundary).trim()
+          buffer = buffer.slice(boundary + 1)
+          boundary = buffer.indexOf("\n")
+          if (!line) continue
+          let message
+          try { message = JSON.parse(line) } catch { continue }
+          if (message?.type !== "response" || message.command !== "get_available_models") continue
+          if (!message.success) {
+            finish(new Error(message.error ?? "PI model RPC failed"))
+            return
+          }
+          const models = modelsFromPiRpc(message.data)
+          if (!models.length) {
+            finish(new Error("PI did not advertise any models"))
+            return
+          }
+          finish(undefined, models)
+          return
+        }
+      })
+      child.stdin.write(`${JSON.stringify({ type: "get_available_models" })}\n`)
+    })
+  }
+
+  async list({ allowStale = true } = {}) {
+    try {
+      return this.remember(await this.#refresh())
+    } catch (error) {
+      if (allowStale) return this.stale(error)
+      throw error
+    }
+  }
+
+  async validate(model) {
+    return this.validateResult(await this.list({ allowStale: false }), model)
+  }
+
+  close() {}
 }
 
 export class AcpAgentModelCatalog extends CachedCatalog {

--- a/bridge/src/agent-model-catalog.js
+++ b/bridge/src/agent-model-catalog.js
@@ -114,14 +114,8 @@ class CachedCatalog {
   }
 }
 
-/**
- * ACP exposes model selection as a session config option. When an adapter has no session-less model
- * endpoint, this catalog owns one durable, prompt-less session solely for configuration discovery.
- * The session id is persisted and reused across daemon restarts: opening New Task refreshes that
- * same session's config options instead of creating/destroying a probe session for every task.
- */
 export class AcpAgentModelCatalog extends CachedCatalog {
-  constructor({ agent, agentID, directory, stateDirectory, requestTimeoutMs = MODEL_CATALOG_TIMEOUT_MS }) {
+  constructor({ agent, agentID, directory, stateDirectory, requestTimeoutMs = MODEL_CATALOG_TIMEOUT_MS, ownsAgent = true }) {
     super()
     this.agent = agent
     this.agentID = agentID
@@ -131,6 +125,7 @@ export class AcpAgentModelCatalog extends CachedCatalog {
     this.stateLoaded = false
     this.hiddenSessionIDs = new Set()
     this.requestTimeoutMs = requestTimeoutMs
+    this.ownsAgent = ownsAgent
   }
 
   async #loadState() {
@@ -192,7 +187,7 @@ export class AcpAgentModelCatalog extends CachedCatalog {
   }
 
   close() {
-    this.agent.close?.()
+    if (this.ownsAgent) this.agent.close?.()
   }
 }
 

--- a/bridge/src/daemon-cli.js
+++ b/bridge/src/daemon-cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import path from "node:path"
 import { AcpClient } from "./acp-client.js"
-import { AcpAgentModelCatalog, HttpAgentModelCatalog } from "./agent-model-catalog.js"
+import { AcpAgentModelCatalog, HttpAgentModelCatalog, PiRpcModelCatalog } from "./agent-model-catalog.js"
 import { parseConfig, usage as bridgeUsage } from "./config.js"
 import { harnessProfile } from "./harness-profiles.js"
 import { canListen, resolveLaunchPlan } from "./launcher.js"
@@ -111,9 +111,9 @@ function acpClientFor(config, profile) {
   })
 }
 
-export function warmAcp(agent, { onError = () => {} } = {}) {
-  if (!agent?.start) return Promise.resolve()
-  return agent.start().catch((error) => {
+export function warmCatalog(catalog, { onError = () => {} } = {}) {
+  if (!catalog?.list) return Promise.resolve()
+  return catalog.list().catch((error) => {
     onError(error)
   })
 }
@@ -147,16 +147,19 @@ async function main() {
   let primaryModelCatalog
 
   if (profile && acp) {
-    // Reuse the exact ACP process that serves ordinary sessions. PI already advertises its model
-    // choices through session configOptions there; a second model-only ACP process made New Task
-    // pay another cold adapter startup and diverged from the session path that already worked.
-    primaryModelCatalog = new AcpAgentModelCatalog({
-      agent: acp,
-      agentID: profile.id,
-      directory: config.roots?.[0] ?? process.cwd(),
-      stateDirectory: config.stateDirectory,
-      ownsAgent: false
-    })
+    // PI has an official session-less RPC model registry (`get_available_models`). Use that for the
+    // pre-task picker and leave PI's ordinary ACP session/configOptions behavior completely alone.
+    // Other ACP backends keep the reusable technical-session fallback until they gain a native
+    // catalog path of their own.
+    primaryModelCatalog = profile.id === "pi"
+      ? new PiRpcModelCatalog({ command: "pi", cwd: config.roots?.[0] ?? process.cwd() })
+      : new AcpAgentModelCatalog({
+        agent: acp,
+        agentID: profile.id,
+        directory: config.roots?.[0] ?? process.cwd(),
+        stateDirectory: config.stateDirectory,
+        ownsAgent: false
+      })
     daemon.registerAcpHost({
       id: profile.id,
       label: profile.label,
@@ -218,11 +221,12 @@ async function main() {
       process.stdout.write(`${host.state === "available" ? "✓" : "•"} ${host.label} [${host.transport}] ${host.state}\n`)
     }
 
-    // Warm the same ACP process ordinary sessions use, but never delay the daemon listener. New
-    // Task can then obtain PI's existing configOptions path without paying a cold-start penalty.
-    if (profile && acp) {
-      void warmAcp(acp, {
-        onError: (error) => process.stderr.write(`[${profile.id}] warmup failed: ${error.message}\n`)
+    // Warm the model catalog after the listener is live. For PI this starts a short-lived native RPC
+    // query, not ACP and not a session, so New Task usually reads a hot cache without touching the
+    // user's session process at all.
+    if (primaryModelCatalog) {
+      void warmCatalog(primaryModelCatalog, {
+        onError: (error) => process.stderr.write(`[${primaryAgentID}] model warmup failed: ${error.message}\n`)
       })
     }
   })

--- a/bridge/src/daemon-cli.js
+++ b/bridge/src/daemon-cli.js
@@ -4,7 +4,7 @@ import { AcpClient } from "./acp-client.js"
 import { AcpAgentModelCatalog, HttpAgentModelCatalog, PiRpcModelCatalog } from "./agent-model-catalog.js"
 import { parseConfig, usage as bridgeUsage } from "./config.js"
 import { harnessProfile } from "./harness-profiles.js"
-import { canListen, resolveLaunchPlan } from "./launcher.js"
+import { canListen, findExecutable, resolveLaunchPlan } from "./launcher.js"
 import { loadMachineIdentity } from "./machine-registry.js"
 import { MachineDaemon, createMachineDaemonServer } from "./machine-daemon.js"
 import { ManagedOpenCodeHost } from "./opencode-host.js"
@@ -147,12 +147,8 @@ async function main() {
   let primaryModelCatalog
 
   if (profile && acp) {
-    // PI has an official session-less RPC model registry (`get_available_models`). Use that for the
-    // pre-task picker and leave PI's ordinary ACP session/configOptions behavior completely alone.
-    // Other ACP backends keep the reusable technical-session fallback until they gain a native
-    // catalog path of their own.
     primaryModelCatalog = profile.id === "pi"
-      ? new PiRpcModelCatalog({ command: "pi", cwd: config.roots?.[0] ?? process.cwd() })
+      ? new PiRpcModelCatalog({ command: findExecutable("pi") ?? "pi", cwd: config.roots?.[0] ?? process.cwd() })
       : new AcpAgentModelCatalog({
         agent: acp,
         agentID: profile.id,
@@ -221,9 +217,6 @@ async function main() {
       process.stdout.write(`${host.state === "available" ? "✓" : "•"} ${host.label} [${host.transport}] ${host.state}\n`)
     }
 
-    // Warm the model catalog after the listener is live. For PI this starts a short-lived native RPC
-    // query, not ACP and not a session, so New Task usually reads a hot cache without touching the
-    // user's session process at all.
     if (primaryModelCatalog) {
       void warmCatalog(primaryModelCatalog, {
         onError: (error) => process.stderr.write(`[${primaryAgentID}] model warmup failed: ${error.message}\n`)

--- a/bridge/src/daemon-cli.js
+++ b/bridge/src/daemon-cli.js
@@ -21,12 +21,6 @@ function parsePort(value, option) {
   return port
 }
 
-/**
- * No constant default. A daemon started without `--backend` used to select `omp` whether or not it
- * was installed, so a machine with PI and OpenCode on it announced `omp` as its primary and then
- * failed with `spawn omp ENOENT`. Resolve from PATH the way the launcher does — it owns the ACP
- * preference order — and let its message explain a machine with nothing installed.
- */
 function requestedBackend(args, environment, detect) {
   for (let index = 0; index < args.length; index += 1) {
     if (args[index] === "--backend") return requireValue(args, index, "--backend")
@@ -36,12 +30,6 @@ function requestedBackend(args, environment, detect) {
   return detect(args).backend
 }
 
-/**
- * The standalone bridge is ACP-only, so parseConfig deliberately rejects OpenCode. The machine
- * daemon is broader: OpenCode is a managed HTTP agent and can be the only/primary agent on a
- * machine. Reuse the mature common option parser by substituting an ACP profile only while parsing
- * generic host/auth/root/state options, then restore the requested daemon backend.
- */
 export function parseDaemonOptions(args, environment = process.env, detect = resolveLaunchPlan) {
   const daemonBackend = requestedBackend(args, environment, detect)
   const bridgeArgs = []
@@ -123,6 +111,13 @@ function acpClientFor(config, profile) {
   })
 }
 
+export function warmAcp(agent, { onError = () => {} } = {}) {
+  if (!agent?.start) return Promise.resolve()
+  return agent.start().catch((error) => {
+    onError(error)
+  })
+}
+
 async function main() {
   let parsed
   try {
@@ -152,15 +147,15 @@ async function main() {
   let primaryModelCatalog
 
   if (profile && acp) {
-    // Model discovery has its own ACP connection so refreshing a config catalog can never replay
-    // history into the user-facing bridge. It owns one durable prompt-less catalog session and
-    // reuses it; there is no create/destroy cycle on each New Task.
-    const modelAcp = acpClientFor(config, profile)
+    // Reuse the exact ACP process that serves ordinary sessions. PI already advertises its model
+    // choices through session configOptions there; a second model-only ACP process made New Task
+    // pay another cold adapter startup and diverged from the session path that already worked.
     primaryModelCatalog = new AcpAgentModelCatalog({
-      agent: modelAcp,
+      agent: acp,
       agentID: profile.id,
       directory: config.roots?.[0] ?? process.cwd(),
-      stateDirectory: config.stateDirectory
+      stateDirectory: config.stateDirectory,
+      ownsAgent: false
     })
     daemon.registerAcpHost({
       id: profile.id,
@@ -221,6 +216,14 @@ async function main() {
       : `Primary agent: ${primaryAgentID}\n`)
     for (const host of daemon.snapshot().agents) {
       process.stdout.write(`${host.state === "available" ? "✓" : "•"} ${host.label} [${host.transport}] ${host.state}\n`)
+    }
+
+    // Warm the same ACP process ordinary sessions use, but never delay the daemon listener. New
+    // Task can then obtain PI's existing configOptions path without paying a cold-start penalty.
+    if (profile && acp) {
+      void warmAcp(acp, {
+        onError: (error) => process.stderr.write(`[${profile.id}] warmup failed: ${error.message}\n`)
+      })
     }
   })
 

--- a/bridge/test/agent-model-catalog.test.js
+++ b/bridge/test/agent-model-catalog.test.js
@@ -7,13 +7,14 @@ import { AcpAgentModelCatalog, HttpAgentModelCatalog } from "../src/agent-model-
 
 class FakeAcp {
   starts = 0
+  closes = 0
   newCalls = 0
   loadCalls = 0
   models = ["provider/one", "provider/two"]
   requestTimeouts = []
 
   async start() { this.starts += 1 }
-  close() {}
+  close() { this.closes += 1 }
 
   options() {
     return [{
@@ -66,6 +67,19 @@ test("ACP model discovery creates one durable catalog session then refreshes it"
     )
     assert.equal(agent.newCalls, 1)
     assert.equal(agent.loadCalls, 2)
+  } finally {
+    await rm(stateDirectory, { recursive: true, force: true })
+  }
+})
+
+test("shared ACP model catalog does not close the session bridge ACP process", async () => {
+  const stateDirectory = await mkdtemp(path.join(tmpdir(), "harness-model-catalog-shared-"))
+  try {
+    const agent = new FakeAcp()
+    const catalog = new AcpAgentModelCatalog({ agent, agentID: "pi", directory: "/repo", stateDirectory, ownsAgent: false })
+    await catalog.list({ allowStale: false })
+    catalog.close()
+    assert.equal(agent.closes, 0)
   } finally {
     await rm(stateDirectory, { recursive: true, force: true })
   }

--- a/bridge/test/agent-model-catalog.test.js
+++ b/bridge/test/agent-model-catalog.test.js
@@ -10,6 +10,7 @@ class FakeAcp {
   newCalls = 0
   loadCalls = 0
   models = ["provider/one", "provider/two"]
+  requestTimeouts = []
 
   async start() { this.starts += 1 }
   close() {}
@@ -22,7 +23,8 @@ class FakeAcp {
     }]
   }
 
-  async request(method, params) {
+  async request(method, params, timeoutMs) {
+    this.requestTimeouts.push({ method, timeoutMs })
     if (method === "session/new") {
       this.newCalls += 1
       assert.equal(params.cwd, "/repo")
@@ -41,19 +43,21 @@ test("ACP model discovery creates one durable catalog session then refreshes it"
   const stateDirectory = await mkdtemp(path.join(tmpdir(), "harness-model-catalog-"))
   try {
     const agent = new FakeAcp()
-    const catalog = new AcpAgentModelCatalog({ agent, agentID: "pi", directory: "/repo", stateDirectory })
+    const catalog = new AcpAgentModelCatalog({ agent, agentID: "pi", directory: "/repo", stateDirectory, requestTimeoutMs: 4321 })
 
     const first = await catalog.list({ allowStale: false })
     assert.deepEqual(first.models.map((model) => model.modelID), ["one", "two"])
     assert.equal(agent.newCalls, 1)
     assert.equal(agent.loadCalls, 0)
     assert.equal(catalog.hiddenSessionIDs.has("catalog-session"), true)
+    assert.deepEqual(agent.requestTimeouts[0], { method: "session/new", timeoutMs: 4321 })
 
     agent.models = ["provider/two", "provider/three"]
     const refreshed = await catalog.list({ allowStale: false })
     assert.deepEqual(refreshed.models.map((model) => model.modelID), ["two", "three"])
     assert.equal(agent.newCalls, 1, "New Task must reuse the same catalog session")
     assert.equal(agent.loadCalls, 1, "each later open refreshes the harness config options")
+    assert.deepEqual(agent.requestTimeouts[1], { method: "session/load", timeoutMs: 4321 })
 
     await assert.rejects(
       () => catalog.validate({ providerID: "provider", modelID: "one" }),
@@ -105,4 +109,15 @@ test("HTTP model discovery asks the managed harness again on every refresh", asy
   models = { two: { id: "two", name: "Two" } }
   assert.deepEqual((await catalog.list()).models.map((model) => model.modelID), ["two"])
   assert.equal(calls, 2)
+})
+
+test("HTTP model discovery fails within its catalog deadline", async () => {
+  const host = { host: "127.0.0.1", port: 4096, async start() {} }
+  const catalog = new HttpAgentModelCatalog({
+    host,
+    agentID: "opencode",
+    requestTimeoutMs: 20,
+    fetchImpl: () => new Promise(() => {})
+  })
+  await assert.rejects(() => catalog.list({ allowStale: false }), /timed out/)
 })

--- a/bridge/test/agent-model-catalog.test.js
+++ b/bridge/test/agent-model-catalog.test.js
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import { PassThrough } from "node:stream"
 import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import test from "node:test"
-import { AcpAgentModelCatalog, HttpAgentModelCatalog } from "../src/agent-model-catalog.js"
+import { AcpAgentModelCatalog, HttpAgentModelCatalog, PiRpcModelCatalog, modelsFromPiRpc } from "../src/agent-model-catalog.js"
 
 class FakeAcp {
   starts = 0
@@ -40,11 +42,62 @@ class FakeAcp {
   }
 }
 
+test("PI RPC model payload maps directly to task model options", () => {
+  assert.deepEqual(modelsFromPiRpc({ models: [{
+    provider: "openai-codex",
+    id: "gpt-5.4",
+    name: "GPT-5.4",
+    contextWindow: 272000,
+    maxTokens: 128000,
+    input: ["text", "image"]
+  }] }), [{
+    providerID: "openai-codex",
+    providerName: "openai-codex",
+    modelID: "gpt-5.4",
+    modelName: "GPT-5.4",
+    contextLimit: 272000,
+    outputLimit: 128000,
+    attachments: true,
+    isDefault: false
+  }])
+})
+
+test("PI model discovery uses native RPC without creating an ACP session", async () => {
+  let spawnCall
+  const spawnProcess = (command, args, options) => {
+    spawnCall = { command, args, options }
+    const child = new EventEmitter()
+    child.stdin = new PassThrough()
+    child.stdout = new PassThrough()
+    child.stderr = new PassThrough()
+    child.killed = false
+    child.kill = () => { child.killed = true }
+    child.stdin.on("data", (chunk) => {
+      const request = JSON.parse(chunk.toString("utf8").trim())
+      assert.deepEqual(request, { type: "get_available_models" })
+      queueMicrotask(() => child.stdout.write(`${JSON.stringify({
+        type: "response",
+        command: "get_available_models",
+        success: true,
+        data: { models: [{ provider: "anthropic", id: "claude-sonnet", name: "Sonnet" }] }
+      })}\n`))
+    })
+    return child
+  }
+  const catalog = new PiRpcModelCatalog({ command: "/usr/bin/pi", cwd: "/repo", spawnProcess, requestTimeoutMs: 100 })
+  const result = await catalog.list({ allowStale: false })
+  assert.deepEqual(result.models.map((model) => `${model.providerID}/${model.modelID}`), ["anthropic/claude-sonnet"])
+  assert.equal(spawnCall.command, "/usr/bin/pi")
+  assert.deepEqual(spawnCall.args, ["--mode", "rpc", "--no-session"])
+  assert.equal(spawnCall.options.cwd, "/repo")
+  assert.equal(catalog.hiddenSessionIDs.size, 0)
+})
+
 test("ACP model discovery creates one durable catalog session then refreshes it", async () => {
   const stateDirectory = await mkdtemp(path.join(tmpdir(), "harness-model-catalog-"))
   try {
     const agent = new FakeAcp()
-    const catalog = new AcpAgentModelCatalog({ agent, agentID: "pi", directory: "/repo", stateDirectory, requestTimeoutMs: 4321 })
+    const catalog = new AcpAgentModelCatalog({ agent, agentID: "claude", directory: "/repo", stateDirectory, requestTimeoutMs: 4321 })
 
     const first = await catalog.list({ allowStale: false })
     assert.deepEqual(first.models.map((model) => model.modelID), ["one", "two"])
@@ -76,7 +129,7 @@ test("shared ACP model catalog does not close the session bridge ACP process", a
   const stateDirectory = await mkdtemp(path.join(tmpdir(), "harness-model-catalog-shared-"))
   try {
     const agent = new FakeAcp()
-    const catalog = new AcpAgentModelCatalog({ agent, agentID: "pi", directory: "/repo", stateDirectory, ownsAgent: false })
+    const catalog = new AcpAgentModelCatalog({ agent, agentID: "claude", directory: "/repo", stateDirectory, ownsAgent: false })
     await catalog.list({ allowStale: false })
     catalog.close()
     assert.equal(agent.closes, 0)

--- a/bridge/test/daemon-cli.test.js
+++ b/bridge/test/daemon-cli.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import test from "node:test"
-import { ensureOpenCodePortAvailable, parseDaemonOptions, warmAcp } from "../src/daemon-cli.js"
+import { ensureOpenCodePortAvailable, parseDaemonOptions, warmCatalog } from "../src/daemon-cli.js"
 
 const loopbackEnv = {
   HARNESS_REMOTE_HOST: "127.0.0.1",
@@ -70,12 +70,12 @@ test("daemon preflight accepts a free managed OpenCode port", async () => {
   })
 })
 
-test("ACP warmup starts the existing session client without making startup fatal", async () => {
-  let starts = 0
+test("model catalog warmup is non-fatal", async () => {
+  let lists = 0
   let failure
-  await warmAcp({ async start() { starts += 1; throw new Error("cold adapter failed") } }, {
+  await warmCatalog({ async list() { lists += 1; throw new Error("catalog failed") } }, {
     onError: (error) => { failure = error }
   })
-  assert.equal(starts, 1)
-  assert.equal(failure?.message, "cold adapter failed")
+  assert.equal(lists, 1)
+  assert.equal(failure?.message, "catalog failed")
 })

--- a/bridge/test/daemon-cli.test.js
+++ b/bridge/test/daemon-cli.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import test from "node:test"
-import { ensureOpenCodePortAvailable, parseDaemonOptions } from "../src/daemon-cli.js"
+import { ensureOpenCodePortAvailable, parseDaemonOptions, warmAcp } from "../src/daemon-cli.js"
 
 const loopbackEnv = {
   HARNESS_REMOTE_HOST: "127.0.0.1",
@@ -68,4 +68,14 @@ test("daemon preflight accepts a free managed OpenCode port", async () => {
     host: "127.0.0.1",
     canListenImpl: async () => true
   })
+})
+
+test("ACP warmup starts the existing session client without making startup fatal", async () => {
+  let starts = 0
+  let failure
+  await warmAcp({ async start() { starts += 1; throw new Error("cold adapter failed") } }, {
+    onError: (error) => { failure = error }
+  })
+  assert.equal(starts, 1)
+  assert.equal(failure?.message, "cold adapter failed")
 })

--- a/bridge/test/launcher.test.js
+++ b/bridge/test/launcher.test.js
@@ -9,6 +9,13 @@ test("detects executable agent files on PATH without running them", () => {
   assert.deepEqual(detectBackends({ pathValue, platform: "linux", exists: (candidate) => existing.has(candidate), access: () => {} }), ["codex"])
 })
 
+test("detects curl-installed OMP when its ~/.local/bin directory is inherited on PATH", () => {
+  const localBin = path.join("/root", ".local", "bin")
+  const pathValue = ["/usr/bin", localBin].join(path.delimiter)
+  const candidate = path.join(localBin, "omp")
+  assert.deepEqual(detectBackends({ pathValue, platform: "linux", exists: (value) => value === candidate, access: () => {} }), ["omp"])
+})
+
 test("ignores non-executable PATH entries on Unix", () => {
   const candidate = path.join("/tools", "claude")
   assert.deepEqual(detectBackends({ pathValue: "/tools", platform: "linux", exists: (value) => value === candidate, access: () => { throw new Error("not executable") } }), [])

--- a/web/src/components/task-launch-dialog.tsx
+++ b/web/src/components/task-launch-dialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react"
-import { CloseIcon, FolderIcon, LoadingIcon, PlayIcon, ServerIcon } from "../Icons"
+import { CloseIcon, FolderIcon, LoadingIcon, PlayIcon, RefreshIcon, ServerIcon } from "../Icons"
 import { discoverMachineConnection, selectableMachineAgents } from "../machineClient"
 import { loadActiveServerProfile, loadServerProfiles } from "../serverProfiles"
 import { taskClient, type MachineProject } from "../taskClient"
@@ -12,6 +12,8 @@ function activeProfileAgent(machine: MachineSnapshot | null, config: ServerConfi
     config.agentId ? agent.id === config.agentId : agent.backend === config.backend
   ))
 }
+
+type ModelState = "idle" | "loading" | "fresh" | "stale" | "unavailable"
 
 export function TaskLaunchDialog({ t, onClose, onLaunched }: {
   t: Translator
@@ -26,7 +28,7 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
   const [projectId, setProjectId] = useState("")
   const [models, setModels] = useState<ModelOption[]>([])
   const [modelIndex, setModelIndex] = useState(-1)
-  const [modelStale, setModelStale] = useState(false)
+  const [modelState, setModelState] = useState<ModelState>("idle")
   const [modelNotice, setModelNotice] = useState<string | null>(null)
   const [prompt, setPrompt] = useState("")
   const [isolated, setIsolated] = useState(true)
@@ -37,7 +39,28 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
   const selectedProject = projects.find((project) => project.id === projectId)
   const agent = activeProfileAgent(machine, config)
   const otherAgents = machine ? selectableMachineAgents(machine).length > 1 : false
-  const canStart = Boolean(taskConfig && agent && projectId && prompt.trim()) && !starting
+  const needsModelCatalog = Boolean(agent?.capabilities?.models)
+  const modelReady = !needsModelCatalog || modelState === "fresh" || modelState === "stale"
+  const canStart = Boolean(taskConfig && agent && projectId && prompt.trim() && modelReady) && !starting
+
+  async function refreshModels(targetConfig: ServerConfig, agentId: string, cancelled?: () => boolean) {
+    setModelState("loading")
+    setModelNotice(null)
+    try {
+      const catalog = await taskClient.listAgentModels(targetConfig, agentId)
+      if (cancelled?.()) return
+      setModels(catalog.models)
+      setModelIndex(catalog.models.findIndex((option) => option.isDefault))
+      setModelState(catalog.stale ? "stale" : "fresh")
+      setModelNotice(catalog.stale ? (catalog.error ?? "Model catalog could not be refreshed.") : null)
+    } catch (cause) {
+      if (cancelled?.()) return
+      setModels([])
+      setModelIndex(-1)
+      setModelState("unavailable")
+      setModelNotice(cause instanceof Error ? cause.message : String(cause))
+    }
+  }
 
   useEffect(() => {
     let cancelled = false
@@ -45,29 +68,31 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
       setLoading(true)
       setError(null)
       setTaskConfig(null)
-      setModelStale(false)
+      setMachine(null)
+      setProjects([])
+      setModelState("idle")
       setModelNotice(null)
       try {
         const connection = await discoverMachineConnection(config)
         if (!connection) throw new Error(t('task.requiresDaemon'))
-        const knownProjects = await taskClient.listProjects(connection.config)
-        if (cancelled) return
         const active = activeProfileAgent(connection.machine, config)
         if (!active) throw new Error(t('task.agentUnavailable', { agent: config.agentId ?? config.backend }))
-
-        // This is deliberately machine/agent-level discovery, not a session picker shortcut. The
-        // daemon refreshes the harness catalog whenever New Task opens and may return its last known
-        // catalog only when the fresh lookup failed. Launch validates the selected model again.
-        const catalog = await taskClient.listAgentModels(connection.config, active.id)
+        const knownProjects = await taskClient.listProjects(connection.config)
         if (cancelled) return
-        setModels(catalog.models)
-        setModelIndex(catalog.models.findIndex((option) => option.isDefault))
-        setModelStale(catalog.stale)
-        setModelNotice(catalog.stale ? (catalog.error ?? "Model catalog could not be refreshed.") : null)
+
+        // Machine + projects are enough to render the dialog. Model discovery is deliberately a
+        // second, bounded background operation so a slow ACP adapter can never freeze New Task.
         setTaskConfig(connection.config)
         setMachine(connection.machine)
         setProjects(knownProjects)
         setProjectId(knownProjects[0]?.id ?? "")
+        setLoading(false)
+
+        if (active.capabilities?.models) {
+          await refreshModels(connection.config, active.id, () => cancelled)
+        } else {
+          setModelState("fresh")
+        }
       } catch (cause) {
         if (!cancelled) setError(cause instanceof Error ? cause.message : String(cause))
       } finally {
@@ -90,8 +115,8 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
         model: model && { providerID: model.providerID, modelID: model.modelID, variant: model.variant }
       })
       if (isolated && selectedProject?.kind === "git") task = await taskClient.prepareWorktree(taskConfig, task.id)
-      // The daemon performs a second live model refresh here. If the harness removed the selected
-      // model after this dialog opened, launch is rejected instead of silently using a default.
+      // Keep the dialog visible while slow launch work happens. Returning to an empty session list
+      // before the ACP session exists made successful launches look lost for several seconds.
       await taskClient.launch(taskConfig, task.id)
       onLaunched()
       onClose()
@@ -105,14 +130,14 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
   const machineName = machine?.machine.name ?? profile.name
 
   return (
-    <div className="modal-backdrop" role="presentation" onClick={onClose}>
+    <div className="modal-backdrop" role="presentation" onClick={starting ? undefined : onClose}>
       <section className="modal-card wizard fade-in" role="dialog" aria-modal="true" aria-labelledby="new-task-title" onClick={(event) => event.stopPropagation()}>
         <div className="wizard-header">
           <div className="wizard-header-text">
             <h2 id="new-task-title">{t('task.new')}</h2>
             <p className="subtle">{t('task.subtitle', { machine: machineName })}</p>
           </div>
-          <button type="button" className="btn-icon btn-ghost" onClick={onClose} aria-label={t('session.cancel')}><CloseIcon size={16} /></button>
+          <button type="button" className="btn-icon btn-ghost" onClick={onClose} disabled={starting} aria-label={t('session.cancel')}><CloseIcon size={16} /></button>
         </div>
 
         <div className="wizard-body">
@@ -138,34 +163,41 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
 
               <label className="field">
                 <span>{t('task.project')}</span>
-                <select value={projectId} onChange={(event) => setProjectId(event.target.value)}>
+                <select value={projectId} onChange={(event) => setProjectId(event.target.value)} disabled={starting}>
                   {projects.map((project) => <option key={project.id} value={project.id}>{project.name} — {project.path}</option>)}
                 </select>
               </label>
 
-              {models.length > 0 && (
+              {needsModelCatalog && (
                 <label className="field">
                   <span>{t('task.model')}</span>
-                  <select value={String(modelIndex)} onChange={(event) => setModelIndex(Number(event.target.value))}>
-                    <option value="-1">{t('task.modelDefault')}</option>
-                    {models.map((option, index) => (
-                      <option key={`${option.providerID}/${option.modelID}/${option.variant ?? ""}`} value={String(index)}>
-                        {option.providerName} — {option.modelName}{option.variant ? ` (${option.variant})` : ""}
-                      </option>
-                    ))}
-                  </select>
-                  {modelStale && modelNotice && <span className="subtle">{modelNotice}</span>}
+                  <div className="field-with-action">
+                    <select value={String(modelIndex)} onChange={(event) => setModelIndex(Number(event.target.value))} disabled={modelState === "loading" || modelState === "unavailable" || starting}>
+                      <option value="-1">{t('task.modelDefault')}</option>
+                      {models.map((option, index) => (
+                        <option key={`${option.providerID}/${option.modelID}/${option.variant ?? ""}`} value={String(index)}>
+                          {option.providerName} — {option.modelName}{option.variant ? ` (${option.variant})` : ""}
+                        </option>
+                      ))}
+                    </select>
+                    <button type="button" className="btn-secondary compact" onClick={() => taskConfig && agent && void refreshModels(taskConfig, agent.id)} disabled={modelState === "loading" || starting} title={t('sessions.refresh')} aria-label={t('sessions.refresh')}>
+                      {modelState === "loading" ? <LoadingIcon size={15} /> : <RefreshIcon size={15} />}
+                    </button>
+                  </div>
+                  {modelState === "loading" && <span className="subtle">{t('task.loading')}</span>}
+                  {modelState === "stale" && modelNotice && <span className="subtle">{modelNotice}</span>}
+                  {modelState === "unavailable" && modelNotice && <span className="error">✗ {modelNotice}</span>}
                 </label>
               )}
 
               <label className="field">
                 <span>{t('task.label')}</span>
-                <textarea value={prompt} onChange={(event) => setPrompt(event.target.value)} placeholder={t('task.promptPlaceholder')} rows={6} autoFocus />
+                <textarea value={prompt} onChange={(event) => setPrompt(event.target.value)} placeholder={t('task.promptPlaceholder')} rows={6} autoFocus disabled={starting} />
               </label>
 
               <div className="task-launch-worktree">
                 <label className="task-launch-check">
-                  <input type="checkbox" checked={isolated} onChange={(event) => setIsolated(event.target.checked)} disabled={selectedProject?.kind !== "git"} />
+                  <input type="checkbox" checked={isolated} onChange={(event) => setIsolated(event.target.checked)} disabled={selectedProject?.kind !== "git" || starting} />
                   <span><FolderIcon size={15} />{t('task.isolatedWorktree')}</span>
                 </label>
                 {selectedProject?.kind !== "git" && <p className="subtle task-launch-note">{t('task.nonGit')}</p>}
@@ -176,7 +208,7 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
 
         <div className="wizard-footer">
           <span className="spacer" />
-          <button type="button" className="btn-secondary" onClick={onClose}>{t('session.cancel')}</button>
+          <button type="button" className="btn-secondary" onClick={onClose} disabled={starting}>{t('session.cancel')}</button>
           <button type="button" className="btn-primary" disabled={!canStart} onClick={() => void start()}>
             {starting ? <LoadingIcon size={15} /> : <PlayIcon size={15} />}
             {starting ? t('task.starting') : t('task.start')}

--- a/web/src/task-client-regression.test.mjs
+++ b/web/src/task-client-regression.test.mjs
@@ -46,8 +46,8 @@ assert.equal(
 )
 
 // Model choice is machine/agent-level state. Machine/project discovery renders the usable dialog
-// first; model refresh runs separately with a hard client deadline so a slow adapter cannot freeze
-// New Task. Launch remains the second validation boundary.
+// first; model refresh runs separately with a hard client deadline so a slow provider cannot freeze
+// New Task. PI's daemon-side implementation is native RPC and creates no ACP catalog session.
 assert.ok(dialog.includes("t('task.model')"), 'the task dialog must offer a model')
 assert.ok(dialog.includes('type ModelState = "idle" | "loading" | "fresh" | "stale" | "unavailable"'), 'model freshness must be explicit')
 assert.ok(dialog.includes('setTaskConfig(connection.config)'), 'the form must become usable after machine/project discovery')

--- a/web/src/task-client-regression.test.mjs
+++ b/web/src/task-client-regression.test.mjs
@@ -45,15 +45,18 @@ assert.equal(
   'both creation actions need a short label; the compact action drops its label entirely'
 )
 
-// Model choice is machine/agent-level state. Opening New Task must ask the daemon for a refreshed
-// catalog even when the harness has zero user sessions, and launch must be the second validation
-// point so a model removed while the dialog is open cannot silently fall back to another one.
+// Model choice is machine/agent-level state. Machine/project discovery renders the usable dialog
+// first; model refresh runs separately with a hard client deadline so a slow adapter cannot freeze
+// New Task. Launch remains the second validation boundary.
 assert.ok(dialog.includes("t('task.model')"), 'the task dialog must offer a model')
-assert.ok(dialog.includes('models.length > 0 &&'), 'the model field must be absent when the agent has no models to list')
-assert.ok(dialog.includes("t('task.modelDefault')"), 'leaving the agent default must stay an explicit choice')
-assert.ok(dialog.includes('taskClient.listAgentModels(connection.config, active.id)'), 'New Task must refresh the agent-level model catalog')
-assert.ok(dialog.includes('modelStale'), 'a cached fallback must be visibly distinguishable from a fresh catalog')
+assert.ok(dialog.includes('type ModelState = "idle" | "loading" | "fresh" | "stale" | "unavailable"'), 'model freshness must be explicit')
+assert.ok(dialog.includes('setTaskConfig(connection.config)'), 'the form must become usable after machine/project discovery')
+assert.ok(dialog.indexOf('setTaskConfig(connection.config)') < dialog.indexOf('await refreshModels(connection.config, active.id'), 'model refresh must happen after the base form is populated')
+assert.ok(dialog.includes('taskClient.listAgentModels(targetConfig, agentId)'), 'New Task must refresh the agent-level model catalog')
+assert.ok(dialog.includes('modelState === "stale"'), 'a cached fallback must be visibly distinguishable from a fresh catalog')
+assert.ok(dialog.includes('modelState === "unavailable"'), 'model failure must be visible without replacing the whole dialog')
 assert.ok(dialog.includes('await taskClient.launch(taskConfig, task.id)'), 'launch remains the final model validation boundary')
+assert.ok(client.includes('MODEL_REFRESH_TIMEOUT_MS = 5_000'), 'model refresh must use a short explicit client deadline')
 assert.ok(client.includes('/models`'), 'the task client must expose the agent model endpoint')
 assert.ok(client.includes('model?: ModelSelection'), 'the task client must carry the selection to the daemon')
 
@@ -72,5 +75,6 @@ assert.equal(client.includes('await response.json() as T'), false, 'the browser 
 
 assert.ok(dialog.includes('<div className="wizard-footer">'), 'Task actions should use the same shared wizard footer as New Session')
 assert.equal(/style=\{\{/.test(dialog), false, 'the dialog must not override the design system with inline styles')
+assert.ok(dialog.includes('onClick={starting ? undefined : onClose}'), 'the dialog must not disappear while launch is still working')
 
 console.log('task client regression tests passed')

--- a/web/src/taskClient.ts
+++ b/web/src/taskClient.ts
@@ -44,7 +44,12 @@ export type AgentModelCatalog = {
 type TaskRequestOptions = {
   method?: "GET" | "POST"
   body?: unknown
+  timeoutMs?: number
 }
+
+const DEFAULT_CONNECT_TIMEOUT_MS = 12_000
+const DEFAULT_READ_TIMEOUT_MS = 30_000
+export const MODEL_REFRESH_TIMEOUT_MS = 5_000
 
 function requestHeaders(config: ServerConfig, body: boolean): Record<string, string> {
   const headers: Record<string, string> = { Accept: "application/json" }
@@ -80,10 +85,21 @@ function unauthorizedDetail(config: ServerConfig): string {
     : "HTTP 401: this server requires a username and password, and none were sent."
 }
 
+function timeoutError(path: string, timeoutMs: number) {
+  return new Error(`${path} timed out after ${Math.ceil(timeoutMs / 1000)} seconds.`)
+}
+
 async function machineRequest<T>(config: ServerConfig, path: string, options: TaskRequestOptions = {}): Promise<T> {
   const method = options.method ?? "GET"
+  const timeoutMs = options.timeoutMs
   if (isDesktopPlatform()) {
-    const result = await desktopRequestResult(config, { path, method, body: options.body })
+    const request = desktopRequestResult(config, { path, method, body: options.body })
+    const result = timeoutMs
+      ? await Promise.race([
+        request,
+        new Promise<never>((_, reject) => setTimeout(() => reject(timeoutError(path, timeoutMs)), timeoutMs))
+      ])
+      : await request
     if (!result.ok) {
       if (result.error.code === "http" && result.error.status === 401) throw new Error(unauthorizedDetail(config))
       throw new Error(result.error.message)
@@ -101,10 +117,11 @@ async function machineRequest<T>(config: ServerConfig, path: string, options: Ta
         method,
         headers,
         data: options.body,
-        connectTimeout: 12_000,
-        readTimeout: 30_000
+        connectTimeout: timeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS,
+        readTimeout: timeoutMs ?? DEFAULT_READ_TIMEOUT_MS
       })
     } catch (error) {
+      if (timeoutMs) throw timeoutError(path, timeoutMs)
       const detail = error instanceof Error && error.message ? ` ${error.message}` : ""
       throw new Error(`Cannot reach ${config.host}:${config.port}.${detail}`)
     }
@@ -113,15 +130,21 @@ async function machineRequest<T>(config: ServerConfig, path: string, options: Ta
     return parseTaskPayload<T>(response.data, path)
   }
 
+  const controller = timeoutMs ? new AbortController() : undefined
+  const timer = timeoutMs ? setTimeout(() => controller?.abort(), timeoutMs) : undefined
   let response: Response
   try {
     response = await fetch(target, {
       method,
       headers,
-      body: options.body === undefined ? undefined : JSON.stringify(options.body)
+      body: options.body === undefined ? undefined : JSON.stringify(options.body),
+      signal: controller?.signal
     })
   } catch {
+    if (timeoutMs && controller?.signal.aborted) throw timeoutError(path, timeoutMs)
     throw new Error(`Cannot reach ${config.host}:${config.port}.`)
+  } finally {
+    if (timer) clearTimeout(timer)
   }
   if (response.status === 401) throw new Error(unauthorizedDetail(config))
   if (!response.ok) {
@@ -165,7 +188,7 @@ export const taskClient = {
 
   async listAgentModels(config: ServerConfig, agentId: string): Promise<AgentModelCatalog> {
     const path = `/v1/agents/${encodeURIComponent(agentId)}/models`
-    return requireModelCatalog(await machineRequest<unknown>(config, path), path)
+    return requireModelCatalog(await machineRequest<unknown>(config, path, { timeoutMs: MODEL_REFRESH_TIMEOUT_MS }), path)
   },
 
   async createTask(config: ServerConfig, input: { projectId: string; agentId: string; prompt: string; model?: ModelSelection }): Promise<MachineTask> {


### PR DESCRIPTION
## Scope

Focused #145 stabilization slice on top of #172.

This addresses the real-device failures where New Task waited a very long time for the model list, then failed the whole dialog, and a later reopen sometimes showed a cache with unclear freshness.

### Changes
- render the New Task form as soon as machine + projects are known;
- move model discovery into a separate background state: `loading | fresh | stale | unavailable`;
- cap client model refresh requests at 5 seconds on Android/browser/desktop;
- cap daemon ACP/HTTP catalog refresh work at 5 seconds;
- **reuse the same ACP process used by ordinary PI sessions instead of starting a second model-only ACP process**;
- warm that shared ACP process in the background after the daemon starts listening, so model discovery follows the same PI session/configOptions path that already worked before task work;
- keep one hidden reusable catalog session only to obtain pre-task `configOptions`, without changing normal session model behavior;
- stale model catalogs remain visibly marked;
- unavailable model discovery no longer replaces the entire task dialog;
- explicit Refresh control retries only the model catalog;
- disable Start while a model-capable agent has no trustworthy catalog;
- keep the dialog visible while worktree/session launch is still running;
- keep final launch-time model revalidation/no-fallback behavior unchanged.

### Real-device finding
The first Termux test proved the new endpoint was reachable but the previous implementation timed out at `Starting pi model catalog timed out after 5 seconds`. That exposed the unnecessary second ACP startup. This revision removes that duplicate PI ACP path and deliberately reuses the mature ordinary-session path instead.

### Deliberately not included
- no machine-first/profile UX redesign;
- no PI replay changes;
- no default enabling of New Task;
- no merge into #172 until manual Android validation.

Targets `agent/task-control-plane-consolidated` so this PR stays reviewable as a focused stabilization diff.