### PR TITLE
test: add real Android harness matrix for PI, OMP and OpenCode

### DIFF
--- a/.github/workflows/real-harness-matrix.yml
+++ b/.github/workflows/real-harness-matrix.yml
@@ -1,0 +1,113 @@
+name: Real Android harness matrix
+
+# GitHub-hosted runners cannot exercise the user's local credentials, Termux networking or real
+# agents. This workflow is intentionally manual and targets the ARM64 Debian runner on Android.
+# It is evidence, not a synthetic replacement for the Android client acceptance pass.
+"on":
+  workflow_dispatch:
+    inputs:
+      primary_backend:
+        description: "ACP agent managed by TaskDesk; OpenCode is always tested through the same daemon."
+        required: true
+        type: choice
+        options:
+          - pi
+          - omp
+
+permissions:
+  contents: read
+
+concurrency:
+  group: real-harness-android-${{ inputs.primary_backend }}
+  cancel-in-progress: false
+
+jobs:
+  real-harness:
+    name: Android Debian (${{ inputs.primary_backend }} + OpenCode)
+    # Install the official runner in Debian with the custom label documented in
+    # docs/REAL_HARNESS_TEST_MATRIX.md. The default labels also identify Linux ARM64.
+    runs-on: [self-hosted, Linux, ARM64, harness-remote-android]
+    timeout-minutes: 35
+    env:
+      MATRIX_ROOT: ${{ runner.temp }}/harness-remote-real
+      MATRIX_PORT: "4597"
+      MATRIX_OPENCODE_PORT: "4596"
+      MATRIX_USERNAME: harness-matrix
+      MATRIX_PASSWORD: matrix-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Checkout tested revision
+        uses: actions/checkout@v7
+
+      - name: Verify host prerequisites
+        run: |
+          node --version
+          node -e 'const major = Number(process.versions.node.split(".")[0]); if (major < 20) process.exit(1)'
+          command -v opencode
+          command -v "${{ inputs.primary_backend }}"
+          git --version
+
+      - name: Run deterministic bridge regression suite
+        run: npm test
+        working-directory: bridge
+
+      - name: Prepare isolated agent workspace
+        run: |
+          rm -rf "$MATRIX_ROOT"
+          mkdir -p "$MATRIX_ROOT/workspace" "$MATRIX_ROOT/state" "$MATRIX_ROOT/reports"
+          git init "$MATRIX_ROOT/workspace"
+          git -C "$MATRIX_ROOT/workspace" config user.email harness-matrix@example.invalid
+          git -C "$MATRIX_ROOT/workspace" config user.name "Harness Matrix"
+          printf '# Harness real matrix fixture\n' > "$MATRIX_ROOT/workspace/README.md"
+          git -C "$MATRIX_ROOT/workspace" add README.md
+          git -C "$MATRIX_ROOT/workspace" commit -m "test: initialize real harness fixture"
+
+      - name: Start TaskDesk daemon
+        run: |
+          node bridge/src/daemon-cli.js \
+            --backend "${{ inputs.primary_backend }}" \
+            --host 127.0.0.1 \
+            --port "$MATRIX_PORT" \
+            --opencode-port "$MATRIX_OPENCODE_PORT" \
+            --opencode-timeout 60000 \
+            --username "$MATRIX_USERNAME" \
+            --password "$MATRIX_PASSWORD" \
+            --root "$MATRIX_ROOT/workspace" \
+            --state-dir "$MATRIX_ROOT/state" > "$MATRIX_ROOT/daemon.log" 2>&1 &
+          echo "MATRIX_DAEMON_PID=$!" >> "$GITHUB_ENV"
+
+      - name: Exercise real ACP primary
+        run: |
+          node bridge/scripts/real-harness-smoke.mjs \
+            --base-url "http://127.0.0.1:$MATRIX_PORT" \
+            --agent "${{ inputs.primary_backend }}" \
+            --username "$MATRIX_USERNAME" \
+            --password "$MATRIX_PASSWORD" \
+            --workspace "$MATRIX_ROOT/workspace" \
+            --report "$MATRIX_ROOT/reports/${{ inputs.primary_backend }}.json"
+
+      - name: Exercise real managed OpenCode
+        run: |
+          node bridge/scripts/real-harness-smoke.mjs \
+            --base-url "http://127.0.0.1:$MATRIX_PORT" \
+            --agent opencode \
+            --username "$MATRIX_USERNAME" \
+            --password "$MATRIX_PASSWORD" \
+            --workspace "$MATRIX_ROOT/workspace" \
+            --report "$MATRIX_ROOT/reports/opencode.json"
+
+      - name: Stop TaskDesk daemon
+        if: always()
+        run: |
+          if [ -n "${MATRIX_DAEMON_PID:-}" ] && kill -0 "$MATRIX_DAEMON_PID" 2>/dev/null; then
+            kill "$MATRIX_DAEMON_PID"
+            wait "$MATRIX_DAEMON_PID" || true
+          fi
+
+      - name: Upload real-harness evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: real-harness-${{ inputs.primary_backend }}-opencode-${{ github.run_id }}
+          path: ${{ runner.temp }}/harness-remote-real
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/real-harness-matrix.yml
+++ b/.github/workflows/real-harness-matrix.yml
@@ -1,33 +1,29 @@
 name: Real Android harness matrix
 
 # GitHub-hosted runners cannot exercise the user's local credentials, Termux networking or real
