### PR TITLE
fix(v3): hide managed OpenCode internal endpoint

### DIFF
--- a/bridge/src/daemon-cli.js
+++ b/bridge/src/daemon-cli.js
@@ -210,8 +210,7 @@ async function main() {
       process.stdout.write(`  • ${host.label} — primary (${host.transport.toUpperCase()})\n`)
       continue
     }
-    const location = host.id === "opencode" ? ` on 127.0.0.1:${openCodePort}` : ""
-    process.stdout.write(`  • ${host.label} — managed ${host.transport.toUpperCase()}${location}, ${host.state}\n`)
+    process.stdout.write(`  • ${host.label} — managed ${host.transport.toUpperCase()}, ${host.state}\n`)
   }
   for (const result of managedResults) {
     if (result.status !== "available") process.stderr.write(`[${result.id}] unavailable: ${result.error?.message ?? "startup failed"}\n`)

--- a/bridge/test/daemon-cli-output.test.js
+++ b/bridge/test/daemon-cli-output.test.js
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+const source = await import("node:fs/promises").then(({ readFile }) => readFile(new URL("../src/daemon-cli.js", import.meta.url), "utf8"))
+
+test("managed agent summary does not expose the internal OpenCode endpoint", () => {
+  assert.doesNotMatch(source, /managed HTTP on 127\.0\.0\.1/)
+  assert.doesNotMatch(source, /const location = host\.id === "opencode"/)
+  assert.match(source, /managed \$\{host\.transport\.toUpperCase\(\)\}, \$\{host\.state\}/)
+})


### PR DESCRIPTION
Removes the internal managed OpenCode loopback address and port from the user-facing Active agents summary. The client should only use the public Harness Remote endpoint printed above; the managed OpenCode host remains an internal daemon detail.

Adds a regression test to keep that internal endpoint out of the summary.

Targets `v3/taskdesk` only. `main` is untouched.