### PR TITLE
Prevent the server wizard from saving PI and OMP as Codex

### DIFF
--- a/web/src/components/panels.tsx
+++ b/web/src/components/panels.tsx
@@ -265,12 +265,8 @@ export function ConnectServerWizard({
   const [machine, setMachine] = useState<MachineSnapshot | null>(null)
   const [agentId, setAgentId] = useState("")
 
-  const selectedAgent = machine?.agents.find((agent) => agent.id === agentId)
-  const selectedBackend = selectedAgent && BACKEND_KINDS.includes(selectedAgent.backend as BackendKind)
-    ? selectedAgent.backend as BackendKind
-    : backend
   const config: ServerConfig = {
-    backend: selectedBackend,
+    backend,
     host: host.trim(),
     port,
     username: username.trim(),
@@ -315,13 +311,13 @@ export function ConnectServerWizard({
 
       if (discovered) {
         const available = discovered.agents.filter((agent) => agent.state === "available" || agent.state === "configured")
-        const preferred = available.find((agent) => agent.backend === backend) ?? available[0]
+        const preferred = available.find((agent) => agent.backend === backend)
         setMachine(discovered)
         setAgentId(preferred?.id ?? "")
         if (preferred) setName(`${discovered.machine.name} · ${preferred.label}`)
         setTestResult({
-          ok: available.length > 0,
-          message: available.length > 0
+          ok: Boolean(preferred),
+          message: preferred
             ? `${t('connection.connected')} · ${discovered.machine.name}`
             : `${discovered.machine.name} · ${t('detail.unavailable')}`
         })
@@ -493,7 +489,7 @@ export function ConnectServerWizard({
                       if (next) setName(`${machine.machine.name} · ${next.label}`)
                     }}
                   >
-                    {machine.agents.map((agent) => (
+                    {machine.agents.filter((agent) => agent.backend === backend).map((agent) => (
                       <option
                         key={agent.id}
                         value={agent.id}

--- a/web/src/server-profiles.test.mjs
+++ b/web/src/server-profiles.test.mjs
@@ -59,6 +59,15 @@ malformed[0].config.agentId = { invalid: true }
 storage.set(SERVER_PROFILES_STORAGE_KEY, JSON.stringify(malformed))
 assert.equal(loadServerProfiles()[0].config.agentId, undefined, 'malformed agent ids must not leak from persisted data')
 
+storage.set(SERVER_PROFILES_STORAGE_KEY, JSON.stringify([{
+  id: 'old-pi-wizard-profile',
+  name: 'PI test machine',
+  config: { backend: 'codex', host: 'workstation.local', port: 4097, username: 'harness', password: 'secret', agentId: 'codex' }
+}]))
+const repaired = loadServerProfiles()[0]
+assert.equal(repaired.config.backend, 'pi', 'an unmistakably named PI profile saved by the old fallback must recover PI')
+assert.equal(repaired.config.agentId, 'pi', 'the repaired PI profile must target the PI daemon route')
+
 const storageKeys = readFileSync(new URL('./storageKeys.ts', import.meta.url), 'utf8')
 assert.match(storageKeys, /SERVER_PROFILES_STORAGE_KEY/, 'the crash-recovery reset must clear saved servers')
 assert.match(storageKeys, /ACTIVE_PROFILE_STORAGE_KEY/, 'the crash-recovery reset must clear the selected server')

--- a/web/src/serverProfiles.ts
+++ b/web/src/serverProfiles.ts
@@ -56,6 +56,21 @@ function profileName(backend: BackendKind, position: number): string {
   return position === 0 ? `${label} server` : `${label} server ${position + 1}`
 }
 
+/** Repair only profiles whose human name makes the earlier wrong-agent fallback unambiguous. */
+function namedHarness(name: string): BackendKind | undefined {
+  const value = name.trim().toLowerCase()
+  if (/\boh my pi\b|\bomp\b/.test(value)) return "omp"
+  if (/(^|[\s·._-])pi([\s·._-]|$)/.test(value)) return "pi"
+  if (/\bclaude\b/.test(value)) return "claude"
+  return undefined
+}
+
+function repairMisroutedDaemonProfile(profile: SavedServerProfile): SavedServerProfile {
+  const intended = namedHarness(profile.name)
+  if (!intended || profile.config.backend !== "codex" || profile.config.agentId !== "codex") return profile
+  return { ...profile, config: { ...profile.config, backend: intended, agentId: intended } }
+}
+
 function parseProfiles(value: string | null): SavedServerProfile[] | null {
   if (!value) return null
   try {
@@ -72,7 +87,7 @@ function parseProfiles(value: string | null): SavedServerProfile[] | null {
         config
       }]
     })
-    return profiles.length > 0 ? profiles : null
+    return profiles.length > 0 ? profiles.map(repairMisroutedDaemonProfile) : null
   } catch {
     return null
   }


### PR DESCRIPTION
Removes the first-available-agent fallback in the connection wizard and repairs clearly named profiles that were saved as codex/codex by that fallback.