-# agents. This workflow runs after a labelled same-repository pull request is updated.
+# agents. This workflow runs only after an explicit label is added to a same-repository pull request.
 # That keeps the test on the PR's exact commit without putting a manual workflow on main.
 "on":
-  # One-time bootstrap for this PR: `pull_request` workflows need to exist on the
-  # base branch before GitHub can evaluate them. Future PRs use the labelled trigger below.
-  push:
-    branches: [test/real-harness-matrix]
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [labeled]
 
 permissions:
   contents: read
 
 concurrency:
-  group: real-harness-android-pr-${{ github.event.pull_request.number }}
+  group: real-harness-android-${{ github.event.label.name }}
   cancel-in-progress: false
 
 jobs:
   real-harness:
-    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'real-harness-pi') || contains(github.event.pull_request.labels.*.name, 'real-harness-omp')
-    name: Android Debian (primary ACP + OpenCode)
+    if: github.event.label.name == 'real-harness-pi' || github.event.label.name == 'real-harness-omp'
+    name: Android Debian (${{ github.event.label.name }} + OpenCode)
     # Install the official runner in Debian with the custom label documented in
     # docs/REAL_HARNESS_TEST_MATRIX.md. The default labels also identify Linux ARM64.
     runs-on: [self-hosted, Linux, ARM64, harness-remote-android]
     timeout-minutes: 35
     env:
-      MATRIX_BACKEND: ${{ github.event_name == 'push' && 'pi' || contains(github.event.pull_request.labels.*.name, 'real-harness-pi') && 'pi' || 'omp' }}
+      MATRIX_BACKEND: ${{ github.event.label.name == 'real-harness-pi' && 'pi' || 'omp' }}
       MATRIX_ROOT: ${{ runner.temp }}/harness-remote-real
       MATRIX_PORT: "4597"
       MATRIX_OPENCODE_PORT: "4596"
@@ -106,7 +102,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: real-harness-${{ env.MATRIX_BACKEND }}-${{ github.run_id }}
+          name: real-harness-${{ github.event.label.name }}-${{ github.run_id }}
           path: ${{ runner.temp }}/harness-remote-real
           if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/real-harness-matrix.yml
+++ b/.github/workflows/real-harness-matrix.yml
@@ -1,29 +1,29 @@
 name: Real Android harness matrix
 
 # GitHub-hosted runners cannot exercise the user's local credentials, Termux networking or real
-# agents. This workflow runs only after an explicit label is added to a same-repository pull request.
+# agents. This workflow runs after a labelled same-repository pull request is updated.
 # That keeps the test on the PR's exact commit without putting a manual workflow on main.
 "on":
   pull_request:
-    types: [labeled]
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: read
 
 concurrency:
-  group: real-harness-android-${{ github.event.label.name }}
+  group: real-harness-android-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
   real-harness:
-    if: github.event.label.name == 'real-harness-pi' || github.event.label.name == 'real-harness-omp'
-    name: Android Debian (${{ github.event.label.name }} + OpenCode)
+    if: contains(github.event.pull_request.labels.*.name, 'real-harness-pi') || contains(github.event.pull_request.labels.*.name, 'real-harness-omp')
+    name: Android Debian (primary ACP + OpenCode)
     # Install the official runner in Debian with the custom label documented in
     # docs/REAL_HARNESS_TEST_MATRIX.md. The default labels also identify Linux ARM64.
     runs-on: [self-hosted, Linux, ARM64, harness-remote-android]
     timeout-minutes: 35
     env:
