### PR TITLE
hotfix: restore legacy OMP bridge startup

### DIFF
--- a/bridge/src/harness-profiles.js
+++ b/bridge/src/harness-profiles.js
@@ -1,3 +1,6 @@
+import fs from "node:fs"
+import { homedir } from "node:os"
+import path from "node:path"
 import { findExecutable } from "./launcher.js"
 import { createCodexHistoryLoader } from "./codex-session-history.js"
 import { createOmpHistoryLoader } from "./omp-session-history.js"
@@ -39,10 +42,6 @@ export const HARNESS_PROFILES = {
   pi: {
     id: "pi",
     label: "PI",
-    // @automatalabs/pi-acp embeds PI through its published SDK and runs on Node.
-    // @victor-software-house/pi-acp declares engines.bun and shells out to `bun`, which this
-    // project deliberately does not depend on. The version is pinned because an unpinned
-    // default failed with `notarget` when a release outran its own tarball in the registry.
     command: process.platform === "win32" ? "npx.cmd" : "npx",
     args: ["-y", "@automatalabs/pi-acp@0.2.5"],
     adapterCommand: "pi-acp",
@@ -62,13 +61,7 @@ export const HARNESS_PROFILES = {
   claude: {
     id: "claude",
     label: "Claude Code",
-    // Uses the official ACP adapter for the Claude Agent SDK. The adapter speaks ACP JSON-RPC
-    // over stdio and wraps @anthropic-ai/claude-agent-sdk under the hood. The user must have
-    // run `claude login` or set ANTHROPIC_API_KEY before starting the bridge.
-    // Requires Node 22+ (same as the PI adapter it mirrors).
     command: process.platform === "win32" ? "npx.cmd" : "npx",
-    // Pinned to avoid the `notarget` scenario that PI hit: an unpinned default failed when a
-    // release appeared in the registry index before its tarball could be fetched.
     args: ["-y", "@agentclientprotocol/claude-agent-acp@0.63.0"],
     adapterCommand: "claude-agent-acp",
     permissionMode: "allow",
@@ -76,8 +69,6 @@ export const HARNESS_PROFILES = {
     reloadOnHistoryRefresh: false,
     capabilities: {
       ...COMMON_CAPABILITIES,
-      // The adapter advertises a `model` config option like OMP and PI do; its values are bare ids
-      // rather than `provider/model`, which is handled where the response is built.
       models: true,
       todos: true,
       commands: false,
@@ -89,34 +80,16 @@ export const HARNESS_PROFILES = {
   codex: {
     id: "codex",
     label: "Codex CLI",
-    // Uses the official ACP adapter for the OpenAI Codex CLI. The adapter speaks ACP JSON-RPC
-    // over stdio and embeds @openai/codex, so no separate Codex installation is needed. The
-    // user must have run `codex login` (ChatGPT account) or set an OpenAI API key first.
-    // Requires Node 22+ (same as the PI and Claude adapters it mirrors).
     command: process.platform === "win32" ? "npx.cmd" : "npx",
-    // Pinned to avoid the `notarget` scenario that PI hit: an unpinned default failed when a
-    // release appeared in the registry index before its tarball could be fetched.
     args: ["-y", "@agentclientprotocol/codex-acp@1.1.14"],
     adapterCommand: "codex-acp",
     permissionMode: "allow",
-    // The adapter offers `api-key` before `chat-gpt`; the former demands CODEX_API_KEY or
-    // OPENAI_API_KEY, while a `codex login` leaves ChatGPT credentials the `chat-gpt` method
-    // reads from disk. Prefer the login, exactly like the generic default already avoids
-    // env-var methods for the other harnesses.
     authMethod: "chat-gpt",
-    // Codex holds a single-writer lock for as long as a client keeps a thread open, so a session the
-    // desktop app is showing cannot be loaded over ACP at all. Its rollout file can, which is what
-    // lets those sessions be read here. `messages` already forces a reload for every session this
-    // bridge does not own, so a conversation still running in Codex keeps updating without asking
-    // for the replay that the sessions we do own would otherwise repeat on each refresh.
     historyLoader: createCodexHistoryLoader(),
     preserveListedTimestamps: true,
     reloadOnHistoryRefresh: false,
     capabilities: {
       ...COMMON_CAPABILITIES,
-      // The adapter advertises model ids as bare ids rather than `provider/model`, which is
-      // handled where the response is built. Slash commands and plan updates arrive through
-      // the same notifications OMP emits, so commands and todos reflect the actual wire data.
       models: true,
       todos: true,
       commands: true,
@@ -133,17 +106,22 @@ export function harnessProfile(id) {
   return profile
 }
 
-/**
- * The harness and its ACP adapter are two different installations. `pi` from the project's own
- * installer puts the harness on PATH and no adapter with it, so detecting the harness and then
- * assuming `npx` can fetch an adapter is how a machine with PI installed ends up unable to run PI.
- *
- * An adapter already on PATH is preferred over fetching one: it is what the user installed, it
- * starts without a network round trip, and it sidesteps environments where `npx` cannot link a
- * binary — which is exactly what happens under proot on Android.
- */
+function fallbackHarnessCommand(profile) {
+  if (profile.id !== "omp" || process.platform === "win32") return undefined
+  const candidate = path.join(homedir(), ".local", "bin", "omp")
+  try {
+    fs.accessSync(candidate, fs.constants.X_OK)
+    return candidate
+  } catch {
+    return undefined
+  }
+}
+
 export function resolveAcpLaunch(profile, { find = findExecutable } = {}) {
-  if (!profile.adapterCommand) return { command: profile.command, args: [...profile.args], source: "harness" }
+  if (!profile.adapterCommand) {
+    const installed = find(profile.command) ?? fallbackHarnessCommand(profile)
+    return { command: installed ?? profile.command, args: [...profile.args], source: installed ? "path" : "harness" }
+  }
   const installed = find(profile.adapterCommand)
   if (installed) return { command: installed, args: [], source: "path" }
   return { command: profile.command, args: [...profile.args], source: "npx" }

--- a/bridge/test/daemon-first-run.test.js
+++ b/bridge/test/daemon-first-run.test.js
@@ -4,10 +4,6 @@ import { parseDaemonOptions } from "../src/daemon-cli.js"
 
 const detect = (backend = "pi") => () => ({ backend, detected: ["pi", "opencode"], mode: "daemon" })
 
-// A daemon is started once per machine and is expected to work out what that machine has. The
-// shared bridge parser defaults to `omp`, which is right for the standalone bridge — one server is
-// one harness and the user names it — and wrong here: a phone with PI and OpenCode installed
-// announced `omp` as its primary and then failed with `spawn omp ENOENT`.
 test("a daemon started without --backend resolves one from PATH", () => {
   assert.equal(parseDaemonOptions([], {}, detect()).config.backend, "pi")
 })
@@ -19,16 +15,11 @@ test("an explicit backend and the environment both outrank detection", () => {
   assert.equal(parseDaemonOptions([], { OMP_BRIDGE_BACKEND: "codex" }, never).config.backend, "codex")
 })
 
-// Starting up and failing later is worse than refusing to start: the message the launcher already
-// writes names what it looked for.
 test("a machine with no supported agent is refused rather than defaulted", () => {
   const empty = () => { throw new Error("No supported agent CLI was found on PATH.") }
   assert.throws(() => parseDaemonOptions([], {}, empty), /No supported agent CLI/)
 })
 
-// 15 seconds is not a universal truth. Under proot on a phone — the environment this project keeps
-// optimising for — OpenCode's first start routinely exceeds it, and the host then stays unavailable
-// for the life of the daemon.
 test("the managed OpenCode readiness timeout can be raised", () => {
   assert.equal(parseDaemonOptions([], {}, detect()).openCodeTimeout, 15000)
   assert.equal(parseDaemonOptions(["--opencode-timeout", "60000"], {}, detect()).openCodeTimeout, 60000)
@@ -36,9 +27,6 @@ test("the managed OpenCode readiness timeout can be raised", () => {
   assert.throws(() => parseDaemonOptions(["--opencode-timeout", "5"], {}, detect()), /at least 1000/)
 })
 
-// The harness and its ACP adapter are two separate installations. PI's own installer puts `pi` on
-// PATH and no adapter with it, so detecting the harness and assuming npx can fetch an adapter is
-// how a machine with PI installed ends up unable to run PI.
 test("an ACP adapter already on PATH is preferred over fetching one", async () => {
   const { harnessProfile, resolveAcpLaunch } = await import("../src/harness-profiles.js")
 
@@ -49,11 +37,12 @@ test("an ACP adapter already on PATH is preferred over fetching one", async () =
   assert.equal(fetched.source, "npx")
   assert.ok(fetched.args.includes("@automatalabs/pi-acp@0.2.5"))
 
-  // OMP speaks ACP itself, so there is no adapter to look for and nothing to prefer.
-  assert.deepEqual(resolveAcpLaunch(harnessProfile("omp"), { find: () => "/never/used" }), {
-    command: "omp",
+  // OMP is itself the ACP executable. Resolve it before spawning so a child process does not have
+  // to rediscover a curl-installed ~/.local/bin wrapper from a possibly different npx PATH.
+  assert.deepEqual(resolveAcpLaunch(harnessProfile("omp"), { find: (name) => name === "omp" ? "/home/test/.local/bin/omp" : null }), {
+    command: "/home/test/.local/bin/omp",
     args: ["acp"],
-    source: "harness"
+    source: "path"
   })
 
   for (const backend of ["claude", "codex"]) {


### PR DESCRIPTION
Closed after reproducing the original behavior correctly. The reported `spawn omp ENOENT` was caused by testing from a shell/session where the OMP install directory was not on PATH, not by a regression in the legacy bridge. A clean test with `main` + the legacy per-harness OMP bridge + the stable v2.10.3 APK works as expected, so this hotfix is not needed.

No merge.