### PR TITLE
Fix completion sound timing and Android playback

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -65,6 +65,7 @@ jobs:
           npm run test:catalog-guard
           npm run test:machine-payload
           npm run test:platform
+          npm run test:completion-audio
         working-directory: web
 
       - name: Run bridge tests

--- a/web/package.json
+++ b/web/package.json
@@ -87,8 +87,14 @@
     },
     "linux": {
       "target": [
-        "AppImage",
-        "deb"
+        {
+          "target": "AppImage",
+          "arch": ["x64"]
+        },
+        {
+          "target": "deb",
+          "arch": ["x64"]
+        }
       ],
       "icon": "public/app-icon.png",
       "category": "Development",

--- a/web/package.json
+++ b/web/package.json
@@ -39,6 +39,7 @@
     "test:catalog-guard": "node --experimental-strip-types src/catalog-request-guard.test.mjs",
     "test:machine-payload": "node --experimental-strip-types src/machine-payload.test.mjs",
     "test:platform": "node src/platform-regression.test.mjs",
+    "test:completion-audio": "node src/completion-audio-regression.test.mjs",
     "test:desktop": "npm run build:electron && node --test electron/*.test.mjs",
     "test:desktop:menu": "npm run build:electron && electron scripts/menu-smoke.mjs"
   },