-      MATRIX_BACKEND: ${{ github.event.label.name == 'real-harness-pi' && 'pi' || 'omp' }}
+      MATRIX_BACKEND: ${{ contains(github.event.pull_request.labels.*.name, 'real-harness-pi') && 'pi' || 'omp' }}
       MATRIX_ROOT: ${{ runner.temp }}/harness-remote-real
       MATRIX_PORT: "4597"
       MATRIX_OPENCODE_PORT: "4596"
@@ -102,7 +102,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: real-harness-${{ github.event.label.name }}-${{ github.run_id }}
+          name: real-harness-${{ env.MATRIX_BACKEND }}-${{ github.run_id }}
           path: ${{ runner.temp }}/harness-remote-real
           if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/real-harness-matrix.yml
+++ b/.github/workflows/real-harness-matrix.yml
@@ -4,6 +4,10 @@ name: Real Android harness matrix
 # agents. This workflow runs after a labelled same-repository pull request is updated.
 # That keeps the test on the PR's exact commit without putting a manual workflow on main.
 "on":
+  # One-time bootstrap for this PR: `pull_request` workflows need to exist on the
+  # base branch before GitHub can evaluate them. Future PRs use the labelled trigger below.
+  push:
+    branches: [test/real-harness-matrix]
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
@@ -16,14 +20,14 @@ concurrency:
 
 jobs:
   real-harness:
-    if: contains(github.event.pull_request.labels.*.name, 'real-harness-pi') || contains(github.event.pull_request.labels.*.name, 'real-harness-omp')
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'real-harness-pi') || contains(github.event.pull_request.labels.*.name, 'real-harness-omp')
     name: Android Debian (primary ACP + OpenCode)
     # Install the official runner in Debian with the custom label documented in
     # docs/REAL_HARNESS_TEST_MATRIX.md. The default labels also identify Linux ARM64.
     runs-on: [self-hosted, Linux, ARM64, harness-remote-android]
     timeout-minutes: 35
     env:
-      MATRIX_BACKEND: ${{ contains(github.event.pull_request.labels.*.name, 'real-harness-pi') && 'pi' || 'omp' }}
+      MATRIX_BACKEND: ${{ github.event_name == 'push' && 'pi' || contains(github.event.pull_request.labels.*.name, 'real-harness-pi') && 'pi' || 'omp' }}
       MATRIX_ROOT: ${{ runner.temp }}/harness-remote-real
       MATRIX_PORT: "4597"
       MATRIX_OPENCODE_PORT: "4596"

--- a/.github/workflows/real-harness-matrix.yml
+++ b/.github/workflows/real-harness-matrix.yml
@@ -1,34 +1,29 @@
 name: Real Android harness matrix
 
 # GitHub-hosted runners cannot exercise the user's local credentials, Termux networking or real
-# agents. This workflow is intentionally manual and targets the ARM64 Debian runner on Android.
-# It is evidence, not a synthetic replacement for the Android client acceptance pass.
+# agents. This workflow runs only after an explicit label is added to a same-repository pull request.
+# That keeps the test on the PR's exact commit without putting a manual workflow on main.
 "on":
-  workflow_dispatch:
-    inputs:
-      primary_backend:
-        description: "ACP agent managed by TaskDesk; OpenCode is always tested through the same daemon."
-        required: true
-        type: choice
-        options:
-          - pi
-          - omp
+  pull_request:
+    types: [labeled]
 
 permissions:
   contents: read
 
 concurrency:
-  group: real-harness-android-${{ inputs.primary_backend }}
+  group: real-harness-android-${{ github.event.label.name }}
   cancel-in-progress: false
 
 jobs:
   real-harness:
-    name: Android Debian (${{ inputs.primary_backend }} + OpenCode)
+    if: github.event.label.name == 'real-harness-pi' || github.event.label.name == 'real-harness-omp'
+    name: Android Debian (${{ github.event.label.name }} + OpenCode)
     # Install the official runner in Debian with the custom label documented in
     # docs/REAL_HARNESS_TEST_MATRIX.md. The default labels also identify Linux ARM64.
     runs-on: [self-hosted, Linux, ARM64, harness-remote-android]
     timeout-minutes: 35
     env:
