### PR TITLE
Fix stale profile routing across machine harnesses

### DIFF
--- a/bridge/src/agent-router.js
+++ b/bridge/src/agent-router.js
@@ -84,6 +84,14 @@ export function agentScopedRequest(request) {
   }
 }
 
+function routedAgentForBackend(daemon, route, requestedBackend) {
+  if (!requestedBackend) return route
+  const routedHost = daemon.registry.host(route.agentID)
+  if (routedHost?.backend === requestedBackend) return route
+  const matching = daemon.snapshot().agents.find((agent) => agent.backend === requestedBackend)
+  return matching ? { ...route, agentID: matching.id } : route
+}
+
 export function proxyManagedHttpRequest({
   request,
   response,
@@ -224,11 +232,20 @@ export function createAgentRoutingServer({
       return
     }
 
-    const route = agentScopedRequest(request)
+    const requestedBackend = typeof request.headers["x-harness-backend"] === "string"
+      ? request.headers["x-harness-backend"].trim()
+      : ""
+    let route = agentScopedRequest(request)
     if (!route) {
-      bridgeServer.emit("request", request, response)
-      return
+      const matching = requestedBackend && daemon.snapshot().agents.find((agent) => agent.backend === requestedBackend)
+      if (matching && matching.id !== primaryAgentID) {
+        route = { agentID: matching.id, path: requestURL.pathname, search: requestURL.search }
+      } else {
+        bridgeServer.emit("request", request, response)
+        return
+      }
     }
+    route = routedAgentForBackend(daemon, route, requestedBackend)
 
     if (route.agentID === primaryAgentID) {
       request.url = `${route.path}${route.search}`

--- a/bridge/src/http-policy.js
+++ b/bridge/src/http-policy.js
@@ -18,7 +18,7 @@ export function applyCorsHeaders(request, response, config) {
   if (!origin) return
   response.setHeader("Access-Control-Allow-Origin", origin)
   response.setHeader("Access-Control-Allow-Credentials", "true")
-  response.setHeader("Access-Control-Allow-Headers", "authorization, content-type")
+  response.setHeader("Access-Control-Allow-Headers", "authorization, content-type, x-harness-backend")
   response.setHeader("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
   // Chromium's Private Network Access preflight is sent when this public PWA
   // connects to a local daemon/bridge (for example github.io -> localhost).

--- a/bridge/test/agent-routing-fallback.test.js
+++ b/bridge/test/agent-routing-fallback.test.js
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import test from "node:test"
+import { createAgentRoutingServer } from "../src/agent-router.js"
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  return server.address().port
+}
+
+async function close(server) {
+  await new Promise((resolve) => server.close(resolve))
+}
+
+class BridgeServer extends EventEmitter {}
+
+function daemonWithAgents() {
+  const hosts = {
+    codex: { id: "codex", backend: "codex", state: "available" },
+    omp: { id: "omp", backend: "omp", state: "configured" },
+    pi: { id: "pi", backend: "pi", state: "configured" },
+    opencode: { id: "opencode", backend: "opencode", state: "available" }
+  }
+  const entries = {
+    omp: { id: "omp", kind: "acp" },
+    pi: { id: "pi", kind: "acp" },
+    opencode: { id: "opencode", kind: "http", host: {} }
+  }
+  return {
+    registry: {
+      host(id) { return hosts[id] }
+    },
+    hostEntry(id) { return entries[id] },
+    snapshot() { return { agents: Object.values(hosts) } }
+  }
+}
+
+test("legacy root request is routed by selected harness instead of primary", async () => {
+  const primary = new BridgeServer()
+  primary.on("request", (_request, response) => response.end("primary"))
+  const pi = new BridgeServer()
+  pi.on("request", (request, response) => response.end(`pi:${request.url}`))
+  const server = createAgentRoutingServer({
+    daemon: daemonWithAgents(),
+    config: { username: "", password: "", corsOrigins: [] },
+    primaryAgentID: "codex",
+    bridgeServer: primary,
+    acpBridgeServer: (id) => id === "pi" ? pi : undefined
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/experimental/session`, {
+      headers: { "X-Harness-Backend": "pi" }
+    })
+    assert.equal(await response.text(), "pi:/experimental/session")
+  } finally {
+    await close(server)
+  }
+})
+
+test("stale scoped agent id is corrected by selected harness", async () => {
+  const primary = new BridgeServer()
+  primary.on("request", (_request, response) => response.end("wrong-codex"))
+  const omp = new BridgeServer()
+  omp.on("request", (request, response) => response.end(`omp:${request.url}`))
+  const server = createAgentRoutingServer({
+    daemon: daemonWithAgents(),
+    config: { username: "", password: "", corsOrigins: [] },
+    primaryAgentID: "codex",
+    bridgeServer: primary,
+    acpBridgeServer: (id) => id === "omp" ? omp : undefined
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/agents/codex/session`, {
+      headers: { "X-Harness-Backend": "omp" }
+    })
+    assert.equal(await response.text(), "omp:/session")
+  } finally {
+    await close(server)
+  }
+})
+
+test("correct explicit route is not changed by matching backend hint", async () => {
+  const primary = new BridgeServer()
+  primary.on("request", (_request, response) => response.end("primary"))
+  const pi = new BridgeServer()
+  pi.on("request", (request, response) => response.end(`pi:${request.url}`))
+  const server = createAgentRoutingServer({
+    daemon: daemonWithAgents(),
+    config: { username: "", password: "", corsOrigins: [] },
+    primaryAgentID: "codex",
+    bridgeServer: primary,
+    acpBridgeServer: (id) => id === "pi" ? pi : undefined
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/agents/pi/session`, {
+      headers: { "X-Harness-Backend": "pi" }
+    })
+    assert.equal(await response.text(), "pi:/session")
+  } finally {
+    await close(server)
+  }
+})

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -29,8 +29,8 @@ import type {
 
 export { baseUrl, isValidServerConfig }
 
-// A 401 says the server wants credentials, not that the ones given are wrong — and the app can tell
-// the two apart, because it knows whether it sent any. The connection test enables itself without a
+// A 401 says the server wants credentials, not that the ones given are wrong, and the app can tell
+// the two apart because it knows whether it sent any. The connection test enables itself without a
 // password, so the common case is a server with Basic Auth and an empty password field, which read
 // as "wrong password" and sent people back to re-check credentials that were correct.
 function unauthorizedDetail(config: ServerConfig): string {
@@ -67,7 +67,7 @@ function responseDetail(body: unknown): string | null {
   }
   if (typeof body === "object") {
     // `data.message` and `message` are OpenCode's shapes; the bridge answers `{ "error": "..." }`,
-    // which fell through to the stringify below and put raw JSON on screen — so every bridge
+    // which fell through to the stringify below and put raw JSON on screen, so every bridge
     // failure reached the user as `{"error":"Internal error: ..."}` instead of the sentence in it.
     const value = body as { data?: { message?: string }, message?: string, error?: string }
     const detail = value.data?.message ?? value.message ?? (typeof value.error === "string" ? value.error : undefined)
@@ -115,6 +115,13 @@ type AgentResponse = Array<{
   hidden?: boolean
 }>
 
+function routingHeaders(config: ServerConfig): Record<string, string> {
+  // A direct OpenCode server does not know this compatibility header and may reject it during CORS
+  // preflight. Daemon-backed profiles have an agentId, while ACP bridge profiles can safely send it.
+  if (config.backend === "opencode" && !config.agentId) return {}
+  return { "X-Harness-Backend": config.backend }
+}
+
 async function requestWithHeaders<T>(config: ServerConfig, path: string, options: RequestOptions = {}): Promise<ResponseWithHeaders<T>> {
   const method = options.method ?? "GET"
   if (isDesktopPlatform()) {
@@ -129,7 +136,8 @@ async function requestWithHeaders<T>(config: ServerConfig, path: string, options
 
   const target = `${baseUrl(config)}${path}`
   const headers: Record<string, string> = {
-    Accept: "application/json"
+    Accept: "application/json",
+    ...routingHeaders(config)
   }
   if (hasCredentials(config)) {
     headers.Authorization = authHeader(config)
@@ -229,7 +237,7 @@ function modelWireName(model?: ModelSelection) {
 
 export const api = {
   eventStream(config: ServerConfig) {
-    const headers: Record<string, string> = {}
+    const headers: Record<string, string> = { ...routingHeaders(config) }
     if (hasCredentials(config)) headers.Authorization = authHeader(config)
     return { url: streamURL(baseUrl(config), "global"), headers }
   },

--- a/web/src/settings-regression.test.mjs
+++ b/web/src/settings-regression.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 
 const app = readFileSync(new URL('./App.tsx', import.meta.url), 'utf8')
+const api = readFileSync(new URL('./api.ts', import.meta.url), 'utf8')
 const i18n = readFileSync(new URL('./i18n.ts', import.meta.url), 'utf8')
 const styles = readFileSync(new URL('./styles.css', import.meta.url), 'utf8')
 const shell = readFileSync(new URL('./components/shell.tsx', import.meta.url), 'utf8')
@@ -44,6 +45,15 @@ assert.equal(panels.includes('Agent on '), false, 'the machine picker must not i
 assert.equal(panels.includes('agents discovered'), false, 'machine discovery feedback must not introduce hardcoded English copy')
 assert.equal(panels.includes('{agent.label} · {agent.state}'), false, 'protocol host states must not be rendered verbatim')
 assert.ok(panels.includes('agent.state !== "available" && agent.state !== "configured"'), 'unavailable machine agents must not be selectable')
+
+// Agent-scoped URLs are the primary routing contract. The backend header is a compatibility guard
+// for profiles saved by older builds with no agentId, or with an agentId that points at the old primary.
+// A raw OpenCode server must not receive the custom header because its CORS policy does not know it.
+assert.ok(api.includes('function routingHeaders(config: ServerConfig)'), 'API requests should centralize the compatibility routing hint')
+assert.ok(api.includes('return { "X-Harness-Backend": config.backend }'), 'daemon requests should identify the selected harness backend')
+assert.ok(api.includes('if (config.backend === "opencode" && !config.agentId) return {}'), 'direct legacy OpenCode servers must not receive the daemon routing header')
+assert.ok(api.includes('...routingHeaders(config)'), 'ordinary API requests should carry the selected harness routing hint')
+assert.match(api, /eventStream\(config: ServerConfig\)[\s\S]*?routingHeaders\(config\)/, 'browser SSE should preserve the selected harness routing hint too')
 
 // The server picker used to caption itself with a visually-hidden span, but no rule ever hid it: the
 // caption rendered as stray text above the header. Every class the picker and its actions rely on has


### PR DESCRIPTION
## Summary

Restores the compatibility guard that was lost during the `codex/taskdesk-launch-fixes` to `v3/taskdesk` transition without reverting the newer multi-harness architecture.

The primary contract remains `agentId` scoped requests under `/v1/agents/:id`. This PR adds a backend routing hint only as a fallback for stale or legacy profiles, so a PI/OMP/Claude/Codex profile can never silently fall through to the machine primary and display another harness's sessions.

## Changes

- send `X-Harness-Backend` on daemon/bridge API requests and browser SSE;
- do not send the custom header to direct legacy OpenCode servers;
- allow the header through credentialed CORS;
- route an unscoped legacy request to the daemon agent matching the selected backend;
- correct a stale explicit agent id when it conflicts with the selected backend;
- preserve the current isolated ACP bridge and managed HTTP routing paths;
- add bridge regression tests for root-profile fallback, stale agent ids, and correct explicit routes;
- add web regression assertions so the routing hint cannot disappear again.

This targets `v3/taskdesk` only. It does not touch `main`.

Refs #232 audit context.