### PR TITLE
perf(bridge): trim common prefix before LCS merge replay

### DIFF
--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -73,39 +73,61 @@ function semanticHistorySignature(messages) {
   })))
 }
 
-function mergeReplay(previous, replayed) {
+/** Exported for testing only. */
+export function mergeReplay(previous, replayed) {
   if (previous.length === 0) return replayed
   if (replayed.length === 0) return previous
   const left = previous.map(messageSignature)
   const right = replayed.map(messageSignature)
-  const common = Array.from({ length: left.length + 1 }, () => new Uint32Array(right.length + 1))
-  for (let leftIndex = left.length - 1; leftIndex >= 0; leftIndex -= 1) {
-    for (let rightIndex = right.length - 1; rightIndex >= 0; rightIndex -= 1) {
-      common[leftIndex][rightIndex] = left[leftIndex] === right[rightIndex]
+
+  let prefix = 0
+  const maxPrefix = Math.min(previous.length, replayed.length)
+  while (prefix < maxPrefix && left[prefix] === right[prefix]) {
+    prefix += 1
+  }
+
+  if (prefix === previous.length) {
+    return [...previous, ...replayed.slice(prefix)]
+  }
+
+  const midLeft = left.slice(prefix)
+  const midRight = right.slice(prefix)
+
+  const common = Array.from({ length: midLeft.length + 1 }, () => new Uint32Array(midRight.length + 1))
+  for (let leftIndex = midLeft.length - 1; leftIndex >= 0; leftIndex -= 1) {
+    for (let rightIndex = midRight.length - 1; rightIndex >= 0; rightIndex -= 1) {
+      common[leftIndex][rightIndex] = midLeft[leftIndex] === midRight[rightIndex]
         ? common[leftIndex + 1][rightIndex + 1] + 1
         : Math.max(common[leftIndex + 1][rightIndex], common[leftIndex][rightIndex + 1])
     }
   }
-  const merged = []
 
+  const midMerged = []
   let leftIndex = 0
   let rightIndex = 0
-  while (leftIndex < left.length && rightIndex < right.length) {
-    if (left[leftIndex] === right[rightIndex]) {
-      merged.push(previous[leftIndex])
+  const midPrev = previous.slice(prefix)
+  const midRep = replayed.slice(prefix)
+
+  while (leftIndex < midLeft.length && rightIndex < midRight.length) {
+    if (midLeft[leftIndex] === midRight[rightIndex]) {
+      midMerged.push(midPrev[leftIndex])
       leftIndex += 1
       rightIndex += 1
     } else if (common[leftIndex + 1][rightIndex] >= common[leftIndex][rightIndex + 1]) {
-      merged.push(previous[leftIndex])
+      midMerged.push(midPrev[leftIndex])
       leftIndex += 1
     } else {
-      merged.push(replayed[rightIndex])
+      midMerged.push(midRep[rightIndex])
       rightIndex += 1
     }
   }
-  return [...merged, ...previous.slice(leftIndex), ...replayed.slice(rightIndex)]
+  return [
+    ...previous.slice(0, prefix),
+    ...midMerged,
+    ...midPrev.slice(leftIndex),
+    ...midRep.slice(rightIndex)
+  ]
 }
-
 export function mergeExternalHistory(persisted, cached) {
   const persistedIDs = new Set(persisted.map((message) => message.info.id))
   const remainingBySignature = new Map()

--- a/bridge/test/external-history-dedup.test.js
+++ b/bridge/test/external-history-dedup.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import test from "node:test"
-import { mergeExternalHistory } from "../src/acp-service.js"
+import { mergeExternalHistory, mergeReplay } from "../src/acp-service.js"
 
 function message(id, text, created, extras = {}) {
   return {
@@ -42,4 +42,90 @@ test("semantic matching ignores transient part ids but keeps meaningful part dif
 
   const distinct = message("distinct", "same prompt", 180_000, { type: "reasoning" })
   assert.equal(mergeExternalHistory(persisted, [distinct]).length, 2)
+})
+
+test("mergeReplay preserves common prefix and appends new messages efficiently", () => {
+  const prev = [message("m1", "first", 100), message("m2", "second", 200)]
+  const replayed = [message("m1", "first", 100), message("m2", "second", 200), message("m3", "third", 300)]
+  const merged = mergeReplay(prev, replayed)
+  assert.deepEqual(merged.map((m) => m.info.id), ["m1", "m2", "m3"])
+})
+
+test("mergeReplay handles middle modifications and suffix matches", () => {
+  const prev = [message("m1", "head", 100), message("m2", "old mid", 200), message("m3", "tail", 300)]
+  const replayed = [message("m1", "head", 100), message("m2-new", "new mid", 250), message("m3", "tail", 300)]
+  const merged = mergeReplay(prev, replayed)
+  assert.deepEqual(merged.map((m) => m.info.id), ["m1", "m2", "m2-new", "m3"])
+})
+
+test("mergeExternalHistory handles in-place mutated messages without stale signature leaks", () => {
+  const msg = message("live-1", "initial text", 1_000)
+  // First merge
+  const first = mergeExternalHistory([msg], [msg])
+  assert.equal(first.length, 1)
+
+  // Mutate in place as streaming does
+  msg.parts[0].text = "mutated streaming text"
+  const distinctMsg = message("live-2", "initial text", 2_000)
+
+  // Second merge with mutated message must recognize content difference
+  const second = mergeExternalHistory([msg], [distinctMsg])
+  assert.equal(second.length, 2)
+})
+
+test("differential test: mergeReplay matches full-matrix LCS on random sequences", () => {
+  function referenceMergeReplay(previous, replayed) {
+    if (previous.length === 0) return replayed
+    if (replayed.length === 0) return previous
+    const messageSignature = (m) => `${m?.info?.role ?? ""}\u0000${(m?.parts ?? []).map((p) => p?.text ?? "").join("")}`
+    const left = previous.map(messageSignature)
+    const right = replayed.map(messageSignature)
+    const common = Array.from({ length: left.length + 1 }, () => new Uint32Array(right.length + 1))
+    for (let leftIndex = left.length - 1; leftIndex >= 0; leftIndex -= 1) {
+      for (let rightIndex = right.length - 1; rightIndex >= 0; rightIndex -= 1) {
+        common[leftIndex][rightIndex] = left[leftIndex] === right[rightIndex]
+          ? common[leftIndex + 1][rightIndex + 1] + 1
+          : Math.max(common[leftIndex + 1][rightIndex], common[leftIndex][rightIndex + 1])
+      }
+    }
+    const merged = []
+    let leftIndex = 0
+    let rightIndex = 0
+    while (leftIndex < left.length && rightIndex < right.length) {
+      if (left[leftIndex] === right[rightIndex]) {
+        merged.push(previous[leftIndex])
+        leftIndex += 1
+        rightIndex += 1
+      } else if (common[leftIndex + 1][rightIndex] >= common[leftIndex][rightIndex + 1]) {
+        merged.push(previous[leftIndex])
+        leftIndex += 1
+      } else {
+        merged.push(replayed[rightIndex])
+        rightIndex += 1
+      }
+    }
+    return [...merged, ...previous.slice(leftIndex), ...replayed.slice(rightIndex)]
+  }
+
+  const alphabet = ["A", "B", "C", "D", "E", "F", "G"]
+  let seed = 42
+  function random() {
+    seed = (seed * 1664525 + 1013904223) % 4294967296
+    return seed / 4294967296
+  }
+
+  for (let trial = 0; trial < 1000; trial += 1) {
+    const prevLen = Math.floor(random() * 20)
+    const repLen = Math.floor(random() * 20)
+    const prev = Array.from({ length: prevLen }, (_, i) =>
+      message(`p-${i}`, alphabet[Math.floor(random() * alphabet.length)], 100 + i)
+    )
+    const replayed = Array.from({ length: repLen }, (_, i) =>
+      message(`r-${i}`, alphabet[Math.floor(random() * alphabet.length)], 200 + i)
+    )
+
+    const expected = referenceMergeReplay(prev, replayed).map((m) => m.info.id)
+    const actual = mergeReplay(prev, replayed).map((m) => m.info.id)
+    assert.deepEqual(actual, expected, `Trial ${trial} failed`)
+  }
 })


### PR DESCRIPTION
`mergeReplay` built a full `(n+1)×(m+1)` Uint32Array LCS table on every ACP replay — on multi-thousand-message sessions that's tens of MB of transient allocation and the hot spot of a session load.

- Trim the shared prefix before running LCS, so the table covers only the divergent middle.
- Short-circuit the common append-only replay case (`previous` fully contained in `replayed`) to O(n) with no table at all.
- Signature matching stays cache-free — `messageSignature` computes signatures fresh on every merge, so messages mutated in place during streaming can never be compared against a stale signature. (Correction: an earlier revision of this description claimed the patch removed a cross-call signature cache; no such cache ever existed, in this patch or on `main` — the bullet was a leftover from an early draft.)
- Add a regression test for in-place mutation and a seeded differential test that proves the trimmed merge is identical to the previous full-matrix implementation.

All 93 bridge tests pass.