+      MATRIX_BACKEND: ${{ github.event.label.name == 'real-harness-pi' && 'pi' || 'omp' }}
       MATRIX_ROOT: ${{ runner.temp }}/harness-remote-real
       MATRIX_PORT: "4597"
       MATRIX_OPENCODE_PORT: "4596"
@@ -43,7 +38,7 @@ jobs:
           node --version
           node -e 'const major = Number(process.versions.node.split(".")[0]); if (major < 20) process.exit(1)'
           command -v opencode
-          command -v "${{ inputs.primary_backend }}"
+          command -v "$MATRIX_BACKEND"
           git --version
 
       - name: Run deterministic bridge regression suite
@@ -64,7 +59,7 @@ jobs:
       - name: Start TaskDesk daemon
         run: |
           node bridge/src/daemon-cli.js \
-            --backend "${{ inputs.primary_backend }}" \
+            --backend "$MATRIX_BACKEND" \
             --host 127.0.0.1 \
             --port "$MATRIX_PORT" \
             --opencode-port "$MATRIX_OPENCODE_PORT" \
@@ -79,11 +74,11 @@ jobs:
         run: |
           node bridge/scripts/real-harness-smoke.mjs \
             --base-url "http://127.0.0.1:$MATRIX_PORT" \
-            --agent "${{ inputs.primary_backend }}" \
+            --agent "$MATRIX_BACKEND" \
             --username "$MATRIX_USERNAME" \
             --password "$MATRIX_PASSWORD" \
             --workspace "$MATRIX_ROOT/workspace" \
-            --report "$MATRIX_ROOT/reports/${{ inputs.primary_backend }}.json"
+            --report "$MATRIX_ROOT/reports/$MATRIX_BACKEND.json"
 
       - name: Exercise real managed OpenCode
         run: |
@@ -107,7 +102,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: real-harness-${{ inputs.primary_backend }}-opencode-${{ github.run_id }}
+          name: real-harness-${{ github.event.label.name }}-${{ github.run_id }}
           path: ${{ runner.temp }}/harness-remote-real
           if-no-files-found: warn
           retention-days: 30

