### PR TITLE
fix(v3): restore first-run wizard and OpenCode routing

### DIFF
--- a/web/src/machineClient.ts
+++ b/web/src/machineClient.ts
@@ -9,6 +9,25 @@ function headers(config: ServerConfig): Record<string, string> {
   return value
 }
 
+function machineSnapshot(value: unknown): MachineSnapshot {
+  let parsed = value
+  if (typeof parsed === "string") {
+    try {
+      parsed = JSON.parse(parsed)
+    } catch {
+      throw new Error("Invalid machine discovery response")
+    }
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Invalid machine discovery response")
+  }
+  const candidate = parsed as Partial<MachineSnapshot>
+  if (!candidate.machine || !Array.isArray(candidate.agents)) {
+    throw new Error("Invalid machine discovery response")
+  }
+  return candidate as MachineSnapshot
+}
+
 export function noMachineStatus(status: number | undefined): boolean {
   return status === 404 || status === 503
 }
@@ -24,7 +43,7 @@ export async function discoverMachine(config: ServerConfig): Promise<MachineSnap
       if (result.error.code === "http" && noMachineStatus(result.error.status)) return null
       throw new Error(result.error.message)
     }
-    return result.response.data as MachineSnapshot
+    return machineSnapshot(result.response.data)
   }
 
   const target = `${machineBaseUrl(config)}/v1/machine`
@@ -37,7 +56,7 @@ export async function discoverMachine(config: ServerConfig): Promise<MachineSnap
     }
     if (noMachineStatus(response.status)) return null
     if (response.status >= 400) throw new Error(`HTTP ${response.status}`)
-    return response.data as MachineSnapshot
+    return machineSnapshot(response.data)
   }
 
   let response: Response
@@ -48,7 +67,7 @@ export async function discoverMachine(config: ServerConfig): Promise<MachineSnap
   }
   if (noMachineStatus(response.status)) return null
   if (!response.ok) throw new Error(`HTTP ${response.status}`)
