### PR TITLE
fix(v3): polish server and session setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,22 @@
 
 **Run and supervise AI coding agents on the machines where your code already lives, from anywhere.**
 
-Harness Remote is a **local-first control plane for AI coding agents**. Connect to the machine where your code and credentials already live, then supervise OpenCode, Claude Code, Codex CLI, Oh My Pi and PI from one interface on phone, web or desktop.
+Harness Remote is a local-first control plane for AI coding agents. Connect to a machine where your repositories, CLIs, subscriptions and credentials already live, then supervise OpenCode, Claude Code, Codex CLI, Oh My Pi and PI from one interface on phone, web or desktop.
 
 **One interface. Multiple agents. Your machines, your credentials, your code.**
 
 > Harness Remote is not another coding agent. It is the control plane above them.
 
-Execution stays on your machines. Repositories stay on your machines. Agent credentials and model access stay on your machines. Harness Remote coordinates and supervises the work remotely.
+Execution stays on your machines. Repositories stay on your machines. Agent credentials and model access stay on your machines.
 
 ## Quick start
 
-There are currently two supported server paths. **The per-harness bridge is the stable compatibility path used by the current release.** The machine daemon is the newer path and is still being expanded.
+The v3 / TaskDesk path uses one launcher per machine. The launcher detects supported harness CLIs on `PATH` and chooses the appropriate runtime automatically.
 
-### Stable per-harness bridge
-
-Use this when you want the same connection model as the current stable clients: one configured server per harness.
-
-From a checkout of this repository:
+From a checkout or directly from GitHub:
 
 ```bash
-# Oh My Pi / OMP
-node bridge/src/cli.js \
-  --backend omp \
+npx github:giuliastro/harness-remote \
   --host 0.0.0.0 \
   --port 4097 \
   --username harness \
@@ -31,103 +25,129 @@ node bridge/src/cli.js \
   --root "$HOME/Software"
 ```
 
+The important values for a client connection are the machine address, public port, username and password. The normal public port is **4097**.
+
+When the machine has multiple supported harnesses, Harness Remote starts the machine daemon and exposes the detected agents through that one public endpoint. OpenCode can run as a managed internal host, normally on loopback port **4096**. That 4096 port is an implementation detail and should not be entered in the client wizard.
+
+The launcher currently recognizes:
+
+- OpenCode
+- Claude Code
+- Codex CLI
+- Oh My Pi (OMP)
+- PI
+
+If only one compatible harness is installed, the launcher may use the single-backend compatibility path automatically. The client setup does not change: connect to the public address printed by the launcher and let the connection wizard discover the available harness.
+
+If `--port` is omitted, the launcher starts from the normal public port and chooses an available port when necessary. If username/password are omitted, it generates credentials and prints them.
+
+### Connecting from the app
+
+Use **Connect server** and follow the connection wizard:
+
+1. choose the harness you want to expose as that saved profile;
+2. enter the host running Harness Remote;
+3. use the public daemon port, normally `4097`;
+4. enter the credentials printed by the launcher;
+5. test the connection and save.
+
+The wizard discovers the machine and routes the saved profile to the selected harness. Multiple profiles may point to the same machine and public port while selecting different harnesses.
+
+For example, one machine can appear in the client as separate saved profiles for OpenCode, Codex, Claude, OMP and PI, while all of them use the same `host:4097` endpoint.
+
+## Root and project access
+
+`--root` defines the filesystem boundary the remote client is allowed to browse and use. Pick a directory containing the projects you actually want Harness Remote to access, for example:
+
 ```bash
-# PI
-node bridge/src/cli.js \
-  --backend pi \
-  --host 0.0.0.0 \
-  --port 4097 \
-  --username harness \
-  --password "use-a-long-unique-password" \
-  --root "$HOME/Software"
+--root "$HOME/Software"
 ```
 
-The PI bridge uses `@automatalabs/pi-acp@0.2.5` by default. Claude Code and Codex CLI use the same bridge with `--backend claude` and `--backend codex` respectively. OpenCode continues to support its direct HTTP server path.
+A path outside that boundary is intentionally rejected.
 
