### PR TITLE
test: run real Android PI + OpenCode smoke matrix

### DIFF
--- a/.github/harness-matrix/PI_SMOKE.md
+++ b/.github/harness-matrix/PI_SMOKE.md
@@ -1,0 +1,3 @@
+# Android PI harness smoke
+
+This file is intentionally inert. Its pull request exists only to run the real PI + OpenCode smoke matrix on the Android Debian self-hosted runner.


### PR DESCRIPTION
This intentionally inert PR activates the real PI + OpenCode smoke workflow on the Android Debian self-hosted runner. It must not be merged; its single marker file can be discarded after the run.