@@ -86,14 +87,8 @@
     },
     "linux": {
       "target": [
-        {
-          "target": "AppImage",
-          "arch": ["x64"]
-        },
-        {
-          "target": "deb",
-          "arch": ["x64"]
-        }
+        "AppImage",
+        "deb"
       ],
       "icon": "public/app-icon.png",
       "category": "Development",

--- a/web/src/completion-audio-regression.test.mjs
+++ b/web/src/completion-audio-regression.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+const source = readFileSync(fileURLToPath(new URL("./completion-audio.ts", import.meta.url)), "utf8")
+const main = readFileSync(fileURLToPath(new URL("./main.tsx", import.meta.url)), "utf8")
+
+assert.match(main, /installCompletionAudioGuard\(\)/, "completion guard must be installed before the app renders")
+assert.match(source, /prompt_async\|command/, "prompt and command submissions must arm completion tracking")
+assert.match(source, /\/abort/, "abort must cancel an armed completion")
+assert.match(source, /\/session\/status/, "session status is the authoritative completion source")
+assert.match(source, /WORKING_STATES = new Set\(\["busy", "retry", "waiting"\]\)/)
+assert.match(source, /if \(!entry\.sawWorking && !entry\.sawAssistantActivity\) continue/, "idle before work starts must not play")
+assert.match(source, /noteSuppressedAssistantAudioRequest\(\)/, "the old first-fragment sound request must be suppressed")
+assert.match(source, /primePlayback\(\)/, "playback must be primed at user submission time for native WebView")
+assert.match(source, /CapacitorHttp\.request = async/, "native HTTP status polling must drive the same completion tracker")
+
+console.log("completion audio regression checks passed")

--- a/web/src/completion-audio.ts
+++ b/web/src/completion-audio.ts
@@ -1,79 +1,203 @@
+import { CapacitorHttp } from "@capacitor/core"
 import type { SessionStatus } from "./types"
 
 const COMPLETION_AUDIO_SUFFIX = "audio/staplebops-01.aac"
 const WORKING_STATES = new Set(["busy", "retry", "waiting"])
-
-type AudioLike = HTMLAudioElement
+const PROMPT_PATH = /\/session\/([^/?]+)\/(?:prompt_async|command)(?:\?|$)/
+const ABORT_PATH = /\/session\/([^/?]+)\/abort(?:\?|$)/
 
 type ArmedCompletion = {
   sessionID: string
+  armedAt: number
   sawWorking: boolean
+  sawAssistantActivity: boolean
 }
 
-let armed: ArmedCompletion | null = null
-let deferredAudio: AudioLike | null = null
 let installed = false
 let nativePlay: ((this: HTMLMediaElement) => Promise<void>) | null = null
+let playbackAudio: HTMLAudioElement | null = null
+const armed = new Map<string, ArmedCompletion>()
 
-function isCompletionAudio(element: HTMLMediaElement): element is AudioLike {
+function requestURL(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input
+  if (input instanceof URL) return input.href
+  return input.url
+}
+
+function requestMethod(input: RequestInfo | URL, init?: RequestInit): string {
+  if (init?.method) return init.method.toUpperCase()
+  return typeof Request !== "undefined" && input instanceof Request ? input.method.toUpperCase() : "GET"
+}
+
+function isCompletionAudio(element: HTMLMediaElement): boolean {
   const source = element.currentSrc || (element instanceof HTMLAudioElement ? element.src : "")
   return source.includes(COMPLETION_AUDIO_SUFFIX)
 }
 
-function playDeferredCompletion(): void {
-  const audio = deferredAudio
-  deferredAudio = null
-  if (!audio || !nativePlay) return
+function mostLikelyActiveCompletion(): ArmedCompletion | null {
+  const values = [...armed.values()]
+  if (values.length === 0) return null
+  const working = values.filter((entry) => entry.sawWorking)
+  return (working.length > 0 ? working : values).sort((a, b) => b.armedAt - a.armedAt)[0] ?? null
+}
+
+function primePlayback(): void {
+  if (!playbackAudio || !nativePlay) return
+  const audio = playbackAudio
+  audio.muted = true
+  audio.currentTime = 0
   try {
-    audio.currentTime = 0
-    void nativePlay.call(audio).catch(() => undefined)
+    void nativePlay.call(audio).then(() => {
+      audio.pause()
+      audio.currentTime = 0
+      audio.muted = false
+    }).catch(() => {
+      audio.muted = false
+    })
   } catch {
-    // Audio is best-effort. Completion state must never fail because playback was blocked.
+    audio.muted = false
   }
 }
 
-export function installCompletionAudioGuard(): void {
-  if (installed || typeof HTMLMediaElement === "undefined") return
-  installed = true
-  nativePlay = HTMLMediaElement.prototype.play
-  HTMLMediaElement.prototype.play = function guardedCompletionPlay(this: HTMLMediaElement): Promise<void> {
-    if (!isCompletionAudio(this)) return nativePlay!.call(this)
-    // App.tsx currently asks for the sound when the first assistant fragment arrives. Keep the
-    // request, but defer the actual playback until session/status confirms the run has finished.
-    deferredAudio = this
-    return Promise.resolve()
+function playCompletion(): void {
+  if (!playbackAudio || !nativePlay) return
+  const audio = playbackAudio
+  audio.muted = false
+  audio.currentTime = 0
+  try {
+    void nativePlay.call(audio).catch(() => undefined)
+  } catch {
+    // Playback is best-effort and must never interfere with session state.
   }
 }
 
 export function armCompletionAudio(sessionID: string): void {
-  armed = { sessionID, sawWorking: false }
-  deferredAudio = null
+  armed.set(sessionID, {
+    sessionID,
+    armedAt: Date.now(),
+    sawWorking: false,
+    sawAssistantActivity: false
+  })
+  // This runs at prompt submission time, while the user gesture is still active. Priming the
+  // element here makes later completion playback reliable in Capacitor/WebView without making a
+  // sound at send time.
+  primePlayback()
 }
 
 export function cancelCompletionAudio(sessionID: string): void {
-  if (armed?.sessionID !== sessionID) return
-  armed = null
-  deferredAudio = null
+  armed.delete(sessionID)
 }
 
 export function observeCompletionStatuses(statuses: Record<string, SessionStatus>): void {
-  if (!armed) return
-  const status = statuses[armed.sessionID]?.type ?? "idle"
-  if (WORKING_STATES.has(status)) {
-    armed.sawWorking = true
-    return
-  }
-
-  // The normal case observes working -> idle. Very fast replies can finish between status polls;
-  // in that case App.tsx's deferred playback request proves that an assistant reply actually
-  // arrived, so an idle status is authoritative completion rather than a send-time false positive.
-  if (armed.sawWorking || deferredAudio) {
-    armed = null
-    playDeferredCompletion()
+  for (const [sessionID, entry] of armed) {
+    const sessionStatus = statuses[sessionID]
+    if (!sessionStatus) continue
+    if (WORKING_STATES.has(sessionStatus.type)) {
+      entry.sawWorking = true
+      continue
+    }
+    if (!entry.sawWorking && !entry.sawAssistantActivity) continue
+    armed.delete(sessionID)
+    playCompletion()
   }
 }
 
+function noteSuppressedAssistantAudioRequest(): void {
+  const entry = mostLikelyActiveCompletion()
+  if (entry) entry.sawAssistantActivity = true
+}
+
+function inspectRequest(url: string, method: string): string | null {
+  if (method !== "POST") return null
+  const abort = url.match(ABORT_PATH)
+  if (abort) {
+    cancelCompletionAudio(decodeURIComponent(abort[1]))
+    return null
+  }
+  const prompt = url.match(PROMPT_PATH)
+  if (!prompt) return null
+  const sessionID = decodeURIComponent(prompt[1])
+  armCompletionAudio(sessionID)
+  return sessionID
+}
+
+function parseStatusPayload(value: unknown): Record<string, SessionStatus> | null {
+  if (!value) return null
+  if (typeof value === "string") {
+    try {
+      return parseStatusPayload(JSON.parse(value))
+    } catch {
+      return null
+    }
+  }
+  return typeof value === "object" && !Array.isArray(value) ? value as Record<string, SessionStatus> : null
+}
+
+function installFetchTracking(): void {
+  if (typeof window === "undefined" || typeof window.fetch !== "function") return
+  const originalFetch = window.fetch.bind(window)
+  window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = requestURL(input)
+    const method = requestMethod(input, init)
+    const armedSessionID = inspectRequest(url, method)
+    let response: Response
+    try {
+      response = await originalFetch(input, init)
+    } catch (error) {
+      if (armedSessionID) cancelCompletionAudio(armedSessionID)
+      throw error
+    }
+    if (armedSessionID && !response.ok) cancelCompletionAudio(armedSessionID)
+    if (method === "GET" && url.includes("/session/status") && response.ok) {
+      void response.clone().json().then((payload) => {
+        const statuses = parseStatusPayload(payload)
+        if (statuses) observeCompletionStatuses(statuses)
+      }).catch(() => undefined)
+    }
+    return response
+  }
+}
+
+function installCapacitorTracking(): void {
+  const originalRequest = CapacitorHttp.request.bind(CapacitorHttp)
+  CapacitorHttp.request = async (options) => {
+    const method = (options.method ?? "GET").toUpperCase()
+    const armedSessionID = inspectRequest(options.url, method)
+    try {
+      const response = await originalRequest(options)
+      if (armedSessionID && response.status >= 400) cancelCompletionAudio(armedSessionID)
+      if (method === "GET" && options.url.includes("/session/status") && response.status < 400) {
+        const statuses = parseStatusPayload(response.data)
+        if (statuses) observeCompletionStatuses(statuses)
+      }
+      return response
+    } catch (error) {
+      if (armedSessionID) cancelCompletionAudio(armedSessionID)
+      throw error
+    }
+  }
+}
+
+export function installCompletionAudioGuard(): void {
+  if (installed || typeof HTMLMediaElement === "undefined" || typeof Audio === "undefined") return
+  installed = true
+  nativePlay = HTMLMediaElement.prototype.play
+  playbackAudio = new Audio(`${import.meta.env.BASE_URL}${COMPLETION_AUDIO_SUFFIX}`)
+  playbackAudio.preload = "auto"
+
+  HTMLMediaElement.prototype.play = function guardedCompletionPlay(this: HTMLMediaElement): Promise<void> {
+    if (!isCompletionAudio(this)) return nativePlay!.call(this)
+    // App.tsx currently requests its completion sound as soon as the first assistant fragment
+    // arrives. Suppress that premature playback and use it only as evidence that assistant output
+    // has started; the authoritative playback happens after session/status returns to idle.
+    noteSuppressedAssistantAudioRequest()
+    return Promise.resolve()
+  }
+
+  installFetchTracking()
+  installCapacitorTracking()
+}
+
 export function resetCompletionAudioForTests(): void {
-  armed = null
-  deferredAudio = null
+  armed.clear()
 }

--- a/web/src/completion-audio.ts
+++ b/web/src/completion-audio.ts
@@ -1,0 +1,79 @@
+import type { SessionStatus } from "./types"
+
+const COMPLETION_AUDIO_SUFFIX = "audio/staplebops-01.aac"
+const WORKING_STATES = new Set(["busy", "retry", "waiting"])
+
+type AudioLike = HTMLAudioElement
+
+type ArmedCompletion = {
+  sessionID: string
+  sawWorking: boolean
+}
+
+let armed: ArmedCompletion | null = null
+let deferredAudio: AudioLike | null = null
+let installed = false
+let nativePlay: ((this: HTMLMediaElement) => Promise<void>) | null = null
+
+function isCompletionAudio(element: HTMLMediaElement): element is AudioLike {
+  const source = element.currentSrc || (element instanceof HTMLAudioElement ? element.src : "")
+  return source.includes(COMPLETION_AUDIO_SUFFIX)
+}
+
+function playDeferredCompletion(): void {
+  const audio = deferredAudio
+  deferredAudio = null
+  if (!audio || !nativePlay) return
+  try {
+    audio.currentTime = 0
+    void nativePlay.call(audio).catch(() => undefined)
+  } catch {
+    // Audio is best-effort. Completion state must never fail because playback was blocked.
+  }
+}
+
+export function installCompletionAudioGuard(): void {
+  if (installed || typeof HTMLMediaElement === "undefined") return
+  installed = true
+  nativePlay = HTMLMediaElement.prototype.play
+  HTMLMediaElement.prototype.play = function guardedCompletionPlay(this: HTMLMediaElement): Promise<void> {
+    if (!isCompletionAudio(this)) return nativePlay!.call(this)
+    // App.tsx currently asks for the sound when the first assistant fragment arrives. Keep the
+    // request, but defer the actual playback until session/status confirms the run has finished.
+    deferredAudio = this
+    return Promise.resolve()
+  }
+}
+
+export function armCompletionAudio(sessionID: string): void {
+  armed = { sessionID, sawWorking: false }
+  deferredAudio = null
+}
+
+export function cancelCompletionAudio(sessionID: string): void {
+  if (armed?.sessionID !== sessionID) return
+  armed = null
+  deferredAudio = null
+}
+
+export function observeCompletionStatuses(statuses: Record<string, SessionStatus>): void {
+  if (!armed) return
+  const status = statuses[armed.sessionID]?.type ?? "idle"
+  if (WORKING_STATES.has(status)) {
+    armed.sawWorking = true
+    return
+  }
+
+  // The normal case observes working -> idle. Very fast replies can finish between status polls;
+  // in that case App.tsx's deferred playback request proves that an assistant reply actually
+  // arrived, so an idle status is authoritative completion rather than a send-time false positive.
+  if (armed.sawWorking || deferredAudio) {
+    armed = null
+    playDeferredCompletion()
+  }
+}
+
+export function resetCompletionAudioForTests(): void {
+  armed = null
+  deferredAudio = null
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,9 +2,12 @@ import React from "react"
 import ReactDOM from "react-dom/client"
 import { Capacitor } from "@capacitor/core"
 import App from "./App"
+import { installCompletionAudioGuard } from "./completion-audio"
 import { ErrorBoundary } from "./ErrorBoundary"
 import { SERVER_STORAGE_KEYS } from "./storageKeys"
 import "./styles.css"
+
+installCompletionAudioGuard()
 
 const taskDeskTestMode = import.meta.env.DEV && new URLSearchParams(window.location.search).get("taskdesk-test") === "1"
 


### PR DESCRIPTION
## Summary

Moves completion audio onto the actual session lifecycle instead of the first assistant fragment.

The existing UI can still request its completion sound when assistant output begins, but the new controller suppresses that premature playback and only plays once the same session has actually returned from `busy` / `retry` / `waiting` to a non-working state.

The controller is installed before the app renders and observes both browser `fetch` and native `CapacitorHttp`, so web and Android use the same completion semantics. Prompt/command submission arms tracking, abort or failed submission cancels it, and playback is primed at user-submit time for WebView reliability without making a send-time sound.

Includes a dedicated regression guard and adds it to PR CI.

Targets `v3/taskdesk` only. Does not touch `main`.

Fixes #233.