### PR TITLE
Fix PI streamed Markdown messages

### DIFF
--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -35,6 +35,29 @@ function sessionView(session, status = "idle", title = session.title, external =
   }
 }
 
+/**
+ * Older PI snapshots contain one UUID-identified assistant envelope per streamed fragment. A user
+ * turn is the natural delimiter, so those adjacent envelopes are one visible reply. Keeping them
+ * separate breaks Markdown whenever a marker or word straddles two updates.
+ */
+function mergeFragmentedPiSnapshot(messages) {
+  const merged = []
+  for (const message of messages) {
+    const previous = merged.at(-1)
+    if (
+      message?.info?.role === "assistant"
+      && previous?.info?.role === "assistant"
+      && /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(message.info.id)
+      && /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(previous.info.id)
+    ) {
+      previous.parts.push(...message.parts)
+      continue
+    }
+    merged.push(message)
+  }
+  return merged
+}
+
 function messageSignature(message) {
   return `${message?.info?.role ?? ""}\u0000${(message?.parts ?? []).map((part) => part?.text ?? "").join("")}`
 }
@@ -652,7 +675,7 @@ export class AcpService {
     try {
       const snapshot = JSON.parse(await readFile(this.#snapshotPath(sessionID), "utf8"))
       if (snapshot?.version !== 1) return
-      if (Array.isArray(snapshot.messages)) this.#messages.set(sessionID, snapshot.messages)
+      if (Array.isArray(snapshot.messages)) this.#messages.set(sessionID, mergeFragmentedPiSnapshot(snapshot.messages))
       if (Array.isArray(snapshot.todos)) this.#todos.set(sessionID, snapshot.todos)
       if (typeof snapshot.title === "string" && snapshot.title) this.#titles.set(sessionID, snapshot.title)
       if (snapshot?.deleted === true) this.#deletedSessions.add(sessionID)
@@ -975,7 +998,12 @@ export class AcpService {
     const counterpartKey = `${sessionId}:${role === "user" ? "assistant" : "user"}`
     this.#chunkMessageIDs.delete(counterpartKey)
     const chunkKey = `${sessionId}:${role}`
-    const messageID = update.messageId ?? this.#chunkMessageIDs.get(chunkKey) ?? randomUUID()
+    // PI sends a new message id for every streaming fragment. During a live turn the bridge's
+    // id is authoritative, so all adjacent fragments remain one Markdown message. Replay keeps
+    // adapter ids because it reconstructs historical conversation boundaries.
+    const messageID = !replaying && role === "assistant"
+      ? this.#chunkMessageIDs.get(chunkKey) ?? update.messageId ?? randomUUID()
+      : update.messageId ?? this.#chunkMessageIDs.get(chunkKey) ?? randomUUID()
     this.#chunkMessageIDs.set(chunkKey, messageID)
     const messages = this.#messages.get(sessionId) ?? []
     this.#messages.set(sessionId, messages)

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -1030,6 +1030,40 @@ test("records the submitted user prompt before asynchronous ACP assistant update
   }
 })
 
+test("keeps PI streamed assistant fragments in one Markdown message", async () => {
+  const bridge = await startServer()
+  try {
+    const prompt = fetch(`${bridge.baseURL}/session/session-1/prompt_async`, {
+      method: "POST",
+      headers: { ...authHeaders(), "content-type": "application/json" },
+      body: JSON.stringify({ parts: [{ type: "text", text: "Give an update" }] })
+    })
+    await bridge.acp.loadStarted
+    bridge.acp.releaseLoad()
+    assert.equal((await prompt).status, 200)
+
+    for (const [messageId, text] of [
+      ["2c1b4ee5-0ca2-4656-8c0a-7eece95bb0ae", "## Aggiorn"],
+      ["044ec068-2e43-4ffd-a330-06a7b678d360", "amento\\n\\nIl Markdown resta integro."]
+    ]) {
+      bridge.acp.emit("notification", {
+        method: "session/update",
+        params: {
+          sessionId: "session-1",
+          update: { sessionUpdate: "agent_message_chunk", messageId, content: { type: "text", text } }
+        }
+      })
+    }
+
+    const response = await fetch(`${bridge.baseURL}/session/session-1/message`, { headers: authHeaders() })
+    const assistantMessages = (await response.json()).filter((message) => message.info.role === "assistant")
+    assert.deepEqual(assistantMessages.map((message) => message.parts[0].text), ["## Aggiornamento\\n\\nIl Markdown resta integro."])
+  } finally {
+    bridge.acp.releaseLoad()
+    await bridge.close()
+  }
+})
+
 test("replays persistent user and assistant history when reopening an OMP session", async () => {
   const bridge = await startServer({ acp: new ReplayAcp() })
   try {


### PR DESCRIPTION
## What changed

Preserves one bridge-owned assistant message while PI streams a reply in fragments with distinct ACP message identifiers. Older saved PI snapshots with adjacent fragment envelopes are also normalized when restored.

## Why

PI was presenting one reply as many messages, which split Markdown markers and words across message bubbles.

## Impact

PI conversations render as one coherent Markdown reply during live streaming and after a bridge restart. Other harnesses retain their existing replay behavior.

## Validation

`npm --prefix bridge test` — 211 passing tests, including a new PI multi-fragment Markdown regression test.
