### PR TITLE
Allow OMP and PI model catalogs to finish cold startup

### DIFF
--- a/bridge/src/agent-model-catalog.js
+++ b/bridge/src/agent-model-catalog.js
@@ -1,7 +1,10 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import path from "node:path"
 
+// HTTP providers are already running and should fail quickly. ACP adapters may need their first
+// `npx` launch, authentication, and a technical session before they can expose config options.
 export const MODEL_CATALOG_TIMEOUT_MS = 8_000
+export const ACP_MODEL_CATALOG_TIMEOUT_MS = 90_000
 
 function withTimeout(promise, timeoutMs, label) {
   let timer
@@ -108,7 +111,7 @@ class CachedCatalog {
 }
 
 export class AcpAgentModelCatalog extends CachedCatalog {
-  constructor({ agent, agentID, directory, stateDirectory, timeoutMs = MODEL_CATALOG_TIMEOUT_MS }) {
+  constructor({ agent, agentID, directory, stateDirectory, timeoutMs = ACP_MODEL_CATALOG_TIMEOUT_MS }) {
     super()
     this.agent = agent
     this.agentID = agentID

--- a/bridge/test/agent-model-timeout.test.js
+++ b/bridge/test/agent-model-timeout.test.js
@@ -3,9 +3,20 @@ import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import test from "node:test"
-import { AcpAgentModelCatalog, HttpAgentModelCatalog } from "../src/agent-model-catalog.js"
+import { ACP_MODEL_CATALOG_TIMEOUT_MS, AcpAgentModelCatalog, HttpAgentModelCatalog, MODEL_CATALOG_TIMEOUT_MS } from "../src/agent-model-catalog.js"
 
 const never = () => new Promise(() => {})
+
+test("ACP model discovery reserves the cold-adapter startup budget", () => {
+  const catalog = new AcpAgentModelCatalog({
+    agent: { close() {} },
+    agentID: "omp",
+    directory: "/repo",
+    stateDirectory: "/state"
+  })
+  assert.equal(catalog.timeoutMs, ACP_MODEL_CATALOG_TIMEOUT_MS)
+  assert.ok(ACP_MODEL_CATALOG_TIMEOUT_MS > MODEL_CATALOG_TIMEOUT_MS)
+})
 
 test("ACP model discovery obeys the catalog-wide timeout budget", async () => {
   const stateDirectory = await mkdtemp(path.join(tmpdir(), "harness-model-timeout-"))


### PR DESCRIPTION
Keeps the 8-second limit for already-running HTTP providers, while ACP model discovery gets the same 90-second cold-start budget as ACP initialization. Adds a regression test for the distinct defaults.