### PR TITLE
perf(v3): port mergeReplay prefix trim

### DIFF
--- a/bridge/src/acp-client.js
+++ b/bridge/src/acp-client.js
@@ -9,15 +9,16 @@ const REQUEST_TIMEOUT_MS = 30_000
 const STDERR_KEPT_CHARS = 600
 
 /**
- * JSON-RPC only promises a human-readable `message`, and Codex spends it on a bare "Internal
- * error", putting the part worth reading — "thread <id> already has an active writer" — in
- * `data.details`. Dropping that left the app showing `{"error":"Internal error"}` for a refusal it
- * could otherwise have explained.
+ * JSON-RPC only promises a human-readable `message`, and adapters sometimes spend it on a bare
+ * "Internal error", putting the part worth reading in `data.details` or `data.message`. Dropping
+ * that left the app unable to explain actionable failures such as provider rate limits.
  */
 function acpErrorMessage(error) {
   const message = error?.message ?? "ACP adapter request failed"
-  const details = error?.data?.details
-  return typeof details === "string" && details && !message.includes(details) ? `${message}: ${details}` : message
+  const details = [error?.data?.details, error?.data?.message].find(
+    (value) => typeof value === "string" && value
+  )
+  return details && !message.includes(details) ? `${message}: ${details}` : message
 }
 
 export class AcpClient extends EventEmitter {

--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -73,39 +73,61 @@ function semanticHistorySignature(messages) {
   })))
 }
 
