### PR TITLE
Restore existing PI and OMP task sessions after restart

### DIFF
--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -275,6 +275,22 @@ export class AcpService {
     return sessionView(session, "idle", this.#titleFor(session.sessionId))
   }
 
+  /** Adopt a task session created by an older daemon so PI can open it without session/load. */
+  async adoptTaskSession(sessionID, { title, prompt } = {}) {
+    await this.#refreshSessions()
+    const session = this.#sessions.get(sessionID)
+    if (!session || this.#deletedSessions.has(sessionID)) return false
+    this.#ownedSessions.add(sessionID)
+    this.#loaded.add(sessionID)
+    if (title && !this.#titles.has(sessionID)) this.#titles.set(sessionID, title)
+    const messages = this.#messages.get(sessionID) ?? []
+    if (prompt && !messages.some((message) => message.info?.role === "user" && message.parts?.some((part) => part.text === prompt))) {
+      this.#recordPrompt(sessionID, prompt)
+    }
+    this.#persistSnapshot(sessionID)
+    return true
+  }
+
   async renameSession(sessionID, title) {
     const normalized = title.trim()
     if (!normalized) throw new Error("A session title is required")

--- a/bridge/src/machine-daemon.js
+++ b/bridge/src/machine-daemon.js
@@ -112,7 +112,7 @@ export function createMachineDaemonServer({
     return server?.acpService
   }
   const launcher = taskLauncher ?? new TaskLauncher({ daemon, acpService })
-  const runs = taskRunController ?? new TaskRunController({ taskStore: tasks, taskLauncher: launcher })
+  const runs = taskRunController ?? new TaskRunController({ taskStore: tasks, taskLauncher: launcher, acpService })
   const innerServer = createRouter({ daemon, config, primaryAgentID, bridgeServer, acpBridgeServer, taskStore: tasks, projectCatalog: projects, worktreeManager: worktrees })
   const launchServer = createLaunchServer({ innerServer, config, taskRunController: runs })
   const modelServer = createModelServer({ innerServer: launchServer, config, daemon, taskStore: tasks })

--- a/bridge/src/task-run-controller.js
+++ b/bridge/src/task-run-controller.js
@@ -3,10 +3,11 @@ import { taskLaunchError } from "./task-errors.js"
 import { WorktreeManager } from "./worktree-manager.js"
 
 export class TaskRunController {
-  constructor({ taskStore, taskLauncher, worktreeManager, runIDFactory = randomUUID, clock = () => new Date().toISOString() }) {
+  constructor({ taskStore, taskLauncher, worktreeManager, acpService, runIDFactory = randomUUID, clock = () => new Date().toISOString() }) {
     this.taskStore = taskStore
     this.taskLauncher = taskLauncher
     this.worktreeManager = worktreeManager ?? (taskStore?.stateDirectory ? new WorktreeManager({ stateDirectory: taskStore.stateDirectory }) : undefined)
+    this.acpService = acpService
     this.runIDFactory = runIDFactory
     this.clock = clock
     this.reconciliationError = null
@@ -25,8 +26,17 @@ export class TaskRunController {
     try { await this.taskStore.setRunState(taskID, { status, run, error, expectedRunId: run?.id }) } catch {}
   }
 
+  async #adoptAcpTaskSession(task) {
+    if (!task.run?.sessionId || task.run.transport !== "acp") return
+    const service = this.acpService?.(task.agentId)
+    if (!service) return
+    const title = task.prompt?.trim().split("\n")[0].slice(0, 60)
+    try { await service.adoptTaskSession(task.run.sessionId, { title, prompt: task.prompt }) } catch {}
+  }
+
   async reconcileAll() {
     for (const task of await this.taskStore.list()) {
+      await this.#adoptAcpTaskSession(task)
       if (!["starting", "running"].includes(task.status)) continue
       if (!task.run?.id) {
         try { await this.taskStore.setRunState(task.id, { status: "failed", error: new Error("Active task has no persisted run identity") }) } catch {}
@@ -35,7 +45,7 @@ export class TaskRunController {
       let state = "unknown"
       try { state = await this.taskLauncher.inspectRun?.(task) ?? "unknown" } catch {}
       if (state === "completed") await this.#terminal(task.id, task.run, "completed")
-      else if (state !== "running") await this.#terminal(task.id, task.run, "failed", new Error("Task run could not be confirmed after daemon restart"))
+      else if (state === "failed") await this.#terminal(task.id, task.run, "failed", new Error("Task run could not be confirmed after daemon restart"))
     }
   }
 

--- a/bridge/test/task-run-controller.test.js
+++ b/bridge/test/task-run-controller.test.js
@@ -134,3 +134,31 @@ test("reconciliation load failures stay isolated and surface as unavailable", as
     (error) => error.code === "agent_unavailable" && error.message === "Task state is unavailable"
   )
 })
+
+test("reconciliation adopts an ACP task session and keeps an unconfirmable ACP run active", async () => {
+  let current = draft({
+    status: "running",
+    run: { id: "run-1", agentId: "pi", sessionId: "pi-session", transport: "acp", directory: "/state/worktrees/task-1" }
+  })
+  const adopted = []
+  const controller = new TaskRunController({
+    taskStore: {
+      async list() { return [structuredClone(current)] },
+      async setRunState(_id, update) {
+        current = { ...current, status: update.status, error: update.error }
+        return structuredClone(current)
+      }
+    },
+    taskLauncher: { async inspectRun() { return "unknown" } },
+    acpService: () => ({
+      async adoptTaskSession(sessionID, details) { adopted.push({ sessionID, details }) }
+    })
+  })
+
+  await controller.reconciliation
+  assert.equal(current.status, "running")
+  assert.deepEqual(adopted, [{
+    sessionID: "pi-session",
+    details: { title: "Fix it", prompt: "Fix it" }
+  }])
+})


### PR DESCRIPTION
Restores task-created ACP sessions made before the managed bridge session path. On daemon startup, persisted PI/OMP task sessions are adopted by their bridge service, avoiding PI session/load Invalid params and preserving the submitted prompt. Also leaves active ACP runs active when inspection is inconclusive after a restart.\n\nVerification: npm test (210 passing).