### PR TITLE
Prevent stale profiles from falling back to Codex sessions

### DIFF
--- a/bridge/src/agent-router.js
+++ b/bridge/src/agent-router.js
@@ -84,6 +84,12 @@ export function agentScopedRequest(request) {
   }
 }
 
+function routedAgentForBackend(daemon, route, requestedBackend) {
+  if (!requestedBackend || daemon.registry.host(route.agentID)?.backend === requestedBackend) return route
+  const matching = daemon.snapshot().agents.find((agent) => agent.backend === requestedBackend)
+  return matching ? { ...route, agentID: matching.id } : route
+}
+
 export function proxyManagedHttpRequest({
   request,
   response,
@@ -224,11 +230,22 @@ export function createAgentRoutingServer({
       return
     }
 
-    const route = agentScopedRequest(request)
+    const requestedBackend = typeof request.headers["x-harness-backend"] === "string"
+      ? request.headers["x-harness-backend"].trim()
+      : ""
+    let route = agentScopedRequest(request)
     if (!route) {
-      bridgeServer.emit("request", request, response)
-      return
+      // Old profiles have no agent id at all. The selected backend still identifies the intended
+      // daemon host, so make the root request scoped before it can reach the primary bridge.
+      const matching = requestedBackend && daemon.snapshot().agents.find((agent) => agent.backend === requestedBackend)
+      if (matching && matching.id !== primaryAgentID) {
+        route = { agentID: matching.id, path: requestURL.pathname, search: requestURL.search }
+      } else {
+        bridgeServer.emit("request", request, response)
+        return
+      }
     }
+    route = routedAgentForBackend(daemon, route, requestedBackend)
 
     if (route.agentID === primaryAgentID) {
       request.url = `${route.path}${route.search}`

--- a/bridge/src/http-policy.js
+++ b/bridge/src/http-policy.js
@@ -18,7 +18,7 @@ export function applyCorsHeaders(request, response, config) {
   if (!origin) return
   response.setHeader("Access-Control-Allow-Origin", origin)
   response.setHeader("Access-Control-Allow-Credentials", "true")
-  response.setHeader("Access-Control-Allow-Headers", "authorization, content-type")
+  response.setHeader("Access-Control-Allow-Headers", "authorization, content-type, x-harness-backend")
   response.setHeader("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
   // Chromium's Private Network Access preflight is sent when this public PWA
   // connects to a local daemon/bridge (for example github.io -> localhost).

--- a/bridge/test/agent-router.test.js
+++ b/bridge/test/agent-router.test.js
@@ -88,6 +88,58 @@ test("a non-primary ACP agent is dispatched to its own bridge instead of the pri
   }
 })
 
+test("a stale profile agent id is corrected from its declared harness backend", async () => {
+  const codex = new BridgeServer()
+  codex.on("request", (request, response) => response.end("wrong agent"))
+  const omp = new BridgeServer()
+  omp.on("request", (request, response) => response.end(request.url))
+  const server = createAgentRoutingServer({
+    daemon: {
+      ...daemonWith({ codex: { id: "codex", kind: "acp" }, omp: { id: "omp", kind: "acp" } }, { codex: "available", omp: "configured" }),
+      snapshot() { return { agents: [{ id: "codex", backend: "codex" }, { id: "omp", backend: "omp" }] } }
+    },
+    config: { username: "", password: "", corsOrigins: [] },
+    primaryAgentID: "codex",
+    bridgeServer: codex,
+    acpBridgeServer: (agentID) => agentID === "omp" ? omp : undefined
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/agents/codex/session`, {
+      headers: { "X-Harness-Backend": "omp" }
+    })
+    assert.equal(await response.text(), "/session")
+  } finally {
+    await close(server)
+  }
+})
+
+test("a legacy root profile is scoped from its declared harness backend", async () => {
+  const primary = new BridgeServer()
+  primary.on("request", (request, response) => response.end("primary"))
+  const pi = new BridgeServer()
+  pi.on("request", (request, response) => response.end(request.url))
+  const server = createAgentRoutingServer({
+    daemon: {
+      ...daemonWith({ pi: { id: "pi", kind: "acp" } }, { pi: "configured" }),
+      snapshot() { return { agents: [{ id: "codex", backend: "codex" }, { id: "pi", backend: "pi" }] } }
+    },
+    config: { username: "", password: "", corsOrigins: [] },
+    primaryAgentID: "codex",
+    bridgeServer: primary,
+    acpBridgeServer: (agentID) => agentID === "pi" ? pi : undefined
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/experimental/session`, {
+      headers: { "X-Harness-Backend": "pi" }
+    })
+    assert.equal(await response.text(), "/experimental/session")
+  } finally {
+    await close(server)
+  }
+})
+
 test("managed HTTP routing replaces client credentials with host credentials", async () => {
   let upstreamRequest
   const upstream = http.createServer((request, response) => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -129,7 +129,10 @@ async function requestWithHeaders<T>(config: ServerConfig, path: string, options
 
   const target = `${baseUrl(config)}${path}`
   const headers: Record<string, string> = {
-    Accept: "application/json"
+    Accept: "application/json",
+    // A daemon can repair profiles saved by older clients, which lacked (or stored the wrong)
+    // agentId. It must never fall back to the primary agent just because that stale id is present.
+    "X-Harness-Backend": config.backend
   }
   if (hasCredentials(config)) {
     headers.Authorization = authHeader(config)


### PR DESCRIPTION
Routes daemon requests by the selected harness backend even when a legacy profile has no agentId or a stale primary agentId. Adds CORS support for the routing header and coverage for both cases.