--- a/bridge/scripts/real-harness-smoke.mjs
+++ b/bridge/scripts/real-harness-smoke.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import path from "node:path"
+import process from "node:process"
+
+const PREFIX = "HARNESS_SMOKE_OK"
+
+function usage() {
+  return [
+    "Usage: node bridge/scripts/real-harness-smoke.mjs --base-url <url> --agent <pi|omp|opencode> --username <name> --password <value> --workspace <path> --report <path>",
+    "",
+    "Runs one authenticated real-harness smoke test. It creates a disposable session, waits for model discovery,",
+    "asks the agent to create one uniquely named file, and verifies both the file and an agent reply."
+  ].join("\n")
+}
+
+function parseArgs(args) {
+  const options = {}
+  for (let index = 0; index < args.length; index += 1) {
+    const option = args[index]
+    if (option === "--help") return { help: true }
+    if (!option.startsWith("--")) throw new Error(`Unknown argument: ${option}`)
+    const value = args[index + 1]
+    if (!value || value.startsWith("--")) throw new Error(`${option} requires a value`)
+    options[option.slice(2)] = value
+    index += 1
+  }
+  for (const required of ["base-url", "agent", "username", "password", "workspace", "report"]) {
+    if (!options[required]) throw new Error(`--${required} is required`)
+  }
+  if (!["pi", "omp", "opencode"].includes(options.agent)) throw new Error("--agent must be pi, omp, or opencode")
+  return options
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds))
+}
+
+async function run(options) {
+  const startedAt = new Date().toISOString()
+  const token = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+  const marker = `.harness-remote-smoke-${token}.txt`
+  const markerPath = path.join(options.workspace, marker)
+  const agentPrefix = `/v1/agents/${encodeURIComponent(options.agent)}`
+  const auth = `Basic ${Buffer.from(`${options.username}:${options.password}`).toString("base64")}`
+  const result = {
+    schemaVersion: 1,
+    backend: options.agent,
+    startedAt,
+    completedAt: undefined,
+    token,
+    marker,
+    checks: []
+  }
+
+  async function request(label, pathname, init = {}) {
+    const response = await fetch(new URL(pathname, options["base-url"]), {
+      ...init,
+      headers: { Authorization: auth, ...(init.headers ?? {}) }
+    })
+    const text = await response.text()
+    let body
+    try {
+      body = text ? JSON.parse(text) : undefined
+    } catch {
+      body = text
+    }
+    result.checks.push({ label, status: response.status })
+    if (!response.ok) throw new Error(`${label} returned HTTP ${response.status}: ${typeof body === "string" ? body : JSON.stringify(body)}`)
+    return body
+  }
+
+  async function retry(label, operation, timeoutMs = 90_000) {
+    const deadline = Date.now() + timeoutMs
+    let lastError
+    while (Date.now() < deadline) {
+      try {
+        const value = await operation()
+        if (value) return value
+      } catch (error) {
+        lastError = error
+      }
+      await delay(2_000)
+    }
+    throw new Error(`${label} did not succeed within ${timeoutMs}ms${lastError ? `: ${lastError.message}` : ""}`)
+  }
+
+  try {
+    await request("machine registry", "/v1/machine")
+    const healthPath = options.agent === "opencode" ? "/global/health" : "/v1/health"
+    await retry("health", () => request("health", `${agentPrefix}${healthPath}`), 90_000)
+
+    const sessionPath = `${agentPrefix}/session?directory=${encodeURIComponent(options.workspace)}`
+    await request("session listing", sessionPath)
+    const session = await request("session creation", sessionPath, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: `Harness real smoke ${token}` })
+    })
+    const sessionID = session?.id
+    if (typeof sessionID !== "string" || !sessionID) throw new Error("Session creation did not return a session id")
+    result.sessionID = sessionID
+
+    const providers = await retry("model discovery", async () => {
+      const body = await request("model discovery", `${agentPrefix}/config/providers?sessionID=${encodeURIComponent(sessionID)}`)
+      return Array.isArray(body?.providers) && body.providers.some((provider) => Object.keys(provider?.models ?? {}).length > 0) ? body : undefined
+    }, 90_000)
+    result.modelProviders = providers.providers.map((provider) => provider.id)
+
+    const instruction = [
+      "This is a Harness Remote integration test.",
+      `Use your available tools to create exactly one file named ${marker} in the current workspace.`,
+      `Its complete contents must be: ${PREFIX} ${token}`,
+      `Then reply with exactly: ${PREFIX} ${token}`,
+      "Do not modify any other file."
+    ].join(" ")
+    await request("prompt accepted", `${agentPrefix}/session/${encodeURIComponent(sessionID)}/prompt_async`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ parts: [{ type: "text", text: instruction }] })
+    })
+
+    await retry("workspace mutation", async () => {
+      const content = await readFile(markerPath, "utf8")
+      return content.trim() === `${PREFIX} ${token}`
+    }, 180_000)
+
+    await retry("assistant completion", async () => {
+      const messages = await request("message history", `${agentPrefix}/session/${encodeURIComponent(sessionID)}/message?refresh=1`)
+      return Array.isArray(messages) && messages.some((message) => {
+        const role = message?.info?.role
+        const text = (message?.parts ?? []).map((part) => part?.text ?? "").join("\n")
+        return (role === "assistant" || role === "agent") && text.includes(`${PREFIX} ${token}`)
+      })
+    }, 180_000)
+
+    result.success = true
+  } catch (error) {
+    result.success = false
+    result.error = error instanceof Error ? error.message : String(error)
+    throw error
+  } finally {
+    result.completedAt = new Date().toISOString()
+    await mkdir(path.dirname(options.report), { recursive: true })
+    await writeFile(options.report, `${JSON.stringify(result, null, 2)}\n`)
+  }
+}
+
+let options
+try {
+  options = parseArgs(process.argv.slice(2))
+  if (options.help) {
+    process.stdout.write(`${usage()}\n`)
+  } else {
+    await run(options)
+    process.stdout.write(`Real ${options.agent} harness smoke test passed.\n`)
+  }
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+  process.exitCode = 1
+}

--- a/docs/REAL_HARNESS_TEST_MATRIX.md
+++ b/docs/REAL_HARNESS_TEST_MATRIX.md
@@ -74,7 +74,7 @@ credentials required by the selected harness. Keep it running in a persistent De
 tmux session only while invoking the workflow; it is not a public service and should not be exposed
 outside the local device.
 
