### PR TITLE
fix: restore stable PI adapter on legacy bridge

### DIFF
--- a/bridge/src/cli.js
+++ b/bridge/src/cli.js
@@ -8,7 +8,11 @@ import { createBridgeServer } from "./server.js"
 
 let config
 try {
-  config = parseConfig(process.argv.slice(2))
+  // The standalone bridge is the stable compatibility path. Keep its adapter defaults exactly
+  // profile-pinned (for PI, @automatalabs/pi-acp@0.2.5) instead of silently substituting an
+  // unrelated `pi-acp` binary found on PATH. The machine daemon may prefer installed adapters,
+  // but the legacy bridge must remain deterministic like the current stable release.
+  config = parseConfig(process.argv.slice(2), process.env, { preferInstalledAdapters: false })
 } catch (error) {
   process.stderr.write(`${error.message}\n\n${usage()}\n`)
   process.exitCode = 1

--- a/bridge/src/config.js
+++ b/bridge/src/config.js
@@ -36,16 +36,19 @@ function parseBackend(value) {
   return harnessProfile(value).id
 }
 
-
 function environmentValue(environment, name) {
   return environment[`HARNESS_REMOTE_${name}`] ?? environment[`OMP_BRIDGE_${name}`]
 }
 
+function profileLaunch(profile) {
+  return { command: profile.command, args: [...profile.args] }
+}
 
-export function parseConfig(args, environment = process.env) {
+export function parseConfig(args, environment = process.env, { preferInstalledAdapters = true } = {}) {
   const backend = parseBackend(environmentValue(environment, "BACKEND") ?? "omp")
   const profile = harnessProfile(backend)
-  const launch = resolveAcpLaunch(profile)
+  const launchFor = preferInstalledAdapters ? resolveAcpLaunch : profileLaunch
+  const launch = launchFor(profile)
   const acpCommand = environmentValue(environment, "ACP_COMMAND")
   const acpArgs = environmentValue(environment, "ACP_ARGS")
   const root = environmentValue(environment, "ROOT")
@@ -72,7 +75,7 @@ export function parseConfig(args, environment = process.env) {
       case "--backend":
         config.backend = parseBackend(requireValue(args, index, option))
         {
-          const selected = resolveAcpLaunch(harnessProfile(config.backend))
+          const selected = launchFor(harnessProfile(config.backend))
           if (!acpCommandOverridden) config.acpCommand = selected.command
           if (!acpArgsOverridden) config.acpArgs = [...selected.args]
         }

--- a/bridge/test/config.test.js
+++ b/bridge/test/config.test.js
@@ -48,6 +48,12 @@ test("selects PI defaults for the ACP backend", () => {
   assert.match(parseConfig(["--backend", "pi"], {}).acpArgs[1], /@\d+\.\d+\.\d+$/, "the adapter version must stay pinned")
 })
 
+test("legacy bridge mode never substitutes a PATH adapter for pinned PI", () => {
+  const config = parseConfig(["--backend", "pi"], {}, { preferInstalledAdapters: false })
+  assert.equal(config.acpCommand, process.platform === "win32" ? "npx.cmd" : "npx")
+  assert.deepEqual(config.acpArgs, ["-y", "@automatalabs/pi-acp@0.2.5"])
+})
+
 test("selects Codex defaults for the ACP backend", () => {
   assert.deepEqual(parseConfig(["--backend", "codex"], {}).backend, "codex")
   assert.equal(parseConfig(["--backend", "codex"], {}).acpCommand, process.platform === "win32" ? "npx.cmd" : "npx")


### PR DESCRIPTION
Closed after real-device validation disproved the adapter-selection hypothesis.

Observed on the same APK/session:
- v2.10.3 bridge: transcript correct and model responds;
- #189: duplicated transcript and model does not respond.

Do not merge. The regression is elsewhere in the post-v2.10.3 bridge changes; next diagnostic step is to restore only `bridge/src/acp-service.js` from v2.10.3 on top of current main and retest, without changing the adapter choice.