### PR TITLE
fix(ui): isolate harness session changes

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1348,7 +1348,8 @@ function configKey(config: ServerConfig): string {
     host: config.host.trim(),
     port: config.port,
     username: config.username.trim(),
-    password: config.password
+    password: config.password,
+    agentId: config.agentId?.trim() ?? ""
   })
 }
 
@@ -2510,10 +2511,14 @@ function App() {
     sessionRefreshRequestRef.current += 1
     loadSelectedRequestRef.current += 1
     loadModelsRequestRef.current += 1
+    openingSessionRef.current = null
     autoSelectAttemptedRef.current = false
     dashboardUnsupportedRef.current = false
     setSessions([])
     setSelectedID(null)
+    setLoadingSessionID(null)
+    setActiveDetailSheet(null)
+    setView((current) => current === "detail" ? "sessions" : current)
     setMessages([])
     setLoadedSessionID(null)
     loadedMessagesRef.current = []
@@ -2533,7 +2538,9 @@ function App() {
   }
 
   function applyConfig(nextConfig: ServerConfig, profileID = activeProfileID, sourceProfiles = profiles) {
-    const serverChanged = configKey(nextConfig) !== configKey(config)
+    // A profile is a trust and session boundary, even if two profiles happen to point at the same
+    // host. In particular, agentId distinguishes harnesses exposed by one machine daemon.
+    const serverChanged = profileID !== activeProfileID || configKey(nextConfig) !== configKey(config)
     if (serverChanged) clearServerData(nextConfig.backend)
     const nextProfiles = sourceProfiles.map((profile) => profile.id === profileID ? { ...profile, config: nextConfig } : profile)
     setProfiles(nextProfiles)
@@ -4706,7 +4713,7 @@ function App() {
       )}
 
       {activeDetailSheet && selectedSession && (
-        <div className="sheet-backdrop" role="presentation" onClick={() => setActiveDetailSheet(null)}>
+        <div className="sheet-backdrop" role="presentation">
           <section
             className="bottom-sheet fade-in"
             role="dialog"

--- a/web/src/components/panels.tsx
+++ b/web/src/components/panels.tsx
@@ -335,7 +335,7 @@ export function ConnectServerWizard({
   }
 
   return (
-    <div className="modal-backdrop" role="presentation" onClick={onCancel}>
+    <div className="modal-backdrop" role="presentation">
       <section
         className="modal-card wizard fade-in"
         role="dialog"
@@ -348,7 +348,7 @@ export function ConnectServerWizard({
             <h2 id="connect-server-title">{t('connect.title')}</h2>
             <p className="subtle">{t('connect.subtitle')}</p>
           </div>
-          <button type="button" className="btn-icon btn-ghost" onClick={onCancel} aria-label={t('session.cancel')}>
+          <button type="button" className="btn-icon btn-ghost wizard-close" onClick={onCancel} aria-label={t('session.cancel')}>
             <CloseIcon size={16} />
           </button>
         </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -54,9 +54,9 @@
   --harness-omp: #6d28d9;
   --harness-omp-soft: #f2eaff;
   --harness-omp-border: #ddccff;
-  --harness-pi: #0d7a70;
-  --harness-pi-soft: #e0f4f1;
-  --harness-pi-border: #bde5df;
+  --harness-pi: #2563eb;
+  --harness-pi-soft: #e8efff;
+  --harness-pi-border: #c7d9ff;
   --harness-claude: #b45309;
   --harness-claude-soft: #fdefdb;
   --harness-claude-border: #f5d9ae;
@@ -159,9 +159,9 @@
   --harness-omp: #c4b5fd;
   --harness-omp-soft: rgba(124, 58, 237, 0.22);
   --harness-omp-border: rgba(196, 181, 253, 0.36);
-  --harness-pi: #5eead4;
-  --harness-pi-soft: rgba(13, 122, 112, 0.26);
-  --harness-pi-border: rgba(94, 234, 212, 0.32);
+  --harness-pi: #93c5fd;
+  --harness-pi-soft: rgba(37, 99, 235, 0.26);
+  --harness-pi-border: rgba(147, 197, 253, 0.38);
   --harness-claude: #f6ad55;
   --harness-claude-soft: rgba(180, 83, 9, 0.26);
   --harness-claude-border: rgba(246, 173, 85, 0.34);
@@ -3114,6 +3114,16 @@ a:focus-visible,
   gap: var(--space-1);
 }
 
+.wizard-close,
+.wizard-header > .btn-icon {
+  margin-left: auto;
+  flex: 0 0 auto;
+  width: var(--control-h-lg);
+  height: var(--control-h-lg);
+  min-height: var(--control-h-lg);
+  padding: 0;
+}
+
 .wizard-header h2 {
   margin: 0;
   font-size: var(--font-xl);
@@ -3454,9 +3464,11 @@ a:focus-visible,
 
 .choice-card {
   display: grid;
+  grid-template-rows: 1.5rem minmax(3rem, 1fr);
   align-content: start;
   gap: var(--space-1);
-  min-height: 5rem;
+  min-width: 0;
+  min-height: 6.75rem;
   padding: var(--space-3);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
@@ -3480,6 +3492,9 @@ a:focus-visible,
 }
 
 .choice-card small {
+  display: block;
+  margin: 0;
+  overflow-wrap: anywhere;
   color: var(--muted);
   font-size: var(--font-xs);
   font-weight: 400;

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -122,6 +122,11 @@ assert.ok(app.includes('if (requestID !== sessionRefreshRequestRef.current) retu
 assert.match(app, /message\.startsWith\("HTTP 401:"\)[\s\S]*?clearServerData\(\)/, 'an unauthorized session refresh must clear the previously visible server data')
 assert.match(app, /function DesktopModalOverlay\([\s\S]*?closeOnBackdrop = true/, 'desktop panel overlays must support disabling backdrop dismissal')
 assert.match(app, /ariaLabel=\{t\('settings\.title'\)\} closeOnBackdrop=\{false\}/, 'server configuration must stay open when its backdrop is clicked')
+assert.ok(!app.includes('sheet-backdrop" role="presentation" onClick={() => setActiveDetailSheet(null)}'), 'the model configuration sheet must require an explicit close action')
+assert.ok(!panels.includes('modal-backdrop" role="presentation" onClick={onCancel}'), 'the server connection wizard must not discard a draft when its backdrop is clicked')
+assert.ok(panels.includes('wizard-close'), 'the server connection wizard needs an explicit close control')
+assert.ok(app.includes('profileID !== activeProfileID || configKey(nextConfig) !== configKey(config)'), 'switching profiles must clear the previous harness session even for the same host')
+assert.ok(app.includes('agentId: config.agentId?.trim() ?? ""'), 'the server identity must include the selected daemon agent')
 assert.ok(!taskDialog.includes('role="presentation" onClick={onClose}'), 'the new-task dialog must not discard typed work when the backdrop is clicked')
 assert.ok(taskDialog.includes('onLaunched: (task: MachineTask) => void'), 'the task launcher must return the launched task, not a bare callback')
 assert.ok(taskDialog.includes('task = await taskClient.launch(taskConfig, task.id)'), 'the success view must receive the task returned by launch')
@@ -309,6 +314,9 @@ for (const cls of ['.harness-badge', '.harness-omp', '.harness-pi', '.brand-serv
   assert.ok(styles.includes(cls), `${cls} should be styled`)
 }
 assert.match(styles, /\.brand-server[\s\S]*?text-overflow: ellipsis/, 'a long address must truncate rather than push the badge off screen')
+assert.match(styles, /--harness-pi:\s*#2563eb/, 'PI needs a clearly distinct blue harness color')
+assert.match(styles, /\.wizard-header > \.btn-icon[\s\S]*?margin-left:\s*auto/, 'wizard close controls must stay pinned to the top-right corner')
+assert.match(styles, /\.choice-card\s*\{[\s\S]*?grid-template-rows:\s*1\.5rem minmax\(3rem, 1fr\)/, 'server choice card labels must align across harnesses')
 
 // Mobile keyboard: an address is not a sentence, a port is a number, and a soft keyboard has
 // no Shift key — so the composer flips on touch-primary devices: Enter inserts a new line,


### PR DESCRIPTION
## What changed

- Keeps model and server-connection configuration open until the user explicitly closes it.
- Treats every server profile and daemon agent as a session boundary, clearing the prior harness conversation before loading the next one.
- Pins the server-connection close button to the top-right corner.
- Makes PI visibly blue rather than visually similar to Codex green, and aligns the server-choice cards across desktop and mobile.

## Checks

- `npm --prefix web run test:ui`
- `npm --prefix web run test:settings`
- `npm --prefix web run build`
- Desktop and 390px mobile visual verification in the local app
