### PR TITLE
feat(taskdesk): add universal multi-agent session workspace

### DIFF
--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -231,6 +231,7 @@ export class AcpService {
   #replaying = new Set()
   #historyLoader
   #ownedSessions = new Set()
+  #adoptedSessions = new Set()
   #acpOpenSessions = new Set()
   #promptAcknowledgements = new Map()
   #titles = new Map()
@@ -316,13 +317,22 @@ export class AcpService {
     return sessionView(session, "idle", this.#titleFor(session.sessionId))
   }
 
-  /** Adopt a task session created by an older daemon so PI can open it without session/load. */
+  /**
+   * Adopt a task session created by an older daemon so PI can open it without session/load.
+   *
+   * Ownership here only means "this bridge may prompt it directly"; it does not mean the transcript
+   * in memory is the whole conversation. Everything the task said while no daemon was running lives
+   * in the harness's own journal, and marking the session loaded on adoption made that unreachable:
+   * opening a restarted task showed the one recorded prompt and nothing else until a new message
+   * streamed in. Tracking adoption separately keeps prompting lock-free while still letting the
+   * journal fill in what this process never saw.
+   */
   async adoptTaskSession(sessionID, { title, prompt } = {}) {
     await this.#refreshSessions()
     const session = this.#sessions.get(sessionID)
     if (!session || this.#deletedSessions.has(sessionID)) return false
     this.#ownedSessions.add(sessionID)
-    this.#loaded.add(sessionID)
+    this.#adoptedSessions.add(sessionID)
     if (title && !this.#titles.has(sessionID)) this.#titles.set(sessionID, title)
     const messages = this.#messages.get(sessionID) ?? []
     if (prompt && !messages.some((message) => message.info?.role === "user" && message.parts?.some((part) => part.text === prompt))) {
@@ -346,6 +356,7 @@ export class AcpService {
       await this.#historyLoader.renameSession(sessionID, normalized)
       this.#loaded.delete(sessionID)
       this.#ownedSessions.delete(sessionID)
+      this.#adoptedSessions.delete(sessionID)
       this.#configOptions.delete(sessionID)
       this.#commandCatalogs.delete(sessionID)
       this.#actionStates.delete(sessionID)
@@ -422,6 +433,7 @@ export class AcpService {
     this.#authoritativeActionStates.delete(sessionID)
     this.#loaded.delete(sessionID)
     this.#ownedSessions.delete(sessionID)
+    this.#adoptedSessions.delete(sessionID)
     this.#promptAcknowledgements.delete(sessionID)
     this.#chunkMessageIDs.delete(`${sessionID}:user`)
     this.#chunkMessageIDs.delete(`${sessionID}:assistant`)
@@ -450,10 +462,20 @@ export class AcpService {
         this.#emit("session.error", sessionID, { message: "Harness session history could not be read" })
       }
     }
-    const externalHistory = Boolean(this.#historyLoader && !this.#ownedSessions.has(sessionID))
     const reloadHistory = refresh && this.#reloadOnHistoryRefresh
-    await this.#load(sessionID, reloadHistory || externalHistory)
+    await this.#load(sessionID, reloadHistory || this.#journalBacked(sessionID))
     return this.#messages.get(sessionID) ?? []
+  }
+
+  /**
+   * Whether the harness's own on-disk history is the authority for this session rather than what
+   * this process streamed. True for a session another client owns, and for an adopted task session
+   * until this bridge starts a turn on it — up to that point nothing about the conversation came
+   * through here, so re-reading the journal is what keeps the transcript current.
+   */
+  #journalBacked(sessionID) {
+    if (!this.#historyLoader) return false
+    return !this.#ownedSessions.has(sessionID) || this.#adoptedSessions.has(sessionID)
   }
 
   async todos(sessionID) {
@@ -681,6 +703,9 @@ export class AcpService {
   }
 
   #startTurn(sessionID, text, recorded = false, attachments = []) {
+    // From the first turn this bridge runs, its own stream is the live record for the session, the
+    // same way taking ownership of an external session stops the journal being re-read for it.
+    this.#adoptedSessions.delete(sessionID)
     const generation = (this.#turnGenerations.get(sessionID) ?? 0) + 1
     this.#turnGenerations.set(sessionID, generation)
     this.#cancelledSessions.delete(sessionID)
@@ -845,14 +870,23 @@ export class AcpService {
     // for both at once, which it does on every open. Each kind of load is tracked separately,
     // and a caller that never needed the options retries on its own rather than inheriting a
     // failure that does not apply to it.
-    const inFlight = this.#loads.get(sessionID)
-    if (inFlight && (inFlight.requireConfigOptions || !requireConfigOptions)) {
-      try {
-        await inFlight.promise
-        return
-      } catch (error) {
-        if (requireConfigOptions || !inFlight.requireConfigOptions) throw error
+    // Two loads must never overlap on one session even when they want different things: both blank
+    // #messages before replaying and then merge the replay back into what they captured first, so
+    // whichever finishes last wins and a caller that only asked for the transcript can read a
+    // half-rebuilt history. A load that needs the options therefore waits for a transcript-only
+    // load to settle instead of running beside it.
+    for (let inFlight = this.#loads.get(sessionID); inFlight; inFlight = this.#loads.get(sessionID)) {
+      if (inFlight.requireConfigOptions || !requireConfigOptions) {
+        try {
+          await inFlight.promise
+          return
+        } catch (error) {
+          if (requireConfigOptions || !inFlight.requireConfigOptions) throw error
+        }
+        break
       }
+      await inFlight.promise.catch(() => undefined)
+      if (this.#loads.get(sessionID) === inFlight) break
     }
     const promise = this.#loadSession(sessionID, requireConfigOptions)
     this.#loads.set(sessionID, { promise, requireConfigOptions })
@@ -882,7 +916,7 @@ export class AcpService {
             : mergeExternalHistory(persistedMessages, previousMessages)
           previousMessages = mergeFragmentedPiSnapshot(previousMessages)
           this.#messages.set(sessionID, previousMessages)
-          if (!this.#ownedSessions.has(sessionID) && !requireConfigOptions) {
+          if (this.#journalBacked(sessionID) && !requireConfigOptions) {
             this.#todos.set(sessionID, [])
             this.#loaded.add(sessionID)
             this.#persistSnapshot(sessionID)

--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -89,18 +89,26 @@ function semanticMessagePart(part) {
   return semantic
 }
 
-function semanticMessageSignature(message) {
-  return JSON.stringify({
+/**
+ * A turn that failed carries its reason on the envelope rather than in a part, and two failures are
+ * two different messages even when both have nothing to show. Leaving the reason out of the identity
+ * let one be deduplicated away against the other, and let a newly recorded failure pass for no
+ * change at all.
+ */
+function semanticMessageIdentity(message) {
+  return {
     role: message?.info?.role,
+    ...(message?.info?.error?.message ? { error: message.info.error.message } : {}),
     parts: (message?.parts ?? []).map(semanticMessagePart)
-  })
+  }
+}
+
+function semanticMessageSignature(message) {
+  return JSON.stringify(semanticMessageIdentity(message))
 }
 
 function semanticHistorySignature(messages) {
-  return JSON.stringify(messages.map((message) => ({
-    role: message?.info?.role,
-    parts: (message?.parts ?? []).map(semanticMessagePart)
-  })))
+  return JSON.stringify(messages.map(semanticMessageIdentity))
 }
 
 /** Exported for testing only. */
@@ -722,6 +730,7 @@ export class AcpService {
       ]
     }, 300_000).catch((error) => {
       if (this.#turnGenerations.get(sessionID) === generation) {
+        this.#recordTurnFailure(sessionID, error.message)
         this.#emit("session.error", sessionID, { message: error.message })
       }
     }).finally(() => {
@@ -732,6 +741,30 @@ export class AcpService {
       this.#persistSnapshot(sessionID)
       void this.#runNextQueued(sessionID)
     })
+  }
+
+  /**
+   * A turn that fails leaves the prompt on screen with nothing after it, and the live error banner
+   * that reports why is gone the moment the session is reopened. Attaching the reason to the turn's
+   * own assistant message keeps it in the transcript — and in the snapshot — so a failed reply stays
+   * distinguishable from a reply that never got recorded.
+   */
+  #recordTurnFailure(sessionID, message) {
+    if (typeof message !== "string" || !message.trim()) return
+    const messages = this.#messages.get(sessionID) ?? []
+    this.#messages.set(sessionID, messages)
+    const streamedID = this.#chunkMessageIDs.get(`${sessionID}:assistant`)
+    let target = streamedID ? messages.find((item) => item.info.id === streamedID) : undefined
+    if (!target) {
+      target = {
+        info: { id: randomUUID(), role: "assistant", sessionID, time: { created: Date.now() } },
+        parts: []
+      }
+      messages.push(target)
+    }
+    target.info.error = { name: "HarnessTurnError", message: message.trim() }
+    this.#emit("message.updated", sessionID)
+    this.#persistSnapshot(sessionID)
   }
 
   async #runNextQueued(sessionID) {

--- a/bridge/src/agent-router.js
+++ b/bridge/src/agent-router.js
@@ -92,6 +92,23 @@ function routedAgentForBackend(daemon, route, requestedBackend) {
   return matching ? { ...route, agentID: matching.id } : route
 }
 
+/**
+ * The universal workspace reads a common detail shape for every native session. ACP profiles
+ * deliberately advertise questions/permissions as unsupported, and the ACP bridge has no VCS
+ * endpoint. Do not forward those known-unsupported optional reads just to manufacture a 404 every
+ * poll. Empty data means "nothing exposed by this harness" while preserving real 404s for unknown
+ * agents and for paths we have not explicitly normalized here.
+ */
+function unsupportedOptionalRead(daemon, route, method) {
+  if (method !== "GET") return undefined
+  const host = daemon.registry.host(route.agentID)
+  if (!host) return undefined
+  if (route.path === "/question" && host.capabilities?.questions === false) return []
+  if (route.path === "/permission" && host.capabilities?.permissions === false) return []
+  if (route.path === "/vcs" && daemon.hostEntry(route.agentID)?.kind === "acp") return {}
+  return undefined
+}
+
 export function proxyManagedHttpRequest({
   request,
   response,
@@ -246,6 +263,13 @@ export function createAgentRoutingServer({
       }
     }
     route = routedAgentForBackend(daemon, route, requestedBackend)
+
+    const optionalPayload = unsupportedOptionalRead(daemon, route, request.method)
+    if (optionalPayload !== undefined) {
+      if (!authenticateMachineRequest(request, response, config)) return
+      writeJSON(response, 200, optionalPayload)
+      return
+    }
 
     if (route.agentID === primaryAgentID) {
       request.url = `${route.path}${route.search}`

--- a/bridge/src/omp-session-history.js
+++ b/bridge/src/omp-session-history.js
@@ -30,6 +30,18 @@ function messageParts(content, messageID) {
   })
 }
 
+/**
+ * A turn that failed is journalled as an assistant message with no content and the provider's own
+ * sentence in `errorMessage`. Skipping those for having no parts made a rate-limited or unpaid
+ * session look like it had simply lost its replies: the transcript showed the prompts and nothing
+ * back, with no way to tell a failure from a missing message.
+ */
+function messageError(message) {
+  const detail = typeof message?.errorMessage === "string" ? message.errorMessage.trim() : ""
+  if (!detail) return undefined
+  return { name: "HarnessTurnError", message: detail }
+}
+
 export function createOmpHistoryLoader(sessionRoot = path.join(homedir(), ".omp", "agent", "sessions")) {
   const sessionFiles = new Map()
 
@@ -97,14 +109,16 @@ export function createOmpHistoryLoader(sessionRoot = path.join(homedir(), ".omp"
       if (role !== "user" && role !== "assistant") continue
       const messageID = record.id ?? `${sessionID}:${messages.length}`
       const parts = messageParts(record.message.content, messageID)
-      if (parts.length === 0) continue
+      const error = messageError(record.message)
+      if (parts.length === 0 && !error) continue
       const created = Date.parse(record.timestamp ?? "")
       messages.push({
         info: {
           id: messageID,
           role,
           sessionID,
-          time: { created: Number.isFinite(created) ? created : Date.now() }
+          time: { created: Number.isFinite(created) ? created : Date.now() },
+          ...(error ? { error } : {})
         },
         parts
       })

--- a/bridge/src/pi-session-history.js
+++ b/bridge/src/pi-session-history.js
@@ -29,6 +29,18 @@ function messageParts(content, messageID) {
   })
 }
 
+/**
+ * A turn that failed is journalled as an assistant message with no content and the provider's own
+ * sentence in `errorMessage`. Skipping those for having no parts made a rate-limited or unpaid
+ * session look like it had simply lost its replies: the transcript showed the prompts and nothing
+ * back, with no way to tell a failure from a missing message.
+ */
+function messageError(message) {
+  const detail = typeof message?.errorMessage === "string" ? message.errorMessage.trim() : ""
+  if (!detail) return undefined
+  return { name: "HarnessTurnError", message: detail }
+}
+
 async function readRecords(file) {
   const records = []
   const lines = createInterface({ input: createReadStream(file), crlfDelay: Infinity })
@@ -87,14 +99,16 @@ export function createPiHistoryLoader(sessionRoot = defaultSessionRoot()) {
       if (role !== "user" && role !== "assistant") continue
       const messageID = record.id
       const parts = messageParts(record.message?.content, messageID)
-      if (parts.length === 0) continue
+      const error = messageError(record.message)
+      if (parts.length === 0 && !error) continue
       const created = Date.parse(record.timestamp ?? "")
       messages.push({
         info: {
           id: messageID,
           role,
           sessionID,
-          time: { created: Number.isFinite(created) ? created : Date.now() }
+          time: { created: Number.isFinite(created) ? created : Date.now() },
+          ...(error ? { error } : {})
         },
         parts
       })

--- a/bridge/test/adopted-task-history.test.js
+++ b/bridge/test/adopted-task-history.test.js
@@ -1,0 +1,143 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import { AcpService } from "../src/acp-service.js"
+
+const SESSION = "codex-task-session"
+
+function journalMessage(id, role, text, created) {
+  return {
+    info: { id, role, sessionID: SESSION, time: { created } },
+    parts: [{ id: `${id}:text:0`, messageID: id, type: "text", text }]
+  }
+}
+
+class LockedAcp extends EventEmitter {
+  constructor() {
+    super()
+    this.loads = []
+  }
+
+  async listSessions() {
+    return [{ sessionId: SESSION, cwd: process.cwd(), title: "Task run", updatedAt: new Date().toISOString() }]
+  }
+
+  async request(method, params) {
+    if (method === "session/load") {
+      this.loads.push(params.sessionId)
+      // Codex holds a single-writer lock for as long as any client keeps the thread open.
+      throw new Error(`thread ${params.sessionId} already has an active writer`)
+    }
+    if (method === "session/prompt") return {}
+    throw new Error(`Unexpected request: ${method}`)
+  }
+
+  notify() {}
+}
+
+function historyLoader(messages) {
+  const loader = async () => messages
+  return loader
+}
+
+test("an adopted task session reads the harness journal instead of the recorded prompt alone", async () => {
+  const journal = [
+    journalMessage("j1", "user", "Salutami", 1_000),
+    journalMessage("j2", "assistant", "Ciao!", 2_000),
+    journalMessage("j3", "user", "ci sei?", 3_000),
+    journalMessage("j4", "assistant", "Sì, ci sono", 4_000)
+  ]
+  const acp = new LockedAcp()
+  const service = new AcpService(acp, { historyLoader: historyLoader(journal) })
+
+  assert.equal(await service.adoptTaskSession(SESSION, { title: "Salutami", prompt: "Salutami" }), true)
+
+  const messages = await service.messages(SESSION)
+  assert.deepEqual(
+    messages.map((message) => [message.info.role, message.parts.map((part) => part.text).join("")]),
+    [["user", "Salutami"], ["assistant", "Ciao!"], ["user", "ci sei?"], ["assistant", "Sì, ci sono"]]
+  )
+  // The prompt recorded at adoption must not survive alongside the journal's copy of itself.
+  assert.equal(messages.filter((message) => message.parts.some((part) => part.text === "Salutami")).length, 1)
+  // Adoption exists so a locked thread can be prompted without session/load; reading history
+  // must not reintroduce that request.
+  assert.deepEqual(acp.loads, [])
+})
+
+test("an adopted session keeps picking up journal entries written while the daemon was idle", async () => {
+  const journal = [journalMessage("j1", "user", "first", 1_000)]
+  const acp = new LockedAcp()
+  const service = new AcpService(acp, { historyLoader: async () => journal })
+  await service.adoptTaskSession(SESSION, { prompt: "first" })
+  assert.equal((await service.messages(SESSION)).length, 1)
+
+  journal.push(journalMessage("j2", "assistant", "answered later", 2_000))
+  assert.deepEqual(
+    (await service.messages(SESSION)).map((message) => message.info.id),
+    ["j1", "j2"]
+  )
+})
+
+test("an adopted session stays listed as the app's own rather than as an external one", async () => {
+  const service = new AcpService(new LockedAcp(), { historyLoader: async () => [] })
+  await service.adoptTaskSession(SESSION, { prompt: "task prompt" })
+  const [session] = await service.listSessions()
+  assert.equal(session.external, undefined)
+})
+
+test("a session this bridge prompts stops deferring to the journal", async () => {
+  const journal = [journalMessage("j1", "user", "task prompt", 1_000)]
+  const acp = new LockedAcp()
+  const service = new AcpService(acp, { historyLoader: async () => journal })
+  await service.adoptTaskSession(SESSION, { prompt: "task prompt" })
+  await service.messages(SESSION)
+
+  await service.prompt(SESSION, "live follow-up")
+  // The journal loses the conversation, as a harness rewriting its own branch would: the live
+  // transcript is authoritative from the first turn this process runs, so nothing disappears.
+  journal.length = 0
+  const messages = await service.messages(SESSION)
+  assert.deepEqual(
+    messages.map((message) => message.parts.map((part) => part.text).join("")),
+    ["task prompt", "live follow-up"]
+  )
+  assert.deepEqual(acp.loads, [])
+})
+
+test("a harness with no journal still replays an adopted session over ACP", async () => {
+  const replays = []
+  class ReplayAcp extends EventEmitter {
+    async listSessions() {
+      return [{ sessionId: SESSION, cwd: process.cwd(), title: "Task run", updatedAt: new Date().toISOString() }]
+    }
+
+    async request(method, params) {
+      if (method !== "session/load") throw new Error(`Unexpected request: ${method}`)
+      replays.push(params.sessionId)
+      this.emit("notification", {
+        method: "session/update",
+        params: {
+          sessionId: params.sessionId,
+          update: { sessionUpdate: "user_message_chunk", messageId: "u1", content: { type: "text", text: "task prompt" } }
+        }
+      })
+      this.emit("notification", {
+        method: "session/update",
+        params: {
+          sessionId: params.sessionId,
+          update: { sessionUpdate: "agent_message_chunk", messageId: "a1", content: { type: "text", text: "replayed answer" } }
+        }
+      })
+      return { configOptions: [] }
+    }
+  }
+
+  const service = new AcpService(new ReplayAcp())
+  await service.adoptTaskSession(SESSION, { prompt: "task prompt" })
+  const messages = await service.messages(SESSION)
+  assert.deepEqual(replays, [SESSION])
+  assert.deepEqual(
+    messages.map((message) => [message.info.role, message.parts.map((part) => part.text).join("")]),
+    [["user", "task prompt"], ["assistant", "replayed answer"]]
+  )
+})

--- a/bridge/test/agent-router.test.js
+++ b/bridge/test/agent-router.test.js
@@ -26,7 +26,18 @@ function daemonWith(entries, states = {}) {
   return {
     hostEntry(id) { return entries[id] },
     registry: {
-      host(id) { return states[id] ? { state: states[id] } : undefined }
+      host(id) {
+        const value = states[id]
+        if (!value) return undefined
+        return typeof value === "string" ? { state: value } : value
+      }
+    },
+    snapshot() {
+      return {
+        agents: Object.entries(states).map(([id, value]) => typeof value === "string"
+          ? { id, backend: id, state: value }
+          : { id, backend: value.backend ?? id, ...value })
+      }
     }
   }
 }
@@ -58,6 +69,54 @@ test("primary ACP agent prefix reuses the normalized bridge routes", async () =>
     const response = await fetch(`http://127.0.0.1:${port}/v1/agents/codex/session?directory=%2Fwork`)
     assert.equal(response.status, 200)
     assert.deepEqual(await response.json(), { url: "/session?directory=%2Fwork" })
+  } finally {
+    await close(server)
+  }
+})
+
+test("known unsupported ACP detail reads return empty data without hitting the bridge", async () => {
+  let bridgeHits = 0
+  const bridgeServer = new BridgeServer()
+  bridgeServer.on("request", (_request, response) => {
+    bridgeHits += 1
+    response.writeHead(500)
+    response.end()
+  })
+  const daemon = daemonWith(
+    { codex: { id: "codex", kind: "acp" } },
+    {
+      codex: {
+        state: "available",
+        backend: "codex",
+        capabilities: { questions: false, permissions: false }
+      }
+    }
+  )
+  const server = createAgentRoutingServer({
+    daemon,
+    config: { username: "outer", password: "secret", corsOrigins: [] },
+    primaryAgentID: "codex",
+    bridgeServer
+  })
+  const port = await listen(server)
+  const headers = { Authorization: basic("outer", "secret") }
+  try {
+    const unauthorized = await fetch(`http://127.0.0.1:${port}/v1/agents/codex/question`)
+    assert.equal(unauthorized.status, 401)
+
+    const question = await fetch(`http://127.0.0.1:${port}/v1/agents/codex/question`, { headers })
+    assert.equal(question.status, 200)
+    assert.deepEqual(await question.json(), [])
+
+    const permission = await fetch(`http://127.0.0.1:${port}/v1/agents/codex/permission?directory=%2Fwork`, { headers })
+    assert.equal(permission.status, 200)
+    assert.deepEqual(await permission.json(), [])
+
+    const vcs = await fetch(`http://127.0.0.1:${port}/v1/agents/codex/vcs?directory=%2Fwork`, { headers })
+    assert.equal(vcs.status, 200)
+    assert.deepEqual(await vcs.json(), {})
+
+    assert.equal(bridgeHits, 0)
   } finally {
     await close(server)
   }

--- a/bridge/test/turn-failure-visibility.test.js
+++ b/bridge/test/turn-failure-visibility.test.js
@@ -1,0 +1,83 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import { mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { AcpService } from "../src/acp-service.js"
+import { createOmpHistoryLoader } from "../src/omp-session-history.js"
+import { createPiHistoryLoader } from "../src/pi-session-history.js"
+
+const SESSION = "01a01000-0000-7000-8000-000000000000"
+
+async function journal(prefix, separator, records) {
+  const root = await mkdtemp(path.join(tmpdir(), `harness-${prefix}-`))
+  const file = path.join(root, `2026-08-17T16-48-44-623Z${separator}${SESSION}.jsonl`)
+  await writeFile(file, records.map((record) => JSON.stringify(record)).join("\n"), "utf8")
+  return root
+}
+
+const failedTurn = [
+  { type: "message", id: "m1", parentId: null, timestamp: "2026-08-17T16:48:45.000Z", message: { role: "user", content: "ciao" } },
+  {
+    type: "message",
+    id: "m2",
+    parentId: "m1",
+    timestamp: "2026-08-17T16:49:07.000Z",
+    message: { role: "assistant", content: [], stopReason: "error", errorMessage: "429 Rate limit exceeded" }
+  }
+]
+
+test("an OMP turn that failed stays in the transcript with the provider's reason", async () => {
+  const root = await journal("omp", "_", failedTurn)
+  const messages = await createOmpHistoryLoader(root)(SESSION, { activeSessionLeaf: "m2" })
+  assert.deepEqual(messages.map((message) => message.info.role), ["user", "assistant"])
+  assert.deepEqual(messages[1].parts, [])
+  assert.equal(messages[1].info.error?.message, "429 Rate limit exceeded")
+  assert.equal(messages[0].info.error, undefined)
+})
+
+test("a PI turn that failed stays in the transcript with the provider's reason", async () => {
+  const root = await journal("pi", "_", failedTurn)
+  const messages = await createPiHistoryLoader(root)(SESSION)
+  assert.deepEqual(messages.map((message) => message.info.role), ["user", "assistant"])
+  assert.equal(messages[1].info.error?.message, "429 Rate limit exceeded")
+})
+
+test("a blank errorMessage is not mistaken for a failure worth showing", async () => {
+  const root = await journal("pi-blank", "_", [
+    failedTurn[0],
+    { ...failedTurn[1], message: { role: "assistant", content: [], errorMessage: "   " } }
+  ])
+  const messages = await createPiHistoryLoader(root)(SESSION)
+  assert.deepEqual(messages.map((message) => message.info.role), ["user"])
+})
+
+class FailingAcp extends EventEmitter {
+  async listSessions() {
+    return [{ sessionId: SESSION, cwd: process.cwd(), title: "Failing", updatedAt: new Date().toISOString() }]
+  }
+
+  async request(method, params) {
+    if (method === "session/load") return { configOptions: [] }
+    if (method === "session/prompt") throw new Error("Internal error: provider rejected the request")
+    throw new Error(`Unexpected request: ${method}`)
+  }
+
+  notify() {}
+}
+
+test("a live ACP turn failure is recorded on the transcript, not only announced once", async () => {
+  const service = new AcpService(new FailingAcp())
+  const errors = []
+  service.subscribe((event) => {
+    if (event.type === "session.error") errors.push(event.message)
+  })
+  await service.prompt(SESSION, "ciao")
+  await new Promise((resolve) => setTimeout(resolve, 20))
+
+  assert.deepEqual(errors, ["Internal error: provider rejected the request"])
+  const messages = await service.messages(SESSION)
+  assert.deepEqual(messages.map((message) => message.info.role), ["user", "assistant"])
+  assert.equal(messages[1].info.error?.message, "Internal error: provider rejected the request")
+})

--- a/docs/RELEASE_2.11.1.md
+++ b/docs/RELEASE_2.11.1.md
@@ -1,0 +1,51 @@
+# Harness Remote 2.11.1
+
+Harness Remote 2.11.1 is a bug-fix release for the 2.11 line. It repairs three ways a session could look emptier than it was, and restores per-agent routing in the Desktop application.
+
+## Highlights
+
+- Show the full conversation when opening a task session after a daemon restart, instead of the single prompt recorded at launch.
+- Route every Desktop server profile to the agent it selected, instead of sending them all to the machine's primary agent.
+- Report the provider's own reason when a turn fails, instead of leaving the prompt followed by nothing.
+- Recover a task session's transcript on harnesses that keep no journal of their own, which previously had no path back to it at all.
+- Collapse repeated identical failures from a retried turn into one.
+
+## Task session history after a daemon restart
+
+Opening a task session after restarting the daemon showed the one prompt recorded when the task was launched, and nothing else, until a new message streamed in and filled the rest of the conversation.
+
+The daemon adopts every known task session at startup so a thread another client holds open can still be prompted without `session/load`. That adoption also marked the session's in-memory transcript complete, which meant the harness's own rollout or journal was never read. Adoption is now tracked separately: it grants the right to prompt, and history still comes from the harness until the bridge runs a turn of its own on the session.
+
+Codex was the harness this was reported against, because every Codex task session behaved this way. PI was unaffected only because its loader is already marked authoritative and bypasses the affected path. Claude Code, which keeps no journal for the bridge to read, now replays an adopted session over ACP — a recovery path adoption previously prevented outright.
+
+This release also stops two loads of the same session from overlapping. A transcript-only load and a config-options load both rebuild the session's message list, and the client asks for both every time a session is opened, so a caller that wanted only the transcript could read a half-rebuilt one.
+
+## Desktop agent routing
+
+In the packaged Desktop application every saved server listed the same sessions: those of the machine daemon's primary agent.
+
+A profile's agent id is what scopes its requests to one agent behind the shared machine endpoint. The Desktop main process was discarding that field when it validated a profile, leaving it with a machine-root target for every server, and the daemon routes an unscoped request to its primary agent. The Web client was unaffected because it builds its own URLs and never lost the field.
+
+The main process now keeps and validates the agent id, and treats a change of agent as a real change so the event stream follows it. The compatibility header the daemon uses to correct a wrongly-scoped request is now shared by the browser, Desktop and Android request paths rather than being sent by the browser alone, which is what allowed the two clients to disagree in the first place.
+
+Existing Desktop profiles repair themselves on the next launch; no reconfiguration is needed.
+
+## Failed turns
+
+A turn that fails carries the provider's message on the envelope rather than in the reply, and nothing displayed it. The prompt was followed by nothing at all — the same thing a session with a broken transcript looks like, which is why two unrelated causes were reported as one problem.
+
+- The Oh My Pi and PI journal readers keep a failed turn instead of discarding it for having no content, and carry the provider's sentence with it.
+- A live ACP turn failure is recorded on the transcript rather than only announced once, so it is still there when the session is reopened.
+- The client renders the reason inside the bubble, and folds consecutive identical failures together, since a harness that retries a failing turn records one failed message per attempt.
+
+## Also fixed
+
+- A duplicate React key in the session sidebar, where one project directory legitimately produces several groups.
+
+## Validation
+
+- web type-check and production build
+- web regression tests
+- desktop transport and profile registry tests
+- bridge test suite
+- runtime validation against a live machine daemon with Codex CLI, Claude Code, Oh My Pi, PI and OpenCode: per-agent session lists verified distinct from both the Web and Desktop clients, task session transcripts verified complete before and after a daemon restart, and a live turn verified not to duplicate or lose history

--- a/web/electron/desktop-transport.test.mjs
+++ b/web/electron/desktop-transport.test.mjs
@@ -70,6 +70,11 @@ server = createServer(async (request, response) => {
     response.write('{"partial":')
     return
   }
+  if (request.url.startsWith('/echo') || request.url.startsWith('/v1/') || request.url.startsWith('/global/')) {
+    response.setHeader('content-type', 'application/json')
+    response.end(JSON.stringify({ url: request.url, backend: request.headers['x-harness-backend'] ?? null }))
+    return
+  }
   response.statusCode = 404
   response.end()
 })
@@ -155,4 +160,43 @@ test('HTTP errors expose status without matching prose', async () => {
   const missing = await executeDesktopRequest(localProfile, { path: '/missing' })
   assert.equal(missing.error.code, 'http')
   assert.equal(missing.error.status, 404)
+})
+
+test('the registry keeps the selected agent, which is the only thing that routes a profile', async () => {
+  const scoped = { ...localProfile, backend: 'codex', agentId: 'codex' }
+  assert.deepEqual(validateDesktopProfile(scoped), scoped)
+  assert.equal(validateDesktopProfile({ ...scoped, agentId: '  ' }).agentId, undefined)
+  assert.throws(() => validateDesktopProfile({ ...scoped, agentId: '../codex' }), /agent/)
+  assert.throws(() => validateDesktopProfile({ ...scoped, agentId: 'co dex' }), /agent/)
+  assert.throws(() => validateDesktopProfile({ ...scoped, agentId: 42 }), /agent/)
+
+  const directory = await mkdtemp(join(tmpdir(), 'harness-remote-agents-'))
+  const registry = new ProfileRegistry(join(directory, 'profiles.json'))
+  await registry.replace([scoped])
+  assert.equal(registry.get(scoped.id).agentId, 'codex')
+  // Switching only the agent is a real change: treating it as unchanged left the event stream
+  // subscribed to the agent the user just navigated away from.
+  const switched = await registry.replace([{ ...scoped, backend: 'pi', agentId: 'pi' }])
+  assert.deepEqual(switched.changedProfileIDs, [scoped.id])
+  await rm(directory, { recursive: true, force: true })
+})
+
+test('desktop requests carry the profile scope the browser sends, and leave machine routes alone', async () => {
+  const scoped = { ...localProfile, backend: 'codex', agentId: 'pi' }
+  const agentRequest = await executeDesktopRequest(scoped, { path: '/echo/session' })
+  assert.deepEqual(agentRequest.response.data, { url: '/v1/agents/pi/echo/session', backend: 'codex' })
+
+  // TaskDesk and machine discovery are answered by the daemon itself; scoping them to the
+  // profile's agent aims them at a bridge where those routes do not exist.
+  for (const path of ['/v1/machine', '/global/machine', '/v1/projects', '/v1/tasks', '/v1/tasks/abc/launch', '/v1/agents/omp/models']) {
+    const machineRequest = await executeDesktopRequest(scoped, { path })
+    assert.equal(machineRequest.response.data.url, path, `${path} should reach the daemon unscoped`)
+  }
+  const withQuery = await executeDesktopRequest(scoped, { path: '/v1/tasks?limit=1' })
+  assert.equal(withQuery.response.data.url, '/v1/tasks?limit=1')
+
+  // Nothing preflights a request from the main process, so an unscoped OpenCode profile still says
+  // which harness it wants — which is what lets a daemon route it somewhere other than its primary.
+  const unscoped = await executeDesktopRequest({ ...localProfile, backend: 'opencode' }, { path: '/echo/session' })
+  assert.deepEqual(unscoped.response.data, { url: '/echo/session', backend: 'opencode' })
 })

--- a/web/electron/event-transport.ts
+++ b/web/electron/event-transport.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto"
 import type { WebContents } from "electron"
-import { baseUrl } from "../src/serverConfig.js"
+import { baseUrl, routingHeaders } from "../src/serverConfig.js"
 import { parseSSEFrame, type ParsedOpenCodeEvent } from "../src/sse-parser.js"
 import { ProfileRegistry, type ProfileRegistryChange } from "./profile-registry.js"
 import type {
@@ -160,7 +160,7 @@ export class DesktopEventTransport {
     subscription.controller = controller
     let response: Response
     try {
-      const headers: Record<string, string> = { Accept: "text/event-stream" }
+      const headers: Record<string, string> = { Accept: "text/event-stream", ...routingHeaders(profile, { preflight: false }) }
       const authorization = authHeader(profile)
       if (authorization) headers.Authorization = authorization
       response = await fetch(streamURL(profile, subscription.options), { headers, redirect: "manual", signal: controller.signal })

--- a/web/electron/profile-registry.ts
+++ b/web/electron/profile-registry.ts
@@ -9,6 +9,7 @@ const MAX_PROFILE_COUNT = 100
 const MAX_PROFILE_ID_LENGTH = 128
 const MAX_HOST_LENGTH = 2048
 const MAX_CREDENTIAL_LENGTH = 4096
+const MAX_AGENT_ID_LENGTH = 128
 
 export class DesktopProfileError extends Error {
   constructor(message: string) {
@@ -47,6 +48,21 @@ function validateHost(host: unknown): string {
   return value
 }
 
+/**
+ * The id becomes a path segment, so it is held to what the daemon itself accepts for an agent name
+ * rather than merely being escaped: anything with a separator or an encodable character in it would
+ * be a way to aim a profile at a path other than the agent the user picked.
+ */
+function validateAgentID(value: unknown): string | undefined {
+  if (typeof value !== "string") throw new DesktopProfileError("Profile agent is invalid")
+  const agentID = value.trim()
+  if (!agentID) return undefined
+  if (agentID.length > MAX_AGENT_ID_LENGTH || !/^[A-Za-z0-9._-]+$/.test(agentID)) {
+    throw new DesktopProfileError("Profile agent is invalid")
+  }
+  return agentID
+}
+
 export function validateDesktopProfile(value: unknown): DesktopProfile {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new DesktopProfileError("Profile is invalid")
   const candidate = value as Partial<DesktopProfile>
@@ -63,7 +79,21 @@ export function validateDesktopProfile(value: unknown): DesktopProfile {
   if (candidate.username.length > MAX_CREDENTIAL_LENGTH || candidate.password.length > MAX_CREDENTIAL_LENGTH || hasControlCharacters(candidate.username) || hasControlCharacters(candidate.password)) {
     throw new DesktopProfileError("Profile credentials are invalid")
   }
-  const profile = { id, backend: candidate.backend, host, port, username: candidate.username, password: candidate.password }
+  // A daemon-backed profile is only distinguishable from every other agent on the same machine by
+  // its agent id: it is what puts /v1/agents/<id> in front of the path and what the event stream is
+  // scoped by. Dropping it here left main holding a machine-root target for every profile, so the
+  // desktop app sent all of them to the daemon's primary agent and each server showed that one
+  // agent's sessions. The renderer already carries the field; main has to keep it to route at all.
+  const agentId = candidate.agentId === undefined ? undefined : validateAgentID(candidate.agentId)
+  const profile = {
+    id,
+    backend: candidate.backend,
+    host,
+    port,
+    username: candidate.username,
+    password: candidate.password,
+    ...(agentId ? { agentId } : {})
+  }
   try {
     new URL(baseUrl(profile))
   } catch {
@@ -101,6 +131,7 @@ function sameProfile(left: DesktopProfile, right: DesktopProfile): boolean {
     && left.port === right.port
     && left.username === right.username
     && left.password === right.password
+    && left.agentId === right.agentId
 }
 
 /** Main-owned allowlist. Renderer profile mutation represents user-approved Settings state. */

--- a/web/electron/request-transport.ts
+++ b/web/electron/request-transport.ts
@@ -1,4 +1,4 @@
-import { agentScopedPath, machineBaseUrl } from "../src/serverConfig.js"
+import { agentScopedPath, machineBaseUrl, routingHeaders } from "../src/serverConfig.js"
 import type { DesktopProfile, DesktopRequest, DesktopRequestResult } from "./ipc-contract.js"
 
 export const MAX_RESPONSE_BYTES = 8 * 1024 * 1024
@@ -61,6 +61,14 @@ async function readBoundedBody(response: Response, onReader?: (reader: ReadableS
   return new TextDecoder().decode(bytes)
 }
 
+/**
+ * What the machine daemon answers itself rather than handing to one agent's bridge: the machine
+ * descriptor, the project and task surface behind TaskDesk, and any path the caller already scoped
+ * to an agent of its own choosing. Prefixing these with the profile's agent aims them at a bridge
+ * where they do not exist, so the profile's scope applies to everything except these.
+ */
+const MACHINE_SCOPED_PATH = /^\/(?:v1\/machine|global\/machine|v1\/projects|v1\/tasks(?:\/|$)|v1\/agents\/)/
+
 function validPath(path: unknown): path is string {
   return typeof path === "string"
     && path.length <= MAX_PATH_LENGTH
@@ -77,9 +85,13 @@ function targetURL(profile: DesktopProfile, path: string): URL | null {
   } catch {
     return null
   }
-  const machineScoped = path === "/v1/machine" || path === "/global/machine"
-  const scopedPath = machineScoped ? path : agentScopedPath(profile, path)
   let target: URL
+  try {
+    target = new URL(path, approved.origin)
+  } catch {
+    return null
+  }
+  const scopedPath = MACHINE_SCOPED_PATH.test(target.pathname) ? path : agentScopedPath(profile, path)
   try {
     target = new URL(scopedPath, approved.origin)
   } catch {
@@ -126,7 +138,7 @@ export async function executeDesktopRequest(profile: DesktopProfile, request: De
     controller.abort()
     void activeReader?.cancel().catch(() => undefined)
   }, timeout)
-  const headers: Record<string, string> = { Accept: "application/json" }
+  const headers: Record<string, string> = { Accept: "application/json", ...routingHeaders(profile, { preflight: false }) }
   if (profile.username && profile.password) {
     headers.Authorization = `Basic ${Buffer.from(`${profile.username}:${profile.password}`, "utf8").toString("base64")}`
   }

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harness-remote-web",
   "private": true,
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Companion app for controlling coding-agent harnesses from phone or desktop",
   "homepage": "https://github.com/giuliastro/harness-remote",
   "author": {

--- a/web/package.json
+++ b/web/package.json
@@ -26,7 +26,7 @@
     "cap:sync": "npx cap sync",
     "cap:sync:android": "npx cap sync android && node scripts/sync-native-live-events.mjs",
     "cap:add:android": "npx cap add android",
-    "test:ui": "node src/ui-regression.test.mjs",
+    "test:ui": "node src/ui-regression.test.mjs && node --experimental-strip-types src/taskdesk-home.test.mjs",
     "test:settings": "node src/settings-regression.test.mjs && node src/v3-ux-polish-regression.test.mjs",
     "test:model": "node src/model-regression.test.mjs",
     "test:events": "node --experimental-strip-types src/opencode-events.test.mjs",

--- a/web/public/harness-icons/claude.svg
+++ b/web/public/harness-icons/claude.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="14" fill="#D97757"/><g stroke="#fff" stroke-width="5" stroke-linecap="round"><path d="M32 14v36M14 32h36M19 19l26 26M45 19L19 45"/></g></svg>

--- a/web/public/harness-icons/codex.svg
+++ b/web/public/harness-icons/codex.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="14" fill="#111827"/><circle cx="32" cy="32" r="15" fill="none" stroke="#fff" stroke-width="5"/><path d="M20 32h24M32 20v24" stroke="#fff" stroke-width="5" stroke-linecap="round"/></svg>

--- a/web/public/harness-icons/omp.svg
+++ b/web/public/harness-icons/omp.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="14" fill="#1F2937"/><text x="32" y="39" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="22" font-weight="700" fill="#F8FAFC">OMP</text></svg>

--- a/web/public/harness-icons/opencode.svg
+++ b/web/public/harness-icons/opencode.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="14" fill="#0F172A"/><path d="M24 20L12 32l12 12M40 20l12 12-12 12" fill="none" stroke="#60A5FA" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/><path d="M36 16L28 48" stroke="#fff" stroke-width="5" stroke-linecap="round"/></svg>

--- a/web/public/harness-icons/pi.svg
+++ b/web/public/harness-icons/pi.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="14" fill="#111827"/><text x="32" y="43" text-anchor="middle" font-family="Georgia,serif" font-size="38" font-weight="700" fill="#F8FAFC">π</text></svg>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -235,6 +235,53 @@ function extractText(msg: MessageEnvelope): string {
     .trim()
 }
 
+/**
+ * A turn that ended in a provider or harness failure carries no text and no parts worth rendering,
+ * only the bookkeeping `step-start`. Left unread, the transcript showed the prompt and then nothing
+ * at all, which reads as the reply having gone missing rather than as the model having failed — and
+ * on a session where every turn failed, as the app showing only the messages the user sent.
+ *
+ * OpenCode nests the sentence worth reading under `data.message`, frequently as a JSON document of
+ * its own, so unwrap one level before giving up and showing the error's name.
+ */
+function messageFailure(message: MessageEnvelope): string | undefined {
+  const error = message.info.error
+  if (!error) return undefined
+  const detail = error.data?.message ?? error.message
+  if (typeof detail === "string" && detail.trim()) {
+    try {
+      const parsed = JSON.parse(detail) as { message?: unknown }
+      if (parsed && typeof parsed === "object" && typeof parsed.message === "string" && parsed.message.trim()) {
+        return parsed.message.trim()
+      }
+    } catch {
+      // Not every provider wraps its message in JSON; the plain sentence is already what we want.
+    }
+    return detail.trim()
+  }
+  return typeof error.name === "string" && error.name.trim() ? error.name.trim() : undefined
+}
+
+/** Bookkeeping parts a harness emits around a turn; on their own they are not content to show. */
+function isTurnScaffolding(part: MessagePart): boolean {
+  return part.type === "step-start" || part.type === "step-finish"
+}
+
+/**
+ * A harness that retries a failing turn journals one failed assistant message per attempt, so a
+ * single rate-limited prompt arrives as a dozen messages all saying the same thing. Consecutive
+ * content-free failures with the same reason are one failure as far as the reader is concerned.
+ */
+function collapseRepeatedFailures(messages: (MessageEnvelope & { text: string })[]): (MessageEnvelope & { text: string })[] {
+  const isBareFailure = (message: MessageEnvelope & { text: string }) =>
+    !message.text && Boolean(messageFailure(message)) && message.parts.every(isTurnScaffolding)
+  return messages.filter((message, index) => {
+    const previous = messages[index - 1]
+    if (!previous || !isBareFailure(message) || !isBareFailure(previous)) return true
+    return messageFailure(previous) !== messageFailure(message)
+  })
+}
+
 /** Wraps a message with its extracted text, reusing the previous wrapper when the underlying message object is
  *  unchanged. applyStreamedPartUpdate/applyStreamedPartDelta already keep unrelated messages referentially
  *  identical across streamed updates — without this cache, mapping over the whole array would create a brand
@@ -1796,6 +1843,26 @@ function MessageContextMenu({
   )
 }
 
+/** The failure that replaced a reply, shown in the bubble it belongs to rather than as a transient
+ *  banner: it is part of the transcript and stays readable when the session is reopened later. */
+function MessageFailureView({ messages, t }: { messages: MessageEnvelope[]; t: Translator }) {
+  const failures = messages.flatMap((message) => {
+    const failure = messageFailure(message)
+    return failure ? [{ id: message.info.id, failure }] : []
+  })
+  if (failures.length === 0) return null
+  return (
+    <>
+      {failures.map((entry) => (
+        <p key={`failure-${entry.id}`} className="message-failure" role="status">
+          <span className="message-failure-label">{t('detail.turnFailed')}</span>
+          <span className="message-failure-detail">{entry.failure}</span>
+        </p>
+      ))}
+    </>
+  )
+}
+
 /** Renders one run's continuous timeline (see groupRenderedMessages) as a single message bubble, resolving
  *  each item's timestamp to the specific message that produced it. */
 function ConversationRunView({
@@ -1856,6 +1923,7 @@ function ConversationRunView({
           />
         )
       )}
+      <MessageFailureView messages={[...messagesByID.values()]} t={t} />
     </MessageContextMenu>
   )
 }
@@ -1908,6 +1976,7 @@ const MessageArticle = memo(function MessageArticle({
           />
         )
       )}
+      <MessageFailureView messages={[message]} t={t} />
     </MessageContextMenu>
   )
 })
@@ -2399,10 +2468,11 @@ function App() {
 
   const renderedMessages = useMemo(() => {
     const revertMessageID = config.backend === "opencode" ? selectedSession?.revertMessageID : undefined
-    return [...messages, ...optimisticUserMessages]
+    const visible = [...messages, ...optimisticUserMessages]
       .filter((message) => !revertMessageID || message.info.id < revertMessageID)
       .map(toRenderedMessage)
-      .filter((message) => message.text || message.parts.some((part) => part.type !== "step-start" && part.type !== "step-finish"))
+      .filter((message) => message.text || messageFailure(message) || message.parts.some((part) => !isTurnScaffolding(part)))
+    return collapseRepeatedFailures(visible)
   }, [config.backend, messages, optimisticUserMessages, selectedSession?.revertMessageID])
 
   const timelineGroups = useMemo(() => groupRenderedMessages(renderedMessages), [renderedMessages])

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,7 +1,7 @@
 import { Capacitor, CapacitorHttp } from "@capacitor/core"
 import { desktopRequest, isDesktopPlatform } from "./desktopBridge"
 import { streamURL } from "./opencode-events"
-import { authHeader, baseUrl, hasCredentials, isValidServerConfig } from "./serverConfig"
+import { authHeader, baseUrl, hasCredentials, isValidServerConfig, routingHeaders } from "./serverConfig"
 import type { AttachmentPart } from "./attachments"
 import type {
   AgentOption,
@@ -132,13 +132,6 @@ type AgentResponse = Array<{
   hidden?: boolean
 }>
 
-function routingHeaders(config: ServerConfig): Record<string, string> {
-  // A direct OpenCode server does not know this compatibility header and may reject it during CORS
-  // preflight. Daemon-backed profiles have an agentId, while ACP bridge profiles can safely send it.
-  if (config.backend === "opencode" && !config.agentId) return {}
-  return { "X-Harness-Backend": config.backend }
-}
-
 async function requestWithHeaders<T>(config: ServerConfig, path: string, options: RequestOptions = {}): Promise<ResponseWithHeaders<T>> {
   const method = options.method ?? "GET"
   if (isDesktopPlatform()) {
@@ -154,7 +147,9 @@ async function requestWithHeaders<T>(config: ServerConfig, path: string, options
   const target = `${baseUrl(config)}${path}`
   const headers: Record<string, string> = {
     Accept: "application/json",
-    ...routingHeaders(config)
+    // CapacitorHttp goes out through the platform's own HTTP client, which never preflights, so the
+    // routing hint the browser has to withhold is safe to send from the packaged Android app.
+    ...routingHeaders(config, { preflight: !Capacitor.isNativePlatform() })
   }
   if (hasCredentials(config)) {
     headers.Authorization = authHeader(config)

--- a/web/src/components/session-list.tsx
+++ b/web/src/components/session-list.tsx
@@ -216,7 +216,10 @@ export function SessionSidebar({
       </div>
       <div className="sidebar-sessions" ref={sidebarSessionsRef} onScroll={onScroll}>
         {groups.length === 0 ? <p className="subtle sidebar-empty">{offline ? t('sessions.offlineHint') : t('sessions.emptyTitle')}</p> : groups.map((group) => (
-          <section key={group.directory} className="sidebar-group">
+          // Groups only merge runs of adjacent sessions, and the list is ordered by activity, so one
+          // directory legitimately produces several groups. Keying on the directory made those
+          // collide, and React reserves the right to drop or duplicate children when it happens.
+          <section key={`${group.directory}:${group.sessions[0].id}`} className="sidebar-group">
             <div className="sidebar-group-label" title={group.directory}><FolderIcon size={12} /><span>{projectLabel(group.directory)}</span><span className="sidebar-group-count">{group.sessions.length}</span></div>
             {group.sessions.map((session) => <SessionCard key={session.id} session={session} {...sessionCardProps} />)}
           </section>

--- a/web/src/components/standalone-universal-workspace.tsx
+++ b/web/src/components/standalone-universal-workspace.tsx
@@ -1,0 +1,226 @@
+import { useMemo, useState, type ReactNode } from "react"
+import { discoverMachine } from "../machineClient"
+import {
+  createWorkspaceMachine,
+  type WorkspaceMachine
+} from "../workspaceMachines"
+import { UniversalWorkspace } from "./universal-workspace"
+
+type Props = {
+  machines: WorkspaceMachine[]
+  onPersistMachines: (machines: WorkspaceMachine[]) => void
+  legacyView: ReactNode
+}
+
+type MachineEditorProps = {
+  machine: WorkspaceMachine
+  isNew: boolean
+  onCancel: () => void
+  onSave: (machine: WorkspaceMachine) => void
+}
+
+function MachineEditor({ machine, isNew, onCancel, onSave }: MachineEditorProps) {
+  const [name, setName] = useState(machine.name)
+  const [host, setHost] = useState(machine.config.host)
+  const [port, setPort] = useState(String(machine.config.port))
+  const [username, setUsername] = useState(machine.config.username)
+  const [password, setPassword] = useState(machine.config.password)
+  const [testing, setTesting] = useState(false)
+  const [testResult, setTestResult] = useState<{ ok: boolean; text: string } | null>(null)
+
+  const validPort = Number(port) >= 1 && Number(port) <= 65_535
+  const valid = Boolean(host.trim() && validPort)
+
+  const nextMachine = (): WorkspaceMachine => ({
+    ...machine,
+    name: name.trim() || host.trim() || "Machine",
+    config: {
+      backend: "opencode",
+      host: host.trim(),
+      port: Number(port),
+      username: username.trim(),
+      password
+    }
+  })
+
+  async function testConnection() {
+    if (!valid || testing) return
+    setTesting(true)
+    setTestResult(null)
+    try {
+      const snapshot = await discoverMachine(nextMachine().config)
+      if (!snapshot) {
+        setTestResult({ ok: false, text: "Connected, but this endpoint is not a Harness machine daemon." })
+      } else {
+        const count = snapshot.agents.length
+        setTestResult({
+          ok: true,
+          text: `Connected to ${snapshot.machine.name}. ${count} harness${count === 1 ? "" : "es"} discovered.`
+        })
+      }
+    } catch (error) {
+      setTestResult({ ok: false, text: error instanceof Error ? error.message : String(error) })
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  return (
+    <div className="uw-machine-editor">
+      <div className="uw-machine-editor-grid">
+        <label>
+          <span>Name</span>
+          <input value={name} onChange={(event) => setName(event.target.value)} placeholder="My workstation" />
+        </label>
+        <label>
+          <span>Host</span>
+          <input value={host} onChange={(event) => setHost(event.target.value)} placeholder="192.168.1.20 or localhost" spellCheck={false} />
+        </label>
+        <label>
+          <span>Port</span>
+          <input value={port} onChange={(event) => setPort(event.target.value.replace(/\D/g, ""))} inputMode="numeric" />
+        </label>
+        <label>
+          <span>Username</span>
+          <input value={username} onChange={(event) => setUsername(event.target.value)} autoComplete="username" />
+        </label>
+        <label className="uw-machine-editor-wide">
+          <span>Password</span>
+          <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} autoComplete="current-password" />
+        </label>
+      </div>
+
+      {testResult ? (
+        <div className={`uw-machine-test-result ${testResult.ok ? "ok" : "error"}`}>{testResult.text}</div>
+      ) : null}
+
+      <div className="uw-machine-editor-actions">
+        <button type="button" className="uw-manager-button" onClick={onCancel}>Cancel</button>
+        <button type="button" className="uw-manager-button" disabled={!valid || testing} onClick={() => void testConnection()}>
+          {testing ? "Testing..." : "Test connection"}
+        </button>
+        <button type="button" className="uw-manager-button primary" disabled={!valid} onClick={() => valid && onSave(nextMachine())}>
+          {isNew ? "Add machine" : "Save machine"}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function MachineManager({
+  machines,
+  onClose,
+  onPersist
+}: {
+  machines: WorkspaceMachine[]
+  onClose: () => void
+  onPersist: (machines: WorkspaceMachine[]) => void
+}) {
+  const [editingID, setEditingID] = useState<string | null>(machines.length === 0 ? "new" : null)
+  const draft = useMemo(() => editingID === "new"
+    ? createWorkspaceMachine()
+    : machines.find((machine) => machine.id === editingID) || null, [editingID, machines])
+
+  const save = (machine: WorkspaceMachine) => {
+    if (editingID === "new") onPersist([...machines, machine])
+    else onPersist(machines.map((candidate) => candidate.id === machine.id ? machine : candidate))
+    setEditingID(null)
+  }
+
+  const remove = (machine: WorkspaceMachine) => {
+    if (!window.confirm(`Remove "${machine.name}" from this workspace?`)) return
+    onPersist(machines.filter((candidate) => candidate.id !== machine.id))
+    if (editingID === machine.id) setEditingID(null)
+  }
+
+  return (
+    <div className="uw-manager-backdrop" role="presentation" onMouseDown={onClose}>
+      <section className="uw-machine-manager" role="dialog" aria-modal="true" aria-label="Machines" onMouseDown={(event) => event.stopPropagation()}>
+        <header className="uw-machine-manager-header">
+          <div>
+            <h2>Machines</h2>
+            <p>Configure the machine daemons aggregated by Universal Workspace. Classic connections are separate.</p>
+          </div>
+          <button type="button" className="uw-manager-close" onClick={onClose} aria-label="Close">×</button>
+        </header>
+
+        <div className="uw-machine-manager-body">
+          {machines.length === 0 && editingID !== "new" ? (
+            <div className="uw-machine-manager-empty">
+              <strong>No machines configured</strong>
+              <span>Add a Harness machine daemon to start aggregating native sessions.</span>
+            </div>
+          ) : null}
+
+          {machines.map((machine) => (
+            <div className="uw-machine-config-card" key={machine.id}>
+              <div className="uw-machine-config-main">
+                <strong>{machine.name}</strong>
+                <span>{machine.config.host}:{machine.config.port}</span>
+                <small>{machine.config.username || "No username"}</small>
+              </div>
+              <div className="uw-machine-config-actions">
+                <button type="button" className="uw-manager-button" onClick={() => setEditingID(machine.id)}>Edit</button>
+                <button type="button" className="uw-manager-button danger" onClick={() => remove(machine)}>Remove</button>
+              </div>
+            </div>
+          ))}
+
+          {draft ? (
+            <MachineEditor
+              key={draft.id}
+              machine={draft}
+              isNew={editingID === "new"}
+              onCancel={() => setEditingID(null)}
+              onSave={save}
+            />
+          ) : null}
+        </div>
+
+        <footer className="uw-machine-manager-footer">
+          <span>{machines.length} machine{machines.length === 1 ? "" : "s"} configured</span>
+          <button type="button" className="uw-manager-button primary" onClick={() => setEditingID("new")}>+ Add machine</button>
+        </footer>
+      </section>
+    </div>
+  )
+}
+
+export function StandaloneUniversalWorkspace({ machines, onPersistMachines, legacyView }: Props) {
+  const [managerOpen, setManagerOpen] = useState(machines.length === 0)
+  const [activeMachineID, setActiveMachineID] = useState(machines[0]?.id || "")
+
+  const activeID = machines.some((machine) => machine.id === activeMachineID)
+    ? activeMachineID
+    : machines[0]?.id || ""
+
+  return (
+    <div className="uw-standalone-host">
+      <UniversalWorkspace
+        profiles={machines}
+        activeProfileID={activeID}
+        onPersistProfiles={(nextMachines, nextActiveID) => {
+          onPersistMachines(nextMachines as WorkspaceMachine[])
+          setActiveMachineID(nextActiveID)
+        }}
+        legacyView={legacyView}
+      />
+
+      <button type="button" className="uw-machine-manager-trigger" onClick={() => setManagerOpen(true)} title="Manage machines">
+        Machines
+        <span>{machines.length}</span>
+      </button>
+
+      {managerOpen ? (
+        <MachineManager
+          machines={machines}
+          onClose={() => setManagerOpen(false)}
+          onPersist={(nextMachines) => {
+            onPersistMachines(nextMachines)
+            if (!nextMachines.some((machine) => machine.id === activeID)) setActiveMachineID(nextMachines[0]?.id || "")
+          }}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/web/src/components/taskdesk-home.tsx
+++ b/web/src/components/taskdesk-home.tsx
@@ -7,10 +7,10 @@ import type { MachineSnapshot, ServerConfig } from "../types"
 type TaskDeskHomeProps = {
   config: ServerConfig
   sessions: ReactNode
+  onUpdateConnection: (config: ServerConfig) => void
 }
 
 type TaskDeskView = "tasks" | "sessions"
-
 type LoadState = "loading" | "ready" | "unavailable" | "error"
 
 const TASKDESK_DISCOVERY_TIMEOUT_MS = 12_000
@@ -18,10 +18,7 @@ const TASKDESK_DISCOVERY_TIMEOUT_MS = 12_000
 function formatLastActivity(value: string): string {
   const timestamp = Date.parse(value)
   if (!Number.isFinite(timestamp)) return "Unknown activity"
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short"
-  }).format(timestamp)
+  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(timestamp)
 }
 
 function withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
@@ -42,17 +39,76 @@ function withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
 
 function browserConnectionHint(config: ServerConfig): string {
   if (typeof window === "undefined") return ""
-  const origin = window.location.origin
-  return ` Browser access requires the daemon to allow this exact origin with --cors ${origin}. Target: ${config.host}:${config.port}.`
+  return ` Browser access requires the daemon to allow this exact origin with --cors ${window.location.origin}. Target: ${config.host}:${config.port}.`
 }
 
-export function TaskDeskHome({ config, sessions }: TaskDeskHomeProps) {
+function ConnectionEditor({
+  config,
+  onCancel,
+  onSave
+}: {
+  config: ServerConfig
+  onCancel: () => void
+  onSave: (config: ServerConfig) => void
+}) {
+  const [host, setHost] = useState(config.host)
+  const [port, setPort] = useState(String(config.port))
+  const [username, setUsername] = useState(config.username)
+  const [password, setPassword] = useState(config.password)
+  const parsedPort = Number(port)
+  const valid = host.trim().length > 0 && Number.isInteger(parsedPort) && parsedPort > 0 && parsedPort <= 65_535
+
+  return (
+    <div className="modal-backdrop" role="presentation" onClick={onCancel}>
+      <section className="modal-card wizard taskdesk-connection-editor" role="dialog" aria-modal="true" aria-labelledby="taskdesk-connection-title" onClick={(event) => event.stopPropagation()}>
+        <div className="wizard-header">
+          <div className="wizard-header-text">
+            <h2 id="taskdesk-connection-title">Machine connection</h2>
+            <p className="subtle">Use the Address, Username and Password printed by the Harness Remote daemon.</p>
+          </div>
+        </div>
+        <div className="wizard-body">
+          <label className="field">
+            <span>Host</span>
+            <input value={host} onChange={(event) => setHost(event.target.value)} spellCheck={false} autoCapitalize="none" autoCorrect="off" />
+          </label>
+          <label className="field">
+            <span>Port</span>
+            <input value={port} inputMode="numeric" onChange={(event) => setPort(event.target.value)} />
+          </label>
+          <label className="field">
+            <span>Username</span>
+            <input value={username} onChange={(event) => setUsername(event.target.value)} spellCheck={false} autoCapitalize="none" autoCorrect="off" />
+          </label>
+          <label className="field">
+            <span>Password</span>
+            <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} autoComplete="current-password" />
+          </label>
+        </div>
+        <div className="wizard-footer">
+          <button type="button" className="btn-secondary" onClick={onCancel}>Cancel</button>
+          <button
+            type="button"
+            className="btn-primary"
+            disabled={!valid}
+            onClick={() => onSave({ ...config, host: host.trim(), port: parsedPort, username: username.trim(), password: password.trim() })}
+          >
+            Save and reconnect
+          </button>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+export function TaskDeskHome({ config, sessions, onUpdateConnection }: TaskDeskHomeProps) {
   const [view, setView] = useState<TaskDeskView>("tasks")
   const [machine, setMachine] = useState<MachineSnapshot | null>(null)
   const [tasks, setTasks] = useState<MachineTask[]>([])
   const [state, setState] = useState<LoadState>("loading")
   const [error, setError] = useState<string | null>(null)
   const [revision, setRevision] = useState(0)
+  const [editingConnection, setEditingConnection] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -113,11 +169,12 @@ export function TaskDeskHome({ config, sessions }: TaskDeskHomeProps) {
         <div>
           <p className="taskdesk-eyebrow">TaskDesk 3.0</p>
           <h1>{machine?.machine.name || "Machine"}</h1>
-          <p className="taskdesk-machine-id">
-            {machine ? `${agents.length} agent${agents.length === 1 ? "" : "s"} available` : `${config.host}:${config.port}`}
-          </p>
+          <button type="button" className="taskdesk-machine-address" onClick={() => setEditingConnection(true)} title="Edit machine connection">
+            {machine ? `${agents.length} agent${agents.length === 1 ? "" : "s"} available · ${config.host}:${config.port}` : `${config.host}:${config.port}`}
+          </button>
         </div>
         <div className="taskdesk-topbar-actions">
+          <button type="button" className="taskdesk-secondary-button" onClick={() => setEditingConnection(true)}>Connection</button>
           <button type="button" className="taskdesk-secondary-button" onClick={() => setView("sessions")}>Sessions</button>
           <button type="button" className="taskdesk-secondary-button" onClick={refresh} disabled={state === "loading"}>Refresh</button>
         </div>
@@ -165,13 +222,16 @@ export function TaskDeskHome({ config, sessions }: TaskDeskHomeProps) {
             <div className="taskdesk-state taskdesk-state-warning">
               <strong>This connection does not expose TaskDesk machine APIs.</strong>
               <span>Ordinary sessions still work. Connect to the unified Harness Remote daemon to use Tasks.</span>
-              <button type="button" className="taskdesk-primary-button" onClick={() => setView("sessions")}>Open Sessions</button>
+              <button type="button" className="taskdesk-primary-button" onClick={() => setEditingConnection(true)}>Change connection</button>
             </div>
           ) : state === "error" ? (
             <div className="taskdesk-state taskdesk-state-error" role="alert">
               <strong>Could not load TaskDesk.</strong>
               <span>{error || "Unknown error"}</span>
-              <button type="button" className="taskdesk-primary-button" onClick={refresh}>Try again</button>
+              <div className="taskdesk-state-actions">
+                <button type="button" className="taskdesk-primary-button" onClick={() => setEditingConnection(true)}>Change connection</button>
+                <button type="button" className="taskdesk-secondary-button" onClick={refresh}>Try again</button>
+              </div>
             </div>
           ) : tasks.length === 0 ? (
             <div className="taskdesk-state">
@@ -207,6 +267,17 @@ export function TaskDeskHome({ config, sessions }: TaskDeskHomeProps) {
           )}
         </section>
       </main>
+
+      {editingConnection && (
+        <ConnectionEditor
+          config={config}
+          onCancel={() => setEditingConnection(false)}
+          onSave={(nextConfig) => {
+            setEditingConnection(false)
+            onUpdateConnection(nextConfig)
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/web/src/components/taskdesk-home.tsx
+++ b/web/src/components/taskdesk-home.tsx
@@ -1,0 +1,190 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react"
+import { discoverMachine, selectableMachineAgents } from "../machineClient"
+import { taskClient, type MachineTask } from "../taskClient"
+import { agentLabel, modelLabel, normalizeTaskStatus, sortTasksByActivity, taskStatusLabel, taskTitle } from "../taskdeskHomeModel"
+import type { MachineSnapshot, ServerConfig } from "../types"
+
+type TaskDeskHomeProps = {
+  config: ServerConfig
+  sessions: ReactNode
+}
+
+type TaskDeskView = "tasks" | "sessions"
+
+type LoadState = "loading" | "ready" | "unavailable" | "error"
+
+function formatLastActivity(value: string): string {
+  const timestamp = Date.parse(value)
+  if (!Number.isFinite(timestamp)) return "Unknown activity"
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short"
+  }).format(timestamp)
+}
+
+export function TaskDeskHome({ config, sessions }: TaskDeskHomeProps) {
+  const [view, setView] = useState<TaskDeskView>("tasks")
+  const [machine, setMachine] = useState<MachineSnapshot | null>(null)
+  const [tasks, setTasks] = useState<MachineTask[]>([])
+  const [state, setState] = useState<LoadState>("loading")
+  const [error, setError] = useState<string | null>(null)
+  const [revision, setRevision] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+    setState("loading")
+    setError(null)
+
+    void Promise.all([
+      discoverMachine(config),
+      taskClient.listTasks(config).catch((reason) => ({ error: reason instanceof Error ? reason : new Error(String(reason)) }))
+    ]).then(([snapshot, taskResult]) => {
+      if (cancelled) return
+      setMachine(snapshot)
+      if (!snapshot) {
+        setTasks([])
+        setState("unavailable")
+        return
+      }
+      if ("error" in taskResult) {
+        setTasks([])
+        setError(taskResult.error.message)
+        setState("error")
+        return
+      }
+      setTasks(sortTasksByActivity(taskResult))
+      setState("ready")
+    }).catch((reason) => {
+      if (cancelled) return
+      setMachine(null)
+      setTasks([])
+      setError(reason instanceof Error ? reason.message : String(reason))
+      setState("error")
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [config.backend, config.host, config.port, config.username, config.password, config.agentId, revision])
+
+  const refresh = useCallback(() => setRevision((value) => value + 1), [])
+  const agents = useMemo(() => machine ? selectableMachineAgents(machine) : [], [machine])
+
+  if (view === "sessions") {
+    return (
+      <div className="taskdesk-shell taskdesk-shell-sessions">
+        <header className="taskdesk-topbar">
+          <div className="taskdesk-machine-heading">
+            <button className="taskdesk-back" type="button" onClick={() => setView("tasks")}>TaskDesk</button>
+            <span className="taskdesk-divider" aria-hidden="true">/</span>
+            <strong>Sessions</strong>
+          </div>
+        </header>
+        <div className="taskdesk-session-host">{sessions}</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="taskdesk-shell">
+      <header className="taskdesk-topbar">
+        <div>
+          <p className="taskdesk-eyebrow">TaskDesk 3.0</p>
+          <h1>{machine?.machine.name || "Machine"}</h1>
+          <p className="taskdesk-machine-id">
+            {machine ? `${agents.length} agent${agents.length === 1 ? "" : "s"} available` : `${config.host}:${config.port}`}
+          </p>
+        </div>
+        <div className="taskdesk-topbar-actions">
+          <button type="button" className="taskdesk-secondary-button" onClick={() => setView("sessions")}>Sessions</button>
+          <button type="button" className="taskdesk-secondary-button" onClick={refresh} disabled={state === "loading"}>Refresh</button>
+        </div>
+      </header>
+
+      <main className="taskdesk-home">
+        <section className="taskdesk-summary" aria-label="Machine summary">
+          <div className="taskdesk-summary-card">
+            <span>Machine</span>
+            <strong>{machine?.machine.name || (state === "loading" ? "Connecting..." : "Unavailable")}</strong>
+          </div>
+          <div className="taskdesk-summary-card">
+            <span>Agents</span>
+            <strong>{machine ? agents.length : "-"}</strong>
+          </div>
+          <div className="taskdesk-summary-card">
+            <span>Tasks</span>
+            <strong>{state === "ready" ? tasks.length : "-"}</strong>
+          </div>
+        </section>
+
+        {machine && agents.length > 0 ? (
+          <section className="taskdesk-agents" aria-label="Available agents">
+            {agents.map((agent) => (
+              <span className="taskdesk-agent-chip" key={agent.id} title={`${agent.backend} · ${agent.transport}`}>
+                <span className={`taskdesk-agent-dot taskdesk-agent-dot-${agent.state}`} aria-hidden="true" />
+                {agent.label}
+              </span>
+            ))}
+          </section>
+        ) : null}
+
+        <section className="taskdesk-tasks-section">
+          <div className="taskdesk-section-heading">
+            <div>
+              <p className="taskdesk-eyebrow">Work</p>
+              <h2>Tasks</h2>
+            </div>
+            <p>Tasks are durable work. Sessions remain available separately for direct harness conversations.</p>
+          </div>
+
+          {state === "loading" ? (
+            <div className="taskdesk-state" role="status">Loading machine and tasks...</div>
+          ) : state === "unavailable" ? (
+            <div className="taskdesk-state taskdesk-state-warning">
+              <strong>This connection does not expose TaskDesk machine APIs.</strong>
+              <span>Ordinary sessions still work. Connect to the unified Harness Remote daemon to use Tasks.</span>
+              <button type="button" className="taskdesk-primary-button" onClick={() => setView("sessions")}>Open Sessions</button>
+            </div>
+          ) : state === "error" ? (
+            <div className="taskdesk-state taskdesk-state-error" role="alert">
+              <strong>Could not load TaskDesk.</strong>
+              <span>{error || "Unknown error"}</span>
+              <button type="button" className="taskdesk-primary-button" onClick={refresh}>Try again</button>
+            </div>
+          ) : tasks.length === 0 ? (
+            <div className="taskdesk-state">
+              <strong>No tasks yet.</strong>
+              <span>The next TaskDesk milestone will add the final New Task flow here.</span>
+            </div>
+          ) : (
+            <div className="taskdesk-task-list">
+              {tasks.map((task) => {
+                const normalizedStatus = normalizeTaskStatus(task.status)
+                return (
+                  <article className="taskdesk-task-card" key={task.id} data-status={normalizedStatus}>
+                    <div className="taskdesk-task-main">
+                      <div className="taskdesk-task-title-row">
+                        <h3>{taskTitle(task)}</h3>
+                        <span className={`taskdesk-status taskdesk-status-${normalizedStatus}`}>{taskStatusLabel(task.status)}</span>
+                      </div>
+                      <p className="taskdesk-task-project">{task.project?.name || task.projectId}</p>
+                      <div className="taskdesk-task-meta">
+                        <span><b>Agent</b> {agentLabel(agents, task.agentId)}</span>
+                        <span><b>Model</b> {modelLabel(task)}</span>
+                        <span><b>Workspace</b> {task.workspace?.mode || "project"}</span>
+                      </div>
+                    </div>
+                    <div className="taskdesk-task-side">
+                      <time dateTime={task.updatedAt}>{formatLastActivity(task.updatedAt || task.createdAt)}</time>
+                      <span className="taskdesk-task-open-hint">Task detail coming next</span>
+                    </div>
+                  </article>
+                )
+              })}
+            </div>
+          )}
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/web/src/components/taskdesk-home.tsx
+++ b/web/src/components/taskdesk-home.tsx
@@ -13,6 +13,8 @@ type TaskDeskView = "tasks" | "sessions"
 
 type LoadState = "loading" | "ready" | "unavailable" | "error"
 
+const TASKDESK_DISCOVERY_TIMEOUT_MS = 12_000
+
 function formatLastActivity(value: string): string {
   const timestamp = Date.parse(value)
   if (!Number.isFinite(timestamp)) return "Unknown activity"
@@ -20,6 +22,28 @@ function formatLastActivity(value: string): string {
     dateStyle: "medium",
     timeStyle: "short"
   }).format(timestamp)
+}
+
+function withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = window.setTimeout(() => reject(new Error(`${label} timed out after ${TASKDESK_DISCOVERY_TIMEOUT_MS / 1000}s.`)), TASKDESK_DISCOVERY_TIMEOUT_MS)
+    promise.then(
+      (value) => {
+        window.clearTimeout(timer)
+        resolve(value)
+      },
+      (reason) => {
+        window.clearTimeout(timer)
+        reject(reason)
+      }
+    )
+  })
+}
+
+function browserConnectionHint(config: ServerConfig): string {
+  if (typeof window === "undefined") return ""
+  const origin = window.location.origin
+  return ` Browser access requires the daemon to allow this exact origin with --cors ${origin}. Target: ${config.host}:${config.port}.`
 }
 
 export function TaskDeskHome({ config, sessions }: TaskDeskHomeProps) {
@@ -35,32 +59,30 @@ export function TaskDeskHome({ config, sessions }: TaskDeskHomeProps) {
     setState("loading")
     setError(null)
 
-    void Promise.all([
-      discoverMachine(config),
-      taskClient.listTasks(config).catch((reason) => ({ error: reason instanceof Error ? reason : new Error(String(reason)) }))
-    ]).then(([snapshot, taskResult]) => {
-      if (cancelled) return
-      setMachine(snapshot)
-      if (!snapshot) {
+    void (async () => {
+      try {
+        const snapshot = await withTimeout(discoverMachine(config), "Machine discovery")
+        if (cancelled) return
+        setMachine(snapshot)
+        if (!snapshot) {
+          setTasks([])
+          setState("unavailable")
+          return
+        }
+
+        const loadedTasks = await withTimeout(taskClient.listTasks(config), "Task loading")
+        if (cancelled) return
+        setTasks(sortTasksByActivity(loadedTasks))
+        setState("ready")
+      } catch (reason) {
+        if (cancelled) return
+        setMachine(null)
         setTasks([])
-        setState("unavailable")
-        return
-      }
-      if ("error" in taskResult) {
-        setTasks([])
-        setError(taskResult.error.message)
+        const detail = reason instanceof Error ? reason.message : String(reason)
+        setError(`${detail}${browserConnectionHint(config)}`)
         setState("error")
-        return
       }
-      setTasks(sortTasksByActivity(taskResult))
-      setState("ready")
-    }).catch((reason) => {
-      if (cancelled) return
-      setMachine(null)
-      setTasks([])
-      setError(reason instanceof Error ? reason.message : String(reason))
-      setState("error")
-    })
+    })()
 
     return () => {
       cancelled = true

--- a/web/src/components/universal-workspace.tsx
+++ b/web/src/components/universal-workspace.tsx
@@ -1041,30 +1041,20 @@ export function UniversalWorkspace({
     localStorage.setItem(PINNED_STORAGE_KEY, JSON.stringify([...pinned]))
   }, [pinned])
 
+  const machineScopedSessions = useMemo(() =>
+    sessions.filter((item) => machineFilter === "all" || item.machineKey === machineFilter),
+  [sessions, machineFilter])
+
   const projects = useMemo(() => {
     const map = new Map<string, number>()
-    for (const item of sessions) map.set(item.projectName, (map.get(item.projectName) || 0) + 1)
+    for (const item of machineScopedSessions) map.set(item.projectName, (map.get(item.projectName) || 0) + 1)
     return [...map.entries()].sort((left, right) => right[1] - left[1])
-  }, [sessions])
+  }, [machineScopedSessions])
 
-  const counts = useMemo(() => ({
-    all: sessions.length,
-    working: sessions.filter((item) => normalizeStatus(item.status, item.attention) === "working").length,
-    needs: sessions.filter((item) => normalizeStatus(item.status, item.attention) === "needs-you").length,
-    idle: sessions.filter((item) => normalizeStatus(item.status, item.attention) === "idle").length,
-    pinned: sessions.filter((item) => pinned.has(item.key)).length
-  }), [sessions, pinned])
-
-  const filteredSessions = useMemo(() => {
+  const scopedSessions = useMemo(() => {
     const needle = query.trim().toLowerCase()
-    return sessions.filter((item) => {
+    return machineScopedSessions.filter((item) => {
       if (projectFilter !== "all" && item.projectName !== projectFilter) return false
-      if (machineFilter !== "all" && item.machineKey !== machineFilter) return false
-      const normalized = normalizeStatus(item.status, item.attention)
-      if (filter === "working" && normalized !== "working") return false
-      if (filter === "needs-you" && normalized !== "needs-you") return false
-      if (filter === "idle" && normalized !== "idle") return false
-      if (filter === "pinned" && !pinned.has(item.key)) return false
       if (!needle) return true
       return [
         item.session.title,
@@ -1076,7 +1066,24 @@ export function UniversalWorkspace({
         previews[item.key]
       ].some((value) => value?.toLowerCase().includes(needle))
     })
-  }, [sessions, projectFilter, machineFilter, filter, pinned, query, previews])
+  }, [machineScopedSessions, projectFilter, query, previews])
+
+  const counts = useMemo(() => ({
+    all: scopedSessions.length,
+    working: scopedSessions.filter((item) => normalizeStatus(item.status, item.attention) === "working").length,
+    needs: scopedSessions.filter((item) => normalizeStatus(item.status, item.attention) === "needs-you").length,
+    idle: scopedSessions.filter((item) => normalizeStatus(item.status, item.attention) === "idle").length,
+    pinned: scopedSessions.filter((item) => pinned.has(item.key)).length
+  }), [scopedSessions, pinned])
+
+  const filteredSessions = useMemo(() => scopedSessions.filter((item) => {
+    const normalized = normalizeStatus(item.status, item.attention)
+    if (filter === "working" && normalized !== "working") return false
+    if (filter === "needs-you" && normalized !== "needs-you") return false
+    if (filter === "idle" && normalized !== "idle") return false
+    if (filter === "pinned" && !pinned.has(item.key)) return false
+    return true
+  }), [scopedSessions, filter, pinned])
 
   async function sendPrompt() {
     if (!selected || !composer.trim() || sending) return
@@ -1120,6 +1127,26 @@ export function UniversalWorkspace({
     } catch (reason) {
       setGlobalError(reason instanceof Error ? reason.message : String(reason))
     }
+  }
+
+  function selectMachine(machine: MachineSource) {
+    setMachineFilter(machine.key)
+    setProjectFilter("all")
+    setDetailTab("conversation")
+    setSelectedKey((current) => {
+      const currentItem = current ? sessions.find((item) => item.key === current) : undefined
+      if (currentItem?.machineKey === machine.key) return current
+      return sessions.find((item) => item.machineKey === machine.key)?.key || null
+    })
+  }
+
+  function selectProject(project: string) {
+    setProjectFilter(project)
+    setDetailTab("conversation")
+    const candidate = sessions.find((item) =>
+      (machineFilter === "all" || item.machineKey === machineFilter) && item.projectName === project
+    )
+    if (candidate) setSelectedKey(candidate.key)
   }
 
   const selectedMachine = selected ? machines.find((machine) => machine.key === selected.machineKey) : undefined
@@ -1211,7 +1238,7 @@ export function UniversalWorkspace({
               <button type="button" title="Show all projects" onClick={() => setProjectFilter("all")}>×</button>
             </div>
             {projects.slice(0, 8).map(([project, count]) => (
-              <button key={project} className={projectFilter === project ? "active" : ""} onClick={() => setProjectFilter(project)}>
+              <button key={project} className={projectFilter === project ? "active" : ""} onClick={() => selectProject(project)}>
                 <FolderIcon size={15} /><span title={project}>{project}</span><b>{count}</b>
               </button>
             ))}
@@ -1221,13 +1248,16 @@ export function UniversalWorkspace({
           <section className="uw-nav-section uw-machines-section">
             <div className="uw-nav-heading">
               <span className="uw-nav-label">Machines</span>
-              <button type="button" onClick={() => setMachineFilter("all")} title="Show every machine">×</button>
+              <button type="button" onClick={() => {
+                setMachineFilter("all")
+                setProjectFilter("all")
+              }} title="Show every machine">×</button>
             </div>
             {machines.map((machine) => (
               <button
                 key={machine.key}
                 className={machineFilter === machine.key ? "active" : ""}
-                onClick={() => setMachineFilter(machine.key)}
+                onClick={() => selectMachine(machine)}
                 onDoubleClick={() => setConnectionProfileID(machine.profile.id)}
                 title={machine.error || `${machine.profile.config.host}:${machine.profile.config.port}`}
               >

--- a/web/src/components/universal-workspace.tsx
+++ b/web/src/components/universal-workspace.tsx
@@ -111,7 +111,7 @@ function machineLabel(source: MachineSource): string {
 function directoryLabel(directory: string): string {
   const normalized = directory.replace(/[\\/]+$/, "")
   const chunks = normalized.split(/[\\/]/).filter(Boolean)
-  return chunks.at(-1) || directory || "Project"
+  return (chunks.length ? chunks[chunks.length - 1] : "") || directory || "Project"
 }
 
 function projectNameFor(session: Session): string {
@@ -752,7 +752,7 @@ function QuestionPanel({
   async function submit() {
     setSending(true)
     try {
-      const payload = request.questions.map((question, index) => {
+      const payload = request.questions.map((_question, index) => {
         const selected = answers[index] || []
         const customValue = custom[index]?.trim()
         return customValue ? [...selected, customValue] : selected

--- a/web/src/components/universal-workspace.tsx
+++ b/web/src/components/universal-workspace.tsx
@@ -42,6 +42,13 @@ const REFRESH_INTERVAL_MS = 4_000
 const DETAIL_REFRESH_INTERVAL_MS = 2_500
 const AGENT_SESSION_LOAD_TIMEOUT_MS = 12_000
 const PINNED_STORAGE_KEY = "harness-remote.universal-workspace.pinned"
+const HARNESS_ICON_URLS: Record<string, string> = {
+  codex: "https://openai.com/favicon.ico",
+  claude: "https://claude.ai/favicon.ico",
+  opencode: "https://opencode.ai/favicon.ico",
+  omp: "https://omp.sh/favicon.ico",
+  pi: "https://pi.dev/favicon.ico"
+}
 
 type WorkspaceFilter = "all" | "working" | "needs-you" | "idle" | "pinned"
 type DetailTab = "conversation" | "changes"
@@ -196,6 +203,10 @@ function modelLabel(model?: Session["model"] | ModelSelection | null): string {
   return `${model.providerID}/${candidate}${variant}`
 }
 
+function modelOptionKey(model: ModelSelection): string {
+  return `${model.providerID}/${model.modelID}/${model.variant || ""}`
+}
+
 function uniqueEndpointProfiles(profiles: SavedServerProfile[]): SavedServerProfile[] {
   const seen = new Set<string>()
   return profiles.filter((profile) => {
@@ -346,14 +357,28 @@ function ToolCard({ message }: { message: MessageEnvelope }) {
   )
 }
 
-function MessageBubble({ message, agentLabel }: { message: MessageEnvelope; agentLabel: string }) {
+function HarnessAvatar({ backend, label }: { backend: string; label: string }) {
+  const [failed, setFailed] = useState(false)
+  const source = HARNESS_ICON_URLS[backend.toLowerCase()]
+  return (
+    <div className="uw-avatar uw-avatar-agent" title={label}>
+      {source && !failed ? (
+        <img src={source} alt="" aria-hidden="true" onError={() => setFailed(true)} />
+      ) : label.slice(0, 2).toUpperCase()}
+    </div>
+  )
+}
+
+function MessageBubble({ message, agentLabel, agentBackend }: { message: MessageEnvelope; agentLabel: string; agentBackend: string }) {
   const isUser = message.info.role === "user"
   const text = extractText(message)
   return (
     <article className={`uw-message ${isUser ? "uw-message-user" : "uw-message-agent"}`}>
-      <div className={`uw-avatar ${isUser ? "uw-avatar-user" : "uw-avatar-agent"}`}>
-        {isUser ? "You" : agentLabel.slice(0, 2).toUpperCase()}
-      </div>
+      {isUser ? (
+        <div className="uw-avatar uw-avatar-user">You</div>
+      ) : (
+        <HarnessAvatar backend={agentBackend} label={agentLabel} />
+      )}
       <div className="uw-message-body">
         <header>
           <strong>{isUser ? "You" : agentLabel}</strong>
@@ -861,6 +886,9 @@ export function UniversalWorkspace({
   const [detailLoading, setDetailLoading] = useState(false)
   const [detailTab, setDetailTab] = useState<DetailTab>("conversation")
   const [composer, setComposer] = useState("")
+  const [sessionModels, setSessionModels] = useState<ModelOption[]>([])
+  const [sessionModelKey, setSessionModelKey] = useState("")
+  const [sessionModelsLoading, setSessionModelsLoading] = useState(false)
   const [sending, setSending] = useState(false)
   const [newSessionOpen, setNewSessionOpen] = useState(false)
   const [handoffOpen, setHandoffOpen] = useState(false)
@@ -874,6 +902,7 @@ export function UniversalWorkspace({
   const transcriptRef = useRef<HTMLDivElement>(null)
 
   const selected = sessions.find((item) => item.key === selectedKey) || null
+  const selectedSessionModel = sessionModels.find((model) => modelOptionKey(model) === sessionModelKey)
 
   const refreshAll = useCallback(async (silent = false) => {
     if (refreshInFlight.current) return
@@ -1033,6 +1062,39 @@ export function UniversalWorkspace({
   }, [selected?.key, questionRevision, loadDetail])
 
   useEffect(() => {
+    if (!selected) {
+      setSessionModels([])
+      setSessionModelKey("")
+      setSessionModelsLoading(false)
+      return
+    }
+    let cancelled = false
+    setSessionModelsLoading(true)
+    void withTimeout(
+      api.listModels(selected.config, selected.session.directory, selected.session.id),
+      `${selected.agent.label} model loading`
+    ).then((models) => {
+      if (cancelled) return
+      setSessionModels(models)
+      const nativeModel = selected.session.model
+        ? models.find((model) => model.providerID === selected.session.model?.providerID
+          && model.modelID === selected.session.model?.id
+          && (model.variant || "") === (selected.session.model?.variant || ""))
+        : undefined
+      const currentModel = nativeModel || models.find((model) => model.isDefault) || models[0]
+      setSessionModelKey(currentModel ? modelOptionKey(currentModel) : "")
+    }).catch(() => {
+      if (!cancelled) {
+        setSessionModels([])
+        setSessionModelKey("")
+      }
+    }).finally(() => {
+      if (!cancelled) setSessionModelsLoading(false)
+    })
+    return () => { cancelled = true }
+  }, [selected?.key])
+
+  useEffect(() => {
     if (!transcriptRef.current || detailTab !== "conversation") return
     transcriptRef.current.scrollTop = transcriptRef.current.scrollHeight
   }, [selected?.key, detail.messages.length, detailTab])
@@ -1092,9 +1154,11 @@ export function UniversalWorkspace({
     setSending(true)
     setGlobalError(null)
     try {
-      const model = selected.session.model
-        ? { providerID: selected.session.model.providerID, modelID: selected.session.model.id, variant: selected.session.model.variant }
-        : undefined
+      const model = selectedSessionModel
+        ? { providerID: selectedSessionModel.providerID, modelID: selectedSessionModel.modelID, variant: selectedSessionModel.variant }
+        : selected.session.model
+          ? { providerID: selected.session.model.providerID, modelID: selected.session.model.id, variant: selected.session.model.variant }
+          : undefined
       await api.sendPrompt(selected.config, selected.session.id, text, selected.session.directory, model)
       await loadDetail(selected, true)
       await refreshAll(true)
@@ -1154,6 +1218,7 @@ export function UniversalWorkspace({
   const connectionProfile = profiles.find((profile) => profile.id === connectionProfileID) || null
   const selectedQuestions = detail.questions
   const selectedPermissions = detail.permissions
+  const selectedModelLabel = selectedSessionModel ? modelLabel(selectedSessionModel) : modelLabel(selected?.session.model)
 
   if (classicOpen) {
     return (
@@ -1368,7 +1433,24 @@ export function UniversalWorkspace({
                   <div className="uw-context-strip">
                     <span><small>Project</small><b>{selected.projectName}</b></span>
                     <span><small>Harness</small><b>{selected.agent.label}</b></span>
-                    <span><small>Model</small><b>{modelLabel(selected.session.model)}</b></span>
+                    <span className="uw-context-model">
+                      <small>Model</small>
+                      {sessionModels.length > 0 ? (
+                        <select
+                          className="uw-context-model-select"
+                          value={sessionModelKey}
+                          onChange={(event) => setSessionModelKey(event.target.value)}
+                          disabled={sessionModelsLoading || sending}
+                          title="Model used for the next turn"
+                        >
+                          {sessionModels.map((model) => (
+                            <option key={modelOptionKey(model)} value={modelOptionKey(model)}>
+                              {model.modelName}{model.variant ? ` (${model.variant})` : ""}
+                            </option>
+                          ))}
+                        </select>
+                      ) : <b>{sessionModelsLoading ? "Loading…" : selectedModelLabel}</b>}
+                    </span>
                     <span><small>Machine</small><b>{selected.machineName}</b></span>
                     <span className={statusClass(selected.status, selected.attention)}><small>Status</small><b>{statusLabel(selected.status, selected.attention)}</b></span>
                   </div>
@@ -1400,7 +1482,12 @@ export function UniversalWorkspace({
                     ) : detail.messages.length === 0 ? (
                       <div className="uw-empty-panel"><ChatIcon size={24} /><strong>This session has no messages yet.</strong></div>
                     ) : detail.messages.map((message) => (
-                      <MessageBubble key={message.info.id} message={message} agentLabel={selected.agent.label} />
+                      <MessageBubble
+                        key={message.info.id}
+                        message={message}
+                        agentLabel={selected.agent.label}
+                        agentBackend={selected.agent.backend}
+                      />
                     ))}
                   </div>
 
@@ -1418,7 +1505,7 @@ export function UniversalWorkspace({
                       rows={3}
                     />
                     <div className="uw-composer-footer">
-                      <span>{selected.session.directory}</span>
+                      <span className="uw-composer-directory">{selected.session.directory}</span>
                       <div>
                         <small>Shift+Enter for newline</small>
                         <BeautifulButton variant="primary" disabled={!composer.trim() || sending} onClick={() => void sendPrompt()}>
@@ -1480,7 +1567,7 @@ export function UniversalWorkspace({
             <section className="uw-inspector-grid">
               <span>Project</span><b>{selected.projectName}</b>
               <span>Harness</span><b>{selected.agent.label}</b>
-              <span>Model</span><b>{modelLabel(selected.session.model)}</b>
+              <span>Model</span><b>{selectedModelLabel}</b>
               <span>Machine</span><b>{selected.machineName}</b>
               <span>Working directory</span><code>{selected.session.directory}</code>
               <span>Branch</span><b>{detail.vcs?.branch || "Unknown"}</b>

--- a/web/src/components/universal-workspace.tsx
+++ b/web/src/components/universal-workspace.tsx
@@ -94,6 +94,15 @@ type UniversalWorkspaceProps = {
   legacyView: ReactNode
 }
 
+const EMPTY_DETAIL: SelectedDetail = {
+  messages: [],
+  diff: [],
+  todos: [],
+  vcs: null,
+  questions: [],
+  permissions: []
+}
+
 function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = AGENT_SESSION_LOAD_TIMEOUT_MS): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timer = window.setTimeout(
@@ -887,7 +896,8 @@ export function UniversalWorkspace({
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
   const [globalError, setGlobalError] = useState<string | null>(null)
-  const [detail, setDetail] = useState<SelectedDetail>({ messages: [], diff: [], todos: [], vcs: null, questions: [], permissions: [] })
+  const [detail, setDetail] = useState<SelectedDetail>(EMPTY_DETAIL)
+  const [detailSessionKey, setDetailSessionKey] = useState<string | null>(null)
   const [detailLoading, setDetailLoading] = useState(false)
   const [detailTab, setDetailTab] = useState<DetailTab>("conversation")
   const [composer, setComposer] = useState("")
@@ -904,10 +914,13 @@ export function UniversalWorkspace({
   const [questionRevision, setQuestionRevision] = useState(0)
   const refreshGeneration = useRef(0)
   const refreshInFlight = useRef(false)
+  const selectedKeyRef = useRef<string | null>(null)
   const transcriptRef = useRef<HTMLDivElement>(null)
 
   const selected = sessions.find((item) => item.key === selectedKey) || null
+  selectedKeyRef.current = selectedKey
   const selectedSessionModel = sessionModels.find((model) => modelOptionKey(model) === sessionModelKey)
+  const detailReady = Boolean(selected && detailSessionKey === selected.key)
 
   const refreshAll = useCallback(async (silent = false) => {
     if (refreshInFlight.current) return
@@ -1040,6 +1053,7 @@ export function UniversalWorkspace({
         api.loadQuestions(item.config, item.session.directory).catch(() => []),
         api.loadPermissions(item.config, item.session.directory).catch(() => [])
       ])
+      if (selectedKeyRef.current !== item.key) return
       setDetail({
         messages,
         diff,
@@ -1048,18 +1062,26 @@ export function UniversalWorkspace({
         questions: questions.filter((request) => request.sessionID === item.session.id),
         permissions: permissions.filter((request) => request.sessionID === item.session.id)
       })
+      setDetailSessionKey(item.key)
     } catch (reason) {
-      if (!silent) setGlobalError(reason instanceof Error ? reason.message : String(reason))
+      if (!silent && selectedKeyRef.current === item.key) {
+        setGlobalError(reason instanceof Error ? reason.message : String(reason))
+      }
     } finally {
-      if (!silent) setDetailLoading(false)
+      if (!silent && selectedKeyRef.current === item.key) setDetailLoading(false)
     }
   }, [])
 
   useEffect(() => {
     if (!selected) {
-      setDetail({ messages: [], diff: [], todos: [], vcs: null, questions: [], permissions: [] })
+      setDetail(EMPTY_DETAIL)
+      setDetailSessionKey(null)
+      setDetailLoading(false)
       return
     }
+    setDetail(EMPTY_DETAIL)
+    setDetailSessionKey(null)
+    setDetailLoading(true)
     void loadDetail(selected, false)
     const timer = window.setInterval(() => void loadDetail(selected, true), DETAIL_REFRESH_INTERVAL_MS)
     return () => window.clearInterval(timer)
@@ -1099,9 +1121,9 @@ export function UniversalWorkspace({
   }, [selected?.key])
 
   useEffect(() => {
-    if (!transcriptRef.current || detailTab !== "conversation") return
+    if (!transcriptRef.current || detailTab !== "conversation" || !detailReady) return
     transcriptRef.current.scrollTop = transcriptRef.current.scrollHeight
-  }, [selected?.key, detail.messages.length, detailTab])
+  }, [selected?.key, detail.messages.length, detailTab, detailReady])
 
   useEffect(() => {
     localStorage.setItem(PINNED_STORAGE_KEY, JSON.stringify([...pinned]))
@@ -1220,8 +1242,8 @@ export function UniversalWorkspace({
   const selectedMachine = selected ? machines.find((machine) => machine.key === selected.machineKey) : undefined
   const activeProfile = profiles.find((profile) => profile.id === activeProfileID) || profiles[0]
   const connectionProfile = profiles.find((profile) => profile.id === connectionProfileID) || null
-  const selectedQuestions = detail.questions
-  const selectedPermissions = detail.permissions
+  const selectedQuestions = detailReady ? detail.questions : []
+  const selectedPermissions = detailReady ? detail.permissions : []
   const selectedModelLabel = selectedSessionModel ? modelLabel(selectedSessionModel) : modelLabel(selected?.session.model)
 
   if (classicOpen) {
@@ -1474,15 +1496,15 @@ export function UniversalWorkspace({
               <div className="uw-detail-tabs">
                 <button type="button" className={detailTab === "conversation" ? "active" : ""} onClick={() => setDetailTab("conversation")}>Conversation</button>
                 <button type="button" className={detailTab === "changes" ? "active" : ""} onClick={() => setDetailTab("changes")}>
-                  Changes <span>{detail.diff.length}</span>
+                  Changes <span>{detailReady ? detail.diff.length : 0}</span>
                 </button>
               </div>
 
               {detailTab === "conversation" ? (
                 <>
                   <div className="uw-transcript" ref={transcriptRef}>
-                    {detailLoading && detail.messages.length === 0 ? (
-                      <div className="uw-empty-panel"><LoadingIcon size={22} /><strong>Loading conversation…</strong></div>
+                    {detailLoading || !detailReady ? (
+                      <div className="uw-empty-panel"><LoadingIcon size={22} /><strong>Loading session…</strong></div>
                     ) : detail.messages.length === 0 ? (
                       <div className="uw-empty-panel"><ChatIcon size={24} /><strong>This session has no messages yet.</strong></div>
                     ) : detail.messages.map((message) => (
@@ -1512,7 +1534,7 @@ export function UniversalWorkspace({
                       <span className="uw-composer-directory">{selected.session.directory}</span>
                       <div>
                         <small>Shift+Enter for newline</small>
-                        <BeautifulButton variant="primary" disabled={!composer.trim() || sending} onClick={() => void sendPrompt()}>
+                        <BeautifulButton variant="primary" disabled={!composer.trim() || sending || !detailReady} onClick={() => void sendPrompt()}>
                           {sending ? <LoadingIcon size={15} /> : "↑"}
                           {sending ? "Sending" : "Send"}
                         </BeautifulButton>
@@ -1520,6 +1542,10 @@ export function UniversalWorkspace({
                     </div>
                   </div>
                 </>
+              ) : detailLoading || !detailReady ? (
+                <div className="uw-changes-pane">
+                  <div className="uw-empty-panel"><LoadingIcon size={22} /><strong>Loading session…</strong></div>
+                </div>
               ) : (
                 <div className="uw-changes-pane">
                   <header>
@@ -1574,7 +1600,7 @@ export function UniversalWorkspace({
               <span>Model</span><b>{selectedModelLabel}</b>
               <span>Machine</span><b>{selected.machineName}</b>
               <span>Working directory</span><code>{selected.session.directory}</code>
-              <span>Branch</span><b>{detail.vcs?.branch || "Unknown"}</b>
+              <span>Branch</span><b>{detailReady ? detail.vcs?.branch || "Unknown" : "Loading…"}</b>
               <span>Last active</span><b>{formatRelative(selected.session.time.updated)} ago</b>
             </section>
 
@@ -1608,20 +1634,21 @@ export function UniversalWorkspace({
             <section className="uw-inspector-section">
               <div className="uw-inspector-section-heading">
                 <span className="uw-inspector-label">Files touched</span>
-                <button type="button" onClick={() => setDetailTab("changes")}>{detail.diff.length ? `View ${detail.diff.length}` : ""}</button>
+                <button type="button" onClick={() => setDetailTab("changes")}>{detailReady && detail.diff.length ? `View ${detail.diff.length}` : ""}</button>
               </div>
               <div className="uw-file-list">
-                {detail.diff.slice(0, 8).map((file) => (
+                {detailReady ? detail.diff.slice(0, 8).map((file) => (
                   <button type="button" key={file.file} onClick={() => setDetailTab("changes")}>
                     <code>{file.file}</code>
                     <span><b>+{file.additions}</b><i>−{file.deletions}</i></span>
                   </button>
-                ))}
-                {detail.diff.length === 0 ? <p>No diff reported yet.</p> : null}
+                )) : null}
+                {detailReady && detail.diff.length === 0 ? <p>No diff reported yet.</p> : null}
+                {!detailReady ? <p>Loading session…</p> : null}
               </div>
             </section>
 
-            {detail.todos.length > 0 ? (
+            {detailReady && detail.todos.length > 0 ? (
               <section className="uw-inspector-section">
                 <span className="uw-inspector-label">Agent plan</span>
                 <div className="uw-todo-list">
@@ -1685,7 +1712,7 @@ export function UniversalWorkspace({
       {handoffOpen && selected ? (
         <HandoffModal
           current={selected}
-          messages={detail.messages}
+          messages={detailReady ? detail.messages : []}
           machines={machines.filter((machine) => machine.state === "online" && machine.agents.length > 0)}
           onClose={() => setHandoffOpen(false)}
           onCreated={(machine, agent, created) => {

--- a/web/src/components/universal-workspace.tsx
+++ b/web/src/components/universal-workspace.tsx
@@ -40,6 +40,7 @@ import {
 const REMARK_PLUGINS = [remarkGfm]
 const REFRESH_INTERVAL_MS = 4_000
 const DETAIL_REFRESH_INTERVAL_MS = 2_500
+const AGENT_SESSION_LOAD_TIMEOUT_MS = 12_000
 const PINNED_STORAGE_KEY = "harness-remote.universal-workspace.pinned"
 
 type WorkspaceFilter = "all" | "working" | "needs-you" | "idle" | "pinned"
@@ -84,6 +85,25 @@ type UniversalWorkspaceProps = {
   activeProfileID: string
   onPersistProfiles: (profiles: SavedServerProfile[], activeProfileID: string) => void
   legacyView: ReactNode
+}
+
+function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = AGENT_SESSION_LOAD_TIMEOUT_MS): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = window.setTimeout(
+      () => reject(new Error(`${label} timed out after ${Math.round(timeoutMs / 1000)}s.`)),
+      timeoutMs
+    )
+    promise.then(
+      (value) => {
+        window.clearTimeout(timer)
+        resolve(value)
+      },
+      (reason) => {
+        window.clearTimeout(timer)
+        reject(reason)
+      }
+    )
+  })
 }
 
 function endpointKey(config: ServerConfig): string {
@@ -850,11 +870,14 @@ export function UniversalWorkspace({
   const [pinned, setPinned] = useState<Set<string>>(() => loadPinned())
   const [questionRevision, setQuestionRevision] = useState(0)
   const refreshGeneration = useRef(0)
+  const refreshInFlight = useRef(false)
   const transcriptRef = useRef<HTMLDivElement>(null)
 
   const selected = sessions.find((item) => item.key === selectedKey) || null
 
   const refreshAll = useCallback(async (silent = false) => {
+    if (refreshInFlight.current) return
+    refreshInFlight.current = true
     const generation = ++refreshGeneration.current
     if (!silent) setLoading(true)
     else setRefreshing(true)
@@ -908,12 +931,12 @@ export function UniversalWorkspace({
       const collected = (await Promise.all(nextMachines.flatMap((machine) => machine.agents.map(async (agent) => {
         const config = configForAgent(machine, agent)
         try {
-          const [agentSessions, statuses, questions, permissions] = await Promise.all([
+          const [agentSessions, statuses, questions, permissions] = await withTimeout(Promise.all([
             api.listGlobalSessions(config).catch(() => api.listSessions(config)),
             api.listStatuses(config).catch(() => ({} as Record<string, SessionStatus>)),
             api.loadQuestions(config).catch(() => []),
             api.loadPermissions(config).catch(() => [])
-          ])
+          ]), `${agent.label} session loading`)
           const attentionBySession = new Map<string, number>()
           for (const request of [...questions, ...permissions]) {
             attentionBySession.set(request.sessionID, (attentionBySession.get(request.sessionID) || 0) + 1)
@@ -963,6 +986,7 @@ export function UniversalWorkspace({
         setLoading(false)
         setRefreshing(false)
       }
+      refreshInFlight.current = false
     }
   }, [profiles])
 

--- a/web/src/components/universal-workspace.tsx
+++ b/web/src/components/universal-workspace.tsx
@@ -1,0 +1,1566 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
+import ReactMarkdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+import { api, isValidServerConfig } from "../api"
+import { backendDisplayName } from "../backendSetup"
+import { discoverMachine, selectableMachineAgents } from "../machineClient"
+import { taskClient, type MachineProject } from "../taskClient"
+import type { SavedServerProfile } from "../serverProfiles"
+import type {
+  BackendKind,
+  DiffFile,
+  MachineAgentHost,
+  MachineSnapshot,
+  MessageEnvelope,
+  ModelOption,
+  ModelSelection,
+  PermissionRequest,
+  QuestionRequest,
+  ServerConfig,
+  Session,
+  SessionStatus,
+  TodoItem,
+  VcsStatus
+} from "../types"
+import {
+  ChatIcon,
+  CloseIcon,
+  FolderIcon,
+  LoadingIcon,
+  MoreVerticalIcon,
+  PanelRightIcon,
+  PlusIcon,
+  RefreshIcon,
+  SearchIcon,
+  ServerIcon,
+  SettingsIcon,
+  StopCircleIcon
+} from "../Icons"
+
+const REMARK_PLUGINS = [remarkGfm]
+const REFRESH_INTERVAL_MS = 4_000
+const DETAIL_REFRESH_INTERVAL_MS = 2_500
+const PINNED_STORAGE_KEY = "harness-remote.universal-workspace.pinned"
+
+type WorkspaceFilter = "all" | "working" | "needs-you" | "idle" | "pinned"
+type DetailTab = "conversation" | "changes"
+type ConnectionState = "online" | "offline" | "loading"
+
+type MachineSource = {
+  key: string
+  profile: SavedServerProfile
+  machine: MachineSnapshot | null
+  agents: MachineAgentHost[]
+  projects: MachineProject[]
+  state: ConnectionState
+  error?: string
+}
+
+type UniversalSession = {
+  key: string
+  machineKey: string
+  machineId: string
+  machineName: string
+  profileId: string
+  agent: MachineAgentHost
+  config: ServerConfig
+  session: Session
+  status: SessionStatus
+  attention: number
+  projectName: string
+}
+
+type SelectedDetail = {
+  messages: MessageEnvelope[]
+  diff: DiffFile[]
+  todos: TodoItem[]
+  vcs: VcsStatus | null
+  questions: QuestionRequest[]
+  permissions: PermissionRequest[]
+}
+
+type UniversalWorkspaceProps = {
+  profiles: SavedServerProfile[]
+  activeProfileID: string
+  onPersistProfiles: (profiles: SavedServerProfile[], activeProfileID: string) => void
+  legacyView: ReactNode
+}
+
+function endpointKey(config: ServerConfig): string {
+  return `${config.host.trim().toLowerCase()}:${config.port}:${config.username}`
+}
+
+function supportedBackend(value: string, fallback: BackendKind): BackendKind {
+  return value === "opencode" || value === "omp" || value === "pi" || value === "claude" || value === "codex"
+    ? value
+    : fallback
+}
+
+function configForAgent(source: MachineSource, agent: MachineAgentHost): ServerConfig {
+  return {
+    ...source.profile.config,
+    backend: supportedBackend(agent.backend, source.profile.config.backend),
+    agentId: agent.id
+  }
+}
+
+function machineLabel(source: MachineSource): string {
+  return source.machine?.machine.name || source.profile.name || `${source.profile.config.host}:${source.profile.config.port}`
+}
+
+function directoryLabel(directory: string): string {
+  const normalized = directory.replace(/[\\/]+$/, "")
+  const chunks = normalized.split(/[\\/]/).filter(Boolean)
+  return chunks.at(-1) || directory || "Project"
+}
+
+function projectNameFor(session: Session): string {
+  return session.project?.name || directoryLabel(session.directory)
+}
+
+function normalizeStatus(status: SessionStatus | undefined, attention: number): "working" | "needs-you" | "idle" | "failed" {
+  if (attention > 0) return "needs-you"
+  const type = (status?.type || "idle").toLowerCase()
+  if (type === "busy" || type === "running" || type === "retry" || type === "waiting" || type === "active") return "working"
+  if (type === "failed" || type === "error") return "failed"
+  return "idle"
+}
+
+function statusLabel(status: SessionStatus | undefined, attention: number): string {
+  const normalized = normalizeStatus(status, attention)
+  if (normalized === "needs-you") return "Needs you"
+  if (normalized === "working") return status?.type === "retry" ? "Retrying" : "Working"
+  if (normalized === "failed") return "Failed"
+  return "Idle"
+}
+
+function statusClass(status: SessionStatus | undefined, attention: number): string {
+  return `uw-status-${normalizeStatus(status, attention)}`
+}
+
+function formatRelative(timestamp: number): string {
+  if (!timestamp) return ""
+  const delta = Date.now() - timestamp
+  if (delta < 60_000) return "now"
+  if (delta < 3_600_000) return `${Math.max(1, Math.round(delta / 60_000))}m`
+  if (delta < 86_400_000) return `${Math.round(delta / 3_600_000)}h`
+  if (delta < 604_800_000) return `${Math.round(delta / 86_400_000)}d`
+  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(timestamp)
+}
+
+function formatClock(timestamp: number): string {
+  if (!timestamp) return ""
+  return new Intl.DateTimeFormat(undefined, { hour: "2-digit", minute: "2-digit" }).format(timestamp)
+}
+
+function extractText(message: MessageEnvelope): string {
+  return message.parts
+    .filter((part) => part.type === "text" && part.text)
+    .map((part) => part.text || "")
+    .join("\n")
+    .trim()
+}
+
+function latestReadableText(messages: MessageEnvelope[]): string {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const text = extractText(messages[index])
+    if (text) return text.replace(/\s+/g, " ").trim()
+  }
+  return ""
+}
+
+function modelLabel(model?: Session["model"] | ModelSelection | null): string {
+  if (!model) return "Default model"
+  const candidate = "modelID" in model ? model.modelID : model.id
+  const variant = model.variant ? ` · ${model.variant}` : ""
+  return `${model.providerID}/${candidate}${variant}`
+}
+
+function uniqueEndpointProfiles(profiles: SavedServerProfile[]): SavedServerProfile[] {
+  const seen = new Set<string>()
+  return profiles.filter((profile) => {
+    if (!isValidServerConfig(profile.config)) return false
+    const key = endpointKey(profile.config)
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+function loadPinned(): Set<string> {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(PINNED_STORAGE_KEY) || "[]")
+    return new Set(Array.isArray(parsed) ? parsed.filter((value): value is string => typeof value === "string") : [])
+  } catch {
+    return new Set()
+  }
+}
+
+function BeautifulButton({
+  children,
+  onClick,
+  variant = "ghost",
+  disabled = false,
+  title,
+  className = "",
+  type = "button"
+}: {
+  children: ReactNode
+  onClick?: () => void
+  variant?: "primary" | "secondary" | "ghost" | "danger"
+  disabled?: boolean
+  title?: string
+  className?: string
+  type?: "button" | "submit"
+}) {
+  return (
+    <button
+      type={type}
+      className={`uw-button uw-button-${variant}${className ? ` ${className}` : ""}`}
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+    >
+      {children}
+    </button>
+  )
+}
+
+function BeautifulPill({
+  children,
+  active = false,
+  onClick,
+  count
+}: {
+  children: ReactNode
+  active?: boolean
+  onClick?: () => void
+  count?: number
+}) {
+  return (
+    <button type="button" className={`uw-pill${active ? " active" : ""}`} onClick={onClick}>
+      <span>{children}</span>
+      {count !== undefined ? <span className="uw-pill-count">{count}</span> : null}
+    </button>
+  )
+}
+
+function BeautifulSelect({
+  value,
+  onChange,
+  children,
+  disabled = false
+}: {
+  value: string
+  onChange: (value: string) => void
+  children: ReactNode
+  disabled?: boolean
+}) {
+  return (
+    <div className="uw-select-wrap">
+      <select className="uw-select" value={value} onChange={(event) => onChange(event.target.value)} disabled={disabled}>
+        {children}
+      </select>
+      <span className="uw-select-chevron" aria-hidden="true">⌄</span>
+    </div>
+  )
+}
+
+function Modal({
+  title,
+  subtitle,
+  onClose,
+  children
+}: {
+  title: string
+  subtitle?: string
+  onClose: () => void
+  children: ReactNode
+}) {
+  return (
+    <div className="uw-modal-backdrop" role="presentation" onMouseDown={onClose}>
+      <section className="uw-modal" role="dialog" aria-modal="true" aria-label={title} onMouseDown={(event) => event.stopPropagation()}>
+        <header className="uw-modal-header">
+          <div>
+            <h2>{title}</h2>
+            {subtitle ? <p>{subtitle}</p> : null}
+          </div>
+          <BeautifulButton onClick={onClose} title="Close"><CloseIcon size={16} /></BeautifulButton>
+        </header>
+        {children}
+      </section>
+    </div>
+  )
+}
+
+function ToolCard({ message }: { message: MessageEnvelope }) {
+  const tools = message.parts.filter((part) => part.type === "tool")
+  if (!tools.length) return null
+  return (
+    <div className="uw-tool-stack">
+      {tools.map((part) => {
+        const state = part.state
+        const status = state?.status || "running"
+        const input = state?.input || {}
+        const command = typeof input.command === "string"
+          ? input.command
+          : typeof input.filePath === "string"
+            ? input.filePath
+            : typeof input.path === "string"
+              ? input.path
+              : ""
+        const output = state?.error || state?.output || ""
+        return (
+          <details key={part.id} className={`uw-tool-card uw-tool-${status}`} open={status === "error"}>
+            <summary>
+              <span className="uw-tool-icon">{status === "completed" ? "✓" : status === "error" ? "!" : "⋯"}</span>
+              <span className="uw-tool-title">{state?.title || part.tool || "Tool"}</span>
+              {command ? <code>{command.length > 90 ? `${command.slice(0, 90)}…` : command}</code> : null}
+              <span className="uw-tool-status">{status}</span>
+            </summary>
+            {output ? <pre>{output.length > 4_000 ? `${output.slice(0, 4_000)}\n…` : output}</pre> : null}
+          </details>
+        )
+      })}
+    </div>
+  )
+}
+
+function MessageBubble({ message, agentLabel }: { message: MessageEnvelope; agentLabel: string }) {
+  const isUser = message.info.role === "user"
+  const text = extractText(message)
+  return (
+    <article className={`uw-message ${isUser ? "uw-message-user" : "uw-message-agent"}`}>
+      <div className={`uw-avatar ${isUser ? "uw-avatar-user" : "uw-avatar-agent"}`}>
+        {isUser ? "You" : agentLabel.slice(0, 2).toUpperCase()}
+      </div>
+      <div className="uw-message-body">
+        <header>
+          <strong>{isUser ? "You" : agentLabel}</strong>
+          <time>{formatClock(message.info.time.created)}</time>
+        </header>
+        {text ? (
+          <div className="uw-markdown">
+            <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{text}</ReactMarkdown>
+          </div>
+        ) : null}
+        <ToolCard message={message} />
+      </div>
+    </article>
+  )
+}
+
+function SessionCard({
+  item,
+  selected,
+  pinned,
+  preview,
+  onSelect,
+  onTogglePin
+}: {
+  item: UniversalSession
+  selected: boolean
+  pinned: boolean
+  preview?: string
+  onSelect: () => void
+  onTogglePin: () => void
+}) {
+  const session = item.session
+  const status = statusLabel(item.status, item.attention)
+  return (
+    <button type="button" className={`uw-session-card${selected ? " selected" : ""}`} onClick={onSelect}>
+      <span className={`uw-session-accent ${statusClass(item.status, item.attention)}`} />
+      <span className="uw-session-card-main">
+        <span className="uw-session-title-row">
+          <strong>{session.title || "Untitled session"}</strong>
+          <span className={`uw-status-chip ${statusClass(item.status, item.attention)}`}>{status}</span>
+        </span>
+        <span className="uw-session-meta">
+          {item.agent.label} · {modelLabel(session.model)} · {item.machineName}
+        </span>
+        <span className="uw-session-preview">
+          {preview || (session.summary?.files ? `${session.summary.files} files changed · +${session.summary.additions} −${session.summary.deletions}` : item.session.directory)}
+        </span>
+        <span className="uw-session-footer">
+          <span>{item.projectName}</span>
+          <span>{formatRelative(session.time.updated)}</span>
+        </span>
+      </span>
+      <span
+        role="button"
+        tabIndex={0}
+        className={`uw-pin${pinned ? " pinned" : ""}`}
+        title={pinned ? "Unpin session" : "Pin session"}
+        onClick={(event) => {
+          event.preventDefault()
+          event.stopPropagation()
+          onTogglePin()
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault()
+            event.stopPropagation()
+            onTogglePin()
+          }
+        }}
+      >
+        {pinned ? "★" : "☆"}
+      </span>
+    </button>
+  )
+}
+
+function ConnectionEditor({
+  profile,
+  onSave,
+  onClose
+}: {
+  profile: SavedServerProfile
+  onSave: (next: SavedServerProfile) => void
+  onClose: () => void
+}) {
+  const [name, setName] = useState(profile.name)
+  const [host, setHost] = useState(profile.config.host)
+  const [port, setPort] = useState(String(profile.config.port))
+  const [username, setUsername] = useState(profile.config.username)
+  const [password, setPassword] = useState(profile.config.password)
+
+  const validPort = Number(port) >= 1 && Number(port) <= 65_535
+  const valid = Boolean(host.trim() && validPort)
+
+  return (
+    <Modal title="Connection" subtitle="Edit the selected machine endpoint." onClose={onClose}>
+      <div className="uw-modal-body uw-form-grid">
+        <label>
+          <span>Name</span>
+          <input value={name} onChange={(event) => setName(event.target.value)} />
+        </label>
+        <label>
+          <span>Host</span>
+          <input value={host} onChange={(event) => setHost(event.target.value)} spellCheck={false} />
+        </label>
+        <label>
+          <span>Port</span>
+          <input value={port} onChange={(event) => setPort(event.target.value.replace(/\D/g, ""))} inputMode="numeric" />
+        </label>
+        <label>
+          <span>Username</span>
+          <input value={username} onChange={(event) => setUsername(event.target.value)} autoComplete="username" />
+        </label>
+        <label className="uw-form-span-2">
+          <span>Password</span>
+          <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} autoComplete="current-password" />
+        </label>
+      </div>
+      <footer className="uw-modal-footer">
+        <BeautifulButton onClick={onClose}>Cancel</BeautifulButton>
+        <BeautifulButton
+          variant="primary"
+          disabled={!valid}
+          onClick={() => {
+            if (!valid) return
+            onSave({
+              ...profile,
+              name: name.trim() || profile.name,
+              config: {
+                ...profile.config,
+                host: host.trim(),
+                port: Number(port),
+                username: username.trim(),
+                password
+              }
+            })
+          }}
+        >
+          Save and reconnect
+        </BeautifulButton>
+      </footer>
+    </Modal>
+  )
+}
+
+function NewSessionModal({
+  machines,
+  initialMachineKey,
+  initialProject,
+  initialAgentId,
+  onClose,
+  onCreated
+}: {
+  machines: MachineSource[]
+  initialMachineKey?: string
+  initialProject?: string
+  initialAgentId?: string
+  onClose: () => void
+  onCreated: (machine: MachineSource, agent: MachineAgentHost, session: Session) => void
+}) {
+  const firstMachine = machines.find((machine) => machine.state === "online" && machine.agents.length > 0) || machines[0]
+  const [machineKey, setMachineKey] = useState(initialMachineKey || firstMachine?.key || "")
+  const machine = machines.find((candidate) => candidate.key === machineKey) || firstMachine
+  const availableAgents = machine?.agents || []
+  const [agentId, setAgentId] = useState(initialAgentId && availableAgents.some((agent) => agent.id === initialAgentId)
+    ? initialAgentId
+    : availableAgents[0]?.id || "")
+  const agent = availableAgents.find((candidate) => candidate.id === agentId) || availableAgents[0]
+  const [directory, setDirectory] = useState(initialProject || machine?.projects[0]?.path || "")
+  const [prompt, setPrompt] = useState("")
+  const [models, setModels] = useState<ModelOption[]>([])
+  const [modelKey, setModelKey] = useState("")
+  const [loadingModels, setLoadingModels] = useState(false)
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!machine) return
+    if (!machine.projects.some((project) => project.path === directory)) {
+      setDirectory(initialProject && machine.projects.some((project) => project.path === initialProject)
+        ? initialProject
+        : machine.projects[0]?.path || "")
+    }
+    if (!availableAgents.some((candidate) => candidate.id === agentId)) {
+      setAgentId(availableAgents[0]?.id || "")
+    }
+  }, [machineKey])
+
+  useEffect(() => {
+    if (!machine || !agent) {
+      setModels([])
+      setModelKey("")
+      return
+    }
+    let cancelled = false
+    setLoadingModels(true)
+    setError(null)
+    void taskClient.listAgentModels(machine.profile.config, agent.id)
+      .then((catalog) => {
+        if (cancelled) return
+        setModels(catalog.models)
+        const defaultModel = catalog.models.find((model) => model.isDefault) || catalog.models[0]
+        setModelKey(defaultModel ? `${defaultModel.providerID}/${defaultModel.modelID}/${defaultModel.variant || ""}` : "")
+      })
+      .catch(async () => {
+        try {
+          const fallback = await api.listModels(configForAgent(machine, agent), directory || undefined)
+          if (cancelled) return
+          setModels(fallback)
+          const defaultModel = fallback.find((model) => model.isDefault) || fallback[0]
+          setModelKey(defaultModel ? `${defaultModel.providerID}/${defaultModel.modelID}/${defaultModel.variant || ""}` : "")
+        } catch (reason) {
+          if (!cancelled) {
+            setModels([])
+            setModelKey("")
+            setError(reason instanceof Error ? reason.message : String(reason))
+          }
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingModels(false)
+      })
+    return () => { cancelled = true }
+  }, [machineKey, agentId, directory])
+
+  const selectedModel = models.find((model) => `${model.providerID}/${model.modelID}/${model.variant || ""}` === modelKey)
+  const canCreate = Boolean(machine && agent && directory && !creating)
+
+  async function create() {
+    if (!machine || !agent || !directory || creating) return
+    setCreating(true)
+    setError(null)
+    try {
+      const config = configForAgent(machine, agent)
+      const title = prompt.trim() ? prompt.trim().split(/\r?\n/)[0].slice(0, 88) : undefined
+      const model = selectedModel
+        ? { providerID: selectedModel.providerID, modelID: selectedModel.modelID, variant: selectedModel.variant }
+        : undefined
+      const created = await api.createSession(config, title, model, directory)
+      if (prompt.trim()) {
+        await api.sendPrompt(config, created.id, prompt.trim(), created.directory || directory, model)
+      }
+      onCreated(machine, agent, created)
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason))
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <Modal title="New Session" subtitle="Start native work on any available harness." onClose={onClose}>
+      <div className="uw-modal-body uw-new-session-grid">
+        <label>
+          <span>Machine</span>
+          <BeautifulSelect value={machine?.key || ""} onChange={setMachineKey}>
+            {machines.map((candidate) => (
+              <option key={candidate.key} value={candidate.key}>{machineLabel(candidate)}</option>
+            ))}
+          </BeautifulSelect>
+        </label>
+        <label>
+          <span>Project</span>
+          <BeautifulSelect value={directory} onChange={setDirectory}>
+            {machine?.projects.map((project) => (
+              <option key={project.id || project.path} value={project.path}>{project.name}</option>
+            ))}
+            {!machine?.projects.length && directory ? <option value={directory}>{directoryLabel(directory)}</option> : null}
+          </BeautifulSelect>
+        </label>
+        <label>
+          <span>Harness</span>
+          <BeautifulSelect value={agent?.id || ""} onChange={setAgentId}>
+            {availableAgents.map((candidate) => (
+              <option key={candidate.id} value={candidate.id}>{candidate.label}</option>
+            ))}
+          </BeautifulSelect>
+        </label>
+        <label>
+          <span>Model</span>
+          <BeautifulSelect value={modelKey} onChange={setModelKey} disabled={loadingModels || models.length === 0}>
+            {loadingModels ? <option value="">Loading models…</option> : null}
+            {!loadingModels && models.length === 0 ? <option value="">Harness default</option> : null}
+            {models.map((model) => {
+              const key = `${model.providerID}/${model.modelID}/${model.variant || ""}`
+              return <option key={key} value={key}>{model.providerName}: {model.modelName}{model.variant ? ` (${model.variant})` : ""}</option>
+            })}
+          </BeautifulSelect>
+        </label>
+        <label className="uw-form-span-2">
+          <span>Initial request</span>
+          <textarea
+            rows={7}
+            value={prompt}
+            onChange={(event) => setPrompt(event.target.value)}
+            placeholder="What do you want the agent to work on?"
+            autoFocus
+          />
+        </label>
+        {error ? <div className="uw-inline-error uw-form-span-2">{error}</div> : null}
+      </div>
+      <footer className="uw-modal-footer">
+        <BeautifulButton onClick={onClose}>Cancel</BeautifulButton>
+        <BeautifulButton variant="primary" disabled={!canCreate} onClick={() => void create()}>
+          {creating ? <LoadingIcon size={15} /> : <PlusIcon size={15} />}
+          {creating ? "Starting…" : "Start session"}
+        </BeautifulButton>
+      </footer>
+    </Modal>
+  )
+}
+
+function HandoffModal({
+  current,
+  messages,
+  machines,
+  onClose,
+  onCreated
+}: {
+  current: UniversalSession
+  messages: MessageEnvelope[]
+  machines: MachineSource[]
+  onClose: () => void
+  onCreated: (machine: MachineSource, agent: MachineAgentHost, session: Session) => void
+}) {
+  const choices = machines.flatMap((machine) => machine.agents.map((agent) => ({ machine, agent })))
+  const initial = choices.find((choice) => choice.agent.id !== current.agent.id || choice.machine.key !== current.machineKey) || choices[0]
+  const [choiceKey, setChoiceKey] = useState(initial ? `${initial.machine.key}|${initial.agent.id}` : "")
+  const selected = choices.find((choice) => `${choice.machine.key}|${choice.agent.id}` === choiceKey) || initial
+  const targetProject = selected?.machine.projects.find((project) => project.name === current.projectName)
+    || selected?.machine.projects.find((project) => project.path === current.session.directory)
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handoff() {
+    if (!selected || !targetProject || creating) return
+    setCreating(true)
+    setError(null)
+    try {
+      const config = configForAgent(selected.machine, selected.agent)
+      const transcript = messages.slice(-10).map((message) => {
+        const role = message.info.role === "user" ? "User" : current.agent.label
+        const text = extractText(message)
+        return text ? `${role}: ${text}` : ""
+      }).filter(Boolean).join("\n\n")
+      const prompt = [
+        "Continue the work from another Harness Remote session.",
+        `Project: ${current.projectName}`,
+        `Previous harness: ${current.agent.label}`,
+        `Previous session: ${current.session.title || current.session.id}`,
+        "",
+        "Before changing anything, inspect the current repository state and continue from what is already on disk.",
+        transcript ? `\nRecent conversation:\n${transcript}` : ""
+      ].join("\n")
+      const created = await api.createSession(config, current.session.title || "Continued session", undefined, targetProject.path)
+      await api.sendPrompt(config, created.id, prompt, created.directory || targetProject.path)
+      onCreated(selected.machine, selected.agent, created)
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason))
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <Modal title="Continue with another agent" subtitle="Create a native session on another harness and hand over the recent context." onClose={onClose}>
+      <div className="uw-modal-body uw-form-grid">
+        <label className="uw-form-span-2">
+          <span>Target agent</span>
+          <BeautifulSelect value={choiceKey} onChange={setChoiceKey}>
+            {choices.map(({ machine, agent }) => (
+              <option key={`${machine.key}|${agent.id}`} value={`${machine.key}|${agent.id}`}>
+                {agent.label} · {machineLabel(machine)}
+              </option>
+            ))}
+          </BeautifulSelect>
+        </label>
+        <div className="uw-handoff-summary uw-form-span-2">
+          <strong>{current.session.title}</strong>
+          <span>{current.agent.label} → {selected?.agent.label || "Agent"}</span>
+          <span>Project mapping: {targetProject ? targetProject.path : "No matching project on target machine"}</span>
+        </div>
+        {!targetProject ? (
+          <div className="uw-inline-error uw-form-span-2">
+            Harness Remote cannot safely hand this session to that machine because the same project was not discovered there.
+          </div>
+        ) : null}
+        {error ? <div className="uw-inline-error uw-form-span-2">{error}</div> : null}
+      </div>
+      <footer className="uw-modal-footer">
+        <BeautifulButton onClick={onClose}>Cancel</BeautifulButton>
+        <BeautifulButton variant="primary" disabled={!selected || !targetProject || creating} onClick={() => void handoff()}>
+          {creating ? <LoadingIcon size={15} /> : <ChatIcon size={15} />}
+          {creating ? "Handing off…" : "Create handoff session"}
+        </BeautifulButton>
+      </footer>
+    </Modal>
+  )
+}
+
+function QuestionPanel({
+  request,
+  config,
+  directory,
+  onResolved
+}: {
+  request: QuestionRequest
+  config: ServerConfig
+  directory: string
+  onResolved: () => void
+}) {
+  const [answers, setAnswers] = useState<Record<number, string[]>>({})
+  const [custom, setCustom] = useState<Record<number, string>>({})
+  const [sending, setSending] = useState(false)
+
+  async function submit() {
+    setSending(true)
+    try {
+      const payload = request.questions.map((question, index) => {
+        const selected = answers[index] || []
+        const customValue = custom[index]?.trim()
+        return customValue ? [...selected, customValue] : selected
+      })
+      await api.replyQuestion(config, request.id, payload, directory)
+      onResolved()
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return (
+    <div className="uw-attention-card">
+      <strong>Agent question</strong>
+      {request.questions.map((question, index) => (
+        <div className="uw-question" key={`${request.id}-${index}`}>
+          <span>{question.header || question.question}</span>
+          {question.header ? <p>{question.question}</p> : null}
+          <div className="uw-question-options">
+            {question.options.map((option) => {
+              const selected = answers[index]?.includes(option.label) || false
+              return (
+                <button
+                  type="button"
+                  key={option.label}
+                  className={`uw-choice${selected ? " selected" : ""}`}
+                  onClick={() => {
+                    setAnswers((current) => {
+                      const existing = current[index] || []
+                      const next = question.multiple
+                        ? selected ? existing.filter((value) => value !== option.label) : [...existing, option.label]
+                        : [option.label]
+                      return { ...current, [index]: next }
+                    })
+                  }}
+                  title={option.description}
+                >
+                  {option.label}
+                </button>
+              )
+            })}
+          </div>
+          {question.custom ? (
+            <input
+              value={custom[index] || ""}
+              onChange={(event) => setCustom((current) => ({ ...current, [index]: event.target.value }))}
+              placeholder="Custom answer…"
+            />
+          ) : null}
+        </div>
+      ))}
+      <div className="uw-attention-actions">
+        <BeautifulButton
+          variant="danger"
+          disabled={sending}
+          onClick={() => void api.rejectQuestion(config, request.id, directory).then(onResolved)}
+        >
+          Reject
+        </BeautifulButton>
+        <BeautifulButton variant="primary" disabled={sending} onClick={() => void submit()}>
+          {sending ? "Sending…" : "Reply"}
+        </BeautifulButton>
+      </div>
+    </div>
+  )
+}
+
+export function UniversalWorkspace({
+  profiles,
+  activeProfileID,
+  onPersistProfiles,
+  legacyView
+}: UniversalWorkspaceProps) {
+  const [machines, setMachines] = useState<MachineSource[]>([])
+  const [sessions, setSessions] = useState<UniversalSession[]>([])
+  const [previews, setPreviews] = useState<Record<string, string>>({})
+  const [selectedKey, setSelectedKey] = useState<string | null>(null)
+  const [filter, setFilter] = useState<WorkspaceFilter>("all")
+  const [projectFilter, setProjectFilter] = useState<string>("all")
+  const [machineFilter, setMachineFilter] = useState<string>("all")
+  const [query, setQuery] = useState("")
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [globalError, setGlobalError] = useState<string | null>(null)
+  const [detail, setDetail] = useState<SelectedDetail>({ messages: [], diff: [], todos: [], vcs: null, questions: [], permissions: [] })
+  const [detailLoading, setDetailLoading] = useState(false)
+  const [detailTab, setDetailTab] = useState<DetailTab>("conversation")
+  const [composer, setComposer] = useState("")
+  const [sending, setSending] = useState(false)
+  const [newSessionOpen, setNewSessionOpen] = useState(false)
+  const [handoffOpen, setHandoffOpen] = useState(false)
+  const [classicOpen, setClassicOpen] = useState(false)
+  const [inspectorOpen, setInspectorOpen] = useState(true)
+  const [connectionProfileID, setConnectionProfileID] = useState<string | null>(null)
+  const [pinned, setPinned] = useState<Set<string>>(() => loadPinned())
+  const [questionRevision, setQuestionRevision] = useState(0)
+  const refreshGeneration = useRef(0)
+  const transcriptRef = useRef<HTMLDivElement>(null)
+
+  const selected = sessions.find((item) => item.key === selectedKey) || null
+
+  const refreshAll = useCallback(async (silent = false) => {
+    const generation = ++refreshGeneration.current
+    if (!silent) setLoading(true)
+    else setRefreshing(true)
+    setGlobalError(null)
+    try {
+      const sourceProfiles = uniqueEndpointProfiles(profiles)
+      const nextMachines = await Promise.all(sourceProfiles.map(async (profile): Promise<MachineSource> => {
+        const key = endpointKey(profile.config)
+        try {
+          const machine = await discoverMachine(profile.config)
+          if (!machine) {
+            return {
+              key,
+              profile,
+              machine: null,
+              agents: [{
+                id: profile.config.agentId || profile.config.backend,
+                label: backendDisplayName(profile.config.backend),
+                backend: profile.config.backend,
+                transport: "http",
+                managed: false,
+                state: "available",
+                capabilities: {}
+              }],
+              projects: [],
+              state: "online"
+            }
+          }
+          const projects = await taskClient.listProjects(profile.config).catch(() => [])
+          return {
+            key,
+            profile,
+            machine,
+            agents: selectableMachineAgents(machine),
+            projects,
+            state: "online"
+          }
+        } catch (reason) {
+          return {
+            key,
+            profile,
+            machine: null,
+            agents: [],
+            projects: [],
+            state: "offline",
+            error: reason instanceof Error ? reason.message : String(reason)
+          }
+        }
+      }))
+
+      const collected = (await Promise.all(nextMachines.flatMap((machine) => machine.agents.map(async (agent) => {
+        const config = configForAgent(machine, agent)
+        try {
+          const [agentSessions, statuses, questions, permissions] = await Promise.all([
+            api.listGlobalSessions(config).catch(() => api.listSessions(config)),
+            api.listStatuses(config).catch(() => ({} as Record<string, SessionStatus>)),
+            api.loadQuestions(config).catch(() => []),
+            api.loadPermissions(config).catch(() => [])
+          ])
+          const attentionBySession = new Map<string, number>()
+          for (const request of [...questions, ...permissions]) {
+            attentionBySession.set(request.sessionID, (attentionBySession.get(request.sessionID) || 0) + 1)
+          }
+          return agentSessions.map((session): UniversalSession => ({
+            key: `${machine.key}|${agent.id}|${session.id}`,
+            machineKey: machine.key,
+            machineId: machine.machine?.machine.id || machine.key,
+            machineName: machineLabel(machine),
+            profileId: machine.profile.id,
+            agent,
+            config,
+            session,
+            status: statuses[session.id] || { type: "idle" },
+            attention: attentionBySession.get(session.id) || 0,
+            projectName: projectNameFor(session)
+          }))
+        } catch {
+          return []
+        }
+      })))).flat()
+
+      if (generation !== refreshGeneration.current) return
+      collected.sort((left, right) => right.session.time.updated - left.session.time.updated)
+      setMachines(nextMachines)
+      setSessions(collected)
+      setSelectedKey((current) => {
+        if (current && collected.some((item) => item.key === current)) return current
+        return collected[0]?.key || null
+      })
+
+      const topSessions = collected.slice(0, 18)
+      void Promise.all(topSessions.map(async (item) => {
+        try {
+          const latest = await api.loadLatestMessage(item.config, item.session.id, item.session.directory)
+          const preview = latestReadableText(latest)
+          if (preview) setPreviews((current) => current[item.key] === preview ? current : { ...current, [item.key]: preview })
+        } catch {
+          // A preview is optional. The session itself remains fully usable.
+        }
+      }))
+    } catch (reason) {
+      if (generation !== refreshGeneration.current) return
+      setGlobalError(reason instanceof Error ? reason.message : String(reason))
+    } finally {
+      if (generation === refreshGeneration.current) {
+        setLoading(false)
+        setRefreshing(false)
+      }
+    }
+  }, [profiles])
+
+  useEffect(() => {
+    void refreshAll(false)
+    const timer = window.setInterval(() => void refreshAll(true), REFRESH_INTERVAL_MS)
+    return () => window.clearInterval(timer)
+  }, [refreshAll])
+
+  const loadDetail = useCallback(async (item: UniversalSession, silent = false) => {
+    if (!silent) setDetailLoading(true)
+    try {
+      const [messages, diff, todos, vcs, questions, permissions] = await Promise.all([
+        api.loadMessages(item.config, item.session.id, item.session.directory),
+        api.loadDiff(item.config, item.session.id, item.session.directory).catch(() => []),
+        api.loadTodo(item.config, item.session.id, item.session.directory).catch(() => []),
+        api.loadVcs(item.config, item.session.directory).catch(() => null),
+        api.loadQuestions(item.config, item.session.directory).catch(() => []),
+        api.loadPermissions(item.config, item.session.directory).catch(() => [])
+      ])
+      setDetail({
+        messages,
+        diff,
+        todos,
+        vcs,
+        questions: questions.filter((request) => request.sessionID === item.session.id),
+        permissions: permissions.filter((request) => request.sessionID === item.session.id)
+      })
+    } catch (reason) {
+      if (!silent) setGlobalError(reason instanceof Error ? reason.message : String(reason))
+    } finally {
+      if (!silent) setDetailLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!selected) {
+      setDetail({ messages: [], diff: [], todos: [], vcs: null, questions: [], permissions: [] })
+      return
+    }
+    void loadDetail(selected, false)
+    const timer = window.setInterval(() => void loadDetail(selected, true), DETAIL_REFRESH_INTERVAL_MS)
+    return () => window.clearInterval(timer)
+  }, [selected?.key, questionRevision, loadDetail])
+
+  useEffect(() => {
+    if (!transcriptRef.current || detailTab !== "conversation") return
+    transcriptRef.current.scrollTop = transcriptRef.current.scrollHeight
+  }, [selected?.key, detail.messages.length, detailTab])
+
+  useEffect(() => {
+    localStorage.setItem(PINNED_STORAGE_KEY, JSON.stringify([...pinned]))
+  }, [pinned])
+
+  const projects = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const item of sessions) map.set(item.projectName, (map.get(item.projectName) || 0) + 1)
+    return [...map.entries()].sort((left, right) => right[1] - left[1])
+  }, [sessions])
+
+  const counts = useMemo(() => ({
+    all: sessions.length,
+    working: sessions.filter((item) => normalizeStatus(item.status, item.attention) === "working").length,
+    needs: sessions.filter((item) => normalizeStatus(item.status, item.attention) === "needs-you").length,
+    idle: sessions.filter((item) => normalizeStatus(item.status, item.attention) === "idle").length,
+    pinned: sessions.filter((item) => pinned.has(item.key)).length
+  }), [sessions, pinned])
+
+  const filteredSessions = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    return sessions.filter((item) => {
+      if (projectFilter !== "all" && item.projectName !== projectFilter) return false
+      if (machineFilter !== "all" && item.machineKey !== machineFilter) return false
+      const normalized = normalizeStatus(item.status, item.attention)
+      if (filter === "working" && normalized !== "working") return false
+      if (filter === "needs-you" && normalized !== "needs-you") return false
+      if (filter === "idle" && normalized !== "idle") return false
+      if (filter === "pinned" && !pinned.has(item.key)) return false
+      if (!needle) return true
+      return [
+        item.session.title,
+        item.projectName,
+        item.agent.label,
+        item.machineName,
+        item.session.directory,
+        modelLabel(item.session.model),
+        previews[item.key]
+      ].some((value) => value?.toLowerCase().includes(needle))
+    })
+  }, [sessions, projectFilter, machineFilter, filter, pinned, query, previews])
+
+  async function sendPrompt() {
+    if (!selected || !composer.trim() || sending) return
+    const text = composer.trim()
+    setComposer("")
+    setSending(true)
+    setGlobalError(null)
+    try {
+      const model = selected.session.model
+        ? { providerID: selected.session.model.providerID, modelID: selected.session.model.id, variant: selected.session.model.variant }
+        : undefined
+      await api.sendPrompt(selected.config, selected.session.id, text, selected.session.directory, model)
+      await loadDetail(selected, true)
+      await refreshAll(true)
+    } catch (reason) {
+      setComposer((current) => current || text)
+      setGlobalError(reason instanceof Error ? reason.message : String(reason))
+    } finally {
+      setSending(false)
+    }
+  }
+
+  async function stopSession() {
+    if (!selected) return
+    try {
+      await api.abort(selected.config, selected.session.id, selected.session.directory)
+      await loadDetail(selected, true)
+      await refreshAll(true)
+    } catch (reason) {
+      setGlobalError(reason instanceof Error ? reason.message : String(reason))
+    }
+  }
+
+  async function renameSelected() {
+    if (!selected) return
+    const nextTitle = window.prompt("Session title", selected.session.title || "")
+    if (!nextTitle?.trim() || nextTitle.trim() === selected.session.title) return
+    try {
+      await api.renameSession(selected.config, selected.session.id, nextTitle.trim(), selected.session.directory)
+      await refreshAll(true)
+    } catch (reason) {
+      setGlobalError(reason instanceof Error ? reason.message : String(reason))
+    }
+  }
+
+  const selectedMachine = selected ? machines.find((machine) => machine.key === selected.machineKey) : undefined
+  const activeProfile = profiles.find((profile) => profile.id === activeProfileID) || profiles[0]
+  const connectionProfile = profiles.find((profile) => profile.id === connectionProfileID) || null
+  const selectedQuestions = detail.questions
+  const selectedPermissions = detail.permissions
+
+  if (classicOpen) {
+    return (
+      <div className="uw-classic-shell">
+        <div className="uw-classic-bar">
+          <BeautifulButton onClick={() => setClassicOpen(false)}>← Universal workspace</BeautifulButton>
+          <span>Classic session UI</span>
+        </div>
+        <div className="uw-classic-host">{legacyView}</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="uw-shell">
+      <header className="uw-topbar">
+        <div className="uw-brand">
+          <span className="uw-brand-mark">H</span>
+          <div>
+            <strong>Harness Remote</strong>
+            <small>Universal workspace</small>
+          </div>
+        </div>
+
+        <div className="uw-global-search">
+          <SearchIcon size={16} />
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search sessions, projects, agents, machines…"
+          />
+          <kbd>⌘K</kbd>
+        </div>
+
+        <div className="uw-top-actions">
+          <BeautifulButton onClick={() => void refreshAll(true)} disabled={refreshing} title="Refresh everything">
+            <RefreshIcon size={16} />
+            <span className="uw-desktop-label">{refreshing ? "Refreshing" : "Refresh"}</span>
+          </BeautifulButton>
+          <BeautifulButton onClick={() => setClassicOpen(true)} title="Open the existing interface">
+            <ChatIcon size={16} />
+            <span className="uw-desktop-label">Classic</span>
+          </BeautifulButton>
+          <BeautifulButton
+            onClick={() => activeProfile && setConnectionProfileID(activeProfile.id)}
+            title="Connection settings"
+          >
+            <SettingsIcon size={16} />
+          </BeautifulButton>
+        </div>
+      </header>
+
+      <div className="uw-layout">
+        <aside className="uw-nav">
+          <BeautifulButton variant="primary" className="uw-new-button" onClick={() => setNewSessionOpen(true)}>
+            <PlusIcon size={16} />
+            New Session
+          </BeautifulButton>
+
+          <section className="uw-nav-section">
+            <span className="uw-nav-label">Quick views</span>
+            <button className={filter === "all" ? "active" : ""} onClick={() => setFilter("all")}>
+              <ChatIcon size={15} /><span>All Sessions</span><b>{counts.all}</b>
+            </button>
+            <button className={filter === "needs-you" ? "active" : ""} onClick={() => setFilter("needs-you")}>
+              <span className="uw-nav-symbol">!</span><span>Needs You</span><b className="attention">{counts.needs}</b>
+            </button>
+            <button className={filter === "working" ? "active" : ""} onClick={() => setFilter("working")}>
+              <span className="uw-nav-symbol">●</span><span>Working</span><b>{counts.working}</b>
+            </button>
+            <button className={filter === "idle" ? "active" : ""} onClick={() => setFilter("idle")}>
+              <span className="uw-nav-symbol">○</span><span>Idle</span><b>{counts.idle}</b>
+            </button>
+            <button className={filter === "pinned" ? "active" : ""} onClick={() => setFilter("pinned")}>
+              <span className="uw-nav-symbol">★</span><span>Pinned</span><b>{counts.pinned}</b>
+            </button>
+          </section>
+
+          <section className="uw-nav-section">
+            <div className="uw-nav-heading">
+              <span className="uw-nav-label">Projects</span>
+              <button type="button" title="Show all projects" onClick={() => setProjectFilter("all")}>×</button>
+            </div>
+            {projects.slice(0, 8).map(([project, count]) => (
+              <button key={project} className={projectFilter === project ? "active" : ""} onClick={() => setProjectFilter(project)}>
+                <FolderIcon size={15} /><span title={project}>{project}</span><b>{count}</b>
+              </button>
+            ))}
+            {projects.length === 0 ? <p className="uw-nav-empty">Projects appear from native sessions.</p> : null}
+          </section>
+
+          <section className="uw-nav-section uw-machines-section">
+            <div className="uw-nav-heading">
+              <span className="uw-nav-label">Machines</span>
+              <button type="button" onClick={() => setMachineFilter("all")} title="Show every machine">×</button>
+            </div>
+            {machines.map((machine) => (
+              <button
+                key={machine.key}
+                className={machineFilter === machine.key ? "active" : ""}
+                onClick={() => setMachineFilter(machine.key)}
+                onDoubleClick={() => setConnectionProfileID(machine.profile.id)}
+                title={machine.error || `${machine.profile.config.host}:${machine.profile.config.port}`}
+              >
+                <ServerIcon size={15} />
+                <span>{machineLabel(machine)}</span>
+                <i className={`uw-machine-dot ${machine.state}`} />
+              </button>
+            ))}
+          </section>
+
+          <div className="uw-nav-bottom">
+            <button type="button" className={filter === "needs-you" ? "active" : ""} onClick={() => setFilter("needs-you")}>
+              <span className="uw-nav-symbol">!</span><span>Needs You</span><b className="attention">{counts.needs}</b>
+            </button>
+          </div>
+        </aside>
+
+        <section className="uw-session-column">
+          <div className="uw-session-column-header">
+            <div>
+              <h2>Sessions</h2>
+              <span>{filteredSessions.length} visible</span>
+            </div>
+            <button type="button" title="Clear filters" onClick={() => {
+              setFilter("all")
+              setProjectFilter("all")
+              setMachineFilter("all")
+              setQuery("")
+            }}>
+              <MoreVerticalIcon size={16} />
+            </button>
+          </div>
+
+          <div className="uw-filter-row">
+            <BeautifulPill active={filter === "all"} onClick={() => setFilter("all")} count={counts.all}>All</BeautifulPill>
+            <BeautifulPill active={filter === "working"} onClick={() => setFilter("working")} count={counts.working}>Working</BeautifulPill>
+            <BeautifulPill active={filter === "needs-you"} onClick={() => setFilter("needs-you")} count={counts.needs}>Needs You</BeautifulPill>
+          </div>
+
+          <div className="uw-session-list">
+            {loading && sessions.length === 0 ? (
+              <div className="uw-empty-panel"><LoadingIcon size={22} /><strong>Loading native sessions…</strong></div>
+            ) : filteredSessions.length === 0 ? (
+              <div className="uw-empty-panel">
+                <ChatIcon size={24} />
+                <strong>No sessions match this view.</strong>
+                <span>Change filters or start a new session.</span>
+              </div>
+            ) : filteredSessions.map((item) => (
+              <SessionCard
+                key={item.key}
+                item={item}
+                selected={selectedKey === item.key}
+                pinned={pinned.has(item.key)}
+                preview={previews[item.key]}
+                onSelect={() => {
+                  setSelectedKey(item.key)
+                  setDetailTab("conversation")
+                }}
+                onTogglePin={() => setPinned((current) => {
+                  const next = new Set(current)
+                  if (next.has(item.key)) next.delete(item.key)
+                  else next.add(item.key)
+                  return next
+                })}
+              />
+            ))}
+          </div>
+        </section>
+
+        <main className="uw-main">
+          {globalError ? (
+            <div className="uw-global-error">
+              <span>{globalError}</span>
+              <button type="button" onClick={() => setGlobalError(null)}>×</button>
+            </div>
+          ) : null}
+
+          {!selected ? (
+            <div className="uw-welcome">
+              <div className="uw-welcome-icon"><ChatIcon size={32} /></div>
+              <h1>{loading ? "Connecting to your agents…" : "Your agents, one workspace."}</h1>
+              <p>Sessions stay native to Codex, Claude Code, OpenCode, PI and OMP. Harness Remote only gives them one place to live.</p>
+              <BeautifulButton variant="primary" onClick={() => setNewSessionOpen(true)}>
+                <PlusIcon size={16} /> New Session
+              </BeautifulButton>
+            </div>
+          ) : (
+            <>
+              <header className="uw-session-header">
+                <div className="uw-session-heading">
+                  <div className="uw-session-heading-title">
+                    <h1>{selected.session.title || "Untitled session"}</h1>
+                    <button
+                      type="button"
+                      className={`uw-header-pin${pinned.has(selected.key) ? " pinned" : ""}`}
+                      onClick={() => setPinned((current) => {
+                        const next = new Set(current)
+                        if (next.has(selected.key)) next.delete(selected.key)
+                        else next.add(selected.key)
+                        return next
+                      })}
+                      title={pinned.has(selected.key) ? "Unpin" : "Pin"}
+                    >
+                      {pinned.has(selected.key) ? "★" : "☆"}
+                    </button>
+                  </div>
+                  <div className="uw-context-strip">
+                    <span><small>Project</small><b>{selected.projectName}</b></span>
+                    <span><small>Harness</small><b>{selected.agent.label}</b></span>
+                    <span><small>Model</small><b>{modelLabel(selected.session.model)}</b></span>
+                    <span><small>Machine</small><b>{selected.machineName}</b></span>
+                    <span className={statusClass(selected.status, selected.attention)}><small>Status</small><b>{statusLabel(selected.status, selected.attention)}</b></span>
+                  </div>
+                </div>
+                <div className="uw-session-actions">
+                  <BeautifulButton variant="primary" onClick={() => setHandoffOpen(true)}>Continue with…</BeautifulButton>
+                  <BeautifulButton onClick={() => void renameSelected()}>Rename</BeautifulButton>
+                  {normalizeStatus(selected.status, selected.attention) === "working" ? (
+                    <BeautifulButton onClick={() => void stopSession()}><StopCircleIcon size={15} /> Stop</BeautifulButton>
+                  ) : null}
+                  <BeautifulButton onClick={() => setInspectorOpen((value) => !value)} title="Toggle inspector">
+                    <PanelRightIcon size={16} />
+                  </BeautifulButton>
+                </div>
+              </header>
+
+              <div className="uw-detail-tabs">
+                <button type="button" className={detailTab === "conversation" ? "active" : ""} onClick={() => setDetailTab("conversation")}>Conversation</button>
+                <button type="button" className={detailTab === "changes" ? "active" : ""} onClick={() => setDetailTab("changes")}>
+                  Changes <span>{detail.diff.length}</span>
+                </button>
+              </div>
+
+              {detailTab === "conversation" ? (
+                <>
+                  <div className="uw-transcript" ref={transcriptRef}>
+                    {detailLoading && detail.messages.length === 0 ? (
+                      <div className="uw-empty-panel"><LoadingIcon size={22} /><strong>Loading conversation…</strong></div>
+                    ) : detail.messages.length === 0 ? (
+                      <div className="uw-empty-panel"><ChatIcon size={24} /><strong>This session has no messages yet.</strong></div>
+                    ) : detail.messages.map((message) => (
+                      <MessageBubble key={message.info.id} message={message} agentLabel={selected.agent.label} />
+                    ))}
+                  </div>
+
+                  <div className="uw-composer-shell">
+                    <textarea
+                      value={composer}
+                      onChange={(event) => setComposer(event.target.value)}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" && !event.shiftKey) {
+                          event.preventDefault()
+                          void sendPrompt()
+                        }
+                      }}
+                      placeholder={`Continue this ${selected.agent.label} session…`}
+                      rows={3}
+                    />
+                    <div className="uw-composer-footer">
+                      <span>{selected.session.directory}</span>
+                      <div>
+                        <small>Shift+Enter for newline</small>
+                        <BeautifulButton variant="primary" disabled={!composer.trim() || sending} onClick={() => void sendPrompt()}>
+                          {sending ? <LoadingIcon size={15} /> : "↑"}
+                          {sending ? "Sending" : "Send"}
+                        </BeautifulButton>
+                      </div>
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <div className="uw-changes-pane">
+                  <header>
+                    <div>
+                      <h2>Workspace changes</h2>
+                      <p>Native diff reported by {selected.agent.label} for this session.</p>
+                    </div>
+                    <div className="uw-diff-total">
+                      <span>+{detail.diff.reduce((sum, file) => sum + file.additions, 0)}</span>
+                      <span>−{detail.diff.reduce((sum, file) => sum + file.deletions, 0)}</span>
+                    </div>
+                  </header>
+                  {detail.diff.length === 0 ? (
+                    <div className="uw-empty-panel"><strong>No changed files reported.</strong></div>
+                  ) : detail.diff.map((file) => (
+                    <details className="uw-diff-file" key={file.file}>
+                      <summary>
+                        <code>{file.file}</code>
+                        <span><b>+{file.additions}</b><i>−{file.deletions}</i></span>
+                      </summary>
+                      {file.patch ? <pre>{file.patch}</pre> : <p>No patch text available from this harness.</p>}
+                    </details>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </main>
+
+        {selected && inspectorOpen ? (
+          <aside className="uw-inspector">
+            <header>
+              <div>
+                <h3>Session details</h3>
+                <span>Native session metadata</span>
+              </div>
+              <button type="button" onClick={() => setInspectorOpen(false)}><CloseIcon size={15} /></button>
+            </header>
+
+            <section className="uw-inspector-section">
+              <span className="uw-inspector-label">Status</span>
+              <div className="uw-status-line">
+                <i className={`uw-machine-dot ${normalizeStatus(selected.status, selected.attention) === "working" ? "online" : "idle"}`} />
+                <strong>{statusLabel(selected.status, selected.attention)}</strong>
+                <small>{formatRelative(selected.session.time.updated)} ago</small>
+              </div>
+            </section>
+
+            <section className="uw-inspector-grid">
+              <span>Project</span><b>{selected.projectName}</b>
+              <span>Harness</span><b>{selected.agent.label}</b>
+              <span>Model</span><b>{modelLabel(selected.session.model)}</b>
+              <span>Machine</span><b>{selected.machineName}</b>
+              <span>Working directory</span><code>{selected.session.directory}</code>
+              <span>Branch</span><b>{detail.vcs?.branch || "Unknown"}</b>
+              <span>Last active</span><b>{formatRelative(selected.session.time.updated)} ago</b>
+            </section>
+
+            {(selectedPermissions.length > 0 || selectedQuestions.length > 0) ? (
+              <section className="uw-inspector-section">
+                <span className="uw-inspector-label">Needs You</span>
+                {selectedPermissions.map((permission) => (
+                  <div className="uw-attention-card" key={permission.id}>
+                    <strong>Permission request</strong>
+                    <p>{permission.permission}</p>
+                    {permission.patterns?.length ? <code>{permission.patterns.join(", ")}</code> : null}
+                    <div className="uw-attention-actions">
+                      <BeautifulButton variant="danger" onClick={() => void api.replyPermission(selected.config, permission.id, "reject", selected.session.directory).then(() => setQuestionRevision((value) => value + 1))}>Reject</BeautifulButton>
+                      <BeautifulButton onClick={() => void api.replyPermission(selected.config, permission.id, "once", selected.session.directory).then(() => setQuestionRevision((value) => value + 1))}>Once</BeautifulButton>
+                      <BeautifulButton variant="primary" onClick={() => void api.replyPermission(selected.config, permission.id, "always", selected.session.directory).then(() => setQuestionRevision((value) => value + 1))}>Always</BeautifulButton>
+                    </div>
+                  </div>
+                ))}
+                {selectedQuestions.map((request) => (
+                  <QuestionPanel
+                    key={request.id}
+                    request={request}
+                    config={selected.config}
+                    directory={selected.session.directory}
+                    onResolved={() => setQuestionRevision((value) => value + 1)}
+                  />
+                ))}
+              </section>
+            ) : null}
+
+            <section className="uw-inspector-section">
+              <div className="uw-inspector-section-heading">
+                <span className="uw-inspector-label">Files touched</span>
+                <button type="button" onClick={() => setDetailTab("changes")}>{detail.diff.length ? `View ${detail.diff.length}` : ""}</button>
+              </div>
+              <div className="uw-file-list">
+                {detail.diff.slice(0, 8).map((file) => (
+                  <button type="button" key={file.file} onClick={() => setDetailTab("changes")}>
+                    <code>{file.file}</code>
+                    <span><b>+{file.additions}</b><i>−{file.deletions}</i></span>
+                  </button>
+                ))}
+                {detail.diff.length === 0 ? <p>No diff reported yet.</p> : null}
+              </div>
+            </section>
+
+            {detail.todos.length > 0 ? (
+              <section className="uw-inspector-section">
+                <span className="uw-inspector-label">Agent plan</span>
+                <div className="uw-todo-list">
+                  {detail.todos.map((todo) => (
+                    <div key={todo.id}>
+                      <span className={`uw-todo-state uw-todo-${todo.status}`}>{todo.status === "completed" ? "✓" : "•"}</span>
+                      <span>{todo.content}</span>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ) : null}
+
+            <section className="uw-inspector-section">
+              <span className="uw-inspector-label">Continue on another agent</span>
+              <p className="uw-inspector-copy">Hand off the recent context to another native harness session.</p>
+              <div className="uw-agent-buttons">
+                {machines.flatMap((machine) => machine.agents)
+                  .filter((agent, index, all) => all.findIndex((candidate) => candidate.id === agent.id) === index)
+                  .filter((agent) => agent.id !== selected.agent.id)
+                  .slice(0, 4)
+                  .map((agent) => (
+                    <button type="button" key={agent.id} onClick={() => setHandoffOpen(true)}>{agent.label}</button>
+                  ))}
+              </div>
+            </section>
+
+            <section className="uw-inspector-section uw-inspector-danger">
+              <BeautifulButton
+                variant="danger"
+                onClick={() => {
+                  if (!window.confirm(`Delete "${selected.session.title}"?`)) return
+                  void api.deleteSession(selected.config, selected.session.id, selected.session.directory)
+                    .then(() => refreshAll(true))
+                    .catch((reason) => setGlobalError(reason instanceof Error ? reason.message : String(reason)))
+                }}
+              >
+                Delete session
+              </BeautifulButton>
+            </section>
+          </aside>
+        ) : null}
+      </div>
+
+      {newSessionOpen ? (
+        <NewSessionModal
+          machines={machines.filter((machine) => machine.state === "online" && machine.agents.length > 0)}
+          initialMachineKey={selectedMachine?.key}
+          initialProject={selected?.session.directory}
+          initialAgentId={selected?.agent.id}
+          onClose={() => setNewSessionOpen(false)}
+          onCreated={(machine, agent, created) => {
+            setNewSessionOpen(false)
+            void refreshAll(true).then(() => {
+              setSelectedKey(`${machine.key}|${agent.id}|${created.id}`)
+            })
+          }}
+        />
+      ) : null}
+
+      {handoffOpen && selected ? (
+        <HandoffModal
+          current={selected}
+          messages={detail.messages}
+          machines={machines.filter((machine) => machine.state === "online" && machine.agents.length > 0)}
+          onClose={() => setHandoffOpen(false)}
+          onCreated={(machine, agent, created) => {
+            setHandoffOpen(false)
+            void refreshAll(true).then(() => setSelectedKey(`${machine.key}|${agent.id}|${created.id}`))
+          }}
+        />
+      ) : null}
+
+      {connectionProfile ? (
+        <ConnectionEditor
+          profile={connectionProfile}
+          onClose={() => setConnectionProfileID(null)}
+          onSave={(nextProfile) => {
+            const nextProfiles = profiles.map((profile) => profile.id === nextProfile.id ? nextProfile : profile)
+            onPersistProfiles(nextProfiles, nextProfile.id)
+            setConnectionProfileID(null)
+          }}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/web/src/components/universal-workspace.tsx
+++ b/web/src/components/universal-workspace.tsx
@@ -42,12 +42,12 @@ const REFRESH_INTERVAL_MS = 4_000
 const DETAIL_REFRESH_INTERVAL_MS = 2_500
 const AGENT_SESSION_LOAD_TIMEOUT_MS = 12_000
 const PINNED_STORAGE_KEY = "harness-remote.universal-workspace.pinned"
-const HARNESS_ICON_URLS: Record<string, string> = {
-  codex: "https://openai.com/favicon.ico",
-  claude: "https://claude.ai/favicon.ico",
-  opencode: "https://opencode.ai/favicon.ico",
-  omp: "https://omp.sh/favicon.ico",
-  pi: "https://pi.dev/favicon.ico"
+const HARNESS_ICON_FILES: Record<string, string> = {
+  codex: "codex.svg",
+  claude: "claude.svg",
+  opencode: "opencode.svg",
+  omp: "omp.svg",
+  pi: "pi.svg"
 }
 
 type WorkspaceFilter = "all" | "working" | "needs-you" | "idle" | "pinned"
@@ -207,6 +207,11 @@ function modelOptionKey(model: ModelSelection): string {
   return `${model.providerID}/${model.modelID}/${model.variant || ""}`
 }
 
+function harnessIconUrl(backend: string): string | undefined {
+  const file = HARNESS_ICON_FILES[backend.toLowerCase()]
+  return file ? `${import.meta.env.BASE_URL}harness-icons/${file}` : undefined
+}
+
 function uniqueEndpointProfiles(profiles: SavedServerProfile[]): SavedServerProfile[] {
   const seen = new Set<string>()
   return profiles.filter((profile) => {
@@ -359,7 +364,7 @@ function ToolCard({ message }: { message: MessageEnvelope }) {
 
 function HarnessAvatar({ backend, label }: { backend: string; label: string }) {
   const [failed, setFailed] = useState(false)
-  const source = HARNESS_ICON_URLS[backend.toLowerCase()]
+  const source = harnessIconUrl(backend)
   return (
     <div className="uw-avatar uw-avatar-agent" title={label}>
       {source && !failed ? (
@@ -1004,7 +1009,6 @@ export function UniversalWorkspace({
           const preview = latestReadableText(latest)
           if (preview) setPreviews((current) => current[item.key] === preview ? current : { ...current, [item.key]: preview })
         } catch {
-          // A preview is optional. The session itself remains fully usable.
         }
       }))
     } catch (reason) {

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -114,6 +114,7 @@ type TranslationKey =
   | 'detail.nothingToUndo'
   | 'detail.nothingToRedo'
   | 'detail.revertToMessage'
+  | 'detail.turnFailed'
   | 'detail.undoConfirm'
   | 'detail.revertConfirm'
   | 'detail.send'
@@ -410,6 +411,7 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'detail.nothingToUndo': 'Nothing to undo in this session.',
     'detail.nothingToRedo': 'Nothing to redo in this session.',
     'detail.revertToMessage': 'Revert to this message',
+    'detail.turnFailed': 'The reply failed:',
     'detail.undoConfirm': 'Undo the last turn and restore its file changes?',
     'detail.revertConfirm': 'Revert the conversation and file changes to this message?',
     'detail.send': 'Send',
@@ -705,6 +707,7 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'detail.nothingToUndo': 'Non c’è nulla da annullare in questa sessione.',
     'detail.nothingToRedo': 'Non c’è nulla da ripristinare in questa sessione.',
     'detail.revertToMessage': 'Ripristina fino a questo messaggio',
+    'detail.turnFailed': 'La risposta è fallita:',
     'detail.undoConfirm': 'Annullare l’ultimo turno e ripristinare le sue modifiche ai file?',
     'detail.revertConfirm': 'Ripristinare conversazione e modifiche ai file fino a questo messaggio?',
     'detail.send': 'Invia',
@@ -1000,6 +1003,7 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'detail.nothingToUndo': '此工作階段沒有可復原的內容。',
     'detail.nothingToRedo': '此工作階段沒有可重做的內容。',
     'detail.revertToMessage': '還原到這則訊息',
+    'detail.turnFailed': '回覆失敗：',
     'detail.undoConfirm': '要復原上一個回合及其檔案變更嗎？',
     'detail.revertConfirm': '要將對話和檔案變更還原到這則訊息嗎？',
     'detail.send': '傳送',
@@ -1244,6 +1248,7 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'detail.nothingToUndo': '此会话没有可撤销的内容。',
     'detail.nothingToRedo': '此会话没有可重做的内容。',
     'detail.revertToMessage': '还原到这条消息',
+    'detail.turnFailed': '回复失败：',
     'detail.undoConfirm': '要撤销上一轮及其文件更改吗？',
     'detail.revertConfirm': '要将对话和文件更改还原到这条消息吗？',
     'detail.send': '发送',

--- a/web/src/machineClient.ts
+++ b/web/src/machineClient.ts
@@ -3,6 +3,8 @@ import { desktopRequestResult, isDesktopPlatform } from "./desktopBridge"
 import { authHeader, hasCredentials, machineBaseUrl } from "./serverConfig"
 import type { MachineSnapshot, ServerConfig } from "./types"
 
+const BROWSER_DISCOVERY_TIMEOUT_MS = 12_000
+
 function headers(config: ServerConfig): Record<string, string> {
   const value: Record<string, string> = { Accept: "application/json" }
   if (hasCredentials(config)) value.Authorization = authHeader(config)
@@ -59,11 +61,18 @@ export async function discoverMachine(config: ServerConfig): Promise<MachineSnap
     return machineSnapshot(response.data)
   }
 
+  const controller = new AbortController()
+  const timer = globalThis.setTimeout(() => controller.abort(), BROWSER_DISCOVERY_TIMEOUT_MS)
   let response: Response
   try {
-    response = await fetch(target, { headers: headers(config) })
-  } catch {
+    response = await fetch(target, { headers: headers(config), signal: controller.signal })
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(`Machine discovery at ${config.host}:${config.port} timed out after ${BROWSER_DISCOVERY_TIMEOUT_MS / 1000}s.`)
+    }
     throw new Error(`Cannot reach ${config.host}:${config.port}.`)
+  } finally {
+    globalThis.clearTimeout(timer)
   }
   if (noMachineStatus(response.status)) return null
   if (!response.ok) throw new Error(`HTTP ${response.status}`)

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom/client"
 import { Capacitor } from "@capacitor/core"
 import App from "./App"
 import { installCompletionAudioGuard } from "./completion-audio"
-import { UniversalWorkspace } from "./components/universal-workspace"
+import { StandaloneUniversalWorkspace } from "./components/standalone-universal-workspace"
 import { ErrorBoundary } from "./ErrorBoundary"
 import { SERVER_STORAGE_KEYS } from "./storageKeys"
 import {
@@ -38,8 +38,8 @@ function TaskDeskBoundary() {
   }
 
   return (
-    <UniversalWorkspace
-      machineProfiles={machines}
+    <StandaloneUniversalWorkspace
+      machines={machines}
       onPersistMachines={persistMachines}
       legacyView={<App />}
     />

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -57,6 +57,13 @@ function AppProfileBoundary() {
   const [checkedRoutingKey, setCheckedRoutingKey] = useState<string | null>(null)
   const profiles = useMemo(loadServerProfiles, [revision])
   const activeProfile = useMemo(() => loadActiveServerProfile(profiles), [profiles])
+  // UniversalWorkspace collapses duplicate machine endpoints. Put the active profile first so the
+  // credentials the user just selected win over stale legacy/backend-specific profiles that may
+  // point at the same daemon with an old or empty password.
+  const workspaceProfiles = useMemo(
+    () => [activeProfile, ...profiles.filter((profile) => profile.id !== activeProfile.id)],
+    [activeProfile, profiles]
+  )
   const t = useMemo(
     () => createTranslator(normalizeLanguage(localStorage.getItem(LANGUAGE_STORAGE_KEY) || navigator.language)),
     [revision]
@@ -157,7 +164,7 @@ function AppProfileBoundary() {
 
   return (
     <UniversalWorkspace
-      profiles={profiles}
+      profiles={workspaceProfiles}
       activeProfileID={activeProfile.id}
       onPersistProfiles={persistWorkspaceProfiles}
       legacyView={<App key={revision} />}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -202,6 +202,19 @@ async function renderApp() {
 
 void renderApp()
 
+if (import.meta.env.DEV && !Capacitor.isNativePlatform() && !window.harnessDesktop?.platform.isDesktop) {
+  if ("serviceWorker" in navigator) {
+    void navigator.serviceWorker.getRegistrations().then((registrations) =>
+      Promise.all(registrations.map((registration) => registration.unregister()))
+    )
+  }
+  if ("caches" in window) {
+    void caches.keys().then((keys) =>
+      Promise.all(keys.filter((key) => key.startsWith("harness-remote-")).map((key) => caches.delete(key)))
+    )
+  }
+}
+
 if (import.meta.env.PROD && !Capacitor.isNativePlatform() && !window.harnessDesktop?.platform.isDesktop && "serviceWorker" in navigator) {
   window.addEventListener("load", () => {
     const base = import.meta.env.BASE_URL

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -6,7 +6,7 @@ import { api, isValidServerConfig } from "./api"
 import { backendDisplayName } from "./backendSetup"
 import { installCompletionAudioGuard } from "./completion-audio"
 import { ConnectServerWizard } from "./components/panels"
-import { TaskDeskHome } from "./components/taskdesk-home"
+import { UniversalWorkspace } from "./components/universal-workspace"
 import { ErrorBoundary } from "./ErrorBoundary"
 import { createTranslator, normalizeLanguage } from "./i18n"
 import { discoverMachine } from "./machineClient"
@@ -20,7 +20,7 @@ import { SERVER_STORAGE_KEYS } from "./storageKeys"
 import type { MachineSnapshot, ServerConfig } from "./types"
 import "./styles.css"
 import "./v3-polish.css"
-import "./taskdesk-home.css"
+import "./universal-workspace.css"
 
 installCompletionAudioGuard()
 
@@ -101,11 +101,8 @@ function AppProfileBoundary() {
     }
   }, [activeProfile, needsRoutingDiscovery, profiles, routingKey])
 
-  const saveConnection = (config: ServerConfig) => {
-    const nextProfiles = profiles.map((profile) =>
-      profile.id === activeProfile.id ? { ...profile, config } : profile
-    )
-    persistServerProfiles(nextProfiles, activeProfile.id)
+  const persistWorkspaceProfiles = (nextProfiles: typeof profiles, nextActiveProfileID: string) => {
+    persistServerProfiles(nextProfiles, nextActiveProfileID)
     setCheckedRoutingKey(null)
     setRevision((value) => value + 1)
   }
@@ -141,9 +138,7 @@ function AppProfileBoundary() {
                 ? { ...profile, name: name.trim() || profile.name, config: routedConfig }
                 : profile
             )
-            persistServerProfiles(nextProfiles, activeProfile.id)
-            setCheckedRoutingKey(null)
-            setRevision((value) => value + 1)
+            persistWorkspaceProfiles(nextProfiles, activeProfile.id)
           })()
         }}
       />
@@ -161,10 +156,11 @@ function AppProfileBoundary() {
   }
 
   return (
-    <TaskDeskHome
-      config={activeProfile.config}
-      onUpdateConnection={saveConnection}
-      sessions={<App key={revision} />}
+    <UniversalWorkspace
+      profiles={profiles}
+      activeProfileID={activeProfile.id}
+      onPersistProfiles={persistWorkspaceProfiles}
+      legacyView={<App key={revision} />}
     />
   )
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -24,9 +24,6 @@ import "./taskdesk-home.css"
 
 installCompletionAudioGuard()
 
-// Creating a session is a deliberate multi-step action. A stray click on the dimmed page around
-// the dialog must not throw the user's folder selection away; only the dialog's explicit close or
-// cancel controls dismiss it.
 document.addEventListener("click", (event) => {
   const target = event.target
   if (!(target instanceof HTMLElement) || !target.classList.contains("modal-backdrop")) return
@@ -70,9 +67,6 @@ function AppProfileBoundary() {
 
   useEffect(() => {
     const onProfileChanged = () => {
-      // Settings edits can persist while the user is still typing. If a stale profile-change event
-      // lands during that edit, remounting App would close the modal and start a connection using a
-      // half-edited draft. Keep the editor stable; explicit server selection already updates App.
       if (document.querySelector(".settings")) return
       setCheckedRoutingKey(null)
       setRevision((value) => value + 1)
@@ -106,6 +100,15 @@ function AppProfileBoundary() {
       cancelled = true
     }
   }, [activeProfile, needsRoutingDiscovery, profiles, routingKey])
+
+  const saveConnection = (config: ServerConfig) => {
+    const nextProfiles = profiles.map((profile) =>
+      profile.id === activeProfile.id ? { ...profile, config } : profile
+    )
+    persistServerProfiles(nextProfiles, activeProfile.id)
+    setCheckedRoutingKey(null)
+    setRevision((value) => value + 1)
+  }
 
   if (needsInitialSetup) {
     return (
@@ -160,6 +163,7 @@ function AppProfileBoundary() {
   return (
     <TaskDeskHome
       config={activeProfile.config}
+      onUpdateConnection={saveConnection}
       sessions={<App key={revision} />}
     />
   )

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -15,6 +15,7 @@ import {
 import "./styles.css"
 import "./v3-polish.css"
 import "./universal-workspace.css"
+import "./universal-workspace-readable.css"
 
 installCompletionAudioGuard()
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -6,6 +6,7 @@ import { api, isValidServerConfig } from "./api"
 import { backendDisplayName } from "./backendSetup"
 import { installCompletionAudioGuard } from "./completion-audio"
 import { ConnectServerWizard } from "./components/panels"
+import { TaskDeskHome } from "./components/taskdesk-home"
 import { ErrorBoundary } from "./ErrorBoundary"
 import { createTranslator, normalizeLanguage } from "./i18n"
 import { discoverMachine } from "./machineClient"
@@ -19,6 +20,7 @@ import { SERVER_STORAGE_KEYS } from "./storageKeys"
 import type { MachineSnapshot, ServerConfig } from "./types"
 import "./styles.css"
 import "./v3-polish.css"
+import "./taskdesk-home.css"
 
 installCompletionAudioGuard()
 
@@ -155,7 +157,12 @@ function AppProfileBoundary() {
     )
   }
 
-  return <App key={revision} />
+  return (
+    <TaskDeskHome
+      config={activeProfile.config}
+      sessions={<App key={revision} />}
+    />
+  )
 }
 
 async function renderApp() {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,11 +1,23 @@
-import React, { useMemo, useState } from "react"
+import React, { useEffect, useMemo, useState } from "react"
 import ReactDOM from "react-dom/client"
 import { Capacitor } from "@capacitor/core"
 import App from "./App"
+import { api, isValidServerConfig } from "./api"
+import { backendDisplayName } from "./backendSetup"
 import { installCompletionAudioGuard } from "./completion-audio"
+import { ConnectServerWizard } from "./components/panels"
 import { StandaloneUniversalWorkspace } from "./components/standalone-universal-workspace"
 import { ErrorBoundary } from "./ErrorBoundary"
+import { createTranslator, normalizeLanguage } from "./i18n"
+import { discoverMachine } from "./machineClient"
+import {
+  ACTIVE_PROFILE_CHANGED_EVENT,
+  loadActiveServerProfile,
+  loadServerProfiles,
+  persistServerProfiles
+} from "./serverProfiles"
 import { SERVER_STORAGE_KEYS } from "./storageKeys"
+import type { MachineSnapshot, ServerConfig } from "./types"
 import {
   loadWorkspaceMachines,
   persistWorkspaceMachines,
@@ -27,7 +39,132 @@ document.addEventListener("click", (event) => {
   event.stopImmediatePropagation()
 }, true)
 
+const LANGUAGE_STORAGE_KEY = "opencode.remote.language"
 const taskDeskTestMode = import.meta.env.DEV && new URLSearchParams(window.location.search).get("taskdesk-test") === "1"
+
+function matchingMachineAgent(machine: MachineSnapshot | null, backend: ServerConfig["backend"]) {
+  return machine?.agents.find((agent) =>
+    agent.backend === backend && (agent.state === "available" || agent.state === "configured")
+  )
+}
+
+function profileRoutingKey(profileID: string, config: ServerConfig): string {
+  return JSON.stringify({
+    profileID,
+    backend: config.backend,
+    host: config.host.trim().toLowerCase(),
+    port: config.port,
+    username: config.username,
+    password: config.password
+  })
+}
+
+/** Classic keeps its existing saved-server lifecycle. It is intentionally isolated from TaskDesk machines. */
+function ClassicBoundary() {
+  const [revision, setRevision] = useState(0)
+  const [checkedRoutingKey, setCheckedRoutingKey] = useState<string | null>(null)
+  const profiles = useMemo(loadServerProfiles, [revision])
+  const activeProfile = useMemo(() => loadActiveServerProfile(profiles), [profiles])
+  const t = useMemo(
+    () => createTranslator(normalizeLanguage(localStorage.getItem(LANGUAGE_STORAGE_KEY) || navigator.language)),
+    [revision]
+  )
+  const needsInitialSetup = !isValidServerConfig(activeProfile.config)
+  const routingKey = profileRoutingKey(activeProfile.id, activeProfile.config)
+  const needsRoutingDiscovery = !needsInitialSetup && !activeProfile.config.agentId && checkedRoutingKey !== routingKey
+
+  useEffect(() => {
+    const onProfileChanged = () => {
+      if (document.querySelector(".settings")) return
+      setCheckedRoutingKey(null)
+      setRevision((value) => value + 1)
+    }
+    window.addEventListener(ACTIVE_PROFILE_CHANGED_EVENT, onProfileChanged)
+    return () => window.removeEventListener(ACTIVE_PROFILE_CHANGED_EVENT, onProfileChanged)
+  }, [])
+
+  useEffect(() => {
+    if (!needsRoutingDiscovery) return
+    let cancelled = false
+    void discoverMachine(activeProfile.config).then((machine) => {
+      if (cancelled) return
+      const agent = matchingMachineAgent(machine, activeProfile.config.backend)
+      if (agent) {
+        const nextProfiles = profiles.map((profile) =>
+          profile.id === activeProfile.id
+            ? { ...profile, config: { ...profile.config, agentId: agent.id } }
+            : profile
+        )
+        persistServerProfiles(nextProfiles, activeProfile.id)
+        setCheckedRoutingKey(null)
+        setRevision((value) => value + 1)
+        return
+      }
+      setCheckedRoutingKey(routingKey)
+    }).catch(() => {
+      if (!cancelled) setCheckedRoutingKey(routingKey)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [activeProfile, needsRoutingDiscovery, profiles, routingKey])
+
+  const persistClassicProfiles = (nextProfiles: typeof profiles, nextActiveProfileID: string) => {
+    persistServerProfiles(nextProfiles, nextActiveProfileID)
+    setCheckedRoutingKey(null)
+    setRevision((value) => value + 1)
+  }
+
+  if (needsInitialSetup) {
+    return (
+      <ConnectServerWizard
+        t={t}
+        initialName={activeProfile.name}
+        onCancel={() => undefined}
+        onDiscover={discoverMachine}
+        onTest={async (config: ServerConfig) => {
+          try {
+            const health = await api.health(config)
+            if (health.backend && health.backend !== config.backend) {
+              throw new Error(`Expected ${backendDisplayName(config.backend)} but reached ${backendDisplayName(health.backend)}`)
+            }
+            return { ok: true, message: t('settings.connectedTo', { version: health.version }) }
+          } catch (error) {
+            return { ok: false, message: t('settings.connectionFailed', { message: (error as Error).message }) }
+          }
+        }}
+        onSave={(name, config) => {
+          void (async () => {
+            let routedConfig = config
+            if (!config.agentId) {
+              const machine = await discoverMachine(config).catch(() => null)
+              const agent = matchingMachineAgent(machine, config.backend)
+              if (agent) routedConfig = { ...config, agentId: agent.id }
+            }
+            const nextProfiles = profiles.map((profile) =>
+              profile.id === activeProfile.id
+                ? { ...profile, name: name.trim() || profile.name, config: routedConfig }
+                : profile
+            )
+            persistClassicProfiles(nextProfiles, activeProfile.id)
+          })()
+        }}
+      />
+    )
+  }
+
+  if (needsRoutingDiscovery) {
+    return (
+      <div className="app-shell">
+        <div className="empty-state compact" role="status" aria-live="polite">
+          <p>{t('connection.connecting')}</p>
+        </div>
+      </div>
+    )
+  }
+
+  return <App key={revision} />
+}
 
 function TaskDeskBoundary() {
   const [revision, setRevision] = useState(0)
@@ -42,7 +179,7 @@ function TaskDeskBoundary() {
     <StandaloneUniversalWorkspace
       machines={machines}
       onPersistMachines={persistMachines}
-      legacyView={<App />}
+      legacyView={<ClassicBoundary />}
     />
   )
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,23 +1,17 @@
-import React, { useEffect, useMemo, useState } from "react"
+import React, { useMemo, useState } from "react"
 import ReactDOM from "react-dom/client"
 import { Capacitor } from "@capacitor/core"
 import App from "./App"
-import { api, isValidServerConfig } from "./api"
-import { backendDisplayName } from "./backendSetup"
 import { installCompletionAudioGuard } from "./completion-audio"
-import { ConnectServerWizard } from "./components/panels"
 import { UniversalWorkspace } from "./components/universal-workspace"
 import { ErrorBoundary } from "./ErrorBoundary"
-import { createTranslator, normalizeLanguage } from "./i18n"
-import { discoverMachine } from "./machineClient"
-import {
-  ACTIVE_PROFILE_CHANGED_EVENT,
-  loadActiveServerProfile,
-  loadServerProfiles,
-  persistServerProfiles
-} from "./serverProfiles"
 import { SERVER_STORAGE_KEYS } from "./storageKeys"
-import type { MachineSnapshot, ServerConfig } from "./types"
+import {
+  WORKSPACE_MACHINES_STORAGE_KEY,
+  loadWorkspaceMachines,
+  persistWorkspaceMachines,
+  type WorkspaceMachine
+} from "./workspaceMachines"
 import "./styles.css"
 import "./v3-polish.css"
 import "./universal-workspace.css"
@@ -32,148 +26,28 @@ document.addEventListener("click", (event) => {
   event.stopImmediatePropagation()
 }, true)
 
-const LANGUAGE_STORAGE_KEY = "opencode.remote.language"
 const taskDeskTestMode = import.meta.env.DEV && new URLSearchParams(window.location.search).get("taskdesk-test") === "1"
 
-function matchingMachineAgent(machine: MachineSnapshot | null, backend: ServerConfig["backend"]) {
-  return machine?.agents.find((agent) =>
-    agent.backend === backend && (agent.state === "available" || agent.state === "configured")
-  )
-}
-
-function profileRoutingKey(profileID: string, config: ServerConfig): string {
-  return JSON.stringify({
-    profileID,
-    backend: config.backend,
-    host: config.host.trim().toLowerCase(),
-    port: config.port,
-    username: config.username,
-    password: config.password
-  })
-}
-
-function AppProfileBoundary() {
+function TaskDeskBoundary() {
   const [revision, setRevision] = useState(0)
-  const [checkedRoutingKey, setCheckedRoutingKey] = useState<string | null>(null)
-  const profiles = useMemo(loadServerProfiles, [revision])
-  const activeProfile = useMemo(() => loadActiveServerProfile(profiles), [profiles])
-  // UniversalWorkspace collapses duplicate machine endpoints. Put the active profile first so the
-  // credentials the user just selected win over stale legacy/backend-specific profiles that may
-  // point at the same daemon with an old or empty password.
-  const workspaceProfiles = useMemo(
-    () => [activeProfile, ...profiles.filter((profile) => profile.id !== activeProfile.id)],
-    [activeProfile, profiles]
-  )
-  const t = useMemo(
-    () => createTranslator(normalizeLanguage(localStorage.getItem(LANGUAGE_STORAGE_KEY) || navigator.language)),
-    [revision]
-  )
-  const needsInitialSetup = !isValidServerConfig(activeProfile.config)
-  const routingKey = profileRoutingKey(activeProfile.id, activeProfile.config)
-  const needsRoutingDiscovery = !needsInitialSetup && !activeProfile.config.agentId && checkedRoutingKey !== routingKey
+  const machines = useMemo(loadWorkspaceMachines, [revision])
 
-  useEffect(() => {
-    const onProfileChanged = () => {
-      if (document.querySelector(".settings")) return
-      setCheckedRoutingKey(null)
-      setRevision((value) => value + 1)
-    }
-    window.addEventListener(ACTIVE_PROFILE_CHANGED_EVENT, onProfileChanged)
-    return () => window.removeEventListener(ACTIVE_PROFILE_CHANGED_EVENT, onProfileChanged)
-  }, [])
-
-  useEffect(() => {
-    if (!needsRoutingDiscovery) return
-    let cancelled = false
-    void discoverMachine(activeProfile.config).then((machine) => {
-      if (cancelled) return
-      const agent = matchingMachineAgent(machine, activeProfile.config.backend)
-      if (agent) {
-        const nextProfiles = profiles.map((profile) =>
-          profile.id === activeProfile.id
-            ? { ...profile, config: { ...profile.config, agentId: agent.id } }
-            : profile
-        )
-        persistServerProfiles(nextProfiles, activeProfile.id)
-        setCheckedRoutingKey(null)
-        setRevision((value) => value + 1)
-        return
-      }
-      setCheckedRoutingKey(routingKey)
-    }).catch(() => {
-      if (!cancelled) setCheckedRoutingKey(routingKey)
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [activeProfile, needsRoutingDiscovery, profiles, routingKey])
-
-  const persistWorkspaceProfiles = (nextProfiles: typeof profiles, nextActiveProfileID: string) => {
-    persistServerProfiles(nextProfiles, nextActiveProfileID)
-    setCheckedRoutingKey(null)
+  const persistMachines = (nextMachines: WorkspaceMachine[]) => {
+    persistWorkspaceMachines(nextMachines)
     setRevision((value) => value + 1)
-  }
-
-  if (needsInitialSetup) {
-    return (
-      <ConnectServerWizard
-        t={t}
-        initialName={activeProfile.name}
-        onCancel={() => undefined}
-        onDiscover={discoverMachine}
-        onTest={async (config: ServerConfig) => {
-          try {
-            const health = await api.health(config)
-            if (health.backend && health.backend !== config.backend) {
-              throw new Error(`Expected ${backendDisplayName(config.backend)} but reached ${backendDisplayName(health.backend)}`)
-            }
-            return { ok: true, message: t('settings.connectedTo', { version: health.version }) }
-          } catch (error) {
-            return { ok: false, message: t('settings.connectionFailed', { message: (error as Error).message }) }
-          }
-        }}
-        onSave={(name, config) => {
-          void (async () => {
-            let routedConfig = config
-            if (!config.agentId) {
-              const machine = await discoverMachine(config).catch(() => null)
-              const agent = matchingMachineAgent(machine, config.backend)
-              if (agent) routedConfig = { ...config, agentId: agent.id }
-            }
-            const nextProfiles = profiles.map((profile) =>
-              profile.id === activeProfile.id
-                ? { ...profile, name: name.trim() || profile.name, config: routedConfig }
-                : profile
-            )
-            persistWorkspaceProfiles(nextProfiles, activeProfile.id)
-          })()
-        }}
-      />
-    )
-  }
-
-  if (needsRoutingDiscovery) {
-    return (
-      <div className="app-shell">
-        <div className="empty-state compact" role="status" aria-live="polite">
-          <p>{t('connection.connecting')}</p>
-        </div>
-      </div>
-    )
   }
 
   return (
     <UniversalWorkspace
-      profiles={workspaceProfiles}
-      activeProfileID={activeProfile.id}
-      onPersistProfiles={persistWorkspaceProfiles}
-      legacyView={<App key={revision} />}
+      machineProfiles={machines}
+      onPersistMachines={persistMachines}
+      legacyView={<App />}
     />
   )
 }
 
 async function renderApp() {
-  let content: React.ReactNode = <AppProfileBoundary />
+  let content: React.ReactNode = <TaskDeskBoundary />
   if (taskDeskTestMode) {
     const { TaskDeskTestPage } = await import("./TaskDeskTestPage")
     content = <TaskDeskTestPage />
@@ -181,7 +55,7 @@ async function renderApp() {
 
   ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>
-      <ErrorBoundary resetKeys={SERVER_STORAGE_KEYS}>
+      <ErrorBoundary resetKeys={[...SERVER_STORAGE_KEYS, WORKSPACE_MACHINES_STORAGE_KEY]}>
         {content}
       </ErrorBoundary>
     </React.StrictMode>

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -7,7 +7,6 @@ import { StandaloneUniversalWorkspace } from "./components/standalone-universal-
 import { ErrorBoundary } from "./ErrorBoundary"
 import { SERVER_STORAGE_KEYS } from "./storageKeys"
 import {
-  WORKSPACE_MACHINES_STORAGE_KEY,
   loadWorkspaceMachines,
   persistWorkspaceMachines,
   type WorkspaceMachine
@@ -56,7 +55,7 @@ async function renderApp() {
 
   ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>
-      <ErrorBoundary resetKeys={[...SERVER_STORAGE_KEYS, WORKSPACE_MACHINES_STORAGE_KEY]}>
+      <ErrorBoundary resetKeys={SERVER_STORAGE_KEYS}>
         {content}
       </ErrorBoundary>
     </React.StrictMode>

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -15,6 +15,7 @@ import "./styles.css"
 import "./v3-polish.css"
 import "./universal-workspace.css"
 import "./universal-workspace-readable.css"
+import "./universal-workspace-readable-fixes.css"
 
 installCompletionAudioGuard()
 

--- a/web/src/server-config.test.mjs
+++ b/web/src/server-config.test.mjs
@@ -69,7 +69,7 @@ assert.match(app, /const hasConfiguredServer = isValidServerConfig\(config\)/, '
 const main = readFileSync(new URL('./main.tsx', import.meta.url), 'utf8')
 assert.match(main, /<ErrorBoundary resetKeys=\{SERVER_STORAGE_KEYS\}>/, 'a crash must render recoverable UI instead of an empty root')
 assert.match(main, /ACTIVE_PROFILE_CHANGED_EVENT/, 'server changes must remount App so server-scoped session state is re-read')
-assert.match(main, /return <App key=\{revision\} \/>/, 'the profile boundary must remount App without reloading the page')
+assert.match(main, /sessions=\{<App key=\{revision\} \/>\}/, 'the TaskDesk shell must still remount App on the profile revision without reloading the page')
 
 const serverProfiles = readFileSync(new URL('./serverProfiles.ts', import.meta.url), 'utf8')
 assert.match(serverProfiles, /newSessionDirectoryByProfile/, 'new-session directories must be stored per server profile')

--- a/web/src/server-config.test.mjs
+++ b/web/src/server-config.test.mjs
@@ -69,7 +69,7 @@ assert.match(app, /const hasConfiguredServer = isValidServerConfig\(config\)/, '
 const main = readFileSync(new URL('./main.tsx', import.meta.url), 'utf8')
 assert.match(main, /<ErrorBoundary resetKeys=\{SERVER_STORAGE_KEYS\}>/, 'a crash must render recoverable UI instead of an empty root')
 assert.match(main, /ACTIVE_PROFILE_CHANGED_EVENT/, 'server changes must remount App so server-scoped session state is re-read')
-assert.match(main, /sessions=\{<App key=\{revision\} \/>\}/, 'the TaskDesk shell must still remount App on the profile revision without reloading the page')
+assert.match(main, /legacyView=\{<App key=\{revision\} \/>\}/, 'the universal workspace must still remount the classic App on the profile revision without reloading the page')
 
 const serverProfiles = readFileSync(new URL('./serverProfiles.ts', import.meta.url), 'utf8')
 assert.match(serverProfiles, /newSessionDirectoryByProfile/, 'new-session directories must be stored per server profile')
@@ -97,6 +97,20 @@ assert.equal(
   authHeader(creds('opencode', 'secret')),
   'surrounding whitespace must not change the credentials sent'
 )
+
+// `btoa` encodes Latin-1: `à` went out as one byte where curl and every other client send the two
+// UTF-8 bytes the server decodes, so the password silently did not match. Above U+00FF it threw.
+assert.equal(
+  authHeader(creds('opencode', 'pàssword')),
+  'Basic b3BlbmNvZGU6cMOgc3N3b3Jk',
+  'credentials must be encoded as UTF-8 before base64'
+)
+assert.notEqual(
+  authHeader(creds('opencode', 'pàssword')),
+  'Basic b3BlbmNvZGU6cOBzc3dvcmQ=',
+  'the Latin-1 encoding btoa produces on its own must not be what goes on the wire'
+)
+assert.doesNotThrow(() => authHeader(creds('opencode', 'påsswörd☂')), 'a character above U+00FF must not throw')
 
 // `btoa` encodes Latin-1: `à` went out as one byte where curl and every other client send the two
 // UTF-8 bytes the server decodes, so the password silently did not match. Above U+00FF it threw.

--- a/web/src/server-config.test.mjs
+++ b/web/src/server-config.test.mjs
@@ -69,7 +69,7 @@ assert.match(app, /const hasConfiguredServer = isValidServerConfig\(config\)/, '
 const main = readFileSync(new URL('./main.tsx', import.meta.url), 'utf8')
 assert.match(main, /<ErrorBoundary resetKeys=\{SERVER_STORAGE_KEYS\}>/, 'a crash must render recoverable UI instead of an empty root')
 assert.match(main, /ACTIVE_PROFILE_CHANGED_EVENT/, 'server changes must remount App so server-scoped session state is re-read')
-assert.match(main, /legacyView=\{<App key=\{revision\} \/>\}/, 'the universal workspace must still remount the classic App on the profile revision without reloading the page')
+assert.match(main, /return <App key=\{revision\} \/>/, 'the isolated Classic boundary must still remount App on the profile revision without reloading the page')
 
 const serverProfiles = readFileSync(new URL('./serverProfiles.ts', import.meta.url), 'utf8')
 assert.match(serverProfiles, /newSessionDirectoryByProfile/, 'new-session directories must be stored per server profile')

--- a/web/src/serverConfig.ts
+++ b/web/src/serverConfig.ts
@@ -22,6 +22,27 @@ export function baseUrl(config: ServerConfig): string {
   return agentID ? `${machine}/v1/agents/${encodeURIComponent(agentID)}` : machine
 }
 
+/**
+ * The daemon corrects a stale or wrongly-scoped agent id from this header, so it is what keeps a
+ * profile pointed at the harness the user chose even when the path scope cannot be trusted. It lives
+ * here rather than beside either transport because the browser and the desktop app have separate
+ * request paths, and a header only one of them sent is how the desktop app came to route every
+ * server to the daemon's primary agent.
+ *
+ * A direct OpenCode server does not know the header and may reject it during CORS preflight, so a
+ * profile with no agent id — which is what a pre-daemon OpenCode connection looks like — sends none
+ * from the browser. Nothing preflights a request made from the desktop app's main process or from a
+ * native HTTP client, and a server that does not know the header simply ignores it, so those pass
+ * `preflight: false` and keep the hint that tells a daemon which harness was asked for.
+ */
+export function routingHeaders(
+  config: Pick<ServerConfig, "backend" | "agentId">,
+  { preflight = true }: { preflight?: boolean } = {}
+): Record<string, string> {
+  if (preflight && config.backend === "opencode" && !config.agentId?.trim()) return {}
+  return { "X-Harness-Backend": config.backend }
+}
+
 /** Useful when a caller already has a path and does not build through baseUrl. */
 export function agentScopedPath(config: ServerConfig, path: string): string {
   const agentID = config.agentId?.trim()

--- a/web/src/settings-regression.test.mjs
+++ b/web/src/settings-regression.test.mjs
@@ -9,6 +9,9 @@ const i18n = readFileSync(new URL('./i18n.ts', import.meta.url), 'utf8')
 const styles = readFileSync(new URL('./styles.css', import.meta.url), 'utf8')
 const shell = readFileSync(new URL('./components/shell.tsx', import.meta.url), 'utf8')
 const panels = readFileSync(new URL('./components/panels.tsx', import.meta.url), 'utf8')
+const serverConfig = readFileSync(new URL('./serverConfig.ts', import.meta.url), 'utf8')
+const desktopRequestTransport = readFileSync(new URL('../electron/request-transport.ts', import.meta.url), 'utf8')
+const desktopEventTransport = readFileSync(new URL('../electron/event-transport.ts', import.meta.url), 'utf8')
 
 const testConnection = app.match(/async function testConnection[\s\S]*?async function refreshSessions/)
 assert.ok(testConnection, 'testConnection function should be present')
@@ -80,11 +83,17 @@ assert.match(panels, /setName\(event\.target\.value\)[\s\S]*?setNameEdited\(true
 // Agent-scoped URLs are the primary routing contract. The backend header is a compatibility guard
 // for profiles saved by older builds with no agentId, or with an agentId that points at the old primary.
 // A raw OpenCode server must not receive the custom header because its CORS policy does not know it.
-assert.ok(api.includes('function routingHeaders(config: ServerConfig)'), 'API requests should centralize the compatibility routing hint')
-assert.ok(api.includes('return { "X-Harness-Backend": config.backend }'), 'daemon requests should identify the selected harness backend')
-assert.ok(api.includes('if (config.backend === "opencode" && !config.agentId) return {}'), 'direct legacy OpenCode servers must not receive the daemon routing header')
+// The rule lives with the URL builders, not with one transport: the browser and the desktop app take
+// separate request paths, and a header only the browser sent is how the desktop app came to route
+// every server to the daemon's primary agent.
+assert.match(serverConfig, /export function routingHeaders\(\s*config: Pick<ServerConfig, "backend" \| "agentId">/, 'the routing hint should be defined once beside the URL builders')
+assert.ok(serverConfig.includes('return { "X-Harness-Backend": config.backend }'), 'daemon requests should identify the selected harness backend')
+assert.ok(serverConfig.includes('if (preflight && config.backend === "opencode" && !config.agentId?.trim()) return {}'), 'direct legacy OpenCode servers must not receive the daemon routing header from the browser')
+assert.equal(/function routingHeaders/.test(api), false, 'api.ts should reuse the shared routing hint rather than defining its own')
 assert.ok(api.includes('...routingHeaders(config)'), 'ordinary API requests should carry the selected harness routing hint')
 assert.match(api, /eventStream\(config: ServerConfig\)[\s\S]*?routingHeaders\(config\)/, 'browser SSE should preserve the selected harness routing hint too')
+assert.ok(desktopRequestTransport.includes('...routingHeaders(profile, { preflight: false })'), 'desktop requests never preflight, so they always carry the routing hint')
+assert.ok(desktopEventTransport.includes('...routingHeaders(profile, { preflight: false })'), 'desktop SSE never preflights, so it always carries the routing hint')
 
 // The server picker used to caption itself with a visually-hidden span, but no rule ever hid it: the
 // caption rendered as stray text above the header. Every class the picker and its actions rely on has

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2249,6 +2249,35 @@ a:focus-visible,
   color: var(--danger);
 }
 
+/* A failed turn stands in for the reply that never arrived, so it reads as part of the transcript
+   rather than as chrome: same bubble, same width, distinguished only by the danger palette. */
+.message-failure {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  margin: 0;
+  margin-top: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid var(--danger-border);
+  border-radius: var(--radius-sm);
+  background: var(--danger-soft);
+  color: var(--danger);
+  font-size: var(--font-sm);
+}
+
+.message-failure:first-child {
+  margin-top: 0;
+}
+
+.message-failure-label {
+  font-weight: 600;
+}
+
+.message-failure-detail {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .message-tool-command,
 .message-tool-output {
   margin: 0;

--- a/web/src/taskClient.ts
+++ b/web/src/taskClient.ts
@@ -4,6 +4,8 @@ import { unwrapPayload } from "./machinePayload"
 import { authHeader, hasCredentials, machineBaseUrl } from "./serverConfig"
 import type { ModelOption, ModelSelection, ServerConfig } from "./types"
 
+const BROWSER_MACHINE_REQUEST_TIMEOUT_MS = 12_000
+
 export type MachineProject = {
   id: string
   machineId: string
@@ -114,15 +116,23 @@ async function machineRequest<T>(config: ServerConfig, path: string, options: Ta
     return parseTaskPayload<T>(response.data, path)
   }
 
+  const controller = new AbortController()
+  const timer = globalThis.setTimeout(() => controller.abort(), BROWSER_MACHINE_REQUEST_TIMEOUT_MS)
   let response: Response
   try {
     response = await fetch(target, {
       method,
       headers,
-      body: options.body === undefined ? undefined : JSON.stringify(options.body)
+      body: options.body === undefined ? undefined : JSON.stringify(options.body),
+      signal: controller.signal
     })
-  } catch {
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(`${path} at ${config.host}:${config.port} timed out after ${BROWSER_MACHINE_REQUEST_TIMEOUT_MS / 1000}s.`)
+    }
     throw new Error(`Cannot reach ${config.host}:${config.port}.`)
+  } finally {
+    globalThis.clearTimeout(timer)
   }
   if (response.status === 401) throw new Error(unauthorizedDetail(config))
   if (!response.ok) {

--- a/web/src/taskdesk-home.css
+++ b/web/src/taskdesk-home.css
@@ -1,0 +1,361 @@
+.taskdesk-shell {
+  min-height: 100vh;
+  background: var(--bg, #0f1115);
+  color: var(--text, #f3f4f6);
+}
+
+.taskdesk-shell-sessions {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+}
+
+.taskdesk-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 22px 28px;
+  border-bottom: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+  background: color-mix(in srgb, var(--bg, #0f1115) 92%, transparent);
+  backdrop-filter: blur(16px);
+}
+
+.taskdesk-topbar h1,
+.taskdesk-section-heading h2,
+.taskdesk-task-card h3 {
+  margin: 0;
+}
+
+.taskdesk-topbar h1 {
+  font-size: clamp(24px, 4vw, 34px);
+  letter-spacing: -0.03em;
+}
+
+.taskdesk-eyebrow {
+  margin: 0 0 5px;
+  color: var(--muted, #9ca3af);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.taskdesk-machine-id {
+  margin: 5px 0 0;
+  color: var(--muted, #9ca3af);
+  font-size: 13px;
+}
+
+.taskdesk-topbar-actions,
+.taskdesk-machine-heading,
+.taskdesk-agents,
+.taskdesk-task-title-row,
+.taskdesk-task-meta {
+  display: flex;
+  align-items: center;
+}
+
+.taskdesk-topbar-actions {
+  gap: 8px;
+}
+
+.taskdesk-secondary-button,
+.taskdesk-primary-button,
+.taskdesk-back {
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.14));
+  border-radius: 10px;
+  font: inherit;
+  cursor: pointer;
+}
+
+.taskdesk-secondary-button,
+.taskdesk-back {
+  padding: 9px 13px;
+  background: var(--surface, rgba(255, 255, 255, 0.05));
+  color: inherit;
+}
+
+.taskdesk-secondary-button:hover,
+.taskdesk-back:hover {
+  background: var(--surface-hover, rgba(255, 255, 255, 0.09));
+}
+
+.taskdesk-secondary-button:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.taskdesk-primary-button {
+  align-self: flex-start;
+  padding: 10px 14px;
+  background: var(--text, #f3f4f6);
+  color: var(--bg, #0f1115);
+  font-weight: 700;
+}
+
+.taskdesk-machine-heading {
+  gap: 10px;
+}
+
+.taskdesk-back {
+  padding: 7px 10px;
+}
+
+.taskdesk-divider {
+  color: var(--muted, #9ca3af);
+}
+
+.taskdesk-session-host {
+  min-height: 0;
+  flex: 1;
+}
+
+.taskdesk-session-host > * {
+  min-height: 100%;
+}
+
+.taskdesk-home {
+  width: min(1180px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: 28px 0 56px;
+}
+
+.taskdesk-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.taskdesk-summary-card {
+  display: flex;
+  min-height: 94px;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 16px;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+  border-radius: 14px;
+  background: var(--surface, rgba(255, 255, 255, 0.04));
+}
+
+.taskdesk-summary-card span,
+.taskdesk-task-project,
+.taskdesk-task-meta,
+.taskdesk-task-side,
+.taskdesk-section-heading > p {
+  color: var(--muted, #9ca3af);
+}
+
+.taskdesk-summary-card strong {
+  font-size: 20px;
+}
+
+.taskdesk-agents {
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 16px 0 2px;
+}
+
+.taskdesk-agent-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 10px;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+  border-radius: 999px;
+  background: var(--surface, rgba(255, 255, 255, 0.04));
+  font-size: 12px;
+}
+
+.taskdesk-agent-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.55;
+}
+
+.taskdesk-agent-dot-available,
+.taskdesk-agent-dot-configured {
+  opacity: 1;
+}
+
+.taskdesk-tasks-section {
+  margin-top: 34px;
+}
+
+.taskdesk-section-heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 14px;
+}
+
+.taskdesk-section-heading h2 {
+  font-size: 24px;
+}
+
+.taskdesk-section-heading > p {
+  max-width: 570px;
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.taskdesk-state {
+  display: flex;
+  min-height: 180px;
+  flex-direction: column;
+  justify-content: center;
+  gap: 9px;
+  padding: 24px;
+  border: 1px dashed var(--border, rgba(255, 255, 255, 0.14));
+  border-radius: 16px;
+  color: var(--muted, #9ca3af);
+}
+
+.taskdesk-state strong {
+  color: var(--text, #f3f4f6);
+  font-size: 17px;
+}
+
+.taskdesk-state-warning,
+.taskdesk-state-error {
+  border-style: solid;
+}
+
+.taskdesk-task-list {
+  display: grid;
+  gap: 10px;
+}
+
+.taskdesk-task-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 20px;
+  padding: 17px 18px;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+  border-radius: 14px;
+  background: var(--surface, rgba(255, 255, 255, 0.04));
+}
+
+.taskdesk-task-card:hover {
+  background: var(--surface-hover, rgba(255, 255, 255, 0.065));
+}
+
+.taskdesk-task-title-row {
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.taskdesk-task-card h3 {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 16px;
+  line-height: 1.4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.taskdesk-status {
+  flex: none;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.14);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.taskdesk-status-running,
+.taskdesk-status-waiting {
+  background: rgba(250, 204, 21, 0.13);
+}
+
+.taskdesk-status-completed {
+  background: rgba(34, 197, 94, 0.13);
+}
+
+.taskdesk-status-failed,
+.taskdesk-status-cancelled {
+  background: rgba(239, 68, 68, 0.13);
+}
+
+.taskdesk-task-project {
+  margin: 4px 0 9px;
+  font-size: 12px;
+}
+
+.taskdesk-task-meta {
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  font-size: 12px;
+}
+
+.taskdesk-task-meta b {
+  color: var(--text, #f3f4f6);
+  font-weight: 600;
+}
+
+.taskdesk-task-side {
+  display: flex;
+  min-width: 170px;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 11px;
+}
+
+.taskdesk-task-open-hint {
+  opacity: 0.7;
+}
+
+@media (max-width: 780px) {
+  .taskdesk-topbar {
+    align-items: flex-start;
+    padding: 18px 16px;
+  }
+
+  .taskdesk-topbar-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .taskdesk-home {
+    width: min(100% - 24px, 1180px);
+    padding-top: 18px;
+  }
+
+  .taskdesk-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .taskdesk-summary-card {
+    min-height: 72px;
+  }
+
+  .taskdesk-section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .taskdesk-task-card {
+    grid-template-columns: 1fr;
+  }
+
+  .taskdesk-task-title-row {
+    align-items: flex-start;
+  }
+
+  .taskdesk-task-card h3 {
+    white-space: normal;
+  }
+
+  .taskdesk-task-side {
+    min-width: 0;
+    align-items: flex-start;
+    flex-direction: row;
+  }
+}

--- a/web/src/taskdesk-home.css
+++ b/web/src/taskdesk-home.css
@@ -47,16 +47,35 @@
   font-size: 13px;
 }
 
+.taskdesk-machine-address {
+  display: inline-flex;
+  margin: 5px 0 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--muted, #9ca3af);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.taskdesk-machine-address:hover {
+  color: var(--text, #f3f4f6);
+  text-decoration: underline;
+}
+
 .taskdesk-topbar-actions,
 .taskdesk-machine-heading,
 .taskdesk-agents,
 .taskdesk-task-title-row,
-.taskdesk-task-meta {
+.taskdesk-task-meta,
+.taskdesk-state-actions {
   display: flex;
   align-items: center;
 }
 
-.taskdesk-topbar-actions {
+.taskdesk-topbar-actions,
+.taskdesk-state-actions {
   gap: 8px;
 }
 
@@ -311,6 +330,15 @@
   opacity: 0.7;
 }
 
+.taskdesk-connection-editor {
+  width: min(520px, calc(100vw - 32px));
+}
+
+.taskdesk-connection-editor .wizard-body {
+  display: grid;
+  gap: 14px;
+}
+
 @media (max-width: 780px) {
   .taskdesk-topbar {
     align-items: flex-start;
@@ -357,5 +385,10 @@
     min-width: 0;
     align-items: flex-start;
     flex-direction: row;
+  }
+
+  .taskdesk-state-actions {
+    align-items: flex-start;
+    flex-direction: column;
   }
 }

--- a/web/src/taskdesk-home.test.mjs
+++ b/web/src/taskdesk-home.test.mjs
@@ -64,3 +64,15 @@ test("Universal workspace cannot starve initial loading with overlapping polls",
   assert.match(source, /await withTimeout\(Promise\.all\(\[/)
   assert.match(source, /refreshInFlight\.current = false/)
 })
+
+test("Universal workspace machine configuration is independent from Classic profiles", () => {
+  const main = readFileSync(new URL("./main.tsx", import.meta.url), "utf8")
+  const machineStorage = readFileSync(new URL("./workspaceMachines.ts", import.meta.url), "utf8")
+  const standalone = readFileSync(new URL("./components/standalone-universal-workspace.tsx", import.meta.url), "utf8")
+
+  assert.match(main, /loadWorkspaceMachines/)
+  assert.doesNotMatch(main, /loadServerProfiles/)
+  assert.match(machineStorage, /harness-remote\.workspace\.machines\.v1/)
+  assert.match(standalone, /\+ Add machine/)
+  assert.match(standalone, /Classic connections are separate/)
+})

--- a/web/src/taskdesk-home.test.mjs
+++ b/web/src/taskdesk-home.test.mjs
@@ -101,14 +101,17 @@ test("Universal workspace resolves and can change the model of the selected sess
   assert.match(source, /api\.sendPrompt\(selected\.config, selected\.session\.id, text, selected\.session\.directory, model\)/)
 })
 
-test("Universal workspace gives supported harness replies their own visual identity", () => {
+test("Universal workspace gives supported harness replies their own local visual identity", () => {
   const source = readFileSync(new URL("./components/universal-workspace.tsx", import.meta.url), "utf8")
   const readableFixes = readFileSync(new URL("./universal-workspace-readable-fixes.css", import.meta.url), "utf8")
 
-  assert.match(source, /const HARNESS_ICON_URLS/)
+  assert.match(source, /const HARNESS_ICON_FILES/)
   for (const backend of ["codex", "claude", "opencode", "omp", "pi"]) {
     assert.match(source, new RegExp(`${backend}:`))
+    assert.match(source, new RegExp(`${backend}\\.svg`))
   }
+  assert.match(source, /import\.meta\.env\.BASE_URL.*harness-icons/)
+  assert.doesNotMatch(source, /https:\/\/(?:openai|claude|opencode|omp|pi)\./)
   assert.match(source, /function HarnessAvatar/)
   assert.match(source, /agentBackend=\{selected\.agent\.backend\}/)
   assert.match(readableFixes, /\.uw-avatar-agent img/)

--- a/web/src/taskdesk-home.test.mjs
+++ b/web/src/taskdesk-home.test.mjs
@@ -115,5 +115,18 @@ test("Universal workspace gives supported harness replies their own local visual
   assert.match(source, /function HarnessAvatar/)
   assert.match(source, /agentBackend=\{selected\.agent\.backend\}/)
   assert.match(readableFixes, /\.uw-avatar-agent img/)
-  assert.match(readableFixes, /\.uw-composer-directory[\s\S]*?font-size: 13\.5px/)
+  assert.match(readableFixes, /\.uw-composer-footer > \.uw-composer-directory[\s\S]*?font-size: 13px/)
+  assert.match(readableFixes, /\.uw-context-strip b,[\s\S]*?\.uw-context-model-select[\s\S]*?font-size: 11\.5px/)
+})
+
+test("Universal workspace never renders stale detail for a newly selected session", () => {
+  const source = readFileSync(new URL("./components/universal-workspace.tsx", import.meta.url), "utf8")
+
+  assert.match(source, /const \[detailSessionKey, setDetailSessionKey\] = useState<string \| null>\(null\)/)
+  assert.match(source, /const selectedKeyRef = useRef<string \| null>\(null\)/)
+  assert.match(source, /const detailReady = Boolean\(selected && detailSessionKey === selected\.key\)/)
+  assert.match(source, /if \(selectedKeyRef\.current !== item\.key\) return/)
+  assert.match(source, /setDetailSessionKey\(item\.key\)/)
+  assert.match(source, /detailLoading \|\| !detailReady/)
+  assert.match(source, /Loading session…/)
 })

--- a/web/src/taskdesk-home.test.mjs
+++ b/web/src/taskdesk-home.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
 import test from "node:test"
 import {
   agentLabel,
@@ -53,4 +54,13 @@ test("TaskDesk sorts Tasks by durable task activity rather than session order", 
   const older = task({ id: "older", updatedAt: "2026-08-18T09:00:00.000Z" })
   const newer = task({ id: "newer", updatedAt: "2026-08-18T12:00:00.000Z" })
   assert.deepEqual(sortTasksByActivity([older, newer]).map((item) => item.id), ["newer", "older"])
+})
+
+test("Universal workspace cannot starve initial loading with overlapping polls", () => {
+  const source = readFileSync(new URL("./components/universal-workspace.tsx", import.meta.url), "utf8")
+  assert.match(source, /const AGENT_SESSION_LOAD_TIMEOUT_MS = 12_000/)
+  assert.match(source, /const refreshInFlight = useRef\(false\)/)
+  assert.match(source, /if \(refreshInFlight\.current\) return/)
+  assert.match(source, /await withTimeout\(Promise\.all\(\[/)
+  assert.match(source, /refreshInFlight\.current = false/)
 })

--- a/web/src/taskdesk-home.test.mjs
+++ b/web/src/taskdesk-home.test.mjs
@@ -78,3 +78,14 @@ test("Universal workspace machine configuration is independent from Classic prof
   assert.match(standalone, /\+ Add machine/)
   assert.match(standalone, /Classic connections are separate/)
 })
+
+test("Universal workspace counts and projects follow the selected machine scope", () => {
+  const source = readFileSync(new URL("./components/universal-workspace.tsx", import.meta.url), "utf8")
+
+  assert.match(source, /const machineScopedSessions = useMemo/)
+  assert.match(source, /for \(const item of machineScopedSessions\)/)
+  assert.match(source, /all: scopedSessions\.length/)
+  assert.doesNotMatch(source, /all: sessions\.length/)
+  assert.match(source, /function selectMachine\(machine: MachineSource\)[\s\S]*?setProjectFilter\("all"\)/)
+  assert.match(source, /currentItem\?\.machineKey === machine\.key/)
+})

--- a/web/src/taskdesk-home.test.mjs
+++ b/web/src/taskdesk-home.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import {
+  agentLabel,
+  modelLabel,
+  normalizeTaskStatus,
+  sortTasksByActivity,
+  taskStatusLabel,
+  taskTitle
+} from "./taskdeskHomeModel.ts"
+
+function task(overrides = {}) {
+  return {
+    id: "task-1",
+    machineId: "machine-1",
+    projectId: "project-1",
+    project: { name: "Harness Remote", path: "/repo", kind: "git" },
+    agentId: "codex",
+    prompt: "Fix the authentication regression\nMore context",
+    model: { providerID: "openai", modelID: "gpt-test", variant: "high" },
+    status: "running",
+    workspace: { mode: "worktree", path: "/repo-task" },
+    run: null,
+    createdAt: "2026-08-18T10:00:00.000Z",
+    updatedAt: "2026-08-18T11:00:00.000Z",
+    ...overrides
+  }
+}
+
+test("TaskDesk normalizes backend lifecycle states for the Tasks view", () => {
+  assert.equal(normalizeTaskStatus("created"), "preparing")
+  assert.equal(normalizeTaskStatus("pending"), "queued")
+  assert.equal(normalizeTaskStatus("busy"), "running")
+  assert.equal(normalizeTaskStatus("needs_attention"), "waiting")
+  assert.equal(normalizeTaskStatus("succeeded"), "completed")
+  assert.equal(normalizeTaskStatus("error"), "failed")
+  assert.equal(normalizeTaskStatus("aborted"), "cancelled")
+  assert.equal(normalizeTaskStatus("custom-state"), "unknown")
+  assert.equal(taskStatusLabel("custom-state"), "custom-state")
+})
+
+test("TaskDesk derives stable task row labels without flattening Tasks into Sessions", () => {
+  const value = task()
+  assert.equal(taskTitle(value), "Fix the authentication regression")
+  assert.equal(modelLabel(value), "gpt-test · high")
+  assert.equal(agentLabel([
+    { id: "codex", label: "Codex CLI", backend: "codex", transport: "acp", managed: false, state: "available", capabilities: {} }
+  ], value.agentId), "Codex CLI")
+  assert.equal(agentLabel([], "pi"), "pi")
+})
+
+test("TaskDesk sorts Tasks by durable task activity rather than session order", () => {
+  const older = task({ id: "older", updatedAt: "2026-08-18T09:00:00.000Z" })
+  const newer = task({ id: "newer", updatedAt: "2026-08-18T12:00:00.000Z" })
+  assert.deepEqual(sortTasksByActivity([older, newer]).map((item) => item.id), ["newer", "older"])
+})

--- a/web/src/taskdesk-home.test.mjs
+++ b/web/src/taskdesk-home.test.mjs
@@ -89,3 +89,28 @@ test("Universal workspace counts and projects follow the selected machine scope"
   assert.match(source, /function selectMachine\(machine: MachineSource\)[\s\S]*?setProjectFilter\("all"\)/)
   assert.match(source, /currentItem\?\.machineKey === machine\.key/)
 })
+
+test("Universal workspace resolves and can change the model of the selected session", () => {
+  const source = readFileSync(new URL("./components/universal-workspace.tsx", import.meta.url), "utf8")
+
+  assert.match(source, /api\.listModels\(selected\.config, selected\.session\.directory, selected\.session\.id\)/)
+  assert.match(source, /models\.find\(\(model\) => model\.isDefault\)/)
+  assert.match(source, /className="uw-context-model-select"/)
+  assert.match(source, /setSessionModelKey\(event\.target\.value\)/)
+  assert.match(source, /const model = selectedSessionModel/)
+  assert.match(source, /api\.sendPrompt\(selected\.config, selected\.session\.id, text, selected\.session\.directory, model\)/)
+})
+
+test("Universal workspace gives supported harness replies their own visual identity", () => {
+  const source = readFileSync(new URL("./components/universal-workspace.tsx", import.meta.url), "utf8")
+  const readableFixes = readFileSync(new URL("./universal-workspace-readable-fixes.css", import.meta.url), "utf8")
+
+  assert.match(source, /const HARNESS_ICON_URLS/)
+  for (const backend of ["codex", "claude", "opencode", "omp", "pi"]) {
+    assert.match(source, new RegExp(`${backend}:`))
+  }
+  assert.match(source, /function HarnessAvatar/)
+  assert.match(source, /agentBackend=\{selected\.agent\.backend\}/)
+  assert.match(readableFixes, /\.uw-avatar-agent img/)
+  assert.match(readableFixes, /\.uw-composer-directory[\s\S]*?font-size: 13\.5px/)
+})

--- a/web/src/taskdesk-home.test.mjs
+++ b/web/src/taskdesk-home.test.mjs
@@ -69,9 +69,11 @@ test("Universal workspace machine configuration is independent from Classic prof
   const main = readFileSync(new URL("./main.tsx", import.meta.url), "utf8")
   const machineStorage = readFileSync(new URL("./workspaceMachines.ts", import.meta.url), "utf8")
   const standalone = readFileSync(new URL("./components/standalone-universal-workspace.tsx", import.meta.url), "utf8")
+  const taskDeskBoundary = main.match(/function TaskDeskBoundary\(\) \{[\s\S]*?\n\}\n\nasync function renderApp/)
 
-  assert.match(main, /loadWorkspaceMachines/)
-  assert.doesNotMatch(main, /loadServerProfiles/)
+  assert.ok(taskDeskBoundary, "TaskDesk boundary should remain explicit")
+  assert.match(taskDeskBoundary[0], /loadWorkspaceMachines/)
+  assert.doesNotMatch(taskDeskBoundary[0], /loadServerProfiles/)
   assert.match(machineStorage, /harness-remote\.workspace\.machines\.v1/)
   assert.match(standalone, /\+ Add machine/)
   assert.match(standalone, /Classic connections are separate/)

--- a/web/src/taskdeskHomeModel.ts
+++ b/web/src/taskdeskHomeModel.ts
@@ -1,0 +1,49 @@
+import type { MachineAgentHost } from "./types"
+import type { MachineTask } from "./taskClient"
+
+export type TaskDeskTaskStatus = "preparing" | "queued" | "running" | "waiting" | "completed" | "failed" | "cancelled" | "unknown"
+
+export function taskTitle(task: Pick<MachineTask, "prompt">): string {
+  const firstLine = task.prompt.split(/\r?\n/, 1)[0]?.trim() ?? ""
+  if (!firstLine) return "Untitled task"
+  return firstLine.length > 88 ? `${firstLine.slice(0, 85).trimEnd()}...` : firstLine
+}
+
+export function normalizeTaskStatus(status: string): TaskDeskTaskStatus {
+  const value = status.trim().toLowerCase()
+  if (["preparing", "created", "ready"].includes(value)) return "preparing"
+  if (["queued", "pending"].includes(value)) return "queued"
+  if (["running", "busy", "working", "in_progress", "in-progress"].includes(value)) return "running"
+  if (["waiting", "blocked", "attention", "needs_attention", "needs-attention"].includes(value)) return "waiting"
+  if (["completed", "complete", "done", "finished", "success", "succeeded"].includes(value)) return "completed"
+  if (["failed", "error"].includes(value)) return "failed"
+  if (["cancelled", "canceled", "aborted"].includes(value)) return "cancelled"
+  return "unknown"
+}
+
+export function taskStatusLabel(status: string): string {
+  const normalized = normalizeTaskStatus(status)
+  if (normalized === "unknown") return status.trim() || "Unknown"
+  return normalized[0].toUpperCase() + normalized.slice(1)
+}
+
+export function agentLabel(agents: MachineAgentHost[], agentId: string): string {
+  return agents.find((agent) => agent.id === agentId)?.label?.trim() || agentId || "Unknown agent"
+}
+
+export function modelLabel(task: Pick<MachineTask, "model">): string {
+  const model = task.model
+  if (!model) return "Default model"
+  return model.variant ? `${model.modelID} · ${model.variant}` : model.modelID
+}
+
+export function taskTimestamp(task: Pick<MachineTask, "updatedAt" | "createdAt">): number {
+  const updated = Date.parse(task.updatedAt)
+  if (Number.isFinite(updated)) return updated
+  const created = Date.parse(task.createdAt)
+  return Number.isFinite(created) ? created : 0
+}
+
+export function sortTasksByActivity(tasks: MachineTask[]): MachineTask[] {
+  return [...tasks].sort((left, right) => taskTimestamp(right) - taskTimestamp(left))
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -154,6 +154,9 @@ export type MessageEnvelope = {
       created: number
       completed?: number
     }
+    /** Present when the turn ended in a provider or harness failure instead of a reply. OpenCode
+     *  nests the readable sentence under `data.message`, often as a JSON string of its own. */
+    error?: { name?: string; message?: string; data?: { message?: string } }
   }
   parts: MessagePart[]
 }

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -9,6 +9,7 @@ const styles = readFileSync(new URL('./styles.css', import.meta.url), 'utf8')
 const shell = readFileSync(new URL('./components/shell.tsx', import.meta.url), 'utf8')
 const panels = readFileSync(new URL('./components/panels.tsx', import.meta.url), 'utf8')
 const sessionList = readFileSync(new URL('./components/session-list.tsx', import.meta.url), 'utf8')
+const i18n = readFileSync(new URL('./i18n.ts', import.meta.url), 'utf8')
 const composerView = readFileSync(new URL('./components/session-composer.tsx', import.meta.url), 'utf8')
 const taskDialog = readFileSync(new URL('./components/task-launch-dialog.tsx', import.meta.url), 'utf8')
 const taskDeskTestPage = readFileSync(new URL('./TaskDeskTestPage.tsx', import.meta.url), 'utf8')
@@ -620,6 +621,22 @@ assert.match(styles, /\.task-launch-context,[\s\S]*?\.task-launch-worktree\s*\{[
 assert.match(styles, /@media \(max-width: 780px\)[\s\S]*?\.task-launch-form\s*\{[^}]*grid-template-columns:\s*1fr/, 'TaskDesk launch must collapse to one mobile form column')
 assert.match(styles, /\.task-launch-check input\[type="checkbox"\]\s*\{[^}]*width:\s*1\.125rem;[^}]*max-width:\s*1\.125rem;[^}]*min-height:\s*1\.125rem/, 'TaskDesk worktree checkbox must never inherit full-width text-input sizing')
 assert.match(styles, /\.task-launch-close\s*\{[^}]*margin-left:\s*auto/, 'TaskDesk close control must stay anchored to the header’s right edge')
+
+// A turn that ends in a provider failure has no text and no parts but the bookkeeping step markers.
+// Filtering those out left the prompt on screen with nothing after it — indistinguishable from a
+// reply that went missing, and on a session where every turn failed, from the app showing only what
+// the user typed. The reason has to survive the content filter and reach a bubble.
+assert.match(app, /function messageFailure\(message: MessageEnvelope\): string \| undefined/, 'a failed turn should have one place that reads its reason')
+assert.match(app, /messageFailure\(message\) \|\| message\.parts\.some\(\(part\) => !isTurnScaffolding\(part\)\)/, 'the content filter must keep a message whose only content is its failure')
+assert.ok(app.includes('<MessageFailureView messages={[message]} t={t} />'), 'a standalone bubble should render its own failure')
+assert.ok(app.includes('<MessageFailureView messages={[...messagesByID.values()]} t={t} />'), 'a merged run should render the failures of every message in it')
+assert.match(app, /function collapseRepeatedFailures/, 'retried failures should collapse instead of repeating one reason per attempt')
+assert.match(styles, /\.message-failure\s*\{[^}]*background:\s*var\(--danger-soft\)/, 'a failed turn should read as a failure rather than as ordinary reply text')
+assert.ok(i18n.includes("'detail.turnFailed'"), 'the failed-turn label should be translated')
+
+// Groups merge only runs of adjacent same-directory sessions, so one directory can produce several
+// groups and keying them by directory alone lets React drop or duplicate them.
+assert.match(sessionList, /key=\{`\$\{group\.directory\}:\$\{group\.sessions\[0\]\.id\}`\}/, 'sidebar groups need a key unique per group, not per directory')
 
 console.log('ui regression tests passed')
 

--- a/web/src/universal-workspace-readable-fixes.css
+++ b/web/src/universal-workspace-readable-fixes.css
@@ -1,0 +1,55 @@
+.uw-detail-tabs button span {
+  font-size: 10.5px;
+}
+
+.uw-tool-title {
+  font-size: 11.5px;
+}
+
+.uw-tool-status {
+  font-size: 10.5px;
+}
+
+.uw-composer-footer .uw-button {
+  min-height: 36px;
+  font-size: 12px;
+}
+
+.uw-inspector-grid > b,
+.uw-inspector-grid > code {
+  font-size: 11.5px;
+  line-height: 1.45;
+}
+
+.uw-file-list p,
+.uw-todo-list > div,
+.uw-agent-buttons button,
+.uw-inspector-danger .uw-button,
+.uw-attention-card > strong,
+.uw-question > span,
+.uw-empty-panel span,
+.uw-inline-error,
+.uw-handoff-summary span {
+  font-size: 11.5px;
+}
+
+.uw-attention-card > p,
+.uw-attention-card > code,
+.uw-question > p,
+.uw-question-options button,
+.uw-question input {
+  font-size: 11.5px;
+}
+
+.uw-diff-file summary span,
+.uw-diff-file > p {
+  font-size: 11.5px;
+}
+
+.uw-tool-card summary code {
+  font-size: 11.5px;
+}
+
+.uw-empty-panel strong {
+  font-size: 13px;
+}

--- a/web/src/universal-workspace-readable-fixes.css
+++ b/web/src/universal-workspace-readable-fixes.css
@@ -1,8 +1,100 @@
-.uw-detail-tabs button span {
+.uw-shell {
+  font-size: 12px;
+}
+
+.uw-brand small,
+.uw-session-column-header span,
+.uw-nav-empty {
   font-size: 10.5px;
 }
 
-.uw-tool-title {
+.uw-global-search input,
+.uw-button,
+.uw-nav-section > button > span:nth-child(2),
+.uw-nav-bottom > button > span:nth-child(2) {
+  font-size: 12px;
+}
+
+.uw-nav-label {
+  font-size: 10px;
+}
+
+.uw-nav-section button b,
+.uw-nav-bottom button b,
+.uw-pill,
+.uw-session-meta,
+.uw-session-footer,
+.uw-status-chip {
+  font-size: 10.5px;
+}
+
+.uw-session-title-row > strong {
+  font-size: 12.5px;
+}
+
+.uw-session-preview {
+  font-size: 11.5px;
+  line-height: 1.45;
+}
+
+.uw-context-strip small {
+  font-size: 10px;
+  line-height: 1.15;
+}
+
+.uw-context-strip b,
+.uw-context-model-select {
+  font-size: 11.5px;
+  line-height: 1.3;
+}
+
+.uw-context-model {
+  min-width: 150px;
+}
+
+.uw-context-model-select {
+  max-width: 220px;
+  min-height: 27px;
+  padding: 3px 24px 3px 7px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 6px;
+  color: #dce5f2;
+  background: #111a29;
+  font-family: inherit;
+  font-weight: 620;
+  cursor: pointer;
+}
+
+.uw-context-model-select:disabled {
+  opacity: 0.62;
+  cursor: default;
+}
+
+.uw-session-actions .uw-button,
+.uw-detail-tabs button {
+  font-size: 11.5px;
+}
+
+.uw-detail-tabs button span {
+  font-size: 10px;
+}
+
+.uw-message-body > header strong {
+  font-size: 12px;
+}
+
+.uw-message-body > header time {
+  font-size: 10px;
+}
+
+.uw-markdown {
+  font-size: 12.5px;
+  line-height: 1.6;
+}
+
+.uw-tool-title,
+.uw-tool-card summary code,
+.uw-tool-card pre {
   font-size: 11.5px;
 }
 
@@ -10,19 +102,27 @@
   font-size: 10.5px;
 }
 
-.uw-composer-footer .uw-button {
-  min-height: 36px;
-  font-size: 12px;
+.uw-composer-shell textarea {
+  font-size: 12.5px;
 }
 
-.uw-composer-directory {
+.uw-composer-footer > .uw-composer-directory {
   min-width: 0;
   overflow: hidden;
   color: #aebbd0;
-  font-size: 13.5px;
+  font-size: 13px;
   line-height: 1.4;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.uw-composer-footer small {
+  font-size: 10px;
+}
+
+.uw-composer-footer .uw-button {
+  min-height: 36px;
+  font-size: 12px;
 }
 
 .uw-avatar-agent img {
@@ -33,29 +133,17 @@
   border-radius: 5px;
 }
 
-.uw-context-model {
-  min-width: 150px;
-}
-
-.uw-context-model-select {
-  max-width: 220px;
-  min-height: 25px;
-  padding: 2px 24px 2px 7px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  border-radius: 6px;
-  color: #dce5f2;
-  background: #111a29;
-  font: 600 12px/1.25 Inter, ui-sans-serif, system-ui, sans-serif;
-  cursor: pointer;
-}
-
-.uw-context-model-select:disabled {
-  opacity: 0.62;
-  cursor: default;
+.uw-inspector-grid > span,
+.uw-inspector-label,
+.uw-inspector-copy,
+.uw-status-line small {
+  font-size: 10.5px;
+  line-height: 1.45;
 }
 
 .uw-inspector-grid > b,
-.uw-inspector-grid > code {
+.uw-inspector-grid > code,
+.uw-status-line strong {
   font-size: 11.5px;
   line-height: 1.45;
 }
@@ -68,24 +156,14 @@
 .uw-question > span,
 .uw-empty-panel span,
 .uw-inline-error,
-.uw-handoff-summary span {
-  font-size: 11.5px;
-}
-
+.uw-handoff-summary span,
 .uw-attention-card > p,
 .uw-attention-card > code,
 .uw-question > p,
 .uw-question-options button,
-.uw-question input {
-  font-size: 11.5px;
-}
-
+.uw-question input,
 .uw-diff-file summary span,
 .uw-diff-file > p {
-  font-size: 11.5px;
-}
-
-.uw-tool-card summary code {
   font-size: 11.5px;
 }
 

--- a/web/src/universal-workspace-readable-fixes.css
+++ b/web/src/universal-workspace-readable-fixes.css
@@ -15,6 +15,45 @@
   font-size: 12px;
 }
 
+.uw-composer-directory {
+  min-width: 0;
+  overflow: hidden;
+  color: #aebbd0;
+  font-size: 13.5px;
+  line-height: 1.4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.uw-avatar-agent img {
+  width: 24px;
+  height: 24px;
+  display: block;
+  object-fit: contain;
+  border-radius: 5px;
+}
+
+.uw-context-model {
+  min-width: 150px;
+}
+
+.uw-context-model-select {
+  max-width: 220px;
+  min-height: 25px;
+  padding: 2px 24px 2px 7px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 6px;
+  color: #dce5f2;
+  background: #111a29;
+  font: 600 12px/1.25 Inter, ui-sans-serif, system-ui, sans-serif;
+  cursor: pointer;
+}
+
+.uw-context-model-select:disabled {
+  opacity: 0.62;
+  cursor: default;
+}
+
 .uw-inspector-grid > b,
 .uw-inspector-grid > code {
   font-size: 11.5px;

--- a/web/src/universal-workspace-readable.css
+++ b/web/src/universal-workspace-readable.css
@@ -1,0 +1,568 @@
+.uw-shell {
+  font-size: 15px;
+}
+
+.uw-topbar {
+  height: 68px;
+  grid-template-columns: minmax(230px, 300px) minmax(320px, 680px) minmax(230px, 1fr);
+}
+
+.uw-layout {
+  height: calc(100vh - 68px);
+  grid-template-columns: 230px minmax(320px, 370px) minmax(0, 1fr) 310px;
+}
+
+.uw-brand strong {
+  font-size: 16px;
+}
+
+.uw-brand small {
+  font-size: 12px;
+}
+
+.uw-global-search {
+  height: 42px;
+}
+
+.uw-global-search input {
+  font-size: 14px;
+}
+
+.uw-global-search kbd {
+  font-size: 11px;
+}
+
+.uw-button {
+  min-height: 38px;
+  padding-inline: 13px;
+  font-size: 13px;
+}
+
+.uw-new-button {
+  min-height: 44px;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.uw-nav-label {
+  padding-bottom: 9px;
+  font-size: 10.5px;
+  letter-spacing: 0.1em;
+}
+
+.uw-nav-section > button,
+.uw-nav-bottom > button {
+  min-height: 39px;
+  gap: 8px;
+  padding-inline: 10px;
+}
+
+.uw-nav-section > button > span:nth-child(2),
+.uw-nav-bottom > button > span:nth-child(2) {
+  font-size: 13px;
+}
+
+.uw-nav-section button b,
+.uw-nav-bottom button b {
+  font-size: 11.5px;
+}
+
+.uw-nav-empty {
+  font-size: 11.5px;
+  line-height: 1.55;
+}
+
+.uw-session-column-header {
+  min-height: 72px;
+  padding-inline: 16px;
+}
+
+.uw-session-column-header h2 {
+  font-size: 17px;
+}
+
+.uw-session-column-header span {
+  font-size: 11.5px;
+}
+
+.uw-filter-row {
+  gap: 7px;
+  padding: 10px 12px;
+}
+
+.uw-pill {
+  min-height: 32px;
+  padding-inline: 11px;
+  font-size: 11.5px;
+}
+
+.uw-session-card {
+  min-height: 112px;
+}
+
+.uw-session-title-row strong {
+  font-size: 14px;
+  line-height: 1.35;
+}
+
+.uw-status-chip {
+  font-size: 10.5px;
+}
+
+.uw-session-meta {
+  font-size: 11.5px;
+  line-height: 1.45;
+}
+
+.uw-session-preview {
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+.uw-session-footer {
+  font-size: 11px;
+}
+
+.uw-session-header {
+  min-height: 86px;
+  padding: 14px 20px;
+}
+
+.uw-session-heading-title h1 {
+  font-size: 20px;
+  line-height: 1.25;
+}
+
+.uw-context-strip small {
+  font-size: 10.5px;
+}
+
+.uw-context-strip b {
+  font-size: 12px;
+}
+
+.uw-detail-tabs button {
+  min-height: 42px;
+  font-size: 13px;
+}
+
+.uw-message {
+  gap: 13px;
+}
+
+.uw-message-body header strong {
+  font-size: 13px;
+}
+
+.uw-message-body header time {
+  font-size: 11px;
+}
+
+.uw-markdown {
+  font-size: 14.5px;
+  line-height: 1.65;
+}
+
+.uw-markdown code,
+.uw-tool-card code,
+.uw-tool-card pre,
+.uw-diff-file code,
+.uw-diff-file pre {
+  font-size: 12.5px;
+}
+
+.uw-composer-shell textarea {
+  font-size: 14.5px;
+  line-height: 1.55;
+}
+
+.uw-composer-footer {
+  font-size: 11.5px;
+}
+
+.uw-composer-footer small {
+  font-size: 11px;
+}
+
+.uw-inspector header h3 {
+  font-size: 15px;
+}
+
+.uw-inspector header span,
+.uw-inspector-label,
+.uw-inspector-copy,
+.uw-inspector-grid,
+.uw-file-list,
+.uw-todo-list,
+.uw-status-line {
+  font-size: 12.5px;
+}
+
+.uw-inspector-grid code,
+.uw-file-list code {
+  font-size: 11.5px;
+}
+
+.uw-modal {
+  font-size: 14px;
+}
+
+.uw-modal-header h2 {
+  font-size: 19px;
+}
+
+.uw-modal-header p {
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+.uw-form-grid label > span,
+.uw-new-session-grid label > span {
+  font-size: 12px;
+}
+
+.uw-form-grid input,
+.uw-form-grid textarea,
+.uw-new-session-grid textarea,
+.uw-select {
+  min-height: 42px;
+  font-size: 14px;
+}
+
+.uw-standalone-host {
+  min-height: 100vh;
+}
+
+.uw-standalone-host > .uw-shell .uw-top-actions > .uw-button:last-child {
+  visibility: hidden;
+  width: 92px;
+}
+
+.uw-machine-manager-trigger {
+  position: fixed;
+  top: 15px;
+  right: 18px;
+  z-index: 80;
+  height: 38px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  border: 1px solid rgba(148, 163, 184, 0.23);
+  border-radius: 10px;
+  color: #e8edf5;
+  background: #121b2a;
+  font: 600 13px/1 Inter, ui-sans-serif, system-ui, sans-serif;
+  cursor: pointer;
+}
+
+.uw-machine-manager-trigger:hover {
+  background: #172235;
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.uw-machine-manager-trigger span {
+  min-width: 22px;
+  padding: 3px 6px;
+  border-radius: 999px;
+  background: rgba(79, 124, 255, 0.16);
+  color: #cdd8ff;
+  text-align: center;
+  font-size: 11px;
+}
+
+.uw-manager-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(3, 7, 14, 0.76);
+  backdrop-filter: blur(12px);
+}
+
+.uw-machine-manager {
+  width: min(780px, 96vw);
+  max-height: min(780px, 92vh);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 16px;
+  color: #f7f9fc;
+  background: #0c1320;
+  box-shadow: 0 28px 90px rgba(0, 0, 0, 0.45);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.uw-machine-manager-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 22px 24px 18px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.13);
+}
+
+.uw-machine-manager-header h2 {
+  margin: 0;
+  font-size: 22px;
+}
+
+.uw-machine-manager-header p {
+  max-width: 610px;
+  margin: 7px 0 0;
+  color: #9aa8bc;
+  font-size: 13.5px;
+  line-height: 1.5;
+}
+
+.uw-manager-close {
+  width: 36px;
+  height: 36px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 9px;
+  color: #cbd5e1;
+  background: rgba(255, 255, 255, 0.025);
+  font-size: 22px;
+  cursor: pointer;
+}
+
+.uw-machine-manager-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px 24px;
+  overflow: auto;
+}
+
+.uw-machine-config-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 15px 16px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 12px;
+  background: #101827;
+}
+
+.uw-machine-config-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.uw-machine-config-main strong {
+  font-size: 15px;
+}
+
+.uw-machine-config-main span {
+  color: #b9c4d3;
+  font-size: 13px;
+}
+
+.uw-machine-config-main small {
+  color: #77859a;
+  font-size: 11.5px;
+}
+
+.uw-machine-config-actions,
+.uw-machine-editor-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.uw-manager-button {
+  min-height: 38px;
+  padding: 0 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 9px;
+  color: #dce4ef;
+  background: rgba(255, 255, 255, 0.035);
+  font: 600 12.5px/1 Inter, ui-sans-serif, system-ui, sans-serif;
+  cursor: pointer;
+}
+
+.uw-manager-button:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.075);
+}
+
+.uw-manager-button.primary {
+  border-color: rgba(118, 150, 255, 0.42);
+  background: #466ee8;
+  color: white;
+}
+
+.uw-manager-button.danger {
+  color: #fda4af;
+  border-color: rgba(248, 113, 113, 0.2);
+  background: rgba(127, 29, 29, 0.12);
+}
+
+.uw-manager-button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.uw-machine-editor {
+  padding: 18px;
+  border: 1px solid rgba(79, 124, 255, 0.3);
+  border-radius: 12px;
+  background: rgba(79, 124, 255, 0.055);
+}
+
+.uw-machine-editor-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 13px;
+}
+
+.uw-machine-editor-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.uw-machine-editor-grid label > span {
+  color: #9aa8bc;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.uw-machine-editor-grid input {
+  width: 100%;
+  min-height: 42px;
+  padding: 0 11px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 9px;
+  outline: none;
+  color: #f7f9fc;
+  background: #0a111d;
+  font-size: 14px;
+}
+
+.uw-machine-editor-grid input:focus {
+  border-color: rgba(92, 132, 255, 0.62);
+  box-shadow: 0 0 0 3px rgba(79, 124, 255, 0.1);
+}
+
+.uw-machine-editor-wide {
+  grid-column: 1 / -1;
+}
+
+.uw-machine-editor-actions {
+  justify-content: flex-end;
+  margin-top: 16px;
+}
+
+.uw-machine-test-result {
+  margin-top: 13px;
+  padding: 10px 12px;
+  border-radius: 9px;
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+
+.uw-machine-test-result.ok {
+  color: #bbf7d0;
+  background: rgba(22, 101, 52, 0.2);
+}
+
+.uw-machine-test-result.error {
+  color: #fecaca;
+  background: rgba(127, 29, 29, 0.18);
+}
+
+.uw-machine-manager-empty {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 22px;
+  border: 1px dashed rgba(148, 163, 184, 0.2);
+  border-radius: 12px;
+  text-align: center;
+}
+
+.uw-machine-manager-empty strong {
+  font-size: 15px;
+}
+
+.uw-machine-manager-empty span {
+  color: #8f9caf;
+  font-size: 13px;
+}
+
+.uw-machine-manager-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 24px 20px;
+  border-top: 1px solid rgba(148, 163, 184, 0.13);
+}
+
+.uw-machine-manager-footer > span {
+  color: #8795aa;
+  font-size: 12.5px;
+}
+
+@media (max-width: 1450px) {
+  .uw-layout {
+    grid-template-columns: 220px minmax(300px, 340px) minmax(0, 1fr) 290px;
+  }
+}
+
+@media (max-width: 1180px) {
+  .uw-layout {
+    grid-template-columns: 210px minmax(285px, 330px) minmax(0, 1fr);
+  }
+
+  .uw-inspector {
+    display: none;
+  }
+}
+
+@media (max-width: 780px) {
+  .uw-shell {
+    font-size: 14px;
+  }
+
+  .uw-machine-manager-trigger {
+    right: 10px;
+    top: 14px;
+  }
+
+  .uw-machine-manager-trigger {
+    width: 42px;
+    padding: 0;
+    justify-content: center;
+    font-size: 0;
+  }
+
+  .uw-machine-manager-trigger span {
+    font-size: 11px;
+  }
+
+  .uw-machine-editor-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .uw-machine-editor-wide {
+    grid-column: auto;
+  }
+
+  .uw-machine-config-card {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .uw-machine-config-actions,
+  .uw-machine-editor-actions {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+}

--- a/web/src/universal-workspace.css
+++ b/web/src/universal-workspace.css
@@ -1,0 +1,1998 @@
+.uw-shell {
+  --uw-bg: #080d17;
+  --uw-panel: #0c1320;
+  --uw-panel-2: #101827;
+  --uw-panel-3: #151f31;
+  --uw-border: rgba(148, 163, 184, 0.13);
+  --uw-border-strong: rgba(148, 163, 184, 0.23);
+  --uw-text: #f7f9fc;
+  --uw-muted: #8996aa;
+  --uw-muted-2: #5f6b7c;
+  --uw-blue: #4f7cff;
+  --uw-blue-2: #6a8cff;
+  --uw-blue-soft: rgba(79, 124, 255, 0.13);
+  --uw-green: #4ade80;
+  --uw-orange: #fb923c;
+  --uw-red: #f87171;
+  --uw-purple: #a78bfa;
+  --uw-shadow: 0 22px 70px rgba(0, 0, 0, 0.28);
+  min-height: 100vh;
+  height: 100vh;
+  overflow: hidden;
+  color: var(--uw-text);
+  background:
+    radial-gradient(circle at 65% -20%, rgba(64, 99, 190, 0.14), transparent 32%),
+    linear-gradient(180deg, #080d17 0%, #090f19 100%);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.uw-shell *,
+.uw-shell *::before,
+.uw-shell *::after {
+  box-sizing: border-box;
+}
+
+.uw-shell button,
+.uw-shell input,
+.uw-shell textarea,
+.uw-shell select {
+  font: inherit;
+}
+
+.uw-shell button {
+  color: inherit;
+}
+
+.uw-topbar {
+  height: 64px;
+  display: grid;
+  grid-template-columns: minmax(210px, 280px) minmax(300px, 620px) minmax(210px, 1fr);
+  align-items: center;
+  gap: 20px;
+  padding: 0 18px;
+  border-bottom: 1px solid var(--uw-border);
+  background: rgba(8, 13, 23, 0.86);
+  backdrop-filter: blur(20px);
+  position: relative;
+  z-index: 10;
+}
+
+.uw-brand {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  min-width: 0;
+}
+
+.uw-brand-mark {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  color: #fff;
+  font-weight: 800;
+  font-size: 14px;
+  background:
+    linear-gradient(145deg, rgba(95, 137, 255, 0.95), rgba(39, 82, 205, 0.95));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.22),
+    0 8px 22px rgba(49, 89, 210, 0.25);
+}
+
+.uw-brand > div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  line-height: 1.12;
+}
+
+.uw-brand strong {
+  font-size: 14px;
+  letter-spacing: -0.01em;
+}
+
+.uw-brand small {
+  color: var(--uw-muted);
+  font-size: 10px;
+  margin-top: 3px;
+}
+
+.uw-global-search {
+  height: 38px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 0 11px;
+  border: 1px solid var(--uw-border);
+  border-radius: 11px;
+  background: rgba(17, 25, 39, 0.7);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.018);
+}
+
+.uw-global-search:focus-within {
+  border-color: rgba(92, 132, 255, 0.52);
+  box-shadow: 0 0 0 3px rgba(79, 124, 255, 0.09);
+}
+
+.uw-global-search svg {
+  flex: none;
+  color: var(--uw-muted);
+}
+
+.uw-global-search input {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  color: var(--uw-text);
+  background: transparent;
+  font-size: 12px;
+}
+
+.uw-global-search input::placeholder {
+  color: #6e7a8d;
+}
+
+.uw-global-search kbd {
+  flex: none;
+  padding: 2px 6px;
+  border: 1px solid var(--uw-border);
+  border-radius: 6px;
+  color: var(--uw-muted);
+  background: rgba(255,255,255,0.025);
+  font-size: 10px;
+  font-family: inherit;
+}
+
+.uw-top-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 7px;
+}
+
+.uw-button {
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 0 11px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  outline: 0;
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    transform 120ms ease,
+    background 120ms ease,
+    border-color 120ms ease,
+    box-shadow 120ms ease,
+    color 120ms ease;
+}
+
+.uw-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.uw-button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.uw-button:focus-visible {
+  box-shadow: 0 0 0 3px rgba(79, 124, 255, 0.15);
+}
+
+.uw-button:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.uw-button-ghost {
+  border-color: var(--uw-border);
+  color: #cbd5e1;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.uw-button-ghost:hover:not(:disabled) {
+  border-color: var(--uw-border-strong);
+  background: rgba(255,255,255,0.055);
+}
+
+.uw-button-secondary {
+  border-color: var(--uw-border);
+  color: #dbe4f1;
+  background: #121b2a;
+}
+
+.uw-button-primary {
+  border-color: rgba(118, 150, 255, 0.42);
+  color: #fff;
+  background: linear-gradient(180deg, #527dff, #3d67e6);
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.17),
+    0 8px 20px rgba(45, 78, 175, 0.17);
+}
+
+.uw-button-primary:hover:not(:disabled) {
+  background: linear-gradient(180deg, #6087ff, #466ee8);
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.2),
+    0 10px 25px rgba(45, 78, 175, 0.23);
+}
+
+.uw-button-danger {
+  border-color: rgba(248, 113, 113, 0.21);
+  color: #fda4af;
+  background: rgba(127, 29, 29, 0.13);
+}
+
+.uw-button-danger:hover:not(:disabled) {
+  background: rgba(153, 27, 27, 0.2);
+}
+
+.uw-layout {
+  height: calc(100vh - 64px);
+  display: grid;
+  grid-template-columns: 205px minmax(270px, 330px) minmax(0, 1fr) 290px;
+  overflow: hidden;
+}
+
+.uw-nav,
+.uw-session-column,
+.uw-main,
+.uw-inspector {
+  min-width: 0;
+  min-height: 0;
+}
+
+.uw-nav {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--uw-border);
+  background: rgba(8, 13, 23, 0.76);
+}
+
+.uw-new-button {
+  margin: 14px;
+  width: calc(100% - 28px);
+  min-height: 39px;
+  justify-content: flex-start;
+}
+
+.uw-nav-section {
+  padding: 12px 10px 2px;
+  border-top: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+.uw-nav-label {
+  display: block;
+  padding: 0 8px 7px;
+  color: #718097;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.uw-nav-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.uw-nav-heading > button {
+  width: 23px;
+  height: 23px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 7px;
+  color: var(--uw-muted);
+  background: transparent;
+  cursor: pointer;
+}
+
+.uw-nav-heading > button:hover {
+  color: var(--uw-text);
+  background: rgba(255,255,255,0.04);
+}
+
+.uw-nav-section > button,
+.uw-nav-bottom > button {
+  width: 100%;
+  min-height: 34px;
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 8px;
+  color: #aeb9c8;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.uw-nav-section > button:hover,
+.uw-nav-bottom > button:hover {
+  color: #e4eaf2;
+  background: rgba(255,255,255,0.035);
+}
+
+.uw-nav-section > button.active,
+.uw-nav-bottom > button.active {
+  color: #fff;
+  background:
+    linear-gradient(90deg, rgba(69, 108, 221, 0.17), rgba(69, 108, 221, 0.08));
+  box-shadow: inset 2px 0 0 #4f7cff;
+}
+
+.uw-nav-section > button > span:nth-child(2),
+.uw-nav-bottom > button > span:nth-child(2) {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+}
+
+.uw-nav-section button b,
+.uw-nav-bottom button b {
+  color: #718097;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.uw-nav-section button b.attention,
+.uw-nav-bottom button b.attention {
+  min-width: 20px;
+  padding: 2px 5px;
+  border-radius: 999px;
+  color: #fdba74;
+  background: rgba(234, 88, 12, 0.14);
+  text-align: center;
+}
+
+.uw-nav-symbol {
+  width: 18px;
+  display: inline-grid;
+  place-items: center;
+  color: #8492a7;
+  font-size: 10px;
+}
+
+.uw-nav-empty {
+  margin: 1px 8px 8px;
+  color: #566275;
+  font-size: 10px;
+  line-height: 1.45;
+}
+
+.uw-machines-section {
+  max-height: 235px;
+  overflow: auto;
+}
+
+.uw-machine-dot {
+  width: 7px;
+  height: 7px;
+  justify-self: end;
+  border-radius: 999px;
+  background: #596579;
+  box-shadow: 0 0 0 2px rgba(89, 101, 121, 0.08);
+}
+
+.uw-machine-dot.online {
+  background: var(--uw-green);
+  box-shadow: 0 0 0 3px rgba(74, 222, 128, 0.08);
+}
+
+.uw-machine-dot.offline {
+  background: var(--uw-red);
+}
+
+.uw-machine-dot.loading {
+  background: #facc15;
+}
+
+.uw-machine-dot.idle {
+  background: #64748b;
+}
+
+.uw-nav-bottom {
+  margin-top: auto;
+  padding: 9px 10px 13px;
+  border-top: 1px solid var(--uw-border);
+}
+
+.uw-session-column {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--uw-border);
+  background: rgba(10, 16, 27, 0.72);
+}
+
+.uw-session-column-header {
+  min-height: 66px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 14px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+.uw-session-column-header > div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.uw-session-column-header h2 {
+  margin: 0;
+  font-size: 14px;
+  letter-spacing: -0.015em;
+}
+
+.uw-session-column-header span {
+  color: var(--uw-muted);
+  font-size: 9px;
+}
+
+.uw-session-column-header > button {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 8px;
+  color: var(--uw-muted);
+  background: transparent;
+  cursor: pointer;
+}
+
+.uw-session-column-header > button:hover {
+  color: #fff;
+  background: rgba(255,255,255,0.04);
+}
+
+.uw-filter-row {
+  display: flex;
+  gap: 5px;
+  padding: 8px 10px;
+  overflow-x: auto;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.06);
+}
+
+.uw-pill {
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 9px;
+  border: 1px solid var(--uw-border);
+  border-radius: 999px;
+  color: #8f9caf;
+  background: rgba(255,255,255,0.018);
+  cursor: pointer;
+  white-space: nowrap;
+  font-size: 9px;
+}
+
+.uw-pill:hover,
+.uw-pill.active {
+  color: #e8edf5;
+  border-color: rgba(95, 134, 255, 0.28);
+  background: rgba(79, 124, 255, 0.09);
+}
+
+.uw-pill.active {
+  box-shadow: inset 0 0 0 1px rgba(79, 124, 255, 0.06);
+}
+
+.uw-pill-count {
+  min-width: 17px;
+  padding: 1px 5px;
+  border-radius: 999px;
+  color: #aab6c8;
+  background: rgba(255,255,255,0.045);
+  text-align: center;
+}
+
+.uw-session-list {
+  min-height: 0;
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.uw-session-card {
+  width: 100%;
+  position: relative;
+  display: grid;
+  grid-template-columns: 3px minmax(0, 1fr) 20px;
+  gap: 8px;
+  margin: 0 0 5px;
+  padding: 10px 8px 10px 5px;
+  border: 1px solid transparent;
+  border-radius: 11px;
+  color: inherit;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.uw-session-card:hover {
+  border-color: rgba(148,163,184,0.08);
+  background: rgba(255,255,255,0.025);
+}
+
+.uw-session-card.selected {
+  border-color: rgba(79, 124, 255, 0.22);
+  background:
+    linear-gradient(100deg, rgba(79, 124, 255, 0.12), rgba(79, 124, 255, 0.035) 70%),
+    rgba(255,255,255,0.012);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.018);
+}
+
+.uw-session-accent {
+  width: 3px;
+  min-height: 48px;
+  align-self: stretch;
+  border-radius: 999px;
+  background: #64748b;
+}
+
+.uw-session-accent.uw-status-working {
+  background: #5b82ff;
+  box-shadow: 0 0 12px rgba(79,124,255,0.35);
+}
+
+.uw-session-accent.uw-status-needs-you {
+  background: var(--uw-orange);
+  box-shadow: 0 0 12px rgba(251,146,60,0.26);
+}
+
+.uw-session-accent.uw-status-failed {
+  background: var(--uw-red);
+}
+
+.uw-session-card-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.uw-session-title-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.uw-session-title-row > strong {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #e9eef6;
+  font-size: 11px;
+  font-weight: 670;
+}
+
+.uw-status-chip {
+  flex: none;
+  padding: 2px 5px;
+  border-radius: 5px;
+  color: #a7b2c3;
+  background: rgba(148,163,184,0.09);
+  font-size: 8px;
+  font-weight: 700;
+}
+
+.uw-status-chip.uw-status-working {
+  color: #9eb5ff;
+  background: rgba(79,124,255,0.12);
+}
+
+.uw-status-chip.uw-status-needs-you {
+  color: #fdba74;
+  background: rgba(234,88,12,0.15);
+}
+
+.uw-status-chip.uw-status-failed {
+  color: #fca5a5;
+  background: rgba(239,68,68,0.12);
+}
+
+.uw-session-meta {
+  margin-top: 4px;
+  color: #748197;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 8.5px;
+}
+
+.uw-session-preview {
+  min-height: 28px;
+  margin-top: 6px;
+  color: #99a4b5;
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  font-size: 9px;
+  line-height: 1.5;
+}
+
+.uw-session-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 7px;
+  color: #59677a;
+  font-size: 8px;
+}
+
+.uw-session-footer span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.uw-pin {
+  width: 20px;
+  height: 20px;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  color: #526076;
+  font-size: 12px;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.uw-session-card:hover .uw-pin,
+.uw-pin.pinned,
+.uw-session-card.selected .uw-pin {
+  opacity: 1;
+}
+
+.uw-pin:hover,
+.uw-pin.pinned {
+  color: #facc15;
+  background: rgba(250,204,21,0.06);
+}
+
+.uw-main {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  background:
+    radial-gradient(circle at 50% 0, rgba(76, 104, 177, 0.045), transparent 32%),
+    rgba(9, 15, 25, 0.45);
+}
+
+.uw-global-error {
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  z-index: 20;
+  width: min(680px, calc(100% - 24px));
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid rgba(248,113,113,0.23);
+  border-radius: 10px;
+  color: #fecaca;
+  background: rgba(69, 10, 10, 0.92);
+  box-shadow: var(--uw-shadow);
+  transform: translateX(-50%);
+  font-size: 10px;
+}
+
+.uw-global-error button {
+  border: 0;
+  color: #fca5a5;
+  background: transparent;
+  cursor: pointer;
+}
+
+.uw-welcome {
+  width: min(480px, calc(100% - 40px));
+  margin: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.uw-welcome-icon {
+  width: 58px;
+  height: 58px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(93, 132, 255, 0.22);
+  border-radius: 18px;
+  color: #8ba5ff;
+  background: rgba(79,124,255,0.08);
+}
+
+.uw-welcome h1 {
+  margin: 17px 0 8px;
+  font-size: 22px;
+  letter-spacing: -0.025em;
+}
+
+.uw-welcome p {
+  margin: 0 0 17px;
+  color: var(--uw-muted);
+  font-size: 11px;
+  line-height: 1.6;
+}
+
+.uw-session-header {
+  min-height: 112px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 16px 18px 12px;
+  border-bottom: 1px solid var(--uw-border);
+}
+
+.uw-session-heading {
+  min-width: 0;
+  flex: 1;
+}
+
+.uw-session-heading-title {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.uw-session-heading h1 {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 17px;
+  letter-spacing: -0.02em;
+}
+
+.uw-header-pin {
+  width: 25px;
+  height: 25px;
+  display: grid;
+  place-items: center;
+  flex: none;
+  border: 0;
+  border-radius: 7px;
+  color: #56657b;
+  background: transparent;
+  cursor: pointer;
+}
+
+.uw-header-pin:hover,
+.uw-header-pin.pinned {
+  color: #facc15;
+  background: rgba(250,204,21,0.06);
+}
+
+.uw-context-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.uw-context-strip > span {
+  min-width: 0;
+  max-width: 175px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 5px 8px;
+  border: 1px solid rgba(148,163,184,0.08);
+  border-radius: 8px;
+  background: rgba(255,255,255,0.02);
+}
+
+.uw-context-strip small {
+  color: #5f6c7f;
+  font-size: 7.5px;
+  line-height: 1;
+}
+
+.uw-context-strip b {
+  overflow: hidden;
+  color: #aeb9c8;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 8.5px;
+  font-weight: 620;
+}
+
+.uw-context-strip .uw-status-working b {
+  color: #9eb5ff;
+}
+
+.uw-context-strip .uw-status-needs-you b {
+  color: #fdba74;
+}
+
+.uw-session-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.uw-session-actions .uw-button {
+  min-height: 31px;
+  padding-inline: 9px;
+  font-size: 9px;
+}
+
+.uw-detail-tabs {
+  height: 37px;
+  display: flex;
+  gap: 18px;
+  padding: 0 18px;
+  border-bottom: 1px solid rgba(148,163,184,0.07);
+}
+
+.uw-detail-tabs button {
+  position: relative;
+  border: 0;
+  color: #768397;
+  background: transparent;
+  cursor: pointer;
+  font-size: 9px;
+}
+
+.uw-detail-tabs button:hover,
+.uw-detail-tabs button.active {
+  color: #e6ebf3;
+}
+
+.uw-detail-tabs button.active::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 2px;
+  border-radius: 999px 999px 0 0;
+  background: #5b82ff;
+}
+
+.uw-detail-tabs button span {
+  margin-left: 4px;
+  padding: 1px 4px;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.045);
+  font-size: 8px;
+}
+
+.uw-transcript {
+  min-height: 0;
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px 20px 24px;
+  scroll-behavior: smooth;
+}
+
+.uw-message {
+  width: min(760px, 100%);
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr);
+  gap: 10px;
+  margin: 0 auto 18px;
+}
+
+.uw-avatar {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  font-size: 7.5px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.uw-avatar-user {
+  color: #dbe4ff;
+  background: linear-gradient(145deg, #303d7c, #222d61);
+}
+
+.uw-avatar-agent {
+  color: #c8d5ff;
+  background: rgba(79,124,255,0.12);
+  border: 1px solid rgba(79,124,255,0.18);
+}
+
+.uw-message-body {
+  min-width: 0;
+}
+
+.uw-message-body > header {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 25px;
+}
+
+.uw-message-body > header strong {
+  color: #dfe6f0;
+  font-size: 10px;
+}
+
+.uw-message-body > header time {
+  color: #586577;
+  font-size: 7.5px;
+}
+
+.uw-markdown {
+  color: #c2ccd9;
+  font-size: 10px;
+  line-height: 1.65;
+}
+
+.uw-markdown > :first-child {
+  margin-top: 1px;
+}
+
+.uw-markdown > :last-child {
+  margin-bottom: 0;
+}
+
+.uw-markdown p {
+  margin: 5px 0;
+}
+
+.uw-markdown h1,
+.uw-markdown h2,
+.uw-markdown h3 {
+  color: #eef3f9;
+  line-height: 1.35;
+}
+
+.uw-markdown code {
+  padding: 1px 4px;
+  border: 1px solid rgba(148,163,184,0.09);
+  border-radius: 5px;
+  color: #cbd7e7;
+  background: rgba(255,255,255,0.035);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.9em;
+}
+
+.uw-markdown pre {
+  overflow-x: auto;
+  padding: 10px;
+  border: 1px solid rgba(148,163,184,0.09);
+  border-radius: 9px;
+  background: #080d16;
+}
+
+.uw-markdown pre code {
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.uw-tool-stack {
+  display: grid;
+  gap: 5px;
+  margin-top: 8px;
+}
+
+.uw-tool-card {
+  border: 1px solid rgba(148,163,184,0.09);
+  border-radius: 9px;
+  background: rgba(255,255,255,0.022);
+  overflow: hidden;
+}
+
+.uw-tool-card > summary {
+  min-height: 34px;
+  display: grid;
+  grid-template-columns: 20px auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  padding: 0 9px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.uw-tool-card > summary::-webkit-details-marker {
+  display: none;
+}
+
+.uw-tool-icon {
+  width: 17px;
+  height: 17px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  color: #86efac;
+  background: rgba(34,197,94,0.08);
+  font-size: 8px;
+}
+
+.uw-tool-error .uw-tool-icon {
+  color: #fca5a5;
+  background: rgba(239,68,68,0.08);
+}
+
+.uw-tool-title {
+  color: #b9c4d2;
+  font-size: 8.5px;
+  font-weight: 650;
+}
+
+.uw-tool-card summary code {
+  min-width: 0;
+  overflow: hidden;
+  color: #6f7d91;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 7.5px;
+}
+
+.uw-tool-status {
+  color: #59677b;
+  font-size: 7px;
+  text-transform: capitalize;
+}
+
+.uw-tool-card pre {
+  max-height: 240px;
+  margin: 0;
+  overflow: auto;
+  padding: 8px 10px 10px 35px;
+  border-top: 1px solid rgba(148,163,184,0.06);
+  color: #8f9bae;
+  background: rgba(0,0,0,0.12);
+  white-space: pre-wrap;
+  font-size: 7.5px;
+  line-height: 1.5;
+}
+
+.uw-composer-shell {
+  width: min(790px, calc(100% - 30px));
+  margin: 0 auto 16px;
+  flex: none;
+  border: 1px solid rgba(148,163,184,0.14);
+  border-radius: 13px;
+  background: rgba(14, 22, 35, 0.95);
+  box-shadow:
+    0 16px 38px rgba(0,0,0,0.17),
+    inset 0 1px 0 rgba(255,255,255,0.022);
+  overflow: hidden;
+}
+
+.uw-composer-shell:focus-within {
+  border-color: rgba(79,124,255,0.36);
+  box-shadow:
+    0 16px 38px rgba(0,0,0,0.18),
+    0 0 0 3px rgba(79,124,255,0.06);
+}
+
+.uw-composer-shell textarea {
+  width: 100%;
+  min-height: 66px;
+  max-height: 180px;
+  resize: vertical;
+  padding: 11px 12px 5px;
+  border: 0;
+  outline: 0;
+  color: #eef3f8;
+  background: transparent;
+  font-size: 10px;
+  line-height: 1.5;
+}
+
+.uw-composer-shell textarea::placeholder {
+  color: #667387;
+}
+
+.uw-composer-footer {
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 5px 7px 7px 11px;
+}
+
+.uw-composer-footer > span {
+  min-width: 0;
+  overflow: hidden;
+  color: #5d697a;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 7.5px;
+}
+
+.uw-composer-footer > div {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.uw-composer-footer small {
+  color: #596579;
+  font-size: 7px;
+}
+
+.uw-composer-footer .uw-button {
+  min-height: 30px;
+  font-size: 8.5px;
+}
+
+.uw-changes-pane {
+  min-height: 0;
+  flex: 1;
+  overflow-y: auto;
+  padding: 18px 20px 28px;
+}
+
+.uw-changes-pane > header {
+  width: min(840px, 100%);
+  margin: 0 auto 12px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.uw-changes-pane h2 {
+  margin: 0;
+  font-size: 15px;
+}
+
+.uw-changes-pane header p {
+  margin: 4px 0 0;
+  color: var(--uw-muted);
+  font-size: 9px;
+}
+
+.uw-diff-total {
+  display: flex;
+  gap: 8px;
+  font-size: 9px;
+}
+
+.uw-diff-total span:first-child {
+  color: #86efac;
+}
+
+.uw-diff-total span:last-child {
+  color: #fca5a5;
+}
+
+.uw-diff-file {
+  width: min(840px, 100%);
+  margin: 0 auto 7px;
+  border: 1px solid rgba(148,163,184,0.09);
+  border-radius: 9px;
+  background: rgba(255,255,255,0.018);
+  overflow: hidden;
+}
+
+.uw-diff-file > summary {
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 10px;
+  cursor: pointer;
+}
+
+.uw-diff-file summary code {
+  min-width: 0;
+  overflow: hidden;
+  color: #b8c3d2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 8.5px;
+}
+
+.uw-diff-file summary span {
+  flex: none;
+  display: flex;
+  gap: 7px;
+  font-size: 8px;
+  font-style: normal;
+}
+
+.uw-diff-file summary b {
+  color: #86efac;
+}
+
+.uw-diff-file summary i {
+  color: #fca5a5;
+  font-style: normal;
+}
+
+.uw-diff-file pre {
+  max-height: 520px;
+  margin: 0;
+  overflow: auto;
+  padding: 11px;
+  border-top: 1px solid rgba(148,163,184,0.07);
+  color: #98a5b8;
+  background: #080d16;
+  font-size: 7.5px;
+  line-height: 1.5;
+}
+
+.uw-diff-file > p {
+  margin: 0;
+  padding: 10px;
+  color: var(--uw-muted);
+  font-size: 8px;
+}
+
+.uw-inspector {
+  overflow-y: auto;
+  border-left: 1px solid var(--uw-border);
+  background: rgba(10, 16, 27, 0.76);
+}
+
+.uw-inspector > header {
+  min-height: 66px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 13px;
+  border-bottom: 1px solid rgba(148,163,184,0.08);
+}
+
+.uw-inspector > header > div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.uw-inspector > header h3 {
+  margin: 0;
+  font-size: 11px;
+}
+
+.uw-inspector > header span {
+  color: var(--uw-muted);
+  font-size: 7.5px;
+}
+
+.uw-inspector > header button {
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 7px;
+  color: var(--uw-muted);
+  background: transparent;
+  cursor: pointer;
+}
+
+.uw-inspector > header button:hover {
+  color: #fff;
+  background: rgba(255,255,255,0.04);
+}
+
+.uw-inspector-section {
+  padding: 12px 13px;
+  border-bottom: 1px solid rgba(148,163,184,0.07);
+}
+
+.uw-inspector-label {
+  display: block;
+  margin-bottom: 8px;
+  color: #657288;
+  font-size: 7.5px;
+  font-weight: 800;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.uw-status-line {
+  display: grid;
+  grid-template-columns: 10px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 5px;
+}
+
+.uw-status-line strong {
+  color: #d7dfeb;
+  font-size: 9px;
+}
+
+.uw-status-line small {
+  color: #647186;
+  font-size: 7.5px;
+}
+
+.uw-inspector-grid {
+  display: grid;
+  grid-template-columns: 88px minmax(0, 1fr);
+  gap: 8px 8px;
+  padding: 12px 13px;
+  border-bottom: 1px solid rgba(148,163,184,0.07);
+  align-items: start;
+}
+
+.uw-inspector-grid > span {
+  color: #606d80;
+  font-size: 7.5px;
+}
+
+.uw-inspector-grid > b,
+.uw-inspector-grid > code {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: #aeb9c8;
+  font-size: 8px;
+  font-weight: 570;
+}
+
+.uw-inspector-grid > code {
+  font-family: "SFMono-Regular", Consolas, monospace;
+  line-height: 1.45;
+}
+
+.uw-inspector-section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.uw-inspector-section-heading > button {
+  border: 0;
+  color: #7f9dff;
+  background: transparent;
+  cursor: pointer;
+  font-size: 7.5px;
+}
+
+.uw-inspector-copy {
+  margin: 0 0 8px;
+  color: #6f7b8e;
+  font-size: 8px;
+  line-height: 1.45;
+}
+
+.uw-file-list {
+  display: grid;
+  gap: 2px;
+}
+
+.uw-file-list > button {
+  min-height: 27px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 5px;
+  border: 0;
+  border-radius: 6px;
+  color: #99a6b7;
+  background: transparent;
+  cursor: pointer;
+}
+
+.uw-file-list > button:hover {
+  background: rgba(255,255,255,0.03);
+}
+
+.uw-file-list code {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 7.5px;
+}
+
+.uw-file-list button span {
+  flex: none;
+  display: flex;
+  gap: 5px;
+  font-size: 7px;
+}
+
+.uw-file-list button b {
+  color: #86efac;
+}
+
+.uw-file-list button i {
+  color: #fca5a5;
+  font-style: normal;
+}
+
+.uw-file-list p {
+  margin: 0;
+  color: #596579;
+  font-size: 8px;
+}
+
+.uw-todo-list {
+  display: grid;
+  gap: 7px;
+}
+
+.uw-todo-list > div {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr);
+  gap: 5px;
+  color: #9ca8b8;
+  font-size: 8px;
+  line-height: 1.4;
+}
+
+.uw-todo-state {
+  width: 13px;
+  height: 13px;
+  display: grid;
+  place-items: center;
+  margin-top: 1px;
+  border-radius: 50%;
+  color: #8390a4;
+  background: rgba(255,255,255,0.04);
+  font-size: 7px;
+}
+
+.uw-todo-completed {
+  color: #86efac;
+  background: rgba(34,197,94,0.08);
+}
+
+.uw-agent-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.uw-agent-buttons button {
+  min-height: 28px;
+  padding: 0 8px;
+  border: 1px solid rgba(148,163,184,0.11);
+  border-radius: 8px;
+  color: #aab5c4;
+  background: rgba(255,255,255,0.025);
+  cursor: pointer;
+  font-size: 8px;
+}
+
+.uw-agent-buttons button:hover {
+  border-color: rgba(79,124,255,0.25);
+  color: #d7e0ee;
+  background: rgba(79,124,255,0.07);
+}
+
+.uw-inspector-danger {
+  padding-bottom: 18px;
+}
+
+.uw-inspector-danger .uw-button {
+  width: 100%;
+  font-size: 8px;
+}
+
+.uw-attention-card {
+  margin-top: 7px;
+  padding: 9px;
+  border: 1px solid rgba(251,146,60,0.18);
+  border-radius: 9px;
+  background: rgba(124, 45, 18, 0.08);
+}
+
+.uw-attention-card > strong {
+  color: #fed7aa;
+  font-size: 8.5px;
+}
+
+.uw-attention-card > p,
+.uw-attention-card > code {
+  display: block;
+  margin: 4px 0 0;
+  color: #a99a91;
+  overflow-wrap: anywhere;
+  font-size: 7.5px;
+  line-height: 1.45;
+}
+
+.uw-attention-card > code {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.uw-attention-actions {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 8px;
+}
+
+.uw-attention-actions .uw-button {
+  min-height: 27px;
+  padding-inline: 8px;
+  font-size: 7.5px;
+}
+
+.uw-question {
+  margin-top: 8px;
+}
+
+.uw-question > span {
+  display: block;
+  color: #d4c4b7;
+  font-size: 8px;
+}
+
+.uw-question > p {
+  margin: 3px 0;
+  color: #9d8f84;
+  font-size: 7.5px;
+}
+
+.uw-question-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 5px;
+}
+
+.uw-choice {
+  min-height: 25px;
+  padding: 0 7px;
+  border: 1px solid rgba(251,146,60,0.14);
+  border-radius: 7px;
+  color: #b8a99e;
+  background: rgba(255,255,255,0.018);
+  cursor: pointer;
+  font-size: 7.5px;
+}
+
+.uw-choice.selected {
+  border-color: rgba(251,146,60,0.34);
+  color: #fed7aa;
+  background: rgba(234,88,12,0.12);
+}
+
+.uw-question input {
+  width: 100%;
+  min-height: 29px;
+  margin-top: 5px;
+  padding: 0 8px;
+  border: 1px solid rgba(251,146,60,0.14);
+  border-radius: 7px;
+  outline: 0;
+  color: #e6ddd6;
+  background: rgba(0,0,0,0.12);
+  font-size: 7.5px;
+}
+
+.uw-empty-panel {
+  min-height: 170px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 20px;
+  color: #637084;
+  text-align: center;
+}
+
+.uw-empty-panel strong {
+  color: #9eabba;
+  font-size: 10px;
+}
+
+.uw-empty-panel span {
+  font-size: 8px;
+}
+
+.uw-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: grid;
+  place-items: center;
+  padding: 18px;
+  background: rgba(2, 6, 13, 0.69);
+  backdrop-filter: blur(8px);
+}
+
+.uw-modal {
+  width: min(560px, 100%);
+  max-height: min(760px, calc(100vh - 36px));
+  overflow: auto;
+  border: 1px solid rgba(148,163,184,0.17);
+  border-radius: 16px;
+  background:
+    linear-gradient(180deg, rgba(20, 29, 44, 0.98), rgba(13, 20, 32, 0.99));
+  box-shadow:
+    0 32px 90px rgba(0,0,0,0.52),
+    inset 0 1px 0 rgba(255,255,255,0.025);
+  animation: uw-modal-enter 140ms ease-out;
+}
+
+@keyframes uw-modal-enter {
+  from { opacity: 0; transform: translateY(7px) scale(0.986); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.uw-modal-header {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--uw-border);
+}
+
+.uw-modal-header h2 {
+  margin: 0;
+  font-size: 15px;
+  letter-spacing: -0.02em;
+}
+
+.uw-modal-header p {
+  margin: 4px 0 0;
+  color: var(--uw-muted);
+  font-size: 9px;
+}
+
+.uw-modal-header .uw-button {
+  width: 31px;
+  min-height: 31px;
+  padding: 0;
+}
+
+.uw-modal-body {
+  padding: 16px;
+}
+
+.uw-form-grid,
+.uw-new-session-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.uw-form-grid label,
+.uw-new-session-grid label {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.uw-form-grid label > span,
+.uw-new-session-grid label > span {
+  color: #718097;
+  font-size: 8px;
+  font-weight: 650;
+}
+
+.uw-form-span-2 {
+  grid-column: 1 / -1;
+}
+
+.uw-form-grid input,
+.uw-new-session-grid input,
+.uw-new-session-grid textarea {
+  width: 100%;
+  min-height: 38px;
+  padding: 8px 10px;
+  border: 1px solid rgba(148,163,184,0.13);
+  border-radius: 9px;
+  outline: 0;
+  color: #e7edf5;
+  background: rgba(5, 10, 18, 0.4);
+  font-size: 10px;
+}
+
+.uw-new-session-grid textarea {
+  resize: vertical;
+  line-height: 1.5;
+}
+
+.uw-form-grid input:focus,
+.uw-new-session-grid input:focus,
+.uw-new-session-grid textarea:focus,
+.uw-select:focus {
+  border-color: rgba(79,124,255,0.42);
+  box-shadow: 0 0 0 3px rgba(79,124,255,0.07);
+}
+
+.uw-select-wrap {
+  position: relative;
+}
+
+.uw-select {
+  width: 100%;
+  min-height: 38px;
+  appearance: none;
+  padding: 0 31px 0 10px;
+  border: 1px solid rgba(148,163,184,0.13);
+  border-radius: 9px;
+  outline: 0;
+  color: #dfe6ef;
+  background: #0d1522;
+  cursor: pointer;
+  font-size: 9px;
+}
+
+.uw-select:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.uw-select-chevron {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  color: #667386;
+  pointer-events: none;
+  transform: translateY(-57%);
+  font-size: 12px;
+}
+
+.uw-modal-footer {
+  min-height: 62px;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 7px;
+  padding: 11px 16px;
+  border-top: 1px solid var(--uw-border);
+  background: rgba(4,9,16,0.18);
+}
+
+.uw-modal-footer .uw-button {
+  font-size: 9px;
+}
+
+.uw-inline-error {
+  padding: 9px 10px;
+  border: 1px solid rgba(248,113,113,0.18);
+  border-radius: 8px;
+  color: #fca5a5;
+  background: rgba(127,29,29,0.1);
+  font-size: 8.5px;
+  line-height: 1.45;
+}
+
+.uw-handoff-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 11px;
+  border: 1px solid rgba(148,163,184,0.1);
+  border-radius: 10px;
+  background: rgba(255,255,255,0.018);
+}
+
+.uw-handoff-summary strong {
+  font-size: 10px;
+}
+
+.uw-handoff-summary span {
+  color: #7c899d;
+  font-size: 8px;
+}
+
+.uw-classic-shell {
+  min-height: 100vh;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  color: var(--uw-text, #f7f9fc);
+  background: #080d17;
+}
+
+.uw-classic-bar {
+  height: 48px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 10px;
+  border-bottom: 1px solid rgba(148,163,184,0.13);
+  background: #0a101b;
+  font-size: 10px;
+}
+
+.uw-classic-host {
+  min-height: 0;
+  flex: 1;
+}
+
+.uw-classic-host > * {
+  min-height: 100%;
+}
+
+@media (max-width: 1380px) {
+  .uw-layout {
+    grid-template-columns: 185px minmax(260px, 305px) minmax(0, 1fr) 265px;
+  }
+
+  .uw-context-strip > span {
+    max-width: 140px;
+  }
+
+  .uw-session-actions .uw-button:not(.uw-button-primary) {
+    padding-inline: 8px;
+  }
+}
+
+@media (max-width: 1120px) {
+  .uw-topbar {
+    grid-template-columns: 210px minmax(260px, 1fr) auto;
+  }
+
+  .uw-layout {
+    grid-template-columns: 180px 285px minmax(0, 1fr);
+  }
+
+  .uw-inspector {
+    position: absolute;
+    z-index: 40;
+    top: 64px;
+    right: 0;
+    bottom: 0;
+    width: min(330px, 86vw);
+    box-shadow: -24px 0 60px rgba(0,0,0,0.34);
+  }
+
+  .uw-main {
+    position: relative;
+  }
+
+  .uw-desktop-label {
+    display: none;
+  }
+}
+
+@media (max-width: 820px) {
+  .uw-shell {
+    height: 100dvh;
+  }
+
+  .uw-topbar {
+    height: 56px;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 8px;
+    padding: 0 9px;
+  }
+
+  .uw-brand > div {
+    display: none;
+  }
+
+  .uw-brand-mark {
+    width: 31px;
+    height: 31px;
+  }
+
+  .uw-global-search {
+    height: 34px;
+  }
+
+  .uw-global-search kbd {
+    display: none;
+  }
+
+  .uw-top-actions .uw-button {
+    width: 33px;
+    min-height: 33px;
+    padding: 0;
+  }
+
+  .uw-layout {
+    height: calc(100dvh - 56px);
+    grid-template-columns: 1fr;
+  }
+
+  .uw-nav {
+    display: none;
+  }
+
+  .uw-session-column {
+    position: absolute;
+    z-index: 25;
+    left: 0;
+    top: 56px;
+    bottom: 0;
+    width: min(330px, 90vw);
+    transform: translateX(-100%);
+    box-shadow: 24px 0 60px rgba(0,0,0,0.32);
+  }
+
+  .uw-main {
+    grid-column: 1;
+  }
+
+  .uw-session-header {
+    min-height: auto;
+    padding: 11px 12px 9px;
+    flex-direction: column;
+    gap: 9px;
+  }
+
+  .uw-session-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .uw-session-heading h1 {
+    font-size: 15px;
+  }
+
+  .uw-context-strip {
+    gap: 4px;
+  }
+
+  .uw-context-strip > span {
+    max-width: 46%;
+  }
+
+  .uw-detail-tabs {
+    padding: 0 12px;
+  }
+
+  .uw-transcript {
+    padding: 12px 10px 20px;
+  }
+
+  .uw-message {
+    grid-template-columns: 25px minmax(0, 1fr);
+    gap: 8px;
+  }
+
+  .uw-avatar {
+    width: 24px;
+    height: 24px;
+    font-size: 6.5px;
+  }
+
+  .uw-composer-shell {
+    width: calc(100% - 18px);
+    margin-bottom: 8px;
+  }
+
+  .uw-composer-footer > span,
+  .uw-composer-footer small {
+    display: none;
+  }
+
+  .uw-inspector {
+    top: 56px;
+    width: min(340px, 92vw);
+  }
+
+  .uw-form-grid,
+  .uw-new-session-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .uw-form-span-2 {
+    grid-column: auto;
+  }
+}

--- a/web/src/workspaceMachines.ts
+++ b/web/src/workspaceMachines.ts
@@ -1,0 +1,77 @@
+import type { ServerConfig } from "./types"
+
+export const WORKSPACE_MACHINES_STORAGE_KEY = "harness-remote.workspace.machines.v1"
+
+export type WorkspaceMachine = {
+  id: string
+  name: string
+  config: ServerConfig
+}
+
+function machineID(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `machine-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+function normalizeMachine(value: unknown): WorkspaceMachine | null {
+  if (!value || typeof value !== "object") return null
+  const candidate = value as {
+    id?: unknown
+    name?: unknown
+    config?: Partial<ServerConfig>
+  }
+  const config = candidate.config
+  if (!config || typeof config.host !== "string" || typeof config.port !== "number") return null
+  if (typeof config.username !== "string" || typeof config.password !== "string") return null
+  if (!config.host.trim() || !Number.isInteger(config.port) || config.port < 1 || config.port > 65_535) return null
+
+  return {
+    id: typeof candidate.id === "string" && candidate.id ? candidate.id : machineID(),
+    name: typeof candidate.name === "string" && candidate.name.trim()
+      ? candidate.name.trim()
+      : config.host.trim(),
+    config: {
+      backend: "opencode",
+      host: config.host.trim(),
+      port: config.port,
+      username: config.username,
+      password: config.password
+    }
+  }
+}
+
+export function loadWorkspaceMachines(): WorkspaceMachine[] {
+  try {
+    const raw = localStorage.getItem(WORKSPACE_MACHINES_STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.flatMap((value) => {
+      const machine = normalizeMachine(value)
+      return machine ? [machine] : []
+    })
+  } catch {
+    return []
+  }
+}
+
+export function persistWorkspaceMachines(machines: WorkspaceMachine[]): void {
+  const normalized = machines.flatMap((machine) => {
+    const next = normalizeMachine(machine)
+    return next ? [next] : []
+  })
+  localStorage.setItem(WORKSPACE_MACHINES_STORAGE_KEY, JSON.stringify(normalized))
+}
+
+export function createWorkspaceMachine(): WorkspaceMachine {
+  return {
+    id: machineID(),
+    name: "New machine",
+    config: {
+      backend: "opencode",
+      host: "",
+      port: 4097,
+      username: "harness",
+      password: ""
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Reworks the first TaskDesk 3.0 UI slice around native sessions instead of introducing a separate Task dashboard.

- aggregates native sessions from all agents exposed by each saved machine daemon;
- keeps Session as the primary user-facing unit of work;
- treats project, harness, model and machine as session metadata rather than navigation hierarchy;
- adds global search plus All, Working, Needs You, Idle and Pinned views;
- groups and filters sessions by project and machine;
- opens the real native conversation and continues it through the existing prompt API;
- shows native diff, VCS branch, todos, permission requests and agent questions when the harness exposes them;
- adds New Session with Machine, Project, Harness, Model and Initial request selection;
- adds an experimental Continue with flow that creates a native session on another harness and hands over recent context without pretending session IDs are portable;
- keeps the existing 2.11 interface available as Classic during validation;
- preserves connection editing from the new workspace;
- uses local copy-owned UI primitives so the new shell does not depend on a new component runtime.

## Product direction under test

The goal of this PR is to test Harness Remote as a universal control plane over coding harnesses, not as another coding harness and not as a separate task manager.

Native harnesses continue to own their agent loops, tools, sessions and harness-specific behavior. Harness Remote normalizes discovery, navigation, status, attention and control across them.

## Validation

Type-check/build, web regressions and bridge tests on Linux, Windows and macOS must stay green. Browser testing with real Codex, Claude Code, OpenCode, Oh My Pi and PI sessions is the next release gate.

This PR remains draft until the new workspace is manually validated.

Refs #253
Refs #197