### PR TITLE
Route OMP and PI sessions to their own harness

### DIFF
--- a/bridge/src/agent-router.js
+++ b/bridge/src/agent-router.js
@@ -154,6 +154,7 @@ export function createAgentRoutingServer({
   config,
   primaryAgentID,
   bridgeServer,
+  acpBridgeServer,
   taskStore,
   projectCatalog,
   worktreeManager,
@@ -252,12 +253,19 @@ export function createAgentRoutingServer({
       writeJSON(response, 404, { error: `Unknown agent: ${route.agentID}` })
       return
     }
-    if (entry.kind !== "http") {
-      writeJSON(response, 409, { error: `Agent ${route.agentID} is not routable through the managed HTTP proxy` })
+    if (entry.kind === "http" && daemon.registry.host(route.agentID)?.state !== "available") {
+      writeJSON(response, 503, { error: `Agent ${route.agentID} is unavailable` })
       return
     }
-    if (daemon.registry.host(route.agentID)?.state !== "available") {
-      writeJSON(response, 503, { error: `Agent ${route.agentID} is unavailable` })
+
+    if (entry.kind === "acp") {
+      const scopedServer = acpBridgeServer?.(route.agentID)
+      if (!scopedServer) {
+        writeJSON(response, 409, { error: `Agent ${route.agentID} is not routable through the machine daemon` })
+        return
+      }
+      request.url = `${route.path}${route.search}`
+      scopedServer.emit("request", request, response)
       return
     }
 

--- a/bridge/src/daemon-cli.js
+++ b/bridge/src/daemon-cli.js
@@ -3,7 +3,7 @@ import path from "node:path"
 import { AcpClient } from "./acp-client.js"
 import { AcpAgentModelCatalog, HttpAgentModelCatalog } from "./agent-model-catalog.js"
 import { parseConfig, usage as bridgeUsage } from "./config.js"
-import { harnessProfile } from "./harness-profiles.js"
+import { harnessProfile, resolveAcpLaunch } from "./harness-profiles.js"
 import { canListen, resolveLaunchPlan } from "./launcher.js"
 import { loadMachineIdentity } from "./machine-registry.js"
 import { MachineDaemon, createMachineDaemonServer } from "./machine-daemon.js"
@@ -110,39 +110,54 @@ async function main() {
 
   const identity = await loadMachineIdentity(config.stateDirectory)
   const daemon = new MachineDaemon(identity)
-  const profile = harnessProfile(config.backend)
-  const acp = new AcpClient({
-    command: config.acpCommand,
-    args: config.acpArgs,
-    permissionMode: profile.permissionMode,
-    preferredAuthMethod: profile.authMethod
-  })
-  // Model discovery owns a separate ACP connection and one durable prompt-less session. That keeps
-  // New Task catalog refreshes from interfering with user-facing ACP session history.
-  const modelAcp = new AcpClient({
-    command: config.acpCommand,
-    args: config.acpArgs,
-    permissionMode: profile.permissionMode,
-    preferredAuthMethod: profile.authMethod
-  })
-  const primaryModelCatalog = new AcpAgentModelCatalog({
-    agent: modelAcp,
-    agentID: profile.id,
-    directory: config.roots?.[0] ?? process.cwd(),
-    stateDirectory: config.stateDirectory
-  })
-  // Load the persisted catalog session id before the HTTP server starts so a daemon restart never
-  // briefly exposes the prompt-less technical session in the public session list.
-  await primaryModelCatalog.preloadState()
-
-  daemon.registerAcpHost({
-    id: profile.id,
-    label: profile.label,
-    backend: profile.id,
-    capabilities: profile.capabilities,
-    agent: acp,
-    modelCatalog: primaryModelCatalog
-  })
+  const plan = resolveLaunchPlan(process.argv.slice(2))
+  const acpBackends = [...new Set([...plan.detected.filter((backend) => backend !== "opencode"), config.backend])]
+  const primaryProfile = harnessProfile(config.backend)
+  const acpHosts = new Map()
+  for (const backend of acpBackends) {
+    const profile = harnessProfile(backend)
+    const launch = backend === config.backend
+      ? { command: config.acpCommand, args: config.acpArgs }
+      : resolveAcpLaunch(profile)
+    const agentConfig = { ...config, backend: profile.id, acpCommand: launch.command, acpArgs: launch.args }
+    const acp = new AcpClient({
+      command: launch.command,
+      args: launch.args,
+      permissionMode: profile.permissionMode,
+      preferredAuthMethod: profile.authMethod
+    })
+    // Model discovery owns a separate ACP connection and one durable prompt-less session. That keeps
+    // New Task catalog refreshes from interfering with user-facing ACP session history.
+    const modelCatalog = new AcpAgentModelCatalog({
+      agent: new AcpClient({ command: launch.command, args: launch.args, permissionMode: profile.permissionMode, preferredAuthMethod: profile.authMethod }),
+      agentID: profile.id,
+      directory: config.roots?.[0] ?? process.cwd(),
+      stateDirectory: config.stateDirectory
+    })
+    // Load persisted technical-session ids before the server starts, so they never leak into lists.
+    await modelCatalog.preloadState()
+    daemon.registerAcpHost({
+      id: profile.id,
+      label: profile.label,
+      backend: profile.id,
+      capabilities: profile.capabilities,
+      agent: acp,
+      modelCatalog,
+      bridgeConfig: agentConfig,
+      serviceOptions: {
+        snapshotDirectory: path.join(config.stateDirectory, profile.id),
+        historyLoader: profile.historyLoader,
+        preserveListedTimestamps: profile.preserveListedTimestamps,
+        hiddenSessionIDs: modelCatalog.hiddenSessionIDs,
+        reloadOnHistoryRefresh: profile.reloadOnHistoryRefresh
+      }
+    })
+    acpHosts.set(profile.id, acp)
+    acp.on("stderr", (line) => process.stderr.write(`[${profile.id}] ${line}\n`))
+    acp.on("exit", (error) => process.stderr.write(`[${profile.id}] ${error.message}\n`))
+  }
+  const acp = acpHosts.get(primaryProfile.id)
+  if (!acp) throw new Error(`Primary harness ${primaryProfile.id} was not detected`)
 
   if (openCode) {
     const managedOpenCode = new ManagedOpenCodeHost({
@@ -169,16 +184,13 @@ async function main() {
     config,
     primaryAcp: acp,
     serviceOptions: {
-      snapshotDirectory: path.join(config.stateDirectory, profile.id),
-      historyLoader: profile.historyLoader,
-      preserveListedTimestamps: profile.preserveListedTimestamps,
-      hiddenSessionIDs: primaryModelCatalog.hiddenSessionIDs,
-      reloadOnHistoryRefresh: profile.reloadOnHistoryRefresh
+      snapshotDirectory: path.join(config.stateDirectory, primaryProfile.id),
+      historyLoader: primaryProfile.historyLoader,
+      preserveListedTimestamps: primaryProfile.preserveListedTimestamps,
+      hiddenSessionIDs: daemon.hostEntry(primaryProfile.id).modelCatalog.hiddenSessionIDs,
+      reloadOnHistoryRefresh: primaryProfile.reloadOnHistoryRefresh
     }
   })
-
-  acp.on("stderr", (line) => process.stderr.write(`[${profile.id}] ${line}\n`))
-  acp.on("exit", (error) => process.stderr.write(`[${profile.id}] ${error.message}\n`))
 
   await new Promise((resolve, reject) => {
     const onError = (error) => reject(error)
@@ -194,7 +206,7 @@ async function main() {
   process.stdout.write(`Machine: ${identity.name} (${identity.id})\n`)
   process.stdout.write("Active agents:\n")
   for (const host of daemon.snapshot().agents) {
-    if (host.id === profile.id) {
+    if (host.id === primaryProfile.id) {
       process.stdout.write(`  • ${host.label} — primary (${host.transport.toUpperCase()})\n`)
       continue
     }

--- a/bridge/src/machine-daemon.js
+++ b/bridge/src/machine-daemon.js
@@ -17,10 +17,10 @@ export class MachineDaemon {
     this.hosts = new Map()
   }
 
-  registerAcpHost({ id, label, backend = id, capabilities = {}, agent, modelCatalog, managed = true }) {
+  registerAcpHost({ id, label, backend = id, capabilities = {}, agent, modelCatalog, bridgeConfig, serviceOptions, managed = true }) {
     this.registry.registerHost({ id, label, backend, transport: "acp", managed, state: "configured", capabilities })
     const tracked = trackAgentHostLifecycle(agent, this.registry, id)
-    this.hosts.set(id, { id, kind: "acp", host: tracked, modelCatalog, eager: false })
+    this.hosts.set(id, { id, kind: "acp", host: tracked, modelCatalog, bridgeConfig, serviceOptions, eager: false })
     return tracked
   }
 
@@ -85,6 +85,22 @@ export function createMachineDaemonServer({
   taskRunController
 }) {
   const bridgeServer = createServer({ config, acp: primaryAcp, machineRegistry: daemon.registry, serviceOptions })
+  const scopedAcpServers = new Map()
+  const acpBridgeServer = (agentID) => {
+    if (agentID === primaryAgentID) return bridgeServer
+    const cached = scopedAcpServers.get(agentID)
+    if (cached) return cached
+    const entry = daemon.hostEntry(agentID)
+    if (!entry || entry.kind !== "acp") return undefined
+    const server = createServer({
+      config: entry.bridgeConfig ?? { ...config, backend: agentID },
+      acp: entry.host,
+      machineRegistry: daemon.registry,
+      serviceOptions: entry.serviceOptions
+    })
+    scopedAcpServers.set(agentID, server)
+    return server
+  }
   const machineID = daemon.snapshot().machine.id
   const roots = config.roots?.length ? config.roots : [process.cwd()]
   const stateDirectory = config.stateDirectory ?? process.cwd()
@@ -93,7 +109,7 @@ export function createMachineDaemonServer({
   const worktrees = worktreeManager ?? new WorktreeManager({ stateDirectory })
   const launcher = taskLauncher ?? new TaskLauncher({ daemon })
   const runs = taskRunController ?? new TaskRunController({ taskStore: tasks, taskLauncher: launcher })
-  const innerServer = createRouter({ daemon, config, primaryAgentID, bridgeServer, taskStore: tasks, projectCatalog: projects, worktreeManager: worktrees })
+  const innerServer = createRouter({ daemon, config, primaryAgentID, bridgeServer, acpBridgeServer, taskStore: tasks, projectCatalog: projects, worktreeManager: worktrees })
   const launchServer = createLaunchServer({ innerServer, config, taskRunController: runs })
   const modelServer = createModelServer({ innerServer: launchServer, config, daemon, taskStore: tasks })
   return createFinishServer({ innerServer: modelServer, config, taskStore: tasks, worktreeManager: worktrees, taskRunController: runs })

--- a/bridge/test/agent-router.test.js
+++ b/bridge/test/agent-router.test.js
@@ -63,6 +63,31 @@ test("primary ACP agent prefix reuses the normalized bridge routes", async () =>
   }
 })
 
+test("a non-primary ACP agent is dispatched to its own bridge instead of the primary sessions", async () => {
+  const primary = new BridgeServer()
+  primary.on("request", (request, response) => response.end("primary"))
+  const pi = new BridgeServer()
+  pi.on("request", (request, response) => {
+    response.writeHead(200, { "Content-Type": "application/json" })
+    response.end(JSON.stringify({ agent: "pi", url: request.url }))
+  })
+  const server = createAgentRoutingServer({
+    daemon: daemonWith({ pi: { id: "pi", kind: "acp" } }, { pi: "configured" }),
+    config: { username: "", password: "", corsOrigins: [] },
+    primaryAgentID: "codex",
+    bridgeServer: primary,
+    acpBridgeServer: (agentID) => agentID === "pi" ? pi : undefined
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/agents/pi/session?directory=%2Fwork`)
+    assert.equal(response.status, 200)
+    assert.deepEqual(await response.json(), { agent: "pi", url: "/session?directory=%2Fwork" })
+  } finally {
+    await close(server)
+  }
+})
+
 test("managed HTTP routing replaces client credentials with host credentials", async () => {
   let upstreamRequest
   const upstream = http.createServer((request, response) => {

--- a/bridge/test/machine-daemon.test.js
+++ b/bridge/test/machine-daemon.test.js
@@ -165,6 +165,37 @@ test("machine server wires the shared registry, agent router, task launch, model
   assert.deepEqual(bridgeOptions.machineRegistry.snapshot().agents.map((host) => host.id), ["pi", "opencode"])
 })
 
+test("machine server creates an isolated bridge service for every registered ACP harness", () => {
+  const daemon = new MachineDaemon({ id: "machine_test", name: "workstation" })
+  const codex = new FakeAcp()
+  const pi = new FakeAcp()
+  daemon.registerAcpHost({ id: "codex", agent: codex })
+  daemon.registerAcpHost({ id: "pi", agent: pi, bridgeConfig: { backend: "pi" }, serviceOptions: { marker: "pi" } })
+  const created = []
+  let routerOptions
+  createMachineDaemonServer({
+    daemon,
+    config: { backend: "codex", port: 4097 },
+    primaryAcp: codex,
+    createServer: (options) => {
+      const server = { options, emit() {} }
+      created.push(server)
+      return server
+    },
+    createRouter: (options) => { routerOptions = options; return {} },
+    createLaunchServer: ({ innerServer }) => innerServer,
+    createModelServer: ({ innerServer }) => innerServer,
+    createFinishServer: ({ innerServer }) => innerServer
+  })
+  assert.equal(created.length, 1)
+  const piBridge = routerOptions.acpBridgeServer("pi")
+  assert.equal(created.length, 2)
+  assert.equal(piBridge.options.acp, daemon.hostEntry("pi").host)
+  assert.equal(piBridge.options.config.backend, "pi")
+  assert.equal(piBridge.options.serviceOptions.marker, "pi")
+  assert.equal(routerOptions.acpBridgeServer("pi"), piBridge)
+})
+
 test("daemon exposes registered host entries to its internal router", () => {
   const daemon = new MachineDaemon({ id: "machine_test", name: "workstation" })
   const openCode = new FakeHttpHost()

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,6 +31,7 @@ import { copyToClipboard } from "./clipboard"
 import { backendDisplayName, isBridgeBackend } from "./backendSetup"
 import { taskClient } from "./taskClient"
 import { discoverMachineConnection } from "./taskMachineClient"
+import { discoverMachine, selectableMachineAgents } from "./machineClient"
 import { type AttachmentPart } from "./attachments"
 import { CommandPalette, MenuBar, ServerSwitcher, type MenuDefinition, type MenuEntry, type PaletteCommand } from "./components/shell"
 import { ConnectServerWizard, NewSessionDialog } from "./components/panels"
@@ -3493,14 +3494,32 @@ function App() {
       setConnectionMessage("")
       return
     }
-    setConnectionState("connecting")
-    setConnectionMessage(t('connection.connecting'))
-    backgroundFailureCountRef.current = 0
-    initialSessionLoadRef.current = true
-    refreshSessions(true).catch(() => undefined)
-    loadCommands().catch(() => undefined)
-    if (capabilities.agents) loadAgents().catch(() => undefined)
-    if (capabilities.models) loadModels().catch(() => undefined)
+    let cancelled = false
+    const connect = async () => {
+      // Profiles saved before multi-harness routing did not carry agentId. Resolve a matching
+      // daemon host before any session request: otherwise OMP/PI silently read the primary
+      // harness's sessions from the daemon root.
+      if (isBridgeBackend(config.backend)) {
+        const machine = await discoverMachine(config).catch(() => null)
+        const agents = machine ? selectableMachineAgents(machine) : []
+        const agent = agents.find((candidate) => candidate.backend === config.backend)
+        const selected = agents.find((candidate) => candidate.id === config.agentId)
+        if (agent && (!config.agentId || selected?.backend !== config.backend)) {
+          if (!cancelled) applyConfig({ ...config, agentId: agent.id })
+          return
+        }
+      }
+      if (cancelled) return
+      setConnectionState("connecting")
+      setConnectionMessage(t('connection.connecting'))
+      backgroundFailureCountRef.current = 0
+      initialSessionLoadRef.current = true
+      refreshSessions(true).catch(() => undefined)
+      loadCommands().catch(() => undefined)
+      if (capabilities.agents) loadAgents().catch(() => undefined)
+      if (capabilities.models) loadModels().catch(() => undefined)
+    }
+    void connect()
     const timer = setInterval(() => {
       // Live SSE events already keep sessions and the open session's messages/todos/diffs in sync
       // (via applyStreamedPartUpdate/scheduleRefresh), so polling on top of a working stream is a
@@ -3521,8 +3540,11 @@ function App() {
         loadSelected(selectedSession.id, selectedSession.directory).catch(() => undefined)
       }
     }, 3500)
-    return () => clearInterval(timer)
-  }, [capabilities.agents, capabilities.models, config.backend, config.host, config.port, config.username, config.password, selectedSession?.id, selectedNewSessionDirectory])
+    return () => {
+      cancelled = true
+      clearInterval(timer)
+    }
+  }, [capabilities.agents, capabilities.models, config.agentId, config.backend, config.host, config.port, config.username, config.password, selectedSession?.id, selectedNewSessionDirectory])
 
   useEffect(() => {
     const fallback = DEFAULT_HARNESS_CAPABILITIES[config.backend]


### PR DESCRIPTION
Fixes daemon multi-harness registration and scoped ACP routing. Legacy profiles are reconciled to the matching daemon agent before sessions are loaded, preventing OMP/PI from displaying primary/OpenCode sessions.