### PR TITLE
Merge PI replayed text fragments

### DIFF
--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -50,7 +50,14 @@ function mergeFragmentedPiSnapshot(messages) {
       && /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(message.info.id)
       && /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(previous.info.id)
     ) {
-      previous.parts.push(...message.parts)
+      for (const part of message.parts ?? []) {
+        const lastPart = previous.parts.at(-1)
+        if (lastPart?.type === part?.type && typeof lastPart.text === "string" && typeof part.text === "string") {
+          lastPart.text += part.text
+        } else {
+          previous.parts.push(part)
+        }
+      }
       continue
     }
     merged.push(message)
@@ -772,7 +779,7 @@ export class AcpService {
     if (!session) throw new Error("Harness session not found")
     await this.#restoreSnapshot(sessionID)
     const authoritativeState = await this.#refreshActionState(sessionID, false)
-    let previousMessages = this.#messages.get(sessionID) ?? []
+    let previousMessages = mergeFragmentedPiSnapshot(this.#messages.get(sessionID) ?? [])
     const previousTodos = this.#todos.get(sessionID) ?? []
     const previousMessageSnapshot = semanticHistorySignature(previousMessages)
     if (this.#historyLoader) {
@@ -784,6 +791,7 @@ export class AcpService {
           previousMessages = authoritativeState
             ? persistedMessages
             : mergeExternalHistory(persistedMessages, previousMessages)
+          previousMessages = mergeFragmentedPiSnapshot(previousMessages)
           this.#messages.set(sessionID, previousMessages)
           if (!this.#ownedSessions.has(sessionID) && !requireConfigOptions) {
             this.#todos.set(sessionID, [])
@@ -804,7 +812,7 @@ export class AcpService {
     try {
       const result = await this.#acp.request("session/load", { sessionId: sessionID, cwd: session.cwd, mcpServers: [] }, 300_000)
       this.#rememberConfigOptions(sessionID, result.configOptions)
-      const replayedMessages = this.#messages.get(sessionID) ?? []
+      const replayedMessages = mergeFragmentedPiSnapshot(this.#messages.get(sessionID) ?? [])
       this.#messages.set(sessionID, replaceHistory ? replayedMessages : mergeReplay(previousMessages, replayedMessages))
       const replayedTodos = this.#todos.get(sessionID) ?? []
       this.#todos.set(sessionID, replaceHistory ? replayedTodos : mergeTodos(previousTodos, replayedTodos))

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -1064,6 +1064,39 @@ test("keeps PI streamed assistant fragments in one Markdown message", async () =
   }
 })
 
+test("merges PI assistant fragments replayed during session load", async () => {
+  class FragmentedReplayAcp extends EventEmitter {
+    async start() {}
+
+    async listSessions() {
+      return [{ sessionId: "session-1", cwd: process.cwd(), updatedAt: "2026-08-17T20:00:00.000Z" }]
+    }
+
+    async request(method) {
+      if (method !== "session/load") return {}
+      for (const [messageId, text] of [
+        ["2c1b4ee5-0ca2-4656-8c0a-7eece95bb0ae", "## Aggiorn"],
+        ["044ec068-2e43-4ffd-a330-06a7b678d360", "amento\\n\\nIl Markdown resta integro."]
+      ]) {
+        this.emit("notification", {
+          method: "session/update",
+          params: {
+            sessionId: "session-1",
+            update: { sessionUpdate: "agent_message_chunk", messageId, content: { type: "text", text } }
+          }
+        })
+      }
+      return {}
+    }
+
+    notify() {}
+  }
+
+  const service = new AcpService(new FragmentedReplayAcp())
+  const messages = await service.messages("session-1", true)
+  assert.deepEqual(messages.map((message) => message.parts[0].text), ["## Aggiornamento\\n\\nIl Markdown resta integro."])
+})
+
 test("replays persistent user and assistant history when reopening an OMP session", async () => {
   const bridge = await startServer({ acp: new ReplayAcp() })
   try {


### PR DESCRIPTION
Fixes PI replies that arrive as multiple UUID assistant envelopes during session load. The bridge now coalesces adjacent text parts as well as live fragments, preventing artificial newlines in reopened sessions. Validation: npm --prefix bridge test (212 passing tests).