-After the runner appears as **Idle**, open this PR and add the label `real-harness-pi`.\nThat starts the workflow on this PR's exact commit. Once it has completed, add\n`real-harness-omp`. The labels must be created once from **Issues → Labels** (or the PR label menu)\nbefore their first use. Each run:
+After the runner appears as **Idle**, add the label `real-harness-pi` to this PR. The next commit\non the PR starts the PI + OpenCode workflow on that exact revision. To run OMP afterwards, remove\n`real-harness-pi`, add `real-harness-omp`, then push the next commit. The labels must be created\nonce from **Issues → Labels** (or the PR label menu) before their first use. Each run:
 
 - creates a disposable Git fixture under the runner temp directory;
 - starts TaskDesk with the selected ACP primary and managed OpenCode;

--- a/docs/REAL_HARNESS_TEST_MATRIX.md
+++ b/docs/REAL_HARNESS_TEST_MATRIX.md
@@ -74,7 +74,7 @@ credentials required by the selected harness. Keep it running in a persistent De
 tmux session only while invoking the workflow; it is not a public service and should not be exposed
 outside the local device.
 
-After the runner appears as **Idle**, add the label `real-harness-pi` to this PR. The next commit\non the PR starts the PI + OpenCode workflow on that exact revision. To run OMP afterwards, remove\n`real-harness-pi`, add `real-harness-omp`, then push the next commit. The labels must be created\nonce from **Issues → Labels** (or the PR label menu) before their first use. Each run:
+After this workflow has first been merged into its target base branch, an **Idle** runner can be invoked by adding `real-harness-pi` to a subsequent same-repository PR. That starts the PI + OpenCode workflow on the PR's exact commit. To run OMP afterwards, remove `real-harness-pi` and add `real-harness-omp`. The labels must be created once from **Issues → Labels** (or the PR label menu) before their first use. GitHub cannot label-trigger a workflow that exists only in the candidate PR. Each run:
 
 - creates a disposable Git fixture under the runner temp directory;
 - starts TaskDesk with the selected ACP primary and managed OpenCode;

--- a/docs/REAL_HARNESS_TEST_MATRIX.md
+++ b/docs/REAL_HARNESS_TEST_MATRIX.md
@@ -21,8 +21,8 @@ real device run does not replace normal regression tests.
 | LEGACY-PI | single PI bridge | `npm test` plus direct real-agent smoke where PI is installed | Existing session, model picker, new session, prompt, tool change, reopen | Yes |
 | LEGACY-OMP | single OMP bridge | `npm test` plus direct real-agent smoke where OMP is installed | Existing session, model picker, new session, prompt, tool change, reopen | Yes |
 | LEGACY-OC | direct OpenCode | OpenCode health/session API smoke | Existing session, model picker, new session, prompt, tool change, reopen | Yes |
-| DAEMON-PI-OC | TaskDesk daemon, PI primary + managed OpenCode | Manual `Real Android harness matrix` workflow, input `pi` | Switch PI/OpenCode over one daemon URL; create a task and verify model list appears immediately | Yes for daemon work |
-| DAEMON-OMP-OC | TaskDesk daemon, OMP primary + managed OpenCode | Manual `Real Android harness matrix` workflow, input `omp` | Switch OMP/OpenCode over one daemon URL; create a task and verify model list appears immediately | Yes for daemon work |
+| DAEMON-PI-OC | TaskDesk daemon, PI primary + managed OpenCode | Add the `real-harness-pi` label to this PR | Switch PI/OpenCode over one daemon URL; create a task and verify model list appears immediately | Yes for daemon work |
+| DAEMON-OMP-OC | TaskDesk daemon, OMP primary + managed OpenCode | Add the `real-harness-omp` label to this PR | Switch OMP/OpenCode over one daemon URL; create a task and verify model list appears immediately | Yes for daemon work |
 | TASK-LIFECYCLE | task/project/worktree/launch/finish APIs and UI | route/store/worktree tests; real daemon run above | Create a task, observe it in the list immediately, enter it, select a model, start it, reopen it, inspect result | Yes for task-first UI work |
 
 **A green workflow alone is not a release verdict.** The matching Android client row must be marked
@@ -74,8 +74,7 @@ credentials required by the selected harness. Keep it running in a persistent De
 tmux session only while invoking the workflow; it is not a public service and should not be exposed
 outside the local device.
 
-Then, in **Actions → Real Android harness matrix → Run workflow**, select the branch being tested
-and run `pi`. Repeat for `omp`. Each run:
+After the runner appears as **Idle**, open this PR and add the label `real-harness-pi`.\nThat starts the workflow on this PR's exact commit. Once it has completed, add\n`real-harness-omp`. The labels must be created once from **Issues → Labels** (or the PR label menu)\nbefore their first use. Each run:
 
 - creates a disposable Git fixture under the runner temp directory;
 - starts TaskDesk with the selected ACP primary and managed OpenCode;

