### PR TITLE
Harden TaskDesk profile migration and task lifecycle

### DIFF
--- a/bridge/src/task-run-controller.js
+++ b/bridge/src/task-run-controller.js
@@ -74,11 +74,14 @@ export class TaskRunController {
       const session = await this.taskLauncher.createSession(current)
       const linkedRun = { ...run, sessionId: session.sessionId, transport: session.transport }
       current = await this.taskStore.setRunState(taskID, { status: "starting", run: linkedRun, expectedRunId: run.id })
+      // A transport may complete or fail synchronously as startPrompt attaches its callbacks.
+      // Persist running first, so those callbacks can make a legal running -> terminal transition.
+      current = await this.taskStore.setRunState(taskID, { status: "running", run: linkedRun, expectedRunId: linkedRun.id })
       const onFailed = (error) => void this.#terminal(taskID, linkedRun, "failed", error)
       onFailed.onFailed = onFailed
       onFailed.onCompleted = () => void this.#terminal(taskID, linkedRun, "completed")
       await this.taskLauncher.startPrompt(current, session, onFailed)
-      return await this.taskStore.setRunState(taskID, { status: "running", run: linkedRun, expectedRunId: linkedRun.id })
+      return current
     } catch (error) {
       await this.#terminal(taskID, current.run ?? run, "failed", error)
       throw error

--- a/bridge/test/task-run-controller.test.js
+++ b/bridge/test/task-run-controller.test.js
@@ -43,9 +43,32 @@ test("launch persists run identity before starting the prompt and ends running",
     ["state", "starting", null],
     ["session", "starting"],
     ["state", "starting", "session-1"],
-    ["prompt", "starting", "session-1"],
-    ["state", "running", "session-1"]
+    ["state", "running", "session-1"],
+    ["prompt", "running", "session-1"]
   ])