-  return await response.json() as MachineSnapshot
+  return machineSnapshot(await response.json())
 }
 
 export function selectableMachineAgents(machine: MachineSnapshot): MachineSnapshot["agents"] {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -7,6 +7,7 @@ import { backendDisplayName } from "./backendSetup"
 import { installCompletionAudioGuard } from "./completion-audio"
 import { ConnectServerWizard } from "./components/panels"
 import { ErrorBoundary } from "./ErrorBoundary"
+import { createTranslator, normalizeLanguage } from "./i18n"
 import { discoverMachine } from "./machineClient"
 import {
   ACTIVE_PROFILE_CHANGED_EVENT,
@@ -20,12 +21,17 @@ import "./styles.css"
 
 installCompletionAudioGuard()
 
+const LANGUAGE_STORAGE_KEY = "opencode.remote.language"
 const taskDeskTestMode = import.meta.env.DEV && new URLSearchParams(window.location.search).get("taskdesk-test") === "1"
 
 function AppProfileBoundary() {
   const [revision, setRevision] = useState(0)
   const profiles = useMemo(loadServerProfiles, [revision])
   const activeProfile = useMemo(() => loadActiveServerProfile(profiles), [profiles])
+  const t = useMemo(
+    () => createTranslator(normalizeLanguage(localStorage.getItem(LANGUAGE_STORAGE_KEY) || navigator.language)),
+    [revision]
+  )
   const needsInitialSetup = !isValidServerConfig(activeProfile.config)
 
   useEffect(() => {
@@ -37,10 +43,7 @@ function AppProfileBoundary() {
   if (needsInitialSetup) {
     return (
       <ConnectServerWizard
-        t={(key, values) => {
-          const text = String(key)
-          return values ? Object.entries(values).reduce((result, [name, value]) => result.replace(`{${name}}`, String(value)), text) : text
-        }}
+        t={t}
         initialName={activeProfile.name}
         onCancel={() => undefined}
         onDiscover={discoverMachine}
@@ -50,9 +53,9 @@ function AppProfileBoundary() {
             if (health.backend && health.backend !== config.backend) {
               throw new Error(`Expected ${backendDisplayName(config.backend)} but reached ${backendDisplayName(health.backend)}`)
             }
-            return { ok: true, message: `Connected to ${health.version}` }
+            return { ok: true, message: t('settings.connectedTo', { version: health.version }) }
           } catch (error) {
-            return { ok: false, message: (error as Error).message }
+            return { ok: false, message: t('settings.connectionFailed', { message: (error as Error).message }) }
           }
         }}
         onSave={(name, config) => {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -16,7 +16,7 @@ import {
   persistServerProfiles
 } from "./serverProfiles"
 import { SERVER_STORAGE_KEYS } from "./storageKeys"
-import type { ServerConfig } from "./types"
+import type { MachineSnapshot, ServerConfig } from "./types"
 import "./styles.css"
 
 installCompletionAudioGuard()
@@ -24,8 +24,26 @@ installCompletionAudioGuard()
 const LANGUAGE_STORAGE_KEY = "opencode.remote.language"
 const taskDeskTestMode = import.meta.env.DEV && new URLSearchParams(window.location.search).get("taskdesk-test") === "1"
 
+function matchingMachineAgent(machine: MachineSnapshot | null, backend: ServerConfig["backend"]) {
+  return machine?.agents.find((agent) =>
+    agent.backend === backend && (agent.state === "available" || agent.state === "configured")
+  )
+}
+
+function profileRoutingKey(profileID: string, config: ServerConfig): string {
+  return JSON.stringify({
+    profileID,
+    backend: config.backend,
+    host: config.host.trim().toLowerCase(),
+    port: config.port,
+    username: config.username,
+    password: config.password
+  })
+}
+
 function AppProfileBoundary() {
   const [revision, setRevision] = useState(0)
+  const [checkedRoutingKey, setCheckedRoutingKey] = useState<string | null>(null)
   const profiles = useMemo(loadServerProfiles, [revision])
   const activeProfile = useMemo(() => loadActiveServerProfile(profiles), [profiles])
   const t = useMemo(
@@ -33,12 +51,43 @@ function AppProfileBoundary() {
     [revision]
   )
   const needsInitialSetup = !isValidServerConfig(activeProfile.config)
+  const routingKey = profileRoutingKey(activeProfile.id, activeProfile.config)
+  const needsRoutingDiscovery = !needsInitialSetup && !activeProfile.config.agentId && checkedRoutingKey !== routingKey
 
   useEffect(() => {
-    const onProfileChanged = () => setRevision((value) => value + 1)
+    const onProfileChanged = () => {
+      setCheckedRoutingKey(null)
+      setRevision((value) => value + 1)
+    }
     window.addEventListener(ACTIVE_PROFILE_CHANGED_EVENT, onProfileChanged)
     return () => window.removeEventListener(ACTIVE_PROFILE_CHANGED_EVENT, onProfileChanged)
   }, [])
+
+  useEffect(() => {
+    if (!needsRoutingDiscovery) return
+    let cancelled = false
+    void discoverMachine(activeProfile.config).then((machine) => {
+      if (cancelled) return
+      const agent = matchingMachineAgent(machine, activeProfile.config.backend)
+      if (agent) {
+        const nextProfiles = profiles.map((profile) =>
+          profile.id === activeProfile.id
+            ? { ...profile, config: { ...profile.config, agentId: agent.id } }
+            : profile
+        )
+        persistServerProfiles(nextProfiles, activeProfile.id)
+        setCheckedRoutingKey(null)
+        setRevision((value) => value + 1)
+        return
+      }
+      setCheckedRoutingKey(routingKey)
+    }).catch(() => {
+      if (!cancelled) setCheckedRoutingKey(routingKey)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [activeProfile, needsRoutingDiscovery, profiles, routingKey])
 
   if (needsInitialSetup) {
     return (
@@ -59,13 +108,34 @@ function AppProfileBoundary() {
           }
         }}
         onSave={(name, config) => {
-          const nextProfiles = profiles.map((profile) =>
-            profile.id === activeProfile.id ? { ...profile, name: name.trim() || profile.name, config } : profile
-          )
-          persistServerProfiles(nextProfiles, activeProfile.id)
-          setRevision((value) => value + 1)
+          void (async () => {
+            let routedConfig = config
+            if (!config.agentId) {
+              const machine = await discoverMachine(config).catch(() => null)
+              const agent = matchingMachineAgent(machine, config.backend)
+              if (agent) routedConfig = { ...config, agentId: agent.id }
+            }
+            const nextProfiles = profiles.map((profile) =>
+              profile.id === activeProfile.id
+                ? { ...profile, name: name.trim() || profile.name, config: routedConfig }
+                : profile
+            )
+            persistServerProfiles(nextProfiles, activeProfile.id)
+            setCheckedRoutingKey(null)
+            setRevision((value) => value + 1)
+          })()
         }}
       />
+    )
+  }
+
+  if (needsRoutingDiscovery) {
+    return (
+      <div className="app-shell">
+        <div className="empty-state compact" role="status" aria-live="polite">
+          <p>{t('connection.connecting')}</p>
+        </div>
+      </div>
     )
   }
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,11 +1,21 @@
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useMemo, useState } from "react"
 import ReactDOM from "react-dom/client"
 import { Capacitor } from "@capacitor/core"
 import App from "./App"
+import { api, isValidServerConfig } from "./api"
+import { backendDisplayName } from "./backendSetup"
 import { installCompletionAudioGuard } from "./completion-audio"
+import { ConnectServerWizard } from "./components/panels"
 import { ErrorBoundary } from "./ErrorBoundary"
-import { ACTIVE_PROFILE_CHANGED_EVENT } from "./serverProfiles"
+import { discoverMachine } from "./machineClient"
+import {
+  ACTIVE_PROFILE_CHANGED_EVENT,
+  loadActiveServerProfile,
+  loadServerProfiles,
+  persistServerProfiles
+} from "./serverProfiles"
 import { SERVER_STORAGE_KEYS } from "./storageKeys"
+import type { ServerConfig } from "./types"
 import "./styles.css"
 
 installCompletionAudioGuard()
@@ -14,11 +24,48 @@ const taskDeskTestMode = import.meta.env.DEV && new URLSearchParams(window.locat
 
 function AppProfileBoundary() {
   const [revision, setRevision] = useState(0)
+  const profiles = useMemo(loadServerProfiles, [revision])
+  const activeProfile = useMemo(() => loadActiveServerProfile(profiles), [profiles])
+  const needsInitialSetup = !isValidServerConfig(activeProfile.config)
+
   useEffect(() => {
     const onProfileChanged = () => setRevision((value) => value + 1)
     window.addEventListener(ACTIVE_PROFILE_CHANGED_EVENT, onProfileChanged)
     return () => window.removeEventListener(ACTIVE_PROFILE_CHANGED_EVENT, onProfileChanged)
   }, [])
+
+  if (needsInitialSetup) {
+    return (
+      <ConnectServerWizard
+        t={(key, values) => {
+          const text = String(key)
+          return values ? Object.entries(values).reduce((result, [name, value]) => result.replace(`{${name}}`, String(value)), text) : text
+        }}
+        initialName={activeProfile.name}
+        onCancel={() => undefined}
+        onDiscover={discoverMachine}
+        onTest={async (config: ServerConfig) => {
+          try {
+            const health = await api.health(config)
+            if (health.backend && health.backend !== config.backend) {
+              throw new Error(`Expected ${backendDisplayName(config.backend)} but reached ${backendDisplayName(health.backend)}`)
+            }
+            return { ok: true, message: `Connected to ${health.version}` }
+          } catch (error) {
+            return { ok: false, message: (error as Error).message }
+          }
+        }}
+        onSave={(name, config) => {
+          const nextProfiles = profiles.map((profile) =>
+            profile.id === activeProfile.id ? { ...profile, name: name.trim() || profile.name, config } : profile
+          )
+          persistServerProfiles(nextProfiles, activeProfile.id)
+          setRevision((value) => value + 1)
+        }}
+      />
+    )
+  }
+
   return <App key={revision} />
 }
 

--- a/web/src/platform-regression.test.mjs
+++ b/web/src/platform-regression.test.mjs
@@ -5,6 +5,7 @@ const desktopBridge = readFileSync(new URL('./desktopBridge.ts', import.meta.url
 const main = readFileSync(new URL('./main.tsx', import.meta.url), 'utf8')
 const app = readFileSync(new URL('./App.tsx', import.meta.url), 'utf8')
 const api = readFileSync(new URL('./api.ts', import.meta.url), 'utf8')
+const machineClient = readFileSync(new URL('./machineClient.ts', import.meta.url), 'utf8')
 
 assert.match(desktopBridge, /window\.harnessDesktop/, 'Electron detection must use preload marker')
 assert.match(main, /!window\.harnessDesktop\?\.platform\.isDesktop/, 'Electron must skip service-worker registration')
@@ -17,5 +18,8 @@ assert.match(desktopBridge, /profileId: string/, 'Desktop stream adapter must ac
 assert.match(api, /function normalizeNativeResponseData\(data: unknown\): unknown/, 'Native transport must normalize stringified JSON payloads')
 assert.match(api, /return JSON\.parse\(trimmed\)/, 'Native JSON normalizer must parse JSON-looking strings')
 assert.match(api, /normalizeNativeResponseData\(response\.data\) as T/, 'Capacitor responses must use native JSON normalization before reaching API callers')
+assert.match(machineClient, /if \(typeof parsed === "string"\)/, 'native machine discovery must accept a JSON string payload')
+assert.match(machineClient, /parsed = JSON\.parse\(parsed\)/, 'stringified machine discovery payloads must be decoded')
+assert.match(machineClient, /return machineSnapshot\(response\.data\)/, 'Capacitor machine discovery must validate and normalize the native response before the wizard uses it')
 
 console.log('platform selection regression tests passed')

--- a/web/src/serverProfiles.ts
+++ b/web/src/serverProfiles.ts
@@ -226,7 +226,10 @@ export function persistServerProfiles(profiles: SavedServerProfile[], activeProf
   localStorage.setItem(SERVER_PROFILES_STORAGE_KEY, JSON.stringify(profiles))
   localStorage.setItem(ACTIVE_PROFILE_STORAGE_KEY, activeProfileID)
 
-  if (profileChanged || connectionChanged) {
+  // Switching profiles must remount the app so profile-scoped state is re-read. Editing the host,
+  // port or credentials of the current profile must not: Settings persists valid drafts while the
+  // user types, and remounting there closes the editor and starts a connection mid-entry.
+  if (profileChanged) {
     window.dispatchEvent(new CustomEvent(ACTIVE_PROFILE_CHANGED_EVENT, { detail: activeProfileID }))
   }
 }

--- a/web/src/settings-regression.test.mjs
+++ b/web/src/settings-regression.test.mjs
@@ -3,6 +3,8 @@ import { readFileSync } from 'node:fs'
 
 const app = readFileSync(new URL('./App.tsx', import.meta.url), 'utf8')
 const api = readFileSync(new URL('./api.ts', import.meta.url), 'utf8')
+const main = readFileSync(new URL('./main.tsx', import.meta.url), 'utf8')
+const serverProfiles = readFileSync(new URL('./serverProfiles.ts', import.meta.url), 'utf8')
 const i18n = readFileSync(new URL('./i18n.ts', import.meta.url), 'utf8')
 const styles = readFileSync(new URL('./styles.css', import.meta.url), 'utf8')
 const shell = readFileSync(new URL('./components/shell.tsx', import.meta.url), 'utf8')
@@ -34,6 +36,18 @@ assert.ok(app.includes('health.backend && health.backend !== configToTest.backen
 assert.ok(app.includes('https://github.com/giuliastro/harness-remote#'), 'Help should link to the canonical repository')
 assert.equal(app.includes('https://github.com/gervaso-assistant/opencode-remote-android#'), false, 'Help must not link to the obsolete repository owner')
 
+// First-run configuration is a guided flow, not the editable Settings panel. A blank fallback
+// profile must never mount App first, because App's Settings screen auto-persists valid drafts.
+assert.ok(main.includes('const needsInitialSetup = !isValidServerConfig(activeProfile.config)'), 'first-run setup must be derived from the active profile validity')
+assert.match(main, /if \(needsInitialSetup\) \{[\s\S]*?<ConnectServerWizard/, 'an unconfigured install must render the connection wizard directly')
+assert.match(main, /onCancel=\{\(\) => undefined\}/, 'the required first-run wizard must not dismiss into the raw Settings form')
+
+// Settings may still auto-save edits, but changing the current profile identity must not remount the
+// whole React tree. That remount closed the editor after a couple of typed characters and started a
+// connection with a half-entered address.
+assert.ok(serverProfiles.includes('if (profileChanged) {'), 'only an actual saved-profile switch should emit the remount event')
+assert.doesNotMatch(serverProfiles, /if \(profileChanged \|\| connectionChanged\) \{\s*window\.dispatchEvent/, 'editing host, port or credentials must not remount App')
+
 // A daemon-backed connection discovers the machine before falling back to the backend-specific
 // health check. Legacy servers return null from discovery and therefore keep the existing save flow.
 assert.ok(panels.includes('await import("../machineClient")'), 'the connection wizard should discover a machine without requiring App-level wiring')
@@ -45,6 +59,15 @@ assert.equal(panels.includes('Agent on '), false, 'the machine picker must not i
 assert.equal(panels.includes('agents discovered'), false, 'machine discovery feedback must not introduce hardcoded English copy')
 assert.equal(panels.includes('{agent.label} · {agent.state}'), false, 'protocol host states must not be rendered verbatim')
 assert.ok(panels.includes('agent.state !== "available" && agent.state !== "configured"'), 'unavailable machine agents must not be selectable')
+
+// A valid profile without an agentId is not safe to use against a multi-harness daemon. OpenCode is
+// intentionally not a bridge backend, so the old App-only repair skipped it and its first session
+// request fell through to the daemon primary, commonly Codex. Resolve every unscoped profile before
+// App mounts and repeat the same resolution on first-run Save in case the user skipped Test.
+assert.ok(main.includes('const needsRoutingDiscovery = !needsInitialSetup && !activeProfile.config.agentId'), 'unscoped saved profiles must be resolved before App starts loading sessions')
+assert.ok(main.includes('matchingMachineAgent(machine, activeProfile.config.backend)'), 'routing discovery must match the selected backend, including OpenCode')
+assert.match(main, /if \(needsRoutingDiscovery\) \{[\s\S]*?connection\.connecting/, 'the app must not mount its session UI while daemon routing is unresolved')
+assert.match(main, /onSave=\{\(name, config\) => \{[\s\S]*?if \(!config\.agentId\)[\s\S]*?discoverMachine\(config\)/, 'saving the first server must resolve its daemon agent even when Test was skipped')
 
 // Automatic server names are suggestions. Once the user types a name, later discovery or agent
 // selection must not silently replace it with a generated machine/harness label.


### PR DESCRIPTION
## Summary

- always show the connection wizard when the active profile is not configured, instead of mounting the raw Settings form
- stop current-profile host/port/credential edits from remounting the whole app while Settings auto-saves a draft
- normalize stringified native `/v1/machine` responses before the connection wizard consumes them
- resolve any valid saved profile without an `agentId` against machine discovery before the session UI mounts, including OpenCode profiles
- resolve the same daemon route on first-run Save even if the user skipped the explicit connection test
- keep direct legacy OpenCode servers compatible: when `/v1/machine` is unavailable the app proceeds without inventing an agent route

Adds regression coverage for the first-run wizard, Settings edit stability, pre-session routing, and native machine discovery.

Target: `v3/taskdesk` only. `main` is untouched.