### PR TITLE
Keep OMP and PI task sessions visible in Harness Remote

### DIFF
--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -519,6 +519,32 @@ export class AcpService {
     this.#startTurn(sessionID, text, false, attachments)
   }
 
+  /** Start a prompt through the session service and resolve only when that turn becomes idle. */
+  async promptAndWait(sessionID, text, model, attachments = []) {
+    return new Promise((resolve, reject) => {
+      let started = false
+      let settled = false
+      const finish = (error) => {
+        if (settled) return
+        settled = true
+        unsubscribe()
+        if (error) reject(error)
+        else resolve()
+      }
+      const unsubscribe = this.subscribe((event) => {
+        if (event.sessionId !== sessionID) return
+        if (event.type === "session.error") {
+          finish(new Error(event.message ?? "Harness prompt failed"))
+          return
+        }
+        if (event.type !== "session.updated") return
+        if (this.#isBusy(sessionID)) started = true
+        else if (started) finish()
+      })
+      void this.prompt(sessionID, text, model, attachments).catch(finish)
+    })
+  }
+
   #startTurn(sessionID, text, recorded = false, attachments = []) {
     const generation = (this.#turnGenerations.get(sessionID) ?? 0) + 1
     this.#turnGenerations.set(sessionID, generation)

--- a/bridge/src/machine-daemon.js
+++ b/bridge/src/machine-daemon.js
@@ -107,7 +107,11 @@ export function createMachineDaemonServer({
   const tasks = taskStore ?? new TaskRunStore({ machineID, stateDirectory })
   const projects = projectCatalog ?? (() => discoverProjects({ machineID, roots }))
   const worktrees = worktreeManager ?? new WorktreeManager({ stateDirectory })
-  const launcher = taskLauncher ?? new TaskLauncher({ daemon })
+  const acpService = (agentID) => {
+    const server = agentID === primaryAgentID ? bridgeServer : acpBridgeServer(agentID)
+    return server?.acpService
+  }
+  const launcher = taskLauncher ?? new TaskLauncher({ daemon, acpService })
   const runs = taskRunController ?? new TaskRunController({ taskStore: tasks, taskLauncher: launcher })
   const innerServer = createRouter({ daemon, config, primaryAgentID, bridgeServer, acpBridgeServer, taskStore: tasks, projectCatalog: projects, worktreeManager: worktrees })
   const launchServer = createLaunchServer({ innerServer, config, taskRunController: runs })

--- a/bridge/src/server.js
+++ b/bridge/src/server.js
@@ -114,7 +114,7 @@ export function createBridgeServer({ config, acp, serviceOptions, machineRegistr
     return sessions.filter((session) => !hiddenSessionIDs.has(session.id))
   }
 
-  return http.createServer(async (request, response) => {
+  const server = http.createServer(async (request, response) => {
     applyCorsHeaders(request, response, config)
     if (request.method === "OPTIONS") {
       response.writeHead(allowedOrigin(request, config) ? 204 : 403)
@@ -278,4 +278,8 @@ export function createBridgeServer({ config, acp, serviceOptions, machineRegistr
       writeJSON(response, 400, { error: error instanceof Error ? error.message : "Request failed" })
     }
   })
+  // The machine task launcher must use this exact service so task-created ACP sessions retain
+  // their title, prompt, live messages, and ownership when the user switches harnesses.
+  server.acpService = service
+  return server
 }

--- a/bridge/src/task-launcher.js
+++ b/bridge/src/task-launcher.js
@@ -37,10 +37,15 @@ function acpModelValue(configOptions, model) {
   return option?.options?.find((candidate) => candidate.value === model.modelID)?.value
 }
 
+function acpModelWireName(model) {
+  return model ? `${model.providerID}/${model.modelID}` : undefined
+}
+
 export class TaskLauncher {
-  constructor({ daemon, fetchImpl = fetch }) {
+  constructor({ daemon, fetchImpl = fetch, acpService } = {}) {
     this.daemon = daemon
     this.fetchImpl = fetchImpl
+    this.acpService = acpService
   }
 
   async createSession(task) {
@@ -52,6 +57,16 @@ export class TaskLauncher {
     if (!task.workspace?.path) throw taskLaunchError("workspace_required", "Task workspace is not prepared")
 
     if (entry.kind === "acp") {
+      const service = this.acpService?.(task.agentId)
+      if (service) {
+        const session = await service.createSession({
+          directory: task.workspace.path,
+          title: `Task ${task.id.slice(0, 8)}`,
+          model: acpModelWireName(task.model)
+        })
+        if (!session?.id) throw new Error(`Agent ${task.agentId} did not return a session id`)
+        return { sessionId: session.id, transport: "acp", directory: task.workspace.path }
+      }
       await entry.host.start()
       const result = await entry.host.request("session/new", { cwd: task.workspace.path, mcpServers: [] })
       if (!result?.sessionId) throw new Error(`Agent ${task.agentId} did not return a session id`)
@@ -99,6 +114,15 @@ export class TaskLauncher {
     if (!entry) throw taskLaunchError("unknown_agent", `Unknown agent: ${task.agentId}`)
 
     if (entry.kind === "acp") {
+      const service = this.acpService?.(task.agentId)
+      if (service) {
+        void service.promptAndWait(run.sessionId, task.prompt).then((result) => {
+          onCompleted?.(result)
+        }).catch((error) => {
+          onFailed?.(error)
+        })
+        return
+      }
       void entry.host.request("session/prompt", {
         sessionId: run.sessionId,
         prompt: [{ type: "text", text: task.prompt }]

--- a/bridge/test/task-launcher-model.test.js
+++ b/bridge/test/task-launcher-model.test.js
@@ -58,6 +58,35 @@ test("ACP task launch applies selected model before prompting", async () => {
   assert.equal(calls.at(-1).method, "session/prompt")
 })
 
+test("ACP task launch uses the bridge session service so the task remains visible with its messages", async () => {
+  const calls = []
+  const service = {
+    async createSession(input) {
+      calls.push(["create", input])
+      return { id: "service-session" }
+    },
+    async promptAndWait(sessionID, text) {
+      calls.push(["prompt", sessionID, text])
+    }
+  }
+  const daemon = {
+    hostEntry: () => ({ kind: "acp", host: {} }),
+    registry: { host: () => ({ state: "available" }) }
+  }
+  const launcher = new TaskLauncher({ daemon, acpService: () => service })
+  const selected = task({ agentId: "omp" })
+  const run = await launcher.createSession(selected)
+  let completed = false
+  await launcher.startPrompt(selected, run, { onCompleted: () => { completed = true } })
+  await new Promise((resolve) => setImmediate(resolve))
+
+  assert.deepEqual(calls, [
+    ["create", { directory: "/repo", title: "Task task-123", model: "openai/gpt-x" }],
+    ["prompt", "service-session", "Implement the fix"]
+  ])
+  assert.equal(completed, true)
+})
+
 test("managed HTTP task launch sends selected model and variant", async () => {
   const requests = []
   const fetchImpl = async (url, options = {}) => {


### PR DESCRIPTION
Routes ACP task creation and prompts through the same AcpService instance served to the UI. Task sessions now retain ownership, title, prompt history, live updates, and a completion signal across harness switches. Includes a regression test for the task launcher service path.