+})
+
+test("a synchronous prompt completion cannot race the starting to running transition", async () => {
+  let current = draft()
+  const store = {
+    async get() { return structuredClone(current) },
+    async setRunState(_id, update) {
+      if (update.status === "running" && current.status !== "starting") throw new Error("Task is not starting")
+      if (["completed", "failed"].includes(update.status) && !["starting", "running"].includes(current.status)) throw new Error("Task is not active")
+      current = { ...current, status: update.status, run: structuredClone(update.run), error: update.error }
+      return structuredClone(current)
+    }
+  }
+  const launcher = {
+    async createSession(task) { return { sessionId: "session-1", transport: "acp", directory: task.workspace.path } },
+    async startPrompt(_task, _session, callbacks) { callbacks.onCompleted() }
+  }
+  const controller = new TaskRunController({ taskStore: store, taskLauncher: launcher, runIDFactory: () => "run-1" })
+
+  const launched = await controller.launch("task-1")
+  assert.equal(launched.status, "running")
+  await new Promise((resolve) => setImmediate(resolve))
+  assert.equal(current.status, "completed")
 })
 
 test("Git tasks cannot launch from the primary checkout", async () => {

--- a/web/src/components/task-launch-dialog.tsx
+++ b/web/src/components/task-launch-dialog.tsx
@@ -206,9 +206,9 @@ export function TaskLaunchDialog({ t, onClose, onLaunched }: {
         prompt: prompt.trim(),
         model: model && { providerID: model.providerID, modelID: model.modelID, variant: model.variant }
       })
-      rememberTaskModel(profile.id, agent.id, model && { providerID: model.providerID, modelID: model.modelID, variant: model.variant })
       if (isolated && selectedProject?.kind === "git") task = await taskClient.prepareWorktree(taskConfig, task.id)
       task = await taskClient.launch(taskConfig, task.id)
+      rememberTaskModel(profile.id, agent.id, model && { providerID: model.providerID, modelID: model.modelID, variant: model.variant })
       onLaunched(task)
       onClose()
     } catch (cause) {

--- a/web/src/model-regression.test.mjs
+++ b/web/src/model-regression.test.mjs
@@ -35,6 +35,8 @@ assert.ok(app.includes('activeAgent?.id ?? "build"'), 'agent selection should de
 assert.ok(taskDialog.includes('TASK_MODEL_STORAGE_KEY'), 'TaskDesk should remember the last task model locally')
 assert.ok(taskDialog.includes('readLastTaskModel(profile.id, selectedAgentId)'), 'TaskDesk should preselect the last model for the chosen server and agent')
 assert.ok(taskDialog.includes('rememberTaskModel(profile.id, agent.id'), 'TaskDesk should remember the model used to create a task')
+const taskLaunchBody = taskDialog.slice(taskDialog.indexOf('async function start()'))
+assert.ok(taskLaunchBody.indexOf('task = await taskClient.launch') < taskLaunchBody.indexOf('rememberTaskModel(profile.id, agent.id'), 'TaskDesk must remember a model only after the task launches successfully')
 assert.ok(app.includes('id="agent-select"'), 'AI sheet should render an agent selector')
 assert.ok(app.includes('api.sendPrompt(config, selectedSession.id, text, selectedSession.directory, activeModel, activeAgentID, attachments)'), 'chat prompts should use selected agent and carry staged attachments')
 assert.ok(app.includes('api.sendCommand(config, selectedSession.id, command, args, selectedSession.directory, activeModel, activeAgentID)'), 'slash commands should use selected agent')

--- a/web/src/server-profiles.test.mjs
+++ b/web/src/server-profiles.test.mjs
@@ -68,14 +68,23 @@ const repaired = loadServerProfiles()[0]
 assert.equal(repaired.config.backend, 'pi', 'an unmistakably named PI profile saved by the old fallback must recover PI')
 assert.equal(repaired.config.agentId, 'pi', 'the repaired PI profile must target the PI daemon route')
 
+storage.set(SERVER_PROFILES_STORAGE_KEY, JSON.stringify([
+  { id: 'known-daemon-profile', name: 'Codex CLI server', config: { backend: 'codex', host: 'localhost', port: 5001, username: 'harness', password: 'secret', agentId: 'codex' } },
+  { id: 'old-omp-internal-port-profile', name: 'Oh My Pi TEST', config: { backend: 'omp', host: 'localhost', port: 4096, username: 'harness', password: 'secret' } }
+]))
+const repairedPort = loadServerProfiles().find((profile) => profile.id === 'old-omp-internal-port-profile')
+assert.ok(repairedPort, 'the OMP profile should be retained')
+assert.equal(repairedPort.config.port, 5001, 'a named local OMP profile must reuse the known daemon port instead of assuming 4097')
+assert.equal(repairedPort.config.agentId, 'omp', 'a repaired OMP daemon profile must use the OMP route')
+
 storage.set(SERVER_PROFILES_STORAGE_KEY, JSON.stringify([{
-  id: 'old-omp-internal-port-profile',
+  id: 'unknown-daemon-port-profile',
   name: 'Oh My Pi TEST',
   config: { backend: 'omp', host: 'localhost', port: 4096, username: 'harness', password: 'secret' }
 }]))
-const repairedPort = loadServerProfiles()[0]
-assert.equal(repairedPort.config.port, 4097, 'a named local OMP daemon profile must not point at OpenCode internal port 4096')
-assert.equal(repairedPort.config.agentId, 'omp', 'a repaired OMP daemon profile must use the OMP route')
+const unknownPort = loadServerProfiles()[0]
+assert.equal(unknownPort.config.port, 4096, 'a profile with no known machine daemon port must not be guessed')
+assert.equal(unknownPort.config.agentId, undefined, 'an unknown daemon port must not fabricate an agent route')
 
 const storageKeys = readFileSync(new URL('./storageKeys.ts', import.meta.url), 'utf8')
 assert.match(storageKeys, /SERVER_PROFILES_STORAGE_KEY/, 'the crash-recovery reset must clear saved servers')

--- a/web/src/serverProfiles.ts
+++ b/web/src/serverProfiles.ts
@@ -67,23 +67,24 @@ function namedHarness(name: string): BackendKind | undefined {
 
 function repairMisroutedDaemonProfile(profile: SavedServerProfile): SavedServerProfile {
   const intended = namedHarness(profile.name)
-  if (!intended) return profile
-  const savedAsCodex = profile.config.backend === "codex" && profile.config.agentId === "codex"
-  const loopback = ["localhost", "127.0.0.1", "::1"].includes(profile.config.host.trim().toLowerCase())
-  // Earlier setup guidance incorrectly paired a daemon harness with OpenCode's internal port.
-  // A named local Harness profile with daemon credentials is unambiguously meant for port 4097.
-  const pointedAtOpenCode = profile.config.backend === intended && !profile.config.agentId &&
-    loopback && profile.config.port === 4096 && profile.config.username === "harness"
-  if (!savedAsCodex && !pointedAtOpenCode) return profile
-  return {
-    ...profile,
-    config: {
-      ...profile.config,
-      backend: intended,
-      agentId: intended,
-      ...(pointedAtOpenCode ? { port: 4097 } : {})
-    }
-  }
+  if (!intended || profile.config.backend !== "codex" || profile.config.agentId !== "codex") return profile
+  return { ...profile, config: { ...profile.config, backend: intended, agentId: intended } }
+}
+
+function sameMachine(left: ServerConfig, right: ServerConfig): boolean {
+  return left.host.trim().toLowerCase() === right.host.trim().toLowerCase() && left.username === right.username
+}
+
+/** Repair the bad internal OpenCode port only when another saved daemon profile identifies its port. */
+function repairInternalOpenCodePort(profile: SavedServerProfile, profiles: SavedServerProfile[]): SavedServerProfile {
+  const intended = namedHarness(profile.name)
+  if (!intended || profile.config.backend !== intended || profile.config.agentId || profile.config.port !== 4096) return profile
+  const knownDaemonPort = profiles.find((candidate) =>
+    candidate.id !== profile.id && candidate.config.backend !== "opencode" &&
+    candidate.config.port !== 4096 && sameMachine(candidate.config, profile.config)
+  )?.config.port
+  if (!knownDaemonPort) return profile
+  return { ...profile, config: { ...profile.config, port: knownDaemonPort, agentId: intended } }
 }
 
 function parseProfiles(value: string | null): SavedServerProfile[] | null {
@@ -102,7 +103,9 @@ function parseProfiles(value: string | null): SavedServerProfile[] | null {
         config
       }]
     })
-    return profiles.length > 0 ? profiles.map(repairMisroutedDaemonProfile) : null
+    if (!profiles.length) return null
+    const repaired = profiles.map(repairMisroutedDaemonProfile)
+    return repaired.map((profile) => repairInternalOpenCodePort(profile, repaired))
   } catch {
     return null
   }


### PR DESCRIPTION
Addresses the review findings: derive a repaired OMP/PI daemon port from a known same-machine profile instead of hardcoding 4097; persist running before attaching prompt callbacks so terminal callbacks cannot race the state transition; remember a task model only after launch succeeds. Adds regression coverage for all three.