### PR TITLE
Fix machine daemon backend mismatch in connection test

### DIFF
--- a/bridge/src/server.js
+++ b/bridge/src/server.js
@@ -141,7 +141,16 @@ export function createBridgeServer({ config, acp, serviceOptions, machineRegistr
       }
       if (request.method === "GET" && (url.pathname === "/v1/health" || url.pathname === "/global/health")) {
         await acp.start()
-        writeJSON(response, 200, { healthy: true, backend, version: acp.agentInfo?.version ?? "unknown" })
+        // A machine daemon exposes several harnesses behind one endpoint. Its ACP primary is an
+        // internal routing choice, not the identity of the whole server. Omitting `backend` here
+        // prevents legacy connection tests from rejecting OpenCode/PI/OMP/Claude merely because
+        // Codex (or another ACP harness) happens to be the daemon primary. Single-backend bridge
+        // servers still report their backend exactly as before.
+        writeJSON(response, 200, {
+          healthy: true,
+          ...(machineRegistry ? {} : { backend }),
+          version: acp.agentInfo?.version ?? "unknown"
+        })
         return
       }
       if (request.method === "GET" && url.pathname === "/v1/capabilities") {

--- a/bridge/test/machine-health.test.js
+++ b/bridge/test/machine-health.test.js
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import test from "node:test"
+import { createBridgeServer } from "../src/server.js"
+
+class HealthAcp extends EventEmitter {
+  agentInfo = { version: "test-version" }
+  async start() {}
+}
+
+async function withServer(machineRegistry, run) {
+  const server = createBridgeServer({
+    config: {
+      backend: "codex",
+      roots: [process.cwd()],
+      corsOrigins: [],
+      heartbeatMs: 10_000
+    },
+    acp: new HealthAcp(),
+    machineRegistry
+  })
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
+  try {
+    const address = server.address()
+    await run(`http://127.0.0.1:${address.port}`)
+  } finally {
+    await new Promise((resolve) => server.close(resolve))
+  }
+}
+
+test("machine daemon health does not pretend the ACP primary is the whole server backend", async () => {
+  await withServer({ snapshot: () => ({ machine: { id: "machine-1" }, agents: [] }) }, async (base) => {
+    const response = await fetch(`${base}/global/health`)
+    assert.equal(response.status, 200)
+    const health = await response.json()
+    assert.equal(health.healthy, true)
+    assert.equal(health.version, "test-version")
+    assert.equal("backend" in health, false)
+  })
+})
+
+test("single-backend bridge health still reports its backend", async () => {
+  await withServer(undefined, async (base) => {
+    const response = await fetch(`${base}/global/health`)
+    assert.equal(response.status, 200)
+    const health = await response.json()
+    assert.equal(health.backend, "codex")
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the Android/web connection test rejecting a valid multi-harness machine daemon with errors such as `Expected OpenCode but reached Codex CLI`.

The root cause was `/global/health` on the machine daemon advertising the daemon's ACP primary as if it were the identity of the whole endpoint. That is incorrect for a multi-harness machine: Codex may be the primary while OpenCode, PI, OMP and Claude are all valid agents behind the same daemon.

This change:

- omits `backend` from health responses when the bridge is running as part of a machine daemon;
- preserves the existing backend identity for legacy/single-backend bridge servers;
- adds regression coverage for both cases.

This targets `v3/taskdesk` only and does not touch `main`.