-function mergeReplay(previous, replayed) {
+/** Exported for testing only. */
+export function mergeReplay(previous, replayed) {
   if (previous.length === 0) return replayed
   if (replayed.length === 0) return previous
   const left = previous.map(messageSignature)
   const right = replayed.map(messageSignature)
-  const common = Array.from({ length: left.length + 1 }, () => new Uint32Array(right.length + 1))
-  for (let leftIndex = left.length - 1; leftIndex >= 0; leftIndex -= 1) {
-    for (let rightIndex = right.length - 1; rightIndex >= 0; rightIndex -= 1) {
-      common[leftIndex][rightIndex] = left[leftIndex] === right[rightIndex]
+
+  let prefix = 0
+  const maxPrefix = Math.min(previous.length, replayed.length)
+  while (prefix < maxPrefix && left[prefix] === right[prefix]) {
+    prefix += 1
+  }
+
+  if (prefix === previous.length) {
+    return [...previous, ...replayed.slice(prefix)]
+  }
+
+  const midLeft = left.slice(prefix)
+  const midRight = right.slice(prefix)
+
+  const common = Array.from({ length: midLeft.length + 1 }, () => new Uint32Array(midRight.length + 1))
+  for (let leftIndex = midLeft.length - 1; leftIndex >= 0; leftIndex -= 1) {
+    for (let rightIndex = midRight.length - 1; rightIndex >= 0; rightIndex -= 1) {
+      common[leftIndex][rightIndex] = midLeft[leftIndex] === midRight[rightIndex]
         ? common[leftIndex + 1][rightIndex + 1] + 1
         : Math.max(common[leftIndex + 1][rightIndex], common[leftIndex][rightIndex + 1])
     }
   }
-  const merged = []
 
+  const midMerged = []
   let leftIndex = 0
   let rightIndex = 0
-  while (leftIndex < left.length && rightIndex < right.length) {
-    if (left[leftIndex] === right[rightIndex]) {
-      merged.push(previous[leftIndex])
+  const midPrev = previous.slice(prefix)
+  const midRep = replayed.slice(prefix)
+
+  while (leftIndex < midLeft.length && rightIndex < midRight.length) {
+    if (midLeft[leftIndex] === midRight[rightIndex]) {
+      midMerged.push(midPrev[leftIndex])
       leftIndex += 1
       rightIndex += 1
     } else if (common[leftIndex + 1][rightIndex] >= common[leftIndex][rightIndex + 1]) {
-      merged.push(previous[leftIndex])
+      midMerged.push(midPrev[leftIndex])
       leftIndex += 1
     } else {
-      merged.push(replayed[rightIndex])
+      midMerged.push(midRep[rightIndex])
       rightIndex += 1
     }
   }
-  return [...merged, ...previous.slice(leftIndex), ...replayed.slice(rightIndex)]
+  return [
+    ...previous.slice(0, prefix),
+    ...midMerged,
+    ...midPrev.slice(leftIndex),
+    ...midRep.slice(rightIndex)
+  ]
 }
-
 export function mergeExternalHistory(persisted, cached) {
   const persistedIDs = new Set(persisted.map((message) => message.info.id))
   const remainingBySignature = new Map()

--- a/bridge/test/acp-provider-error.test.js
+++ b/bridge/test/acp-provider-error.test.js
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import test from "node:test"
+import { AcpClient } from "../src/acp-client.js"
+
+class FakeChild extends EventEmitter {
+  killed = false
+  stdout = new EventEmitter()
+  stderr = new EventEmitter()
+
+  constructor() {
+    super()
+    this.stdout.setEncoding = () => undefined
+    this.stderr.setEncoding = () => undefined
+    this.stdin = {
+      writable: true,
+      write: (line, callback) => {
+        const request = JSON.parse(line)
+        if (request.method === "initialize") {
+          this.respond({ jsonrpc: "2.0", id: request.id, result: { agentInfo: { name: "pi" }, authMethods: [] } })
+        } else if (request.method === "session/prompt") {
+          this.respond({
+            jsonrpc: "2.0",
+            id: request.id,
+            error: {
+              code: -32603,
+              message: "Internal error",
+              data: { details: { code: 429 }, errorKind: "rate_limit", message: "provider rate limit" }
+            }
+          })
+        }
+        callback?.()
+        return true
+      }
+    }
+  }
+
+  respond(message) {
+    this.stdout.emit("data", `${JSON.stringify(message)}\n`)
+  }
+
+  kill() {
+    this.killed = true
+    this.stdin.writable = false
+  }
+}
+
+test("surfaces ACP data.message when data.details is structured", async () => {
+  const child = new FakeChild()
+  const client = new AcpClient({ spawnProcess: () => child })
+  await client.start()
+  await assert.rejects(
+    client.request("session/prompt", {}),
+    /Internal error: provider rate limit/
+  )
+  client.close()
+})

--- a/bridge/test/external-history-dedup.test.js
+++ b/bridge/test/external-history-dedup.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import test from "node:test"
-import { mergeExternalHistory } from "../src/acp-service.js"
+import { mergeExternalHistory, mergeReplay } from "../src/acp-service.js"
 
 function message(id, text, created, extras = {}) {
   return {
@@ -42,4 +42,90 @@ test("semantic matching ignores transient part ids but keeps meaningful part dif
 
   const distinct = message("distinct", "same prompt", 180_000, { type: "reasoning" })
   assert.equal(mergeExternalHistory(persisted, [distinct]).length, 2)
+})
+
+test("mergeReplay preserves common prefix and appends new messages efficiently", () => {
+  const prev = [message("m1", "first", 100), message("m2", "second", 200)]
+  const replayed = [message("m1", "first", 100), message("m2", "second", 200), message("m3", "third", 300)]
+  const merged = mergeReplay(prev, replayed)
+  assert.deepEqual(merged.map((m) => m.info.id), ["m1", "m2", "m3"])
+})
+
+test("mergeReplay handles middle modifications and suffix matches", () => {
+  const prev = [message("m1", "head", 100), message("m2", "old mid", 200), message("m3", "tail", 300)]
+  const replayed = [message("m1", "head", 100), message("m2-new", "new mid", 250), message("m3", "tail", 300)]
+  const merged = mergeReplay(prev, replayed)
+  assert.deepEqual(merged.map((m) => m.info.id), ["m1", "m2", "m2-new", "m3"])
+})
+
+test("mergeExternalHistory handles in-place mutated messages without stale signature leaks", () => {
+  const msg = message("live-1", "initial text", 1_000)
+  // First merge
+  const first = mergeExternalHistory([msg], [msg])
+  assert.equal(first.length, 1)
+
+  // Mutate in place as streaming does
+  msg.parts[0].text = "mutated streaming text"
+  const distinctMsg = message("live-2", "initial text", 2_000)
+
+  // Second merge with mutated message must recognize content difference
+  const second = mergeExternalHistory([msg], [distinctMsg])
+  assert.equal(second.length, 2)
+})
+
+test("differential test: mergeReplay matches full-matrix LCS on random sequences", () => {
+  function referenceMergeReplay(previous, replayed) {
+    if (previous.length === 0) return replayed
+    if (replayed.length === 0) return previous
+    const messageSignature = (m) => `${m?.info?.role ?? ""}\u0000${(m?.parts ?? []).map((p) => p?.text ?? "").join("")}`
+    const left = previous.map(messageSignature)
+    const right = replayed.map(messageSignature)
+    const common = Array.from({ length: left.length + 1 }, () => new Uint32Array(right.length + 1))
+    for (let leftIndex = left.length - 1; leftIndex >= 0; leftIndex -= 1) {
+      for (let rightIndex = right.length - 1; rightIndex >= 0; rightIndex -= 1) {
+        common[leftIndex][rightIndex] = left[leftIndex] === right[rightIndex]
+          ? common[leftIndex + 1][rightIndex + 1] + 1
+          : Math.max(common[leftIndex + 1][rightIndex], common[leftIndex][rightIndex + 1])
+      }
+    }
+    const merged = []
+    let leftIndex = 0
+    let rightIndex = 0
+    while (leftIndex < left.length && rightIndex < right.length) {
+      if (left[leftIndex] === right[rightIndex]) {
+        merged.push(previous[leftIndex])
+        leftIndex += 1
+        rightIndex += 1
+      } else if (common[leftIndex + 1][rightIndex] >= common[leftIndex][rightIndex + 1]) {
+        merged.push(previous[leftIndex])
+        leftIndex += 1
+      } else {
+        merged.push(replayed[rightIndex])
+        rightIndex += 1
+      }
+    }
+    return [...merged, ...previous.slice(leftIndex), ...replayed.slice(rightIndex)]
+  }
+
+  const alphabet = ["A", "B", "C", "D", "E", "F", "G"]
+  let seed = 42
+  function random() {
+    seed = (seed * 1664525 + 1013904223) % 4294967296
+    return seed / 4294967296
+  }
+
+  for (let trial = 0; trial < 1000; trial += 1) {
+    const prevLen = Math.floor(random() * 20)
+    const repLen = Math.floor(random() * 20)
+    const prev = Array.from({ length: prevLen }, (_, i) =>
+      message(`p-${i}`, alphabet[Math.floor(random() * alphabet.length)], 100 + i)
+    )
+    const replayed = Array.from({ length: repLen }, (_, i) =>
+      message(`r-${i}`, alphabet[Math.floor(random() * alphabet.length)], 200 + i)
+    )
+
+    const expected = referenceMergeReplay(prev, replayed).map((m) => m.info.id)
+    const actual = mergeReplay(prev, replayed).map((m) => m.info.id)
+    assert.deepEqual(actual, expected, `Trial ${trial} failed`)
+  }
 })


### PR DESCRIPTION
Superseded. The original PR #201 head included unrelated lineage differences versus `v3/taskdesk`, so this PR was intentionally not merged.

The exact #201 two-file patch was instead reconstructed as a single commit directly on top of `v3/taskdesk` and applied there as `ae6f31304699f10b8cd476bcba60cafce1fc3254`.