### PR TITLE
fix(taskdesk): harden task launch flow

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,6 +29,7 @@ import { DEFAULT_HARNESS_CAPABILITIES } from "./backendCapabilities"
 import { BACKEND_CLIENTS } from "./backendClient"
 import { copyToClipboard } from "./clipboard"
 import { backendDisplayName, isBridgeBackend } from "./backendSetup"
+import { taskClient } from "./taskClient"
 import { type AttachmentPart } from "./attachments"
 import { CommandPalette, MenuBar, ServerSwitcher, type MenuDefinition, type MenuEntry, type PaletteCommand } from "./components/shell"
 import { ConnectServerWizard, NewSessionDialog } from "./components/panels"
@@ -792,14 +793,16 @@ function ConditionalWrapper({
 function DesktopModalOverlay({
   onClose,
   ariaLabel,
+  closeOnBackdrop = true,
   children
 }: {
   onClose: () => void
   ariaLabel: string
+  closeOnBackdrop?: boolean
   children: ReactNode
 }) {
   return (
-    <div className="modal-backdrop" role="presentation" onClick={onClose}>
+    <div className="modal-backdrop" role="presentation" onClick={closeOnBackdrop ? onClose : undefined}>
       <section
         className="modal-card desktop-panel-modal fade-in"
         role="dialog"
@@ -2261,6 +2264,7 @@ function App() {
   const awaitingAssistantBaselineRef = useRef("")
   const loadSelectedRequestRef = useRef(0)
   const loadModelsRequestRef = useRef(0)
+  const sessionRefreshRequestRef = useRef(0)
   const backgroundFailureCountRef = useRef(0)
   const initialSessionLoadRef = useRef(true)
   const latestMessageTimesRef = useRef(new Map<string, { sessionUpdated: number; activityTime: number }>())
@@ -2499,32 +2503,37 @@ function App() {
     setLoadingSessionID((activeID) => (activeID === sessionID ? null : activeID))
   }
 
+  function clearServerData(nextBackend = config.backend) {
+    // A credentials change is a hard boundary too: never leave a previous server's
+    // sessions visible while the new configuration is unauthenticated or rejected.
+    sessionRefreshRequestRef.current += 1
+    loadSelectedRequestRef.current += 1
+    loadModelsRequestRef.current += 1
+    autoSelectAttemptedRef.current = false
+    dashboardUnsupportedRef.current = false
+    setSessions([])
+    setSelectedID(null)
+    setMessages([])
+    setLoadedSessionID(null)
+    loadedMessagesRef.current = []
+    setOptimisticUserMessages([])
+    setTodos([])
+    setDiffFiles([])
+    setProjectDashboard(null)
+    setDashboardError(null)
+    setAwaitingAssistantReply(false)
+    setConnectedVersion("")
+    setCommands([])
+    setExtensionActions([])
+    setActionNotice(null)
+    setAgentOptions([])
+    setModelOptions([])
+    setSelectedModelKey(readStoredModel(nextBackend))
+  }
+
   function applyConfig(nextConfig: ServerConfig, profileID = activeProfileID, sourceProfiles = profiles) {
     const serverChanged = configKey(nextConfig) !== configKey(config)
-    if (serverChanged) {
-      loadSelectedRequestRef.current += 1
-      loadModelsRequestRef.current += 1
-      autoSelectAttemptedRef.current = false
-      dashboardUnsupportedRef.current = false
-      setSessions([])
-      setSelectedID(null)
-      setMessages([])
-      setLoadedSessionID(null)
-      loadedMessagesRef.current = []
-      setOptimisticUserMessages([])
-      setTodos([])
-      setDiffFiles([])
-      setProjectDashboard(null)
-      setDashboardError(null)
-      setAwaitingAssistantReply(false)
-      setConnectedVersion("")
-      setCommands([])
-      setExtensionActions([])
-      setActionNotice(null)
-      setAgentOptions([])
-      setModelOptions([])
-      setSelectedModelKey(readStoredModel(nextConfig.backend))
-    }
+    if (serverChanged) clearServerData(nextConfig.backend)
     const nextProfiles = sourceProfiles.map((profile) => profile.id === profileID ? { ...profile, config: nextConfig } : profile)
     setProfiles(nextProfiles)
     setActiveProfileID(profileID)
@@ -2582,6 +2591,7 @@ function App() {
 
   async function refreshSessions(silent = false, preserveSession?: SessionView) {
     if (!isValidServerConfig(config)) return
+    const requestID = ++sessionRefreshRequestRef.current
     if (!silent) {
       setRuntimeError(null)
       setConnectionState(sessions.length === 0 ? "connecting" : "reconnecting")
@@ -2613,10 +2623,12 @@ function App() {
       const statuses = Object.assign({}, ...statusMaps)
       const hydratedItems = items.map((session) => ({ ...session, ...scopedSessions.get(session.id), project: session.project }))
       const activityTimes = await loadSessionActivityTimes(hydratedItems)
+      if (requestID !== sessionRefreshRequestRef.current) return
       const mapped = hydratedItems
         .map((session) => toSessionView(session, statuses[session.id], activityTimes.get(session.id)))
         .sort((a, b) => b.updated - a.updated)
       setSessions((current) => {
+        if (requestID !== sessionRefreshRequestRef.current) return current
         // `current` is the list this refresh started from, so a session opened moments ago may not
         // be in it yet; the ref holds what is actually on screen. Falling back to `current` alone
         // let a refresh that raced an open drop the selected session, and the sessions list then
@@ -2637,7 +2649,16 @@ function App() {
       setConnectionMessage(t('connection.connected'))
       setRuntimeError(null)
     } catch (err) {
+      if (requestID !== sessionRefreshRequestRef.current) return
       const message = (err as Error).message
+      if (message.startsWith("HTTP 401:")) {
+        clearServerData()
+        setConnectionState("offline")
+        setConnectionMessage(t('connection.offline'))
+        setRuntimeError(message)
+        initialSessionLoadRef.current = false
+        return
+      }
       if (!silent) {
         setConnectionState("offline")
         setConnectionMessage(t('connection.offline'))
@@ -2707,7 +2728,18 @@ function App() {
     if (!isValidServerConfig(config) || !capabilities.models) return
     const requestID = ++loadModelsRequestRef.current
     try {
-      const list = await api.listModels(config, directory, backendClient.modelSelectionRequiresSession ? sessionID : undefined)
+      let list: ModelOption[]
+      try {
+        list = await api.listModels(config, directory, backendClient.modelSelectionRequiresSession ? sessionID : undefined)
+      } catch (sessionCatalogError) {
+        // A Codex session held by its desktop client can refuse the legacy session-scoped
+        // /config/providers request. The machine daemon owns an independent agent catalog for
+        // exactly this case; retain the legacy path for ordinary bridge servers.
+        if (!isBridgeBackend(config.backend)) throw sessionCatalogError
+        const catalog = await taskClient.listAgentModels(config, config.agentId ?? config.backend)
+        if (!catalog.models.length) throw sessionCatalogError
+        list = catalog.models
+      }
       if (requestID !== loadModelsRequestRef.current) return
       setModelOptions(list)
       setModelLoadError(null)
@@ -4200,7 +4232,7 @@ function App() {
         <ConditionalWrapper
           condition={isDesktop}
           wrapper={(children) => (
-            <DesktopModalOverlay onClose={() => setView("detail")} ariaLabel={t('settings.title')}>
+            <DesktopModalOverlay onClose={() => setView("detail")} ariaLabel={t('settings.title')} closeOnBackdrop={false}>
               {children}
             </DesktopModalOverlay>
           )}

--- a/web/src/TaskDeskTestPage.tsx
+++ b/web/src/TaskDeskTestPage.tsx
@@ -1,6 +1,11 @@
 import { useMemo, useState } from "react"
 import { TaskLaunchDialog } from "./components/task-launch-dialog"
 import { createTranslator, normalizeLanguage } from "./i18n"
+import type { MachineTask } from "./taskClient"
+
+function runReference(task: MachineTask): string | null {
+  return task.run?.sessionId ?? task.run?.sessionID ?? task.run?.id ?? null
+}
 
 /**
  * Explicit integration-only surface for real-harness TaskDesk testing.
@@ -12,18 +17,39 @@ import { createTranslator, normalizeLanguage } from "./i18n"
 export function TaskDeskTestPage() {
   const t = useMemo(() => createTranslator(normalizeLanguage(localStorage.getItem("opencode.remote.language") || navigator.language)), [])
   const [open, setOpen] = useState(true)
-  const [launchCount, setLaunchCount] = useState(0)
+  const [launchedTask, setLaunchedTask] = useState<MachineTask | null>(null)
 
   if (!open) {
     return (
-      <main className="panel fade-in" style={{ maxWidth: 720, margin: "3rem auto" }}>
+      <main className="panel taskdesk-test-page fade-in">
         <div className="section-heading">
           <div>
             <h2>TaskDesk integration test</h2>
             <p className="subtle">Normal Harness Remote is unchanged. This page exists only on the integration branch.</p>
           </div>
         </div>
-        {launchCount > 0 && <p>Task launch callback received ({launchCount}). Check the runtime and session/task lists.</p>}
+        {launchedTask && (
+          <section className="taskdesk-launch-result" aria-live="polite" aria-labelledby="taskdesk-launch-result-title">
+            <span className="taskdesk-launch-result-mark" aria-hidden="true">✓</span>
+            <div className="taskdesk-launch-result-heading">
+              <p className="eyebrow">Task started</p>
+              <h3 id="taskdesk-launch-result-title">Codex is now working on your task</h3>
+              <p className="subtle">The task was created and sent to the Harness machine daemon successfully.</p>
+            </div>
+            <dl className="taskdesk-launch-details">
+              <dt>Task</dt>
+              <dd><code>{launchedTask.id}</code></dd>
+              <dt>Agent</dt>
+              <dd>{launchedTask.agentId}</dd>
+              <dt>Project</dt>
+              <dd>{launchedTask.project.name}</dd>
+              <dt>Workspace</dt>
+              <dd><code>{launchedTask.workspace.path}</code></dd>
+              <dt>Run</dt>
+              <dd>{runReference(launchedTask) ? <code>{runReference(launchedTask)}</code> : launchedTask.run?.status ?? launchedTask.status}</dd>
+            </dl>
+          </section>
+        )}
         <div className="inline-actions">
           <button type="button" className="btn-primary" onClick={() => setOpen(true)}>Open New Task</button>
           <button type="button" className="btn-secondary" onClick={() => { window.location.href = window.location.pathname }}>Back to Harness Remote</button>
@@ -36,7 +62,7 @@ export function TaskDeskTestPage() {
     <TaskLaunchDialog
       t={t}
       onClose={() => setOpen(false)}
-      onLaunched={() => setLaunchCount((value) => value + 1)}
+      onLaunched={(task) => setLaunchedTask(task)}
     />
   )
 }

--- a/web/src/components/task-launch-dialog.tsx
+++ b/web/src/components/task-launch-dialog.tsx
@@ -3,7 +3,7 @@ import { CloseIcon, FolderIcon, LoadingIcon, PlayIcon, ServerIcon } from "../Ico
 import { createCatalogRequestGuard } from "../catalog-request-guard"
 import { loadActiveServerProfile, loadServerProfiles } from "../serverProfiles"
 import { discoverMachineConnection, selectableMachineAgents } from "../taskMachineClient"
-import { taskClient, type MachineProject } from "../taskClient"
+import { taskClient, type MachineProject, type MachineTask } from "../taskClient"
 import type { Translator } from "../i18n"
 import type { MachineSnapshot, ModelOption, ServerConfig } from "../types"
 
@@ -58,7 +58,7 @@ function preferredAgentID(machine: MachineSnapshot, config: ServerConfig): strin
 export function TaskLaunchDialog({ t, onClose, onLaunched }: {
   t: Translator
   onClose: () => void
-  onLaunched: () => void
+  onLaunched: (task: MachineTask) => void
 }) {
   const profile = useMemo(() => loadActiveServerProfile(loadServerProfiles()), [])
   const config: ServerConfig = profile.config
@@ -168,8 +168,8 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
         model: model && { providerID: model.providerID, modelID: model.modelID, variant: model.variant }
       })
       if (isolated && selectedProject?.kind === "git") task = await taskClient.prepareWorktree(taskConfig, task.id)
-      await taskClient.launch(taskConfig, task.id)
-      onLaunched()
+      task = await taskClient.launch(taskConfig, task.id)
+      onLaunched(task)
       onClose()
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause))
@@ -181,14 +181,14 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
   const machineName = machine?.machine.name ?? profile.name
 
   return (
-    <div className="modal-backdrop" role="presentation" onClick={onClose}>
-      <section className="modal-card wizard fade-in" role="dialog" aria-modal="true" aria-labelledby="new-task-title" onClick={(event) => event.stopPropagation()}>
+    <div className="modal-backdrop" role="presentation">
+      <section className="modal-card wizard task-launch-dialog fade-in" role="dialog" aria-modal="true" aria-labelledby="new-task-title" onClick={(event) => event.stopPropagation()}>
         <div className="wizard-header">
           <div className="wizard-header-text">
             <h2 id="new-task-title">{taskText(t, "task.new")}</h2>
             <p className="subtle">{taskText(t, "task.subtitle", { machine: machineName })}</p>
           </div>
-          <button type="button" className="btn-icon btn-ghost" onClick={onClose} aria-label={t("session.cancel")}><CloseIcon size={16} /></button>
+          <button type="button" className="btn-icon btn-ghost task-launch-close" onClick={onClose} aria-label={t("session.cancel")}><CloseIcon size={16} /></button>
         </div>
 
         <div className="wizard-body">
@@ -200,28 +200,28 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
             <div className="empty-state compact"><FolderIcon size={30} /><p>{taskText(t, "task.noProjects")}</p></div>
           ) : (
             <div className="task-launch-form">
-              <div className="task-context">
+              <div className="task-launch-context">
                 <div className="task-context-item">
                   <span className="eyebrow">{taskText(t, "task.machine")}</span>
                   <strong><ServerIcon size={15} /><span className="truncate">{machineName}</span></strong>
                 </div>
               </div>
 
-              <label className="field">
+              <label className="field task-launch-field task-launch-field--agent">
                 <span>{taskText(t, "task.agent")}</span>
                 <select value={selectedAgentId} onChange={(event) => setSelectedAgentId(event.target.value)}>
                   {agents.map((candidate) => <option key={candidate.id} value={candidate.id}>{candidate.label ?? candidate.id}</option>)}
                 </select>
               </label>
 
-              <label className="field">
+              <label className="field task-launch-field task-launch-field--project">
                 <span>{taskText(t, "task.project")}</span>
                 <select value={projectId} onChange={(event) => setProjectId(event.target.value)}>
                   {projects.map((project) => <option key={project.id} value={project.id}>{project.name} — {project.path}</option>)}
                 </select>
               </label>
 
-              <label className="field">
+              <label className="field task-launch-field task-launch-field--model">
                 <span>{taskText(t, "task.model")}</span>
                 {modelLoading ? (
                   <span className="subtle"><LoadingIcon size={14} /> {taskText(t, "task.modelLoading")}</span>
@@ -242,9 +242,9 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
                 )}
               </label>
 
-              <label className="field">
+              <label className="field task-launch-field task-launch-field--prompt">
                 <span>{taskText(t, "task.label")}</span>
-                <textarea value={prompt} onChange={(event) => setPrompt(event.target.value)} placeholder={taskText(t, "task.promptPlaceholder")} rows={6} autoFocus />
+                <textarea value={prompt} onChange={(event) => setPrompt(event.target.value)} placeholder={taskText(t, "task.promptPlaceholder")} rows={5} autoFocus />
               </label>
 
               <div className="task-launch-worktree">
@@ -258,7 +258,7 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
           )}
         </div>
 
-        <div className="wizard-footer">
+        <div className="wizard-footer task-launch-footer">
           <span className="spacer" />
           <button type="button" className="btn-secondary" onClick={onClose}>{t("session.cancel")}</button>
           <button type="button" className="btn-primary" disabled={!canStart} onClick={() => void start()}>

--- a/web/src/model-regression.test.mjs
+++ b/web/src/model-regression.test.mjs
@@ -23,6 +23,8 @@ assert.ok(app.includes('writeStoredModel(config.backend, selectedSession?.id, ne
 assert.ok(/const activeModel = activeModelOption[\s\S]*?: undefined/.test(app), 'a prompt must never send a stored model that is absent from the current backend catalog')
 assert.ok(app.includes('loadModelsRequestRef'), 'stale model catalogs from another session or backend must be ignored')
 assert.ok(app.includes('if (requestID !== loadModelsRequestRef.current) return'), 'only the latest model request may update the picker')
+assert.ok(app.includes('taskClient.listAgentModels(config, config.agentId ?? config.backend)'), 'a failed bridge session catalog must fall back to the machine agent catalog')
+assert.ok(app.includes('if (!isBridgeBackend(config.backend)) throw sessionCatalogError'), 'the machine-catalog fallback must not alter direct OpenCode behavior')
 assert.ok(app.includes('agentOptions.filter((agent) => agent.mode === "primary" || agent.mode === "all")'), 'agent picker should expose primary agents such as build and plan')
 assert.ok(app.includes('activeAgent?.id ?? "build"'), 'agent selection should default to build')
 assert.ok(app.includes('id="agent-select"'), 'AI sheet should render an agent selector')

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3236,6 +3236,216 @@ a:focus-visible,
   flex: 1 1 auto;
 }
 
+/* --- TaskDesk launch --- */
+
+.taskdesk-test-page {
+  width: min(100% - 2 * var(--space-4), 45rem);
+  margin: clamp(var(--space-6), 8vh, 5rem) auto;
+}
+
+.taskdesk-launch-result {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--space-3);
+  margin: var(--space-5) 0;
+  padding: var(--space-4);
+  border: 1px solid color-mix(in srgb, var(--success) 45%, var(--border));
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--success) 8%, var(--surface));
+}
+
+.taskdesk-launch-result-mark {
+  display: grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--radius-pill);
+  background: var(--success);
+  color: var(--on-accent);
+  font-weight: 800;
+}
+
+.taskdesk-launch-result-heading {
+  min-width: 0;
+}
+
+.taskdesk-launch-result-heading .eyebrow,
+.taskdesk-launch-result-heading h3,
+.taskdesk-launch-result-heading .subtle {
+  margin: 0;
+}
+
+.taskdesk-launch-result-heading h3 {
+  margin-top: var(--space-1);
+  font-size: var(--font-lg);
+}
+
+.taskdesk-launch-result-heading .subtle {
+  margin-top: var(--space-2);
+  line-height: 1.45;
+}
+
+.taskdesk-launch-details {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: minmax(5.5rem, 0.3fr) minmax(0, 1fr);
+  gap: var(--space-2) var(--space-4);
+  margin: var(--space-1) 0 0;
+  padding-top: var(--space-3);
+  border-top: 1px solid color-mix(in srgb, var(--success) 25%, var(--border));
+  font-size: var(--font-sm);
+}
+
+.taskdesk-launch-details dt {
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.taskdesk-launch-details dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.taskdesk-launch-details code {
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-xs);
+}
+
+.task-launch-dialog {
+  width: min(94vw, 46rem);
+}
+
+.task-launch-dialog .wizard-header {
+  align-items: center;
+  padding: var(--space-5);
+}
+
+.task-launch-dialog .wizard-header h2 {
+  font-size: var(--font-xl);
+  letter-spacing: -0.015em;
+}
+
+.task-launch-dialog .wizard-header .subtle {
+  margin-top: var(--space-1);
+  line-height: 1.45;
+}
+
+.task-launch-close {
+  margin-left: auto;
+  flex: 0 0 auto;
+  width: var(--control-h-lg);
+  height: var(--control-h-lg);
+  min-height: var(--control-h-lg);
+  padding: 0;
+}
+
+.task-launch-dialog .wizard-body {
+  padding: var(--space-5);
+  overflow-x: hidden;
+}
+
+.task-launch-form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-4);
+}
+
+.task-launch-context,
+.task-launch-field--model,
+.task-launch-field--prompt,
+.task-launch-worktree {
+  grid-column: 1 / -1;
+}
+
+.task-launch-context {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface-subtle);
+}
+
+.task-context-item {
+  min-width: 0;
+  display: grid;
+  gap: var(--space-1);
+}
+
+.task-context-item strong {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-md);
+  font-weight: 600;
+}
+
+.task-launch-field select,
+.task-launch-field textarea {
+  width: 100%;
+}
+
+.task-launch-field textarea {
+  min-height: 8rem;
+  resize: vertical;
+  line-height: 1.5;
+}
+
+.task-launch-worktree {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface-subtle);
+}
+
+.task-launch-check {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: var(--control-h-lg);
+  color: var(--text);
+  font-size: var(--font-sm);
+  font-weight: 600;
+}
+
+.task-launch-check input[type="checkbox"] {
+  appearance: auto;
+  flex: 0 0 auto;
+  width: 1.125rem;
+  max-width: 1.125rem;
+  height: 1.125rem;
+  min-height: 1.125rem;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  accent-color: var(--primary);
+}
+
+.task-launch-check span {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow-wrap: anywhere;
+}
+
+.task-launch-note {
+  margin: 0;
+  line-height: 1.45;
+}
+
+.task-launch-footer {
+  padding: var(--space-3) var(--space-5);
+}
+
 .choice-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
@@ -3989,6 +4199,63 @@ a:focus-visible,
 
   .modal-actions button {
     width: 100%;
+  }
+
+  .task-launch-dialog {
+    width: min(100%, 42rem);
+    max-height: calc(100dvh - 2 * var(--space-2) - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+  }
+
+  .task-launch-dialog .wizard-header,
+  .task-launch-dialog .wizard-body,
+  .task-launch-footer {
+    padding-left: var(--space-4);
+    padding-right: var(--space-4);
+  }
+
+  .task-launch-dialog .wizard-header {
+    align-items: flex-start;
+    padding-top: var(--space-4);
+    padding-bottom: var(--space-3);
+  }
+
+  .task-launch-form {
+    grid-template-columns: 1fr;
+    gap: var(--space-3);
+  }
+
+  .taskdesk-test-page {
+    width: min(100% - 2 * var(--space-3), 45rem);
+    margin: var(--space-4) auto;
+  }
+
+  .taskdesk-launch-result {
+    padding: var(--space-3);
+  }
+
+  .taskdesk-launch-details {
+    grid-template-columns: 1fr;
+    gap: var(--space-1);
+  }
+
+  .taskdesk-launch-details dt:not(:first-child) {
+    margin-top: var(--space-2);
+  }
+
+  .task-launch-context,
+  .task-launch-field--model,
+  .task-launch-field--prompt,
+  .task-launch-worktree {
+    grid-column: auto;
+  }
+
+  .task-launch-context,
+  .task-launch-worktree {
+    padding: var(--space-3);
+  }
+
+  .task-launch-field textarea {
+    min-height: 7rem;
   }
 
   .session-card .inline-actions {

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -10,6 +10,8 @@ const shell = readFileSync(new URL('./components/shell.tsx', import.meta.url), '
 const panels = readFileSync(new URL('./components/panels.tsx', import.meta.url), 'utf8')
 const sessionList = readFileSync(new URL('./components/session-list.tsx', import.meta.url), 'utf8')
 const composerView = readFileSync(new URL('./components/session-composer.tsx', import.meta.url), 'utf8')
+const taskDialog = readFileSync(new URL('./components/task-launch-dialog.tsx', import.meta.url), 'utf8')
+const taskDeskTestPage = readFileSync(new URL('./TaskDeskTestPage.tsx', import.meta.url), 'utf8')
 
 assert.ok(api.includes('const body = await response.text()'), 'failed HTTP responses must consume their body only once')
 // The bridge reports failures as {"error": "..."}; without unwrapping that the app printed the raw
@@ -115,6 +117,18 @@ assert.ok(app.includes('completionShouldPlayRef.current = true'), 'completion so
 assert.ok(app.includes('wasAwaitingAssistantReplyRef.current && !awaitingAssistantReply && completionShouldPlayRef.current'), 'completion sound should play only when assistant waiting ends, not when the user bubble renders')
 assert.ok(app.includes('loadSelectedRequestRef'), 'session message refreshes should ignore stale overlapping polling responses')
 assert.ok(app.includes('if (requestID !== loadSelectedRequestRef.current) return'), 'older loadSelected requests must not overwrite newer assistant output')
+assert.ok(app.includes('const sessionRefreshRequestRef = useRef(0)'), 'session list refreshes need their own request generation')
+assert.ok(app.includes('if (requestID !== sessionRefreshRequestRef.current) return'), 'an old authenticated session-list response must not repopulate the UI after credentials change')
+assert.match(app, /message\.startsWith\("HTTP 401:"\)[\s\S]*?clearServerData\(\)/, 'an unauthorized session refresh must clear the previously visible server data')
+assert.match(app, /function DesktopModalOverlay\([\s\S]*?closeOnBackdrop = true/, 'desktop panel overlays must support disabling backdrop dismissal')
+assert.match(app, /ariaLabel=\{t\('settings\.title'\)\} closeOnBackdrop=\{false\}/, 'server configuration must stay open when its backdrop is clicked')
+assert.ok(!taskDialog.includes('role="presentation" onClick={onClose}'), 'the new-task dialog must not discard typed work when the backdrop is clicked')
+assert.ok(taskDialog.includes('onLaunched: (task: MachineTask) => void'), 'the task launcher must return the launched task, not a bare callback')
+assert.ok(taskDialog.includes('task = await taskClient.launch(taskConfig, task.id)'), 'the success view must receive the task returned by launch')
+assert.ok(taskDeskTestPage.includes('Codex is now working on your task'), 'the integration page must confirm a successful launch in user language')
+assert.ok(!taskDeskTestPage.includes('Task launch callback received'), 'technical callback wording must not be shown as task-launch confirmation')
+assert.match(styles, /\.taskdesk-launch-details\s*\{[^}]*grid-template-columns:/, 'the launch confirmation must present task details in a structured layout')
+assert.match(styles, /@media \(max-width: 780px\)[\s\S]*?\.taskdesk-launch-details\s*\{[^}]*grid-template-columns:\s*1fr;/, 'launch confirmation details must stack on mobile')
 assert.ok(app.includes('loadedSessionID'), 'the message pane should track whether the selected session history has loaded')
 assert.ok(app.includes('loadedSessionID !== selectedID'), 'an unloaded selected session must render the loading state instead of an empty transcript')
 assert.ok(app.includes('setLoadedSessionID(sessionID)'), 'a successful selected-session snapshot should unlock the empty transcript state')
@@ -588,5 +602,11 @@ assert.match(
   /for \(const \[command, binding\] of Object\.entries\(KEY_BINDINGS\)\) \{\s*if \(!bindingApplies\(binding\)\) continue/,
   'the keydown handler must skip bindings that do not apply to this build'
 )
+
+assert.match(styles, /\.task-launch-form\s*\{[^}]*grid-template-columns:\s*repeat\(2, minmax\(0, 1fr\)\)/, 'TaskDesk launch should use balanced desktop form columns')
+assert.match(styles, /\.task-launch-context,[\s\S]*?\.task-launch-worktree\s*\{[^}]*grid-column:\s*1 \/ -1/, 'TaskDesk context, prompt, model and worktree must span the dialog intentionally')
+assert.match(styles, /@media \(max-width: 780px\)[\s\S]*?\.task-launch-form\s*\{[^}]*grid-template-columns:\s*1fr/, 'TaskDesk launch must collapse to one mobile form column')
+assert.match(styles, /\.task-launch-check input\[type="checkbox"\]\s*\{[^}]*width:\s*1\.125rem;[^}]*max-width:\s*1\.125rem;[^}]*min-height:\s*1\.125rem/, 'TaskDesk worktree checkbox must never inherit full-width text-input sizing')
+assert.match(styles, /\.task-launch-close\s*\{[^}]*margin-left:\s*auto/, 'TaskDesk close control must stay anchored to the header’s right edge')
 
 console.log('ui regression tests passed')


### PR DESCRIPTION
## Summary

- fix authentication-state handling so unauthenticated session data cannot remain visible
- keep server settings and task creation dialogs open when their backdrop is clicked
- load Codex models through the machine daemon catalog and restore the TaskDesk launch form layout
- replace the technical launch callback message with a clear task/run confirmation

## Why

The TaskDesk v3 integration test exposed stale session data after credential changes, an unavailable model catalog for Codex, and a form that could close or overflow unexpectedly.

## Validation

- `npm --prefix web run test:ui`
- `npm --prefix web run test:model`
- `npm --prefix web run build`
- verified two real TaskDesk launches through the Harness machine daemon; the resulting Codex sessions appeared in Harness Remote and produced replies
