### PR TITLE
fix(bridge): surface ACP provider error messages

### DIFF
--- a/bridge/src/acp-client.js
+++ b/bridge/src/acp-client.js
@@ -9,14 +9,13 @@ const REQUEST_TIMEOUT_MS = 30_000
 const STDERR_KEPT_CHARS = 600
 
 /**
- * JSON-RPC only promises a human-readable `message`, and Codex spends it on a bare "Internal
- * error", putting the part worth reading — "thread <id> already has an active writer" — in
- * `data.details`. Dropping that left the app showing `{"error":"Internal error"}` for a refusal it
- * could otherwise have explained.
+ * JSON-RPC only promises a human-readable `message`, and adapters sometimes spend it on a bare
+ * "Internal error", putting the part worth reading in `data.details` or `data.message`. Dropping
+ * that left the app unable to explain actionable failures such as provider rate limits.
  */
 function acpErrorMessage(error) {
   const message = error?.message ?? "ACP adapter request failed"
-  const details = error?.data?.details
+  const details = error?.data?.details ?? error?.data?.message
   return typeof details === "string" && details && !message.includes(details) ? `${message}: ${details}` : message
 }
 

--- a/bridge/src/acp-client.js
+++ b/bridge/src/acp-client.js
@@ -15,8 +15,10 @@ const STDERR_KEPT_CHARS = 600
  */
 function acpErrorMessage(error) {
   const message = error?.message ?? "ACP adapter request failed"
-  const details = error?.data?.details ?? error?.data?.message
-  return typeof details === "string" && details && !message.includes(details) ? `${message}: ${details}` : message
+  const details = [error?.data?.details, error?.data?.message].find(
+    (value) => typeof value === "string" && value
+  )
+  return details && !message.includes(details) ? `${message}: ${details}` : message
 }
 
 export class AcpClient extends EventEmitter {

--- a/bridge/test/acp-provider-error.test.js
+++ b/bridge/test/acp-provider-error.test.js
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import test from "node:test"
+import { AcpClient } from "../src/acp-client.js"
+
+class FakeChild extends EventEmitter {
+  killed = false
+  stdout = new EventEmitter()
+  stderr = new EventEmitter()
+
+  constructor() {
+    super()
+    this.stdout.setEncoding = () => undefined
+    this.stderr.setEncoding = () => undefined
+    this.stdin = {
+      writable: true,
+      write: (line, callback) => {
+        const request = JSON.parse(line)
+        if (request.method === "initialize") {
+          this.respond({ jsonrpc: "2.0", id: request.id, result: { agentInfo: { name: "pi" }, authMethods: [] } })
+        } else if (request.method === "session/prompt") {
+          this.respond({
+            jsonrpc: "2.0",
+            id: request.id,
+            error: {
+              code: -32603,
+              message: "Internal error",
+              data: { details: { code: 429 }, errorKind: "rate_limit", message: "provider rate limit" }
+            }
+          })
+        }
+        callback?.()
+        return true
+      }
+    }
+  }
+
+  respond(message) {
+    this.stdout.emit("data", `${JSON.stringify(message)}\n`)
+  }
+
+  kill() {
+    this.killed = true
+    this.stdin.writable = false
+  }
+}
+
+test("surfaces ACP data.message when data.details is structured", async () => {
+  const child = new FakeChild()
+  const client = new AcpClient({ spawnProcess: () => child })
+  await client.start()
+  await assert.rejects(
+    client.request("session/prompt", {}),
+    /Internal error: provider rate limit/
+  )
+  client.close()
+})


### PR DESCRIPTION
## Summary

Surface actionable ACP provider errors that adapters place in `error.data.message` instead of dropping them behind a generic `Internal error`.

PI currently returns rate limits as:

```json
{"message":"Internal error","data":{"errorKind":"rate_limit","message":"provider rate limit"}}
```

The bridge already preserves `data.details` for adapters such as Codex; this extends the same behavior to `data.message`, so the existing `session.error` path can show the real provider failure in the app.

## Scope

- one bridge-only error formatting change
- no session/model/runtime behavior changes
- no changes to `main` beyond this PR

## Expected UI result

Instead of silently ending / exposing only a generic error, the session receives an actionable error such as:

`Internal error: provider rate limit`

This PR is intentionally narrow and is not merged automatically.