--- a/docs/REAL_HARNESS_TEST_MATRIX.md
+++ b/docs/REAL_HARNESS_TEST_MATRIX.md
@@ -1,0 +1,119 @@
+# Real Harness Test Matrix
+
+This is the release gate for the Harness 3 / TaskDesk restart. It closes the gap that caused the
+archive: unit tests and an APK build were green while real agents and the mobile task flow were not.
+
+The matrix has two different kinds of evidence:
+
+1. **GitHub-hosted CI** proves deterministic regressions, web build and the installable debug APK.
+2. **The Android Debian self-hosted runner** proves the actual installed PI, OMP and OpenCode
+   harnesses, their credentials, adapter startup, model discovery, session creation, prompt/tool
+   execution and the TaskDesk proxy.
+
+Neither replaces the other. A hosted job cannot use the local OAuth credentials on the phone, and a
+real device run does not replace normal regression tests.
+
+## Release matrix
+
+| ID | Path under test | Automated evidence | Android client acceptance | Required before a Harness 3 slice can merge to `main` |
+| --- | --- | --- | --- | --- |
+| CI-01 | bridge, web and Android package | `PR checks` is green and its debug APK installs | Open the exact artifact used for the test | Yes |
+| LEGACY-PI | single PI bridge | `npm test` plus direct real-agent smoke where PI is installed | Existing session, model picker, new session, prompt, tool change, reopen | Yes |
+| LEGACY-OMP | single OMP bridge | `npm test` plus direct real-agent smoke where OMP is installed | Existing session, model picker, new session, prompt, tool change, reopen | Yes |
+| LEGACY-OC | direct OpenCode | OpenCode health/session API smoke | Existing session, model picker, new session, prompt, tool change, reopen | Yes |
+| DAEMON-PI-OC | TaskDesk daemon, PI primary + managed OpenCode | Manual `Real Android harness matrix` workflow, input `pi` | Switch PI/OpenCode over one daemon URL; create a task and verify model list appears immediately | Yes for daemon work |
+| DAEMON-OMP-OC | TaskDesk daemon, OMP primary + managed OpenCode | Manual `Real Android harness matrix` workflow, input `omp` | Switch OMP/OpenCode over one daemon URL; create a task and verify model list appears immediately | Yes for daemon work |
+| TASK-LIFECYCLE | task/project/worktree/launch/finish APIs and UI | route/store/worktree tests; real daemon run above | Create a task, observe it in the list immediately, enter it, select a model, start it, reopen it, inspect result | Yes for task-first UI work |
+
+**A green workflow alone is not a release verdict.** The matching Android client row must be marked
+pass against the same commit and harness versions. A timeout, empty model list, delayed task
+visibility, a missing streamed reply, or a tool that claims success without the expected file is a
+failure, not a warning.
+
+## One-command branches under test
+
+Always test the candidate branch explicitly; never let `npx` silently use `main`.
+
+```bash
+# PI legacy path
+npx --yes --package=github:giuliastro/harness-remote#test/real-harness-matrix \
+  harness-remote --single --backend pi --host 0.0.0.0 --port 4097 \
+  --username harness --password 'CHANGE_ME' --root "$HOME/harness-fixture"
+
+# OMP legacy path
+npx --yes --package=github:giuliastro/harness-remote#test/real-harness-matrix \
+  harness-remote --single --backend omp --host 0.0.0.0 --port 4097 \
+  --username harness --password 'CHANGE_ME' --root "$HOME/harness-fixture"
+
+# OpenCode direct path
+npx --yes --package=github:giuliastro/harness-remote#test/real-harness-matrix \
+  harness-remote --backend opencode --host 0.0.0.0 --port 4097 \
+  --username harness --password 'CHANGE_ME'
+```
+
+For the daemon rows, invoke the same command without `--single` while both the selected ACP
+harness and `opencode` are present on `PATH`. The current archive intentionally supports **one**
+ACP primary plus managed OpenCode; PI and OMP are separate daemon runs, not a claim that both ACP
+servers are live together.
+
+## Android Debian runner
+
+Install the official GitHub Actions self-hosted runner *inside Debian*, not in the Termux host.
+From the repository's **Settings → Actions → Runners → New self-hosted runner**, select Linux/ARM64
+and run the generated download/configuration commands in the Debian shell. Add this custom label
+when configuring it:
+
+```bash
+./config.sh --url https://github.com/giuliastro/harness-remote --token <one-time-token> \
+  --labels harness-remote-android
+./run.sh
+```
+
+The runner must have Node 20+, Git, `opencode`, `pi`, `omp`, and the already-authenticated
+credentials required by the selected harness. Keep it running in a persistent Debian terminal or
+tmux session only while invoking the workflow; it is not a public service and should not be exposed
+outside the local device.
+
+Then, in **Actions → Real Android harness matrix → Run workflow**, select the branch being tested
+and run `pi`. Repeat for `omp`. Each run:
+
+- creates a disposable Git fixture under the runner temp directory;
+- starts TaskDesk with the selected ACP primary and managed OpenCode;
+- verifies authenticated health, session creation and non-empty model discovery for both agents;
+- sends a real prompt that must create one uniquely named file and return a unique completion token;
+- uploads the daemon log and two JSON reports as a 30-day artifact.
+
+The workflow intentionally does not use production repositories and does not print harness
+credentials. It remains manual because it spends real model quota and requires the Android device to
+be awake with its local installations available.
+
+## Android app acceptance script
+
+Use the debug APK attached to the same PR/commit, then for each applicable row:
+
+1. Add the exact daemon or legacy URL and test its connection.
+2. Open an existing session and confirm its history is readable.
+3. Create a new session/task; its card must appear immediately, without leaving and returning.
+4. Open it, wait no more than 15 seconds for the model picker, choose a model and start a tiny
+   file-creation prompt.
+5. Confirm streamed progress, the changed file, completion state and session history after reopening.
+6. For daemon rows, repeat after switching from the ACP primary to managed OpenCode on the *same*
+   daemon profile. For task rows, complete the worktree/release result instead of deleting it.
+
+Record the commit SHA, Android app version, Debian/Node version, harness/adapter version, selected
+model, workflow artifact URL and result for every row in the PR description or a linked issue. Do
+not use a generic “works for me” comment as evidence.
+
+## Failure triage
+
+| Symptom | Owner / first inspection |
+| --- | --- |
+| Adapter never becomes healthy | `harness-profiles.js`, executable discovery, stored credential method, daemon log |
+| Empty or delayed model list | ACP `configOptions` handling, `/config/providers`, session creation timing |
+| New task not visible immediately | task store mutation/reconciliation and client cache/invalidation |
+| OpenCode works directly but not through daemon | agent router prefix, managed-host readiness and proxy auth |
+| Agent reports success but fixture file is absent | permission handling and ACP tool-call completion |
+| Android flow fails while smoke is green | client API routing/state lifecycle; keep legacy profile compatibility intact |
+
+A defect found by this matrix is fixed with a regression test where possible and is rerun on the
+same Android fixture before the relevant slice is considered mergeable.


