### PR TITLE
Align harness choices and distinguish PI

### DIFF
--- a/web/src/components/panels.tsx
+++ b/web/src/components/panels.tsx
@@ -339,6 +339,7 @@ export function ConnectServerWizard({
                   key={kind}
                   type="button"
                   className={`choice-card${backend === kind ? " selected" : ""}`}
+                  aria-pressed={backend === kind}
                   onClick={() => chooseBackend(kind)}
                 >
                   <strong>

--- a/web/src/settings-regression.test.mjs
+++ b/web/src/settings-regression.test.mjs
@@ -5,6 +5,7 @@ const app = readFileSync(new URL('./App.tsx', import.meta.url), 'utf8')
 const i18n = readFileSync(new URL('./i18n.ts', import.meta.url), 'utf8')
 const styles = readFileSync(new URL('./styles.css', import.meta.url), 'utf8')
 const shell = readFileSync(new URL('./components/shell.tsx', import.meta.url), 'utf8')
+const panels = readFileSync(new URL('./components/panels.tsx', import.meta.url), 'utf8')
 
 const testConnection = app.match(/async function testConnection[\s\S]*?async function refreshSessions/)
 assert.ok(testConnection, 'testConnection function should be present')
@@ -42,6 +43,9 @@ for (const className of ['server-profile-actions', 'section-heading-text']) {
 assert.ok(shell.includes('className="server-switcher"'), 'the saved-server UI should use the richer server switcher')
 assert.ok(styles.includes('.server-switcher'), 'the server switcher should be styled instead of relying on default rendering')
 assert.equal(/className="sr-only"/.test(app), false, 'a caption the stylesheet cannot hide must not be rendered at all')
+assert.ok(panels.includes('aria-pressed={backend === kind}'), 'harness choices should expose their selected state without relying on color alone')
+assert.match(styles, /\.choice-card\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\)/, 'harness choice text should share one full-width alignment column')
+assert.match(styles, /--harness-pi:\s*#0e7490/, 'PI should use a distinct cyan hue instead of OpenCode blue')
 
 // Sized to their labels the two actions came out visibly different widths, and a full row of their own
 // pushed a form that already fills the height cap into scrolling for a few pixels.

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -54,9 +54,9 @@
   --harness-omp: #6d28d9;
   --harness-omp-soft: #f2eaff;
   --harness-omp-border: #ddccff;
-  --harness-pi: #2563eb;
-  --harness-pi-soft: #e8efff;
-  --harness-pi-border: #c7d9ff;
+  --harness-pi: #0e7490;
+  --harness-pi-soft: #e0f5fa;
+  --harness-pi-border: #b9e3ed;
   --harness-claude: #b45309;
   --harness-claude-soft: #fdefdb;
   --harness-claude-border: #f5d9ae;
@@ -159,9 +159,9 @@
   --harness-omp: #c4b5fd;
   --harness-omp-soft: rgba(124, 58, 237, 0.22);
   --harness-omp-border: rgba(196, 181, 253, 0.36);
-  --harness-pi: #93c5fd;
-  --harness-pi-soft: rgba(37, 99, 235, 0.26);
-  --harness-pi-border: rgba(147, 197, 253, 0.38);
+  --harness-pi: #67e8f9;
+  --harness-pi-soft: rgba(14, 116, 144, 0.28);
+  --harness-pi-border: rgba(103, 232, 249, 0.38);
   --harness-claude: #f6ad55;
   --harness-claude-soft: rgba(180, 83, 9, 0.26);
   --harness-claude-border: rgba(246, 173, 85, 0.34);
@@ -3279,7 +3279,9 @@ a:focus-visible,
 
 .choice-card {
   display: grid;
-  grid-template-rows: 1.5rem minmax(3rem, 1fr);
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: min-content minmax(3rem, 1fr);
+  justify-items: stretch;
   align-content: start;
   gap: var(--space-1);
   min-width: 0;
@@ -3302,12 +3304,16 @@ a:focus-visible,
   display: flex;
   align-items: center;
   gap: var(--space-2);
+  min-width: 0;
+  min-height: 1.5rem;
   font-size: var(--font-md);
   font-weight: 600;
 }
 
 .choice-card small {
   display: block;
+  align-self: start;
+  min-width: 0;
   margin: 0;
   overflow-wrap: anywhere;
   color: var(--muted);

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -303,9 +303,9 @@ for (const cls of ['.harness-badge', '.harness-omp', '.harness-pi', '.brand-serv
   assert.ok(styles.includes(cls), `${cls} should be styled`)
 }
 assert.match(styles, /\.brand-server[\s\S]*?text-overflow: ellipsis/, 'a long address must truncate rather than push the badge off screen')
-assert.match(styles, /--harness-pi:\s*#2563eb/, 'PI needs a clearly distinct blue harness color')
+assert.match(styles, /--harness-pi:\s*#0e7490/, 'PI needs a clearly distinct cyan harness color')
 assert.match(styles, /\.wizard-header > \.btn-icon[\s\S]*?margin-left:\s*auto/, 'wizard close controls must stay pinned to the top-right corner')
-assert.match(styles, /\.choice-card\s*\{[\s\S]*?grid-template-rows:\s*1\.5rem minmax\(3rem, 1fr\)/, 'server choice card labels must align across harnesses')
+assert.match(styles, /\.choice-card\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\)/, 'server choice card labels must align across harnesses')
 
 // Mobile keyboard: an address is not a sentence, a port is a number, and a soft keyboard has
 // no Shift key — so the composer flips on touch-primary devices: Enter inserts a new line,


### PR DESCRIPTION
Fix the server-connection wizard's harness choice layout and give PI a distinct cyan identity. Verified on desktop and mobile, with UI regression coverage.