### PR TITLE
Explain HTML responses during task discovery

### DIFF
--- a/web/src/machine-payload.test.mjs
+++ b/web/src/machine-payload.test.mjs
@@ -54,6 +54,8 @@ const taskClient = readFileSync(new URL('./taskMachineClient.ts', import.meta.ur
 assert.equal(/fallback\w*Snapshot|synthetic/i.test(taskClient), false)
 assert.ok(taskClient.includes('if (failure !== undefined) throw failure'))
 assert.ok(taskClient.includes('response.status === 401'))
+assert.ok(taskClient.includes('unexpectedMachineResponse'), 'TaskDesk machine discovery should detect an HTML page instead of parsing it as JSON')
+assert.ok(taskClient.includes('returned a web page instead of the Harness machine daemon'), 'an endpoint that returns HTML should explain the daemon-address problem clearly')
 
 const legacyClient = readFileSync(new URL('./machineClient.ts', import.meta.url), 'utf8')
 assert.equal(legacyClient.includes('machineCandidates('), false, 'legacy discovery must not probe TaskDesk candidates')

--- a/web/src/taskMachineClient.ts
+++ b/web/src/taskMachineClient.ts
@@ -27,6 +27,17 @@ function unauthorized(config: ServerConfig): Error {
     : "HTTP 401: this server requires a username and password, and none were sent.")
 }
 
+function unexpectedMachineResponse(config: ServerConfig, value: unknown): Error | null {
+  if (typeof value !== "string") return null
+  // A dev server or reverse proxy often answers its HTML shell with 200 for an unknown API route.
+  // Calling response.json() there leaked the parser exception into the task dialog and made an
+  // endpoint mistake look like an OMP failure.
+  if (/^\s*<!doctype html|^\s*<html[\s>]/i.test(value)) {
+    return new Error(`${config.host}:${config.port} returned a web page instead of the Harness machine daemon.`)
+  }
+  return null
+}
+
 async function nativeGet(config: ServerConfig, path: string) {
   const target = `${machineBaseUrl(config)}${path}`
   try {
@@ -68,7 +79,10 @@ async function discoverMachinePath(config: ServerConfig, path: string): Promise<
   if (noMachineStatus(response.status)) return null
   if (response.status === 401) throw unauthorized(config)
   if (!response.ok) throw new Error(`HTTP ${response.status}`)
-  return parseMachineSnapshot(await response.json())
+  const payload = await response.text()
+  const unexpected = unexpectedMachineResponse(config, payload)
+  if (unexpected) throw unexpected
+  return parseMachineSnapshot(payload)
 }
 
 /** Both routes are published; older machine daemons may answer only the second. */


### PR DESCRIPTION
Avoid parsing an HTML page as JSON when TaskDesk discovers a machine daemon, and report the configured endpoint problem clearly. Verified with the machine payload regression test and production build.