### PR DESCRIPTION
## Purpose

Establishes the real-device acceptance gate required before selectively bringing Harness 3 / TaskDesk work back toward `main`.

## What this adds

- a manual GitHub Actions workflow that runs on a **self-hosted Linux ARM64 runner inside Android Debian**;
- a real harness smoke runner that verifies machine routing, authenticated health, session creation, **non-empty model discovery**, prompt/tool execution, resulting file mutation and streamed completion;
- a documented matrix covering legacy PI/OMP/OpenCode, daemon PI+OpenCode and OMP+OpenCode, plus the mobile task lifecycle;
- explicit one-command branch-ref commands, so Android testing never silently exercises `main`.

## Deliberate limits

GitHub-hosted CI remains responsible for deterministic tests and the debug APK. It cannot prove locally authenticated agent behavior, so this workflow is manual, consumes real quota, and is not a synthetic pass gate.

The archive's daemon currently supports one ACP primary plus managed OpenCode. This PR does not misrepresent PI and OMP as concurrently routable ACP hosts.

## Before marking ready

- [ ] Configure the `harness-remote-android` self-hosted runner in Debian/Termux.
- [ ] Run the workflow once with `pi`.
- [ ] Run the workflow once with `omp`.
- [ ] Run the Android client acceptance rows from `docs/REAL_HARNESS_TEST_MATRIX.md` against the exact tested SHA.
- [ ] Capture versions, selected models and artifact links in this PR.

This targets the archive branch intentionally; it is a stabilization tool, not a proposal to merge the archived Harness 3 tree into `main`.