-Then install a client from [GitHub Releases](https://github.com/giuliastro/harness-remote/releases/latest) and configure the matching harness with that host, port and credentials.
+Manual sessions can still choose a directory inside the configured root. TaskDesk is moving the normal workflow toward selecting a known **Project** and letting the daemon choose the project directory or prepare an isolated Git worktree for the task.
 
-### Experimental machine daemon / one-command launcher
+## TaskDesk / v3
 
-```bash
-npx github:giuliastro/harness-remote
+The v3 branch is evolving Harness Remote from a remote session viewer into a task-first control plane.
+
+The backend already supports:
+
+- machine identity and agent discovery;
+- multiple harnesses behind one machine endpoint;
+- per-agent model catalogs;
+- persisted projects and tasks;
+- Task -> Run -> Session linkage;
+- project-directory or isolated Git worktree execution;
+- running/completed/failed lifecycle state;
+- restart reconciliation;
+- result/workspace inspection and explicit cleanup.
+
+The client UX is being completed and stabilized before v3 replaces the current mainline experience.
+
+The intended product model is:
+
+```text
+Machine
+  Projects
+    Project
+      Tasks
+        Task
+          Run / Session
 ```
 
-The launcher detects supported CLIs on `PATH`, chooses a primary ACP backend, can start OpenCode as a managed internal host, picks a free public port and prints credentials.
+A Task chooses a machine, project, harness and model. For Git projects it can run in an isolated worktree, so the user does not have to type platform-specific filesystem paths from the phone.
 
-**Current limitation:** one launcher connection does **not yet serve every detected ACP backend simultaneously**. Today the daemon serves the selected primary ACP backend plus managed OpenCode when available. Other ACP CLIs may be detected and printed but are not yet independently routable through that same daemon connection. Use the stable per-harness bridge above for PI, OMP, Claude or Codex when you need deterministic compatibility with the current release.
+## Current clients
 
-## What works today
+- **Android**: native Capacitor app
+- **Web / PWA**: browser client
+- **Desktop**: Electron builds for Windows, macOS and Linux
 
-Harness Remote already gives you a common remote UI for five coding-agent harnesses:
+From any client you can monitor sessions, read streamed progress, send prompts, stop work, select models where supported, inspect questions/todos and use the capabilities exposed by each harness.
 
-| Harness | Stable connection |
-|---|---|
-| [OpenCode](https://github.com/sst/opencode) | direct HTTP server |
-| [Claude Code](https://code.claude.com/) | per-harness ACP bridge |
-| [Codex CLI](https://github.com/openai/codex) | per-harness ACP bridge |
-| [Oh My Pi (OMP)](https://omp.sh/) | per-harness ACP bridge |
-| [PI](https://pi.dev/) | per-harness ACP bridge via `@automatalabs/pi-acp` |
+## Legacy compatibility
 
-From Android, the web/PWA or the desktop app you can monitor sessions, read streamed progress, send prompts, stop work, select models where supported, inspect agent questions/todos and use the capabilities each harness exposes.
+The repository still contains the standalone per-harness bridge and direct OpenCode compatibility code because existing installations and stable releases may depend on them.
 
-The machine-daemon work adds a stable machine identity and a foundation for routing multiple agent hosts through one connection, but the fully universal multi-ACP path is still in progress. Legacy per-harness connections remain supported and are the compatibility baseline while that migration continues.
+Those paths are compatibility mechanisms, not the normal v3 onboarding flow. New v3 connections should use the machine launcher and the connection wizard above.
 
-The backend task foundation is also in place: the daemon can discover known projects, persist normalized tasks, prepare isolated Git worktrees, launch supported agents inside those workspaces, reconcile run state after daemon restarts, inspect Git results and explicitly release finished worktrees without silently deleting dirty or unmerged work.
+For low-level legacy setup details see [REFERENCE.md](REFERENCE.md).
 
-These task/worktree/finish primitives are currently **backend/API foundations**. The complete task-first client experience — selecting a project, creating work and reviewing the result directly from the app — is still being built.
+## Development
 
-## Where it is going
+Requirements:
 
-The goal is not just remote chat with coding agents. The goal is a local-first operating layer for **coding work across agents and machines**:
+- Node.js 20+
+- one or more supported harness CLIs installed on the host machine
 
-- **Task-first client UX** — expose the existing project/task/worktree/launch primitives as the normal way to create work from phone, web and desktop.
-- **Review / PR lifecycle** — extend result inspection into diff, tests/checks, review, PR creation and CI visibility.
-- **Multi-machine fleet** — supervise and explicitly place work across desktops, laptops and servers without moving credentials or repositories into a hosted control plane.
-- **Attention plane** — one place for the questions, permissions, failures and completed work that actually need you.
-- **Fleet attention / Inbox** — turn normalized attention into a useful mobile queue once enough concurrent work exists.
-- **Automatic coordination later** — choose machine and agent by availability, capability, workload, cost or rate limits only after explicit task/fleet workflows are reliable.
+Useful commands:
 
-See [docs/HARNESS_3_ROADMAP.md](docs/HARNESS_3_ROADMAP.md) for the architecture and implementation roadmap.
+```bash
+# Launcher / daemon from a checkout
+npm start
 
-## Why local-first
+# Bridge tests
+npm test
 
-Coding agents are most useful where the repositories, build tools, local models, subscriptions and credentials already are. Harness Remote keeps that execution boundary intact and adds the missing remote control layer on top.
+# Web client
+cd web
+npm ci
+npm run dev
+```
 
-That means you can leave a workstation or server doing the work while you use another device to check progress, answer the agent, stop a bad run or start the next step.
-
-## Clients
-
-- **Android** — native Capacitor app.
-- **Web / PWA** — installable web client published from this repository.
-- **Desktop** — Electron builds for Windows, macOS and Linux.
-
-Current screenshots:
-
-<table>
-  <tr>
-    <th width="50%">Sessions</th>
-    <th width="50%">Detail</th>
-  </tr>
-  <tr>
-    <td><img src="docs/screenshots/sessions.jpg" alt="Harness Remote sessions view"></td>
-    <td><img src="docs/screenshots/detail.jpg" alt="Harness Remote session detail"></td>
-  </tr>
-</table>
+The pull-request CI type-checks and builds the web app, runs the regression suites and bridge tests on Linux/macOS/Windows, and produces a signed debug APK for test branches.
 
 ## Documentation
 
-The previous full README — including detailed OpenCode, OMP, PI, Claude Code and Codex setup, Android/Desktop/PWA notes, security caveats, endpoints and build instructions — is preserved as [REFERENCE.md](REFERENCE.md).
-
-Other useful docs:
-
 - [Harness 3 roadmap](docs/HARNESS_3_ROADMAP.md)
+- [Nitsuga / TaskDesk integration plan](docs/NITSUGA_TASKDESK_INTEGRATION_PLAN.md)
 - [Harness dependency notes](docs/DEPENDENCIES.md)
+- [Legacy/full reference](REFERENCE.md)
 - [Contributing](CONTRIBUTING.md)
 
 ## Project status
 
-Harness Remote is evolving from a multi-harness remote client into a local-first control plane. The current stable release continues to use the proven per-harness connection model. The one-command launcher, machine daemon and normalized task/worktree/run/finish backend are the migration path toward a unified machine-level control plane, and are still being stabilized before replacing the compatibility path.
+Harness Remote is moving toward a machine-first, task-first model while keeping compatibility with existing per-harness installations during the transition.
 
-The repository deliberately keeps backward compatibility while that transition lands in small, reviewable slices.
-
-If that is a problem you have too — several coding agents, several machines, and too much terminal babysitting — issues and feedback are especially useful now.
+The immediate v3 goal is stability: every supported harness must route to the correct sessions and models, task launch must preserve project/workspace ownership, web and Android must behave consistently, and the exact candidate SHA must pass real-device testing before promotion to `main`.

--- a/web/package.json
+++ b/web/package.json
@@ -27,7 +27,7 @@
     "cap:sync:android": "npx cap sync android && node scripts/sync-native-live-events.mjs",
     "cap:add:android": "npx cap add android",
     "test:ui": "node src/ui-regression.test.mjs",
-    "test:settings": "node src/settings-regression.test.mjs",
+    "test:settings": "node src/settings-regression.test.mjs && node src/v3-ux-polish-regression.test.mjs",
     "test:model": "node src/model-regression.test.mjs",
     "test:events": "node --experimental-strip-types src/opencode-events.test.mjs",
     "test:profiles": "node --experimental-strip-types src/server-profiles.test.mjs",

--- a/web/src/backendSetup.ts
+++ b/web/src/backendSetup.ts
@@ -13,17 +13,20 @@ export function backendDisplayName(backend: BackendKind): string {
 }
 
 /** Whether the harness is reached through the bundled bridge rather than by talking to a server it
- *  runs itself — which is what decides the command the user has to run on the host machine. */
+ *  runs itself. Kept for API compatibility paths; the normal v3 connection wizard points every
+ *  harness at the machine daemon. */
 export function isBridgeBackend(backend: BackendKind): boolean {
   return backend === "omp" || backend === "pi" || backend === "claude" || backend === "codex"
 }
 
-export function backendDefaultPort(backend: BackendKind): number {
-  return backend === "opencode" ? 4096 : 4097
+/** v3 connects to the public machine daemon. Managed OpenCode may still use 4096 internally, but
+ *  clients must never be configured with that loopback-only implementation detail. */
+export function backendDefaultPort(_backend: BackendKind): number {
+  return 4097
 }
 
-export function backendDefaultUsername(backend: BackendKind): string {
-  return backend === "opencode" ? "opencode" : backend
+export function backendDefaultUsername(_backend: BackendKind): string {
+  return "harness"
 }
 
 export function backendDocsAnchor(backend: BackendKind): string {
@@ -35,28 +38,19 @@ export function backendDocsAnchor(backend: BackendKind): string {
 }
 
 /**
- * The exact line to paste on the machine that runs the agent, filled in with the address and
- * credentials the user has just typed. Setting a server up used to mean reading the Help page,
- * finding the right snippet for the chosen harness and editing four values into it by hand; the
- * wizard shows the finished command instead, which is the single biggest thing standing between a
- * new user and a working connection.
+ * The normal v3 host setup is harness-neutral: one launcher detects the installed harnesses and
+ * exposes them through the public machine daemon. The selected harness only affects which agent
+ * the client chooses after discovery, not which command the user has to start on the host.
  */
 export function backendSetupCommand(
-  backend: BackendKind,
+  _backend: BackendKind,
   options: { port?: number; username?: string; password?: string } = {}
 ): string {
-  const port = options.port && options.port > 0 ? options.port : backendDefaultPort(backend)
-  const username = options.username?.trim() || backendDefaultUsername(backend)
+  const port = options.port && options.port > 0 ? options.port : 4097
+  const username = options.username?.trim() || "harness"
   const password = options.password?.trim() || "your-password"
-  if (backend === "opencode") {
-    return [
-      `OPENCODE_SERVER_USERNAME=${username} \\`,
-      `OPENCODE_SERVER_PASSWORD=${password} \\`,
-      `npx -y opencode-ai serve --hostname 0.0.0.0 --port ${port}`
-    ].join("\n")
-  }
   return [
-    `npx --yes ./bridge --backend ${backend} \\`,
+    `npx github:giuliastro/harness-remote \\`,
     `  --host 0.0.0.0 --port ${port} \\`,
     `  --username ${username} --password ${password} \\`,
     `  --root "$PWD"`

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -18,8 +18,20 @@ import {
 import { SERVER_STORAGE_KEYS } from "./storageKeys"
 import type { MachineSnapshot, ServerConfig } from "./types"
 import "./styles.css"
+import "./v3-polish.css"
 
 installCompletionAudioGuard()
+
+// Creating a session is a deliberate multi-step action. A stray click on the dimmed page around
+// the dialog must not throw the user's folder selection away; only the dialog's explicit close or
+// cancel controls dismiss it.
+document.addEventListener("click", (event) => {
+  const target = event.target
+  if (!(target instanceof HTMLElement) || !target.classList.contains("modal-backdrop")) return
+  if (!target.querySelector("#new-session-title")) return
+  event.preventDefault()
+  event.stopImmediatePropagation()
+}, true)
 
 const LANGUAGE_STORAGE_KEY = "opencode.remote.language"
 const taskDeskTestMode = import.meta.env.DEV && new URLSearchParams(window.location.search).get("taskdesk-test") === "1"
@@ -56,6 +68,10 @@ function AppProfileBoundary() {
 
   useEffect(() => {
     const onProfileChanged = () => {
+      // Settings edits can persist while the user is still typing. If a stale profile-change event
+      // lands during that edit, remounting App would close the modal and start a connection using a
+      // half-edited draft. Keep the editor stable; explicit server selection already updates App.
+      if (document.querySelector(".settings")) return
       setCheckedRoutingKey(null)
       setRevision((value) => value + 1)
     }

--- a/web/src/serverProfiles.ts
+++ b/web/src/serverProfiles.ts
@@ -32,8 +32,8 @@ function defaultConfig(backend: BackendKind): ServerConfig {
   return {
     backend,
     host: "",
-    port: backend === "opencode" ? 4096 : 4097,
-    username: backend === "opencode" ? "opencode" : backend,
+    port: 4097,
+    username: "harness",
     password: ""
   }
 }

--- a/web/src/v3-polish.css
+++ b/web/src/v3-polish.css
@@ -1,0 +1,33 @@
+/* Small v3-only polish kept separate from the main design-system sheet while TaskDesk is still
+   stabilizing. These selectors intentionally depend only on existing DOM structure. */
+
+/* A long server list may scroll, but both server-management actions must remain visible. */
+.server-switcher-menu > .menu-separator:nth-last-child(3),
+.server-switcher-menu > .menu-item:nth-last-child(2),
+.server-switcher-menu > .menu-item:last-child {
+  position: sticky;
+  z-index: 2;
+  background: var(--surface);
+}
+
+.server-switcher-menu > .menu-separator:nth-last-child(3) {
+  bottom: calc(2 * var(--control-h));
+  margin-bottom: 0;
+}
+
+.server-switcher-menu > .menu-item:nth-last-child(2) {
+  bottom: var(--control-h);
+  width: 100%;
+  border-radius: 0;
+}
+
+.server-switcher-menu > .menu-item:last-child {
+  bottom: 0;
+  width: 100%;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
+}
+
+/* The first breadcrumb button already renders '/'. Do not add another separator before 'home'. */
+.path-breadcrumb > span:first-child + span > .path-breadcrumb-sep {
+  display: none;
+}

--- a/web/src/v3-ux-polish-regression.test.mjs
+++ b/web/src/v3-ux-polish-regression.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const read = (name) => fs.readFileSync(path.join(here, name), "utf8")
+const readRoot = (name) => fs.readFileSync(path.join(here, "..", "..", name), "utf8")
+
+const backendSetup = read("backendSetup.ts")
+const profiles = read("serverProfiles.ts")
+const main = read("main.tsx")
+const polish = read("v3-polish.css")
+const readme = readRoot("README.md")
+
+assert.match(backendSetup, /return 4097/)
+assert.doesNotMatch(backendSetup, /opencode-ai serve/)
+assert.match(backendSetup, /npx github:giuliastro\/harness-remote/)
+assert.doesNotMatch(backendSetup, /--backend \$\{backend\}/)
+assert.match(backendSetup, /return "harness"/)
+
+assert.match(profiles, /port: 4097/)
+assert.match(profiles, /username: "harness"/)
+
+assert.match(main, /target\.querySelector\("#new-session-title"\)/)
+assert.match(main, /event\.stopImmediatePropagation\(\)/)
+assert.match(main, /document\.querySelector\("\.settings"\)/)
+assert.match(main, /import "\.\/v3-polish\.css"/)
+
+assert.match(polish, /server-switcher-menu/)
+assert.match(polish, /position: sticky/)
+assert.match(polish, /path-breadcrumb > span:first-child \+ span/)
+
+assert.match(readme, /public port is \*\*4097\*\*/)
+assert.match(readme, /loopback port \*\*4096\*\*/)
+assert.match(readme, /one launcher per machine/)
+assert.doesNotMatch(readme, /does \*\*not yet serve every detected ACP backend simultaneously\*\*/)
+
+console.log("v3 UX polish regressions passed")


### PR DESCRIPTION
## Summary

- keep Connect server and Manage servers visible at the bottom of long server lists
- prevent New Session from closing when the backdrop is clicked
- remove the duplicate leading slash from POSIX folder breadcrumbs
- protect the Settings editor from stale profile-change remounts while configuration fields are being edited
- make the connection wizard machine-daemon-first: public port 4097 and username `harness` for every harness
- replace the old per-harness OpenCode setup command with the single auto-detecting Harness Remote launcher command
- update the README to document the current v3 machine-daemon, discovery, routing, root and TaskDesk workflow
- add regression coverage for the v3 connection/setup behavior

Target: `v3/taskdesk` only. `main` is untouched.