### PR TITLE
Preserve saved server profiles on reload

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3458,10 +3458,6 @@ function App() {
   }, [theme])
 
   useEffect(() => {
-    persistServerProfiles(profiles, activeProfileID)
-  }, [])
-
-  useEffect(() => {
     localStorage.setItem(NEW_SESSION_DIRECTORY_STORAGE_KEY, newSessionDirectory)
   }, [newSessionDirectory])
 

--- a/web/src/server-profiles.test.mjs
+++ b/web/src/server-profiles.test.mjs
@@ -32,6 +32,19 @@ assert.equal(JSON.parse(storage.get(SERVER_PROFILES_STORAGE_KEY)).length, 3, 'sa
 assert.equal(storage.get(ACTIVE_PROFILE_STORAGE_KEY), added.id, 'the selected server should persist independently')
 assert.equal(loadActiveServerProfile(loadServerProfiles()).name, 'Work PI', 'the saved selection should be restored at launch')
 
+// An upgrade can have a new collection created before all older backend-specific keys are migrated.
+// Loading must retain that OMP entry instead of letting a reload overwrite its only representation.
+storage.clear()
+const collectionProfile = {
+  id: 'collection-opencode',
+  name: 'Current OpenCode',
+  config: { backend: 'opencode', host: 'desktop.local', port: 4096, username: 'opencode', password: '' }
+}
+storage.set(SERVER_PROFILES_STORAGE_KEY, JSON.stringify([collectionProfile]))
+storage.set('opencode.remote.server.omp', JSON.stringify({ backend: 'omp', host: 'pi.local', port: 4097, username: 'omp', password: 'secret' }))
+const mergedMigration = loadServerProfiles()
+assert.deepEqual(mergedMigration.map((profile) => profile.config.backend), ['opencode', 'omp'], 'a legacy OMP profile must survive alongside the saved profile collection')
+
 const daemonProfile = {
   id: 'machine-profile',
   name: 'Workstation',

--- a/web/src/serverProfiles.ts
+++ b/web/src/serverProfiles.ts
@@ -78,7 +78,10 @@ function parseProfiles(value: string | null): SavedServerProfile[] | null {
   }
 }
 
-function legacyProfiles(): SavedServerProfile[] {
+/** Read only real legacy entries. Keeping this separate from the blank fallback lets a newer
+    profile collection absorb a configuration from an older backend-specific key without adding
+    an invented empty server on every launch. */
+function readLegacyProfiles(): SavedServerProfile[] {
   const profiles: SavedServerProfile[] = []
   for (const backend of BACKENDS) {
     const raw = localStorage.getItem(BACKEND_STORAGE_KEYS[backend])
@@ -95,15 +98,31 @@ function legacyProfiles(): SavedServerProfile[] {
     const legacy = parseConfig(JSON.parse(localStorage.getItem(LEGACY_STORAGE_KEY) ?? "null"), "opencode")
     if (legacy) return [{ id: profileID(), name: profileName(legacy.backend, 0), config: legacy }]
   } catch {
-    // Start with a blank OpenCode profile when legacy storage is malformed.
+    // Ignore malformed legacy storage and continue with the backend-specific entries.
   }
+  return profiles
+}
+
+function legacyProfiles(): SavedServerProfile[] {
+  const profiles = readLegacyProfiles()
+  if (profiles.length > 0) return profiles
   const backend = localStorage.getItem(ACTIVE_BACKEND_STORAGE_KEY)
   const fallback = isBackend(backend) ? backend : "opencode"
   return [{ id: profileID(), name: profileName(fallback, 0), config: defaultConfig(fallback) }]
 }
 
 export function loadServerProfiles(): SavedServerProfile[] {
-  return parseProfiles(localStorage.getItem(SERVER_PROFILES_STORAGE_KEY)) ?? legacyProfiles()
+  const savedProfiles = parseProfiles(localStorage.getItem(SERVER_PROFILES_STORAGE_KEY))
+  if (!savedProfiles) return legacyProfiles()
+
+  // A user may upgrade while they already have one new-format server plus an older OMP/PI/etc.
+  // backend key. Treat the collection as authoritative for profiles it knows, but retain a legacy
+  // configuration for a backend that the collection does not contain. Previously the startup
+  // persistence below overwrote that key's only path back into the UI.
+  const legacyOnly = readLegacyProfiles().filter((legacyProfile) =>
+    !savedProfiles.some((profile) => profile.config.backend === legacyProfile.config.backend)
+  )
+  return [...savedProfiles, ...legacyOnly]
 }
 
 export function loadActiveServerProfile(profiles: SavedServerProfile[]): SavedServerProfile {


### PR DESCRIPTION
## Summary\n- merge older backend-specific profiles into the saved server collection during upgrade\n- avoid an automatic mount-time write that could make an ignored legacy profile disappear\n- add regression coverage for an OMP profile alongside a modern collection\n\n## Verification\n- npm run test:profiles\n- npm run test:settings\n- npm run build