### PR TITLE
Repair local OMP and PI profiles pointed at OpenCode

### DIFF
--- a/web/src/server-profiles.test.mjs
+++ b/web/src/server-profiles.test.mjs
@@ -68,6 +68,15 @@ const repaired = loadServerProfiles()[0]
 assert.equal(repaired.config.backend, 'pi', 'an unmistakably named PI profile saved by the old fallback must recover PI')
 assert.equal(repaired.config.agentId, 'pi', 'the repaired PI profile must target the PI daemon route')
 
+storage.set(SERVER_PROFILES_STORAGE_KEY, JSON.stringify([{
+  id: 'old-omp-internal-port-profile',
+  name: 'Oh My Pi TEST',
+  config: { backend: 'omp', host: 'localhost', port: 4096, username: 'harness', password: 'secret' }
+}]))
+const repairedPort = loadServerProfiles()[0]
+assert.equal(repairedPort.config.port, 4097, 'a named local OMP daemon profile must not point at OpenCode internal port 4096')
+assert.equal(repairedPort.config.agentId, 'omp', 'a repaired OMP daemon profile must use the OMP route')
+
 const storageKeys = readFileSync(new URL('./storageKeys.ts', import.meta.url), 'utf8')
 assert.match(storageKeys, /SERVER_PROFILES_STORAGE_KEY/, 'the crash-recovery reset must clear saved servers')
 assert.match(storageKeys, /ACTIVE_PROFILE_STORAGE_KEY/, 'the crash-recovery reset must clear the selected server')

--- a/web/src/serverProfiles.ts
+++ b/web/src/serverProfiles.ts
@@ -67,8 +67,23 @@ function namedHarness(name: string): BackendKind | undefined {
 
 function repairMisroutedDaemonProfile(profile: SavedServerProfile): SavedServerProfile {
   const intended = namedHarness(profile.name)
-  if (!intended || profile.config.backend !== "codex" || profile.config.agentId !== "codex") return profile
-  return { ...profile, config: { ...profile.config, backend: intended, agentId: intended } }
+  if (!intended) return profile
+  const savedAsCodex = profile.config.backend === "codex" && profile.config.agentId === "codex"
+  const loopback = ["localhost", "127.0.0.1", "::1"].includes(profile.config.host.trim().toLowerCase())
+  // Earlier setup guidance incorrectly paired a daemon harness with OpenCode's internal port.
+  // A named local Harness profile with daemon credentials is unambiguously meant for port 4097.
+  const pointedAtOpenCode = profile.config.backend === intended && !profile.config.agentId &&
+    loopback && profile.config.port === 4096 && profile.config.username === "harness"
+  if (!savedAsCodex && !pointedAtOpenCode) return profile
+  return {
+    ...profile,
+    config: {
+      ...profile.config,
+      backend: intended,
+      agentId: intended,
+      ...(pointedAtOpenCode ? { port: 4097 } : {})
+    }
+  }
 }
 
 function parseProfiles(value: string | null): SavedServerProfile[] | null {


### PR DESCRIPTION
Repairs named local Harness profiles that were saved with Harness credentials on OpenCode's internal port 4096. The migration assigns daemon port 4097 and the correct agent route, with coverage for OMP.