### PR TITLE
Fix session transcripts and Desktop agent routing (2.11.1)

### DIFF
--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -231,6 +231,7 @@ export class AcpService {
   #replaying = new Set()
   #historyLoader
   #ownedSessions = new Set()
+  #adoptedSessions = new Set()
   #acpOpenSessions = new Set()
   #promptAcknowledgements = new Map()
   #titles = new Map()
@@ -316,13 +317,22 @@ export class AcpService {
     return sessionView(session, "idle", this.#titleFor(session.sessionId))
   }
 
-  /** Adopt a task session created by an older daemon so PI can open it without session/load. */
+  /**
+   * Adopt a task session created by an older daemon so PI can open it without session/load.
+   *
+   * Ownership here only means "this bridge may prompt it directly"; it does not mean the transcript
+   * in memory is the whole conversation. Everything the task said while no daemon was running lives
+   * in the harness's own journal, and marking the session loaded on adoption made that unreachable:
+   * opening a restarted task showed the one recorded prompt and nothing else until a new message
+   * streamed in. Tracking adoption separately keeps prompting lock-free while still letting the
+   * journal fill in what this process never saw.
+   */
   async adoptTaskSession(sessionID, { title, prompt } = {}) {
     await this.#refreshSessions()
     const session = this.#sessions.get(sessionID)
     if (!session || this.#deletedSessions.has(sessionID)) return false
     this.#ownedSessions.add(sessionID)
-    this.#loaded.add(sessionID)
+    this.#adoptedSessions.add(sessionID)
     if (title && !this.#titles.has(sessionID)) this.#titles.set(sessionID, title)
     const messages = this.#messages.get(sessionID) ?? []
     if (prompt && !messages.some((message) => message.info?.role === "user" && message.parts?.some((part) => part.text === prompt))) {
@@ -346,6 +356,7 @@ export class AcpService {
       await this.#historyLoader.renameSession(sessionID, normalized)
       this.#loaded.delete(sessionID)
       this.#ownedSessions.delete(sessionID)
+      this.#adoptedSessions.delete(sessionID)
       this.#configOptions.delete(sessionID)
       this.#commandCatalogs.delete(sessionID)
       this.#actionStates.delete(sessionID)
@@ -422,6 +433,7 @@ export class AcpService {
     this.#authoritativeActionStates.delete(sessionID)
     this.#loaded.delete(sessionID)
     this.#ownedSessions.delete(sessionID)
+    this.#adoptedSessions.delete(sessionID)
     this.#promptAcknowledgements.delete(sessionID)
     this.#chunkMessageIDs.delete(`${sessionID}:user`)
     this.#chunkMessageIDs.delete(`${sessionID}:assistant`)
@@ -450,10 +462,20 @@ export class AcpService {
         this.#emit("session.error", sessionID, { message: "Harness session history could not be read" })
       }
     }
-    const externalHistory = Boolean(this.#historyLoader && !this.#ownedSessions.has(sessionID))
     const reloadHistory = refresh && this.#reloadOnHistoryRefresh
-    await this.#load(sessionID, reloadHistory || externalHistory)
+    await this.#load(sessionID, reloadHistory || this.#journalBacked(sessionID))
     return this.#messages.get(sessionID) ?? []
+  }
+
+  /**
+   * Whether the harness's own on-disk history is the authority for this session rather than what
+   * this process streamed. True for a session another client owns, and for an adopted task session
+   * until this bridge starts a turn on it — up to that point nothing about the conversation came
+   * through here, so re-reading the journal is what keeps the transcript current.
+   */
+  #journalBacked(sessionID) {
+    if (!this.#historyLoader) return false
+    return !this.#ownedSessions.has(sessionID) || this.#adoptedSessions.has(sessionID)
   }
 
   async todos(sessionID) {
@@ -681,6 +703,9 @@ export class AcpService {
   }
 
   #startTurn(sessionID, text, recorded = false, attachments = []) {
+    // From the first turn this bridge runs, its own stream is the live record for the session, the
+    // same way taking ownership of an external session stops the journal being re-read for it.
+    this.#adoptedSessions.delete(sessionID)
     const generation = (this.#turnGenerations.get(sessionID) ?? 0) + 1
     this.#turnGenerations.set(sessionID, generation)
     this.#cancelledSessions.delete(sessionID)
@@ -845,14 +870,23 @@ export class AcpService {
     // for both at once, which it does on every open. Each kind of load is tracked separately,
     // and a caller that never needed the options retries on its own rather than inheriting a
     // failure that does not apply to it.
-    const inFlight = this.#loads.get(sessionID)
-    if (inFlight && (inFlight.requireConfigOptions || !requireConfigOptions)) {
-      try {
-        await inFlight.promise
-        return
-      } catch (error) {
-        if (requireConfigOptions || !inFlight.requireConfigOptions) throw error
+    // Two loads must never overlap on one session even when they want different things: both blank
+    // #messages before replaying and then merge the replay back into what they captured first, so
+    // whichever finishes last wins and a caller that only asked for the transcript can read a
+    // half-rebuilt history. A load that needs the options therefore waits for a transcript-only
+    // load to settle instead of running beside it.
+    for (let inFlight = this.#loads.get(sessionID); inFlight; inFlight = this.#loads.get(sessionID)) {
+      if (inFlight.requireConfigOptions || !requireConfigOptions) {
+        try {
+          await inFlight.promise
+          return
+        } catch (error) {
+          if (requireConfigOptions || !inFlight.requireConfigOptions) throw error
+        }
+        break
       }
+      await inFlight.promise.catch(() => undefined)
+      if (this.#loads.get(sessionID) === inFlight) break
     }
     const promise = this.#loadSession(sessionID, requireConfigOptions)
     this.#loads.set(sessionID, { promise, requireConfigOptions })
@@ -882,7 +916,7 @@ export class AcpService {
             : mergeExternalHistory(persistedMessages, previousMessages)
           previousMessages = mergeFragmentedPiSnapshot(previousMessages)
           this.#messages.set(sessionID, previousMessages)
-          if (!this.#ownedSessions.has(sessionID) && !requireConfigOptions) {
+          if (this.#journalBacked(sessionID) && !requireConfigOptions) {
             this.#todos.set(sessionID, [])
             this.#loaded.add(sessionID)
             this.#persistSnapshot(sessionID)

--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -89,18 +89,26 @@ function semanticMessagePart(part) {
   return semantic
 }
 
-function semanticMessageSignature(message) {
-  return JSON.stringify({
+/**
+ * A turn that failed carries its reason on the envelope rather than in a part, and two failures are
+ * two different messages even when both have nothing to show. Leaving the reason out of the identity
+ * let one be deduplicated away against the other, and let a newly recorded failure pass for no
+ * change at all.
+ */
+function semanticMessageIdentity(message) {
+  return {
     role: message?.info?.role,
+    ...(message?.info?.error?.message ? { error: message.info.error.message } : {}),
     parts: (message?.parts ?? []).map(semanticMessagePart)
-  })
+  }
+}
+
+function semanticMessageSignature(message) {
+  return JSON.stringify(semanticMessageIdentity(message))
 }
 
 function semanticHistorySignature(messages) {
-  return JSON.stringify(messages.map((message) => ({
-    role: message?.info?.role,
-    parts: (message?.parts ?? []).map(semanticMessagePart)
-  })))
+  return JSON.stringify(messages.map(semanticMessageIdentity))
 }
 
 /** Exported for testing only. */
@@ -722,6 +730,7 @@ export class AcpService {
       ]
     }, 300_000).catch((error) => {
       if (this.#turnGenerations.get(sessionID) === generation) {
+        this.#recordTurnFailure(sessionID, error.message)
         this.#emit("session.error", sessionID, { message: error.message })
       }
     }).finally(() => {
@@ -732,6 +741,30 @@ export class AcpService {
       this.#persistSnapshot(sessionID)
       void this.#runNextQueued(sessionID)
     })
+  }
+
+  /**
+   * A turn that fails leaves the prompt on screen with nothing after it, and the live error banner
+   * that reports why is gone the moment the session is reopened. Attaching the reason to the turn's
+   * own assistant message keeps it in the transcript — and in the snapshot — so a failed reply stays
+   * distinguishable from a reply that never got recorded.
+   */
+  #recordTurnFailure(sessionID, message) {
+    if (typeof message !== "string" || !message.trim()) return
+    const messages = this.#messages.get(sessionID) ?? []
+    this.#messages.set(sessionID, messages)
+    const streamedID = this.#chunkMessageIDs.get(`${sessionID}:assistant`)
+    let target = streamedID ? messages.find((item) => item.info.id === streamedID) : undefined
+    if (!target) {
+      target = {
+        info: { id: randomUUID(), role: "assistant", sessionID, time: { created: Date.now() } },
+        parts: []
+      }
+      messages.push(target)
+    }
+    target.info.error = { name: "HarnessTurnError", message: message.trim() }
+    this.#emit("message.updated", sessionID)
+    this.#persistSnapshot(sessionID)
   }
 
   async #runNextQueued(sessionID) {

--- a/bridge/src/omp-session-history.js
+++ b/bridge/src/omp-session-history.js
@@ -30,6 +30,18 @@ function messageParts(content, messageID) {
   })
 }
 
+/**
+ * A turn that failed is journalled as an assistant message with no content and the provider's own
+ * sentence in `errorMessage`. Skipping those for having no parts made a rate-limited or unpaid
+ * session look like it had simply lost its replies: the transcript showed the prompts and nothing
+ * back, with no way to tell a failure from a missing message.
+ */
+function messageError(message) {
+  const detail = typeof message?.errorMessage === "string" ? message.errorMessage.trim() : ""
+  if (!detail) return undefined
+  return { name: "HarnessTurnError", message: detail }
+}
+
 export function createOmpHistoryLoader(sessionRoot = path.join(homedir(), ".omp", "agent", "sessions")) {
   const sessionFiles = new Map()
 
@@ -97,14 +109,16 @@ export function createOmpHistoryLoader(sessionRoot = path.join(homedir(), ".omp"
       if (role !== "user" && role !== "assistant") continue
       const messageID = record.id ?? `${sessionID}:${messages.length}`
       const parts = messageParts(record.message.content, messageID)
-      if (parts.length === 0) continue
+      const error = messageError(record.message)
+      if (parts.length === 0 && !error) continue
       const created = Date.parse(record.timestamp ?? "")
       messages.push({
         info: {
           id: messageID,
           role,
           sessionID,
-          time: { created: Number.isFinite(created) ? created : Date.now() }
+          time: { created: Number.isFinite(created) ? created : Date.now() },
+          ...(error ? { error } : {})
         },
         parts
       })

--- a/bridge/src/pi-session-history.js
+++ b/bridge/src/pi-session-history.js
@@ -29,6 +29,18 @@ function messageParts(content, messageID) {
   })
 }
 
+/**
+ * A turn that failed is journalled as an assistant message with no content and the provider's own
+ * sentence in `errorMessage`. Skipping those for having no parts made a rate-limited or unpaid
+ * session look like it had simply lost its replies: the transcript showed the prompts and nothing
+ * back, with no way to tell a failure from a missing message.
+ */
+function messageError(message) {
+  const detail = typeof message?.errorMessage === "string" ? message.errorMessage.trim() : ""
+  if (!detail) return undefined
+  return { name: "HarnessTurnError", message: detail }
+}
+
 async function readRecords(file) {
   const records = []
   const lines = createInterface({ input: createReadStream(file), crlfDelay: Infinity })
@@ -87,14 +99,16 @@ export function createPiHistoryLoader(sessionRoot = defaultSessionRoot()) {
       if (role !== "user" && role !== "assistant") continue
       const messageID = record.id
       const parts = messageParts(record.message?.content, messageID)
-      if (parts.length === 0) continue
+      const error = messageError(record.message)
+      if (parts.length === 0 && !error) continue
       const created = Date.parse(record.timestamp ?? "")
       messages.push({
         info: {
           id: messageID,
           role,
           sessionID,
-          time: { created: Number.isFinite(created) ? created : Date.now() }
+          time: { created: Number.isFinite(created) ? created : Date.now() },
+          ...(error ? { error } : {})
         },
         parts
       })

--- a/bridge/test/adopted-task-history.test.js
+++ b/bridge/test/adopted-task-history.test.js
@@ -1,0 +1,143 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import { AcpService } from "../src/acp-service.js"
+
+const SESSION = "codex-task-session"
+
+function journalMessage(id, role, text, created) {
+  return {
+    info: { id, role, sessionID: SESSION, time: { created } },
+    parts: [{ id: `${id}:text:0`, messageID: id, type: "text", text }]
+  }
+}
+
+class LockedAcp extends EventEmitter {
+  constructor() {
+    super()
+    this.loads = []
+  }
+
+  async listSessions() {
+    return [{ sessionId: SESSION, cwd: process.cwd(), title: "Task run", updatedAt: new Date().toISOString() }]
+  }
+
+  async request(method, params) {
+    if (method === "session/load") {
+      this.loads.push(params.sessionId)
+      // Codex holds a single-writer lock for as long as any client keeps the thread open.
+      throw new Error(`thread ${params.sessionId} already has an active writer`)
+    }
+    if (method === "session/prompt") return {}
+    throw new Error(`Unexpected request: ${method}`)
+  }
+
+  notify() {}
+}
+
+function historyLoader(messages) {
+  const loader = async () => messages
+  return loader
+}
+
+test("an adopted task session reads the harness journal instead of the recorded prompt alone", async () => {
+  const journal = [
+    journalMessage("j1", "user", "Salutami", 1_000),
+    journalMessage("j2", "assistant", "Ciao!", 2_000),
+    journalMessage("j3", "user", "ci sei?", 3_000),
+    journalMessage("j4", "assistant", "Sì, ci sono", 4_000)
+  ]
+  const acp = new LockedAcp()
+  const service = new AcpService(acp, { historyLoader: historyLoader(journal) })
+
+  assert.equal(await service.adoptTaskSession(SESSION, { title: "Salutami", prompt: "Salutami" }), true)
+
+  const messages = await service.messages(SESSION)
+  assert.deepEqual(
+    messages.map((message) => [message.info.role, message.parts.map((part) => part.text).join("")]),
+    [["user", "Salutami"], ["assistant", "Ciao!"], ["user", "ci sei?"], ["assistant", "Sì, ci sono"]]
+  )
+  // The prompt recorded at adoption must not survive alongside the journal's copy of itself.
+  assert.equal(messages.filter((message) => message.parts.some((part) => part.text === "Salutami")).length, 1)
+  // Adoption exists so a locked thread can be prompted without session/load; reading history
+  // must not reintroduce that request.
+  assert.deepEqual(acp.loads, [])
+})
+
+test("an adopted session keeps picking up journal entries written while the daemon was idle", async () => {
+  const journal = [journalMessage("j1", "user", "first", 1_000)]
+  const acp = new LockedAcp()
+  const service = new AcpService(acp, { historyLoader: async () => journal })
+  await service.adoptTaskSession(SESSION, { prompt: "first" })
+  assert.equal((await service.messages(SESSION)).length, 1)
+
+  journal.push(journalMessage("j2", "assistant", "answered later", 2_000))
+  assert.deepEqual(
+    (await service.messages(SESSION)).map((message) => message.info.id),
+    ["j1", "j2"]
+  )
+})
+
+test("an adopted session stays listed as the app's own rather than as an external one", async () => {
+  const service = new AcpService(new LockedAcp(), { historyLoader: async () => [] })
+  await service.adoptTaskSession(SESSION, { prompt: "task prompt" })
+  const [session] = await service.listSessions()
+  assert.equal(session.external, undefined)
+})
+
+test("a session this bridge prompts stops deferring to the journal", async () => {
+  const journal = [journalMessage("j1", "user", "task prompt", 1_000)]
+  const acp = new LockedAcp()
+  const service = new AcpService(acp, { historyLoader: async () => journal })
+  await service.adoptTaskSession(SESSION, { prompt: "task prompt" })
+  await service.messages(SESSION)
+
+  await service.prompt(SESSION, "live follow-up")
+  // The journal loses the conversation, as a harness rewriting its own branch would: the live
+  // transcript is authoritative from the first turn this process runs, so nothing disappears.
+  journal.length = 0
+  const messages = await service.messages(SESSION)
+  assert.deepEqual(
+    messages.map((message) => message.parts.map((part) => part.text).join("")),
+    ["task prompt", "live follow-up"]
+  )
+  assert.deepEqual(acp.loads, [])
+})
+
+test("a harness with no journal still replays an adopted session over ACP", async () => {
+  const replays = []
+  class ReplayAcp extends EventEmitter {
+    async listSessions() {
+      return [{ sessionId: SESSION, cwd: process.cwd(), title: "Task run", updatedAt: new Date().toISOString() }]
+    }
+
+    async request(method, params) {
+      if (method !== "session/load") throw new Error(`Unexpected request: ${method}`)
+      replays.push(params.sessionId)
+      this.emit("notification", {
+        method: "session/update",
+        params: {
+          sessionId: params.sessionId,
+          update: { sessionUpdate: "user_message_chunk", messageId: "u1", content: { type: "text", text: "task prompt" } }
+        }
+      })
+      this.emit("notification", {
+        method: "session/update",
+        params: {
+          sessionId: params.sessionId,
+          update: { sessionUpdate: "agent_message_chunk", messageId: "a1", content: { type: "text", text: "replayed answer" } }
+        }
+      })
+      return { configOptions: [] }
+    }
+  }
+
+  const service = new AcpService(new ReplayAcp())
+  await service.adoptTaskSession(SESSION, { prompt: "task prompt" })
+  const messages = await service.messages(SESSION)
+  assert.deepEqual(replays, [SESSION])
+  assert.deepEqual(
+    messages.map((message) => [message.info.role, message.parts.map((part) => part.text).join("")]),
+    [["user", "task prompt"], ["assistant", "replayed answer"]]
+  )
+})

--- a/bridge/test/turn-failure-visibility.test.js
+++ b/bridge/test/turn-failure-visibility.test.js
@@ -1,0 +1,83 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import { mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { AcpService } from "../src/acp-service.js"
+import { createOmpHistoryLoader } from "../src/omp-session-history.js"
+import { createPiHistoryLoader } from "../src/pi-session-history.js"
+
+const SESSION = "01a01000-0000-7000-8000-000000000000"
+
+async function journal(prefix, separator, records) {
+  const root = await mkdtemp(path.join(tmpdir(), `harness-${prefix}-`))
+  const file = path.join(root, `2026-08-17T16-48-44-623Z${separator}${SESSION}.jsonl`)
+  await writeFile(file, records.map((record) => JSON.stringify(record)).join("\n"), "utf8")
+  return root
+}
+
+const failedTurn = [
+  { type: "message", id: "m1", parentId: null, timestamp: "2026-08-17T16:48:45.000Z", message: { role: "user", content: "ciao" } },
+  {
+    type: "message",
+    id: "m2",
+    parentId: "m1",
+    timestamp: "2026-08-17T16:49:07.000Z",
+    message: { role: "assistant", content: [], stopReason: "error", errorMessage: "429 Rate limit exceeded" }
+  }
+]
+
+test("an OMP turn that failed stays in the transcript with the provider's reason", async () => {
+  const root = await journal("omp", "_", failedTurn)
+  const messages = await createOmpHistoryLoader(root)(SESSION, { activeSessionLeaf: "m2" })
+  assert.deepEqual(messages.map((message) => message.info.role), ["user", "assistant"])
+  assert.deepEqual(messages[1].parts, [])
+  assert.equal(messages[1].info.error?.message, "429 Rate limit exceeded")
+  assert.equal(messages[0].info.error, undefined)
+})
+
+test("a PI turn that failed stays in the transcript with the provider's reason", async () => {
+  const root = await journal("pi", "_", failedTurn)
+  const messages = await createPiHistoryLoader(root)(SESSION)
+  assert.deepEqual(messages.map((message) => message.info.role), ["user", "assistant"])
+  assert.equal(messages[1].info.error?.message, "429 Rate limit exceeded")
+})
+
+test("a blank errorMessage is not mistaken for a failure worth showing", async () => {
+  const root = await journal("pi-blank", "_", [
+    failedTurn[0],
+    { ...failedTurn[1], message: { role: "assistant", content: [], errorMessage: "   " } }
+  ])
+  const messages = await createPiHistoryLoader(root)(SESSION)
+  assert.deepEqual(messages.map((message) => message.info.role), ["user"])
+})
+
+class FailingAcp extends EventEmitter {
+  async listSessions() {
+    return [{ sessionId: SESSION, cwd: process.cwd(), title: "Failing", updatedAt: new Date().toISOString() }]
+  }
+
+  async request(method, params) {
+    if (method === "session/load") return { configOptions: [] }
+    if (method === "session/prompt") throw new Error("Internal error: provider rejected the request")
+    throw new Error(`Unexpected request: ${method}`)
+  }
+
+  notify() {}
+}
+
+test("a live ACP turn failure is recorded on the transcript, not only announced once", async () => {
+  const service = new AcpService(new FailingAcp())
+  const errors = []
+  service.subscribe((event) => {
+    if (event.type === "session.error") errors.push(event.message)
+  })
+  await service.prompt(SESSION, "ciao")
+  await new Promise((resolve) => setTimeout(resolve, 20))
+
+  assert.deepEqual(errors, ["Internal error: provider rejected the request"])
+  const messages = await service.messages(SESSION)
+  assert.deepEqual(messages.map((message) => message.info.role), ["user", "assistant"])
+  assert.equal(messages[1].info.error?.message, "Internal error: provider rejected the request")
+})

--- a/docs/RELEASE_2.11.1.md
+++ b/docs/RELEASE_2.11.1.md
@@ -1,0 +1,51 @@
+# Harness Remote 2.11.1
+
+Harness Remote 2.11.1 is a bug-fix release for the 2.11 line. It repairs three ways a session could look emptier than it was, and restores per-agent routing in the Desktop application.
+
+## Highlights
+
+- Show the full conversation when opening a task session after a daemon restart, instead of the single prompt recorded at launch.
+- Route every Desktop server profile to the agent it selected, instead of sending them all to the machine's primary agent.
+- Report the provider's own reason when a turn fails, instead of leaving the prompt followed by nothing.
+- Recover a task session's transcript on harnesses that keep no journal of their own, which previously had no path back to it at all.
+- Collapse repeated identical failures from a retried turn into one.
+
+## Task session history after a daemon restart
+
+Opening a task session after restarting the daemon showed the one prompt recorded when the task was launched, and nothing else, until a new message streamed in and filled the rest of the conversation.
+
+The daemon adopts every known task session at startup so a thread another client holds open can still be prompted without `session/load`. That adoption also marked the session's in-memory transcript complete, which meant the harness's own rollout or journal was never read. Adoption is now tracked separately: it grants the right to prompt, and history still comes from the harness until the bridge runs a turn of its own on the session.
+
+Codex was the harness this was reported against, because every Codex task session behaved this way. PI was unaffected only because its loader is already marked authoritative and bypasses the affected path. Claude Code, which keeps no journal for the bridge to read, now replays an adopted session over ACP — a recovery path adoption previously prevented outright.
+
+This release also stops two loads of the same session from overlapping. A transcript-only load and a config-options load both rebuild the session's message list, and the client asks for both every time a session is opened, so a caller that wanted only the transcript could read a half-rebuilt one.
+
+## Desktop agent routing
+
+In the packaged Desktop application every saved server listed the same sessions: those of the machine daemon's primary agent.
+
+A profile's agent id is what scopes its requests to one agent behind the shared machine endpoint. The Desktop main process was discarding that field when it validated a profile, leaving it with a machine-root target for every server, and the daemon routes an unscoped request to its primary agent. The Web client was unaffected because it builds its own URLs and never lost the field.
+
+The main process now keeps and validates the agent id, and treats a change of agent as a real change so the event stream follows it. The compatibility header the daemon uses to correct a wrongly-scoped request is now shared by the browser, Desktop and Android request paths rather than being sent by the browser alone, which is what allowed the two clients to disagree in the first place.
+
+Existing Desktop profiles repair themselves on the next launch; no reconfiguration is needed.
+
+## Failed turns
+
+A turn that fails carries the provider's message on the envelope rather than in the reply, and nothing displayed it. The prompt was followed by nothing at all — the same thing a session with a broken transcript looks like, which is why two unrelated causes were reported as one problem.
+
+- The Oh My Pi and PI journal readers keep a failed turn instead of discarding it for having no content, and carry the provider's sentence with it.
+- A live ACP turn failure is recorded on the transcript rather than only announced once, so it is still there when the session is reopened.
+- The client renders the reason inside the bubble, and folds consecutive identical failures together, since a harness that retries a failing turn records one failed message per attempt.
+
+## Also fixed
+
+- A duplicate React key in the session sidebar, where one project directory legitimately produces several groups.
+
+## Validation
+
+- web type-check and production build
+- web regression tests
+- desktop transport and profile registry tests
+- bridge test suite
+- runtime validation against a live machine daemon with Codex CLI, Claude Code, Oh My Pi, PI and OpenCode: per-agent session lists verified distinct from both the Web and Desktop clients, task session transcripts verified complete before and after a daemon restart, and a live turn verified not to duplicate or lose history

--- a/web/electron/desktop-transport.test.mjs
+++ b/web/electron/desktop-transport.test.mjs
@@ -70,6 +70,11 @@ server = createServer(async (request, response) => {
     response.write('{"partial":')
     return
   }
+  if (request.url.startsWith('/echo') || request.url.startsWith('/v1/') || request.url.startsWith('/global/')) {
+    response.setHeader('content-type', 'application/json')
+    response.end(JSON.stringify({ url: request.url, backend: request.headers['x-harness-backend'] ?? null }))
+    return
+  }
   response.statusCode = 404
   response.end()
 })
@@ -155,4 +160,43 @@ test('HTTP errors expose status without matching prose', async () => {
   const missing = await executeDesktopRequest(localProfile, { path: '/missing' })
   assert.equal(missing.error.code, 'http')
   assert.equal(missing.error.status, 404)
+})
+
+test('the registry keeps the selected agent, which is the only thing that routes a profile', async () => {
+  const scoped = { ...localProfile, backend: 'codex', agentId: 'codex' }
+  assert.deepEqual(validateDesktopProfile(scoped), scoped)
+  assert.equal(validateDesktopProfile({ ...scoped, agentId: '  ' }).agentId, undefined)
+  assert.throws(() => validateDesktopProfile({ ...scoped, agentId: '../codex' }), /agent/)
+  assert.throws(() => validateDesktopProfile({ ...scoped, agentId: 'co dex' }), /agent/)
+  assert.throws(() => validateDesktopProfile({ ...scoped, agentId: 42 }), /agent/)
+
+  const directory = await mkdtemp(join(tmpdir(), 'harness-remote-agents-'))
+  const registry = new ProfileRegistry(join(directory, 'profiles.json'))
+  await registry.replace([scoped])
+  assert.equal(registry.get(scoped.id).agentId, 'codex')
+  // Switching only the agent is a real change: treating it as unchanged left the event stream
+  // subscribed to the agent the user just navigated away from.
+  const switched = await registry.replace([{ ...scoped, backend: 'pi', agentId: 'pi' }])
+  assert.deepEqual(switched.changedProfileIDs, [scoped.id])
+  await rm(directory, { recursive: true, force: true })
+})
+
+test('desktop requests carry the profile scope the browser sends, and leave machine routes alone', async () => {
+  const scoped = { ...localProfile, backend: 'codex', agentId: 'pi' }
+  const agentRequest = await executeDesktopRequest(scoped, { path: '/echo/session' })
+  assert.deepEqual(agentRequest.response.data, { url: '/v1/agents/pi/echo/session', backend: 'codex' })
+
+  // TaskDesk and machine discovery are answered by the daemon itself; scoping them to the
+  // profile's agent aims them at a bridge where those routes do not exist.
+  for (const path of ['/v1/machine', '/global/machine', '/v1/projects', '/v1/tasks', '/v1/tasks/abc/launch', '/v1/agents/omp/models']) {
+    const machineRequest = await executeDesktopRequest(scoped, { path })
+    assert.equal(machineRequest.response.data.url, path, `${path} should reach the daemon unscoped`)
+  }
+  const withQuery = await executeDesktopRequest(scoped, { path: '/v1/tasks?limit=1' })
+  assert.equal(withQuery.response.data.url, '/v1/tasks?limit=1')
+
+  // Nothing preflights a request from the main process, so an unscoped OpenCode profile still says
+  // which harness it wants — which is what lets a daemon route it somewhere other than its primary.
+  const unscoped = await executeDesktopRequest({ ...localProfile, backend: 'opencode' }, { path: '/echo/session' })
+  assert.deepEqual(unscoped.response.data, { url: '/echo/session', backend: 'opencode' })
 })

--- a/web/electron/event-transport.ts
+++ b/web/electron/event-transport.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto"
 import type { WebContents } from "electron"
-import { baseUrl } from "../src/serverConfig.js"
+import { baseUrl, routingHeaders } from "../src/serverConfig.js"
 import { parseSSEFrame, type ParsedOpenCodeEvent } from "../src/sse-parser.js"
 import { ProfileRegistry, type ProfileRegistryChange } from "./profile-registry.js"
 import type {
@@ -160,7 +160,7 @@ export class DesktopEventTransport {
     subscription.controller = controller
     let response: Response
     try {
-      const headers: Record<string, string> = { Accept: "text/event-stream" }
+      const headers: Record<string, string> = { Accept: "text/event-stream", ...routingHeaders(profile, { preflight: false }) }
       const authorization = authHeader(profile)
       if (authorization) headers.Authorization = authorization
       response = await fetch(streamURL(profile, subscription.options), { headers, redirect: "manual", signal: controller.signal })

--- a/web/electron/profile-registry.ts
+++ b/web/electron/profile-registry.ts
@@ -9,6 +9,7 @@ const MAX_PROFILE_COUNT = 100
 const MAX_PROFILE_ID_LENGTH = 128
 const MAX_HOST_LENGTH = 2048
 const MAX_CREDENTIAL_LENGTH = 4096
+const MAX_AGENT_ID_LENGTH = 128
 
 export class DesktopProfileError extends Error {
   constructor(message: string) {
@@ -47,6 +48,21 @@ function validateHost(host: unknown): string {
   return value
 }
 
+/**
+ * The id becomes a path segment, so it is held to what the daemon itself accepts for an agent name
+ * rather than merely being escaped: anything with a separator or an encodable character in it would
+ * be a way to aim a profile at a path other than the agent the user picked.
+ */
+function validateAgentID(value: unknown): string | undefined {
+  if (typeof value !== "string") throw new DesktopProfileError("Profile agent is invalid")
+  const agentID = value.trim()
+  if (!agentID) return undefined
+  if (agentID.length > MAX_AGENT_ID_LENGTH || !/^[A-Za-z0-9._-]+$/.test(agentID)) {
+    throw new DesktopProfileError("Profile agent is invalid")
+  }
+  return agentID
+}
+
 export function validateDesktopProfile(value: unknown): DesktopProfile {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new DesktopProfileError("Profile is invalid")
   const candidate = value as Partial<DesktopProfile>
@@ -63,7 +79,21 @@ export function validateDesktopProfile(value: unknown): DesktopProfile {
   if (candidate.username.length > MAX_CREDENTIAL_LENGTH || candidate.password.length > MAX_CREDENTIAL_LENGTH || hasControlCharacters(candidate.username) || hasControlCharacters(candidate.password)) {
     throw new DesktopProfileError("Profile credentials are invalid")
   }
-  const profile = { id, backend: candidate.backend, host, port, username: candidate.username, password: candidate.password }
+  // A daemon-backed profile is only distinguishable from every other agent on the same machine by
+  // its agent id: it is what puts /v1/agents/<id> in front of the path and what the event stream is
+  // scoped by. Dropping it here left main holding a machine-root target for every profile, so the
+  // desktop app sent all of them to the daemon's primary agent and each server showed that one
+  // agent's sessions. The renderer already carries the field; main has to keep it to route at all.
+  const agentId = candidate.agentId === undefined ? undefined : validateAgentID(candidate.agentId)
+  const profile = {
+    id,
+    backend: candidate.backend,
+    host,
+    port,
+    username: candidate.username,
+    password: candidate.password,
+    ...(agentId ? { agentId } : {})
+  }
   try {
     new URL(baseUrl(profile))
   } catch {
@@ -101,6 +131,7 @@ function sameProfile(left: DesktopProfile, right: DesktopProfile): boolean {
     && left.port === right.port
     && left.username === right.username
     && left.password === right.password
+    && left.agentId === right.agentId
 }
 
 /** Main-owned allowlist. Renderer profile mutation represents user-approved Settings state. */

--- a/web/electron/request-transport.ts
+++ b/web/electron/request-transport.ts
@@ -1,4 +1,4 @@
-import { agentScopedPath, machineBaseUrl } from "../src/serverConfig.js"
+import { agentScopedPath, machineBaseUrl, routingHeaders } from "../src/serverConfig.js"
 import type { DesktopProfile, DesktopRequest, DesktopRequestResult } from "./ipc-contract.js"
 
 export const MAX_RESPONSE_BYTES = 8 * 1024 * 1024
@@ -61,6 +61,14 @@ async function readBoundedBody(response: Response, onReader?: (reader: ReadableS
   return new TextDecoder().decode(bytes)
 }
 
+/**
+ * What the machine daemon answers itself rather than handing to one agent's bridge: the machine
+ * descriptor, the project and task surface behind TaskDesk, and any path the caller already scoped
+ * to an agent of its own choosing. Prefixing these with the profile's agent aims them at a bridge
+ * where they do not exist, so the profile's scope applies to everything except these.
+ */
+const MACHINE_SCOPED_PATH = /^\/(?:v1\/machine|global\/machine|v1\/projects|v1\/tasks(?:\/|$)|v1\/agents\/)/
+
 function validPath(path: unknown): path is string {
   return typeof path === "string"
     && path.length <= MAX_PATH_LENGTH
@@ -77,9 +85,13 @@ function targetURL(profile: DesktopProfile, path: string): URL | null {
   } catch {
     return null
   }
-  const machineScoped = path === "/v1/machine" || path === "/global/machine"
-  const scopedPath = machineScoped ? path : agentScopedPath(profile, path)
   let target: URL
+  try {
+    target = new URL(path, approved.origin)
+  } catch {
+    return null
+  }
+  const scopedPath = MACHINE_SCOPED_PATH.test(target.pathname) ? path : agentScopedPath(profile, path)
   try {
     target = new URL(scopedPath, approved.origin)
   } catch {
@@ -126,7 +138,7 @@ export async function executeDesktopRequest(profile: DesktopProfile, request: De
     controller.abort()
     void activeReader?.cancel().catch(() => undefined)
   }, timeout)
-  const headers: Record<string, string> = { Accept: "application/json" }
+  const headers: Record<string, string> = { Accept: "application/json", ...routingHeaders(profile, { preflight: false }) }
   if (profile.username && profile.password) {
     headers.Authorization = `Basic ${Buffer.from(`${profile.username}:${profile.password}`, "utf8").toString("base64")}`
   }

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harness-remote-web",
   "private": true,
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Companion app for controlling coding-agent harnesses from phone or desktop",
   "homepage": "https://github.com/giuliastro/harness-remote",
   "author": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -235,6 +235,53 @@ function extractText(msg: MessageEnvelope): string {
     .trim()
 }
 
+/**
+ * A turn that ended in a provider or harness failure carries no text and no parts worth rendering,
+ * only the bookkeeping `step-start`. Left unread, the transcript showed the prompt and then nothing
+ * at all, which reads as the reply having gone missing rather than as the model having failed — and
+ * on a session where every turn failed, as the app showing only the messages the user sent.
+ *
+ * OpenCode nests the sentence worth reading under `data.message`, frequently as a JSON document of
+ * its own, so unwrap one level before giving up and showing the error's name.
+ */
+function messageFailure(message: MessageEnvelope): string | undefined {
+  const error = message.info.error
+  if (!error) return undefined
+  const detail = error.data?.message ?? error.message
+  if (typeof detail === "string" && detail.trim()) {
+    try {
+      const parsed = JSON.parse(detail) as { message?: unknown }
+      if (parsed && typeof parsed === "object" && typeof parsed.message === "string" && parsed.message.trim()) {
+        return parsed.message.trim()
+      }
+    } catch {
+      // Not every provider wraps its message in JSON; the plain sentence is already what we want.
+    }
+    return detail.trim()
+  }
+  return typeof error.name === "string" && error.name.trim() ? error.name.trim() : undefined
+}
+
+/** Bookkeeping parts a harness emits around a turn; on their own they are not content to show. */
+function isTurnScaffolding(part: MessagePart): boolean {
+  return part.type === "step-start" || part.type === "step-finish"
+}
+
+/**
+ * A harness that retries a failing turn journals one failed assistant message per attempt, so a
+ * single rate-limited prompt arrives as a dozen messages all saying the same thing. Consecutive
+ * content-free failures with the same reason are one failure as far as the reader is concerned.
+ */
+function collapseRepeatedFailures(messages: (MessageEnvelope & { text: string })[]): (MessageEnvelope & { text: string })[] {
+  const isBareFailure = (message: MessageEnvelope & { text: string }) =>
+    !message.text && Boolean(messageFailure(message)) && message.parts.every(isTurnScaffolding)
+  return messages.filter((message, index) => {
+    const previous = messages[index - 1]
+    if (!previous || !isBareFailure(message) || !isBareFailure(previous)) return true
+    return messageFailure(previous) !== messageFailure(message)
+  })
+}
+
 /** Wraps a message with its extracted text, reusing the previous wrapper when the underlying message object is
  *  unchanged. applyStreamedPartUpdate/applyStreamedPartDelta already keep unrelated messages referentially
  *  identical across streamed updates — without this cache, mapping over the whole array would create a brand
@@ -1796,6 +1843,26 @@ function MessageContextMenu({
   )
 }
 
+/** The failure that replaced a reply, shown in the bubble it belongs to rather than as a transient
+ *  banner: it is part of the transcript and stays readable when the session is reopened later. */
+function MessageFailureView({ messages, t }: { messages: MessageEnvelope[]; t: Translator }) {
+  const failures = messages.flatMap((message) => {
+    const failure = messageFailure(message)
+    return failure ? [{ id: message.info.id, failure }] : []
+  })
+  if (failures.length === 0) return null
+  return (
+    <>
+      {failures.map((entry) => (
+        <p key={`failure-${entry.id}`} className="message-failure" role="status">
+          <span className="message-failure-label">{t('detail.turnFailed')}</span>
+          <span className="message-failure-detail">{entry.failure}</span>
+        </p>
+      ))}
+    </>
+  )
+}
+
 /** Renders one run's continuous timeline (see groupRenderedMessages) as a single message bubble, resolving
  *  each item's timestamp to the specific message that produced it. */
 function ConversationRunView({
@@ -1856,6 +1923,7 @@ function ConversationRunView({
           />
         )
       )}
+      <MessageFailureView messages={[...messagesByID.values()]} t={t} />
     </MessageContextMenu>
   )
 }
@@ -1908,6 +1976,7 @@ const MessageArticle = memo(function MessageArticle({
           />
         )
       )}
+      <MessageFailureView messages={[message]} t={t} />
     </MessageContextMenu>
   )
 })
@@ -2399,10 +2468,11 @@ function App() {
 
   const renderedMessages = useMemo(() => {
     const revertMessageID = config.backend === "opencode" ? selectedSession?.revertMessageID : undefined
-    return [...messages, ...optimisticUserMessages]
+    const visible = [...messages, ...optimisticUserMessages]
       .filter((message) => !revertMessageID || message.info.id < revertMessageID)
       .map(toRenderedMessage)
-      .filter((message) => message.text || message.parts.some((part) => part.type !== "step-start" && part.type !== "step-finish"))
+      .filter((message) => message.text || messageFailure(message) || message.parts.some((part) => !isTurnScaffolding(part)))
+    return collapseRepeatedFailures(visible)
   }, [config.backend, messages, optimisticUserMessages, selectedSession?.revertMessageID])
 
   const timelineGroups = useMemo(() => groupRenderedMessages(renderedMessages), [renderedMessages])

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,7 +1,7 @@
 import { Capacitor, CapacitorHttp } from "@capacitor/core"
 import { desktopRequest, isDesktopPlatform } from "./desktopBridge"
 import { streamURL } from "./opencode-events"
-import { authHeader, baseUrl, hasCredentials, isValidServerConfig } from "./serverConfig"
+import { authHeader, baseUrl, hasCredentials, isValidServerConfig, routingHeaders } from "./serverConfig"
 import type { AttachmentPart } from "./attachments"
 import type {
   AgentOption,
@@ -132,13 +132,6 @@ type AgentResponse = Array<{
   hidden?: boolean
 }>
 
-function routingHeaders(config: ServerConfig): Record<string, string> {
-  // A direct OpenCode server does not know this compatibility header and may reject it during CORS
-  // preflight. Daemon-backed profiles have an agentId, while ACP bridge profiles can safely send it.
-  if (config.backend === "opencode" && !config.agentId) return {}
-  return { "X-Harness-Backend": config.backend }
-}
-
 async function requestWithHeaders<T>(config: ServerConfig, path: string, options: RequestOptions = {}): Promise<ResponseWithHeaders<T>> {
   const method = options.method ?? "GET"
   if (isDesktopPlatform()) {
@@ -154,7 +147,9 @@ async function requestWithHeaders<T>(config: ServerConfig, path: string, options
   const target = `${baseUrl(config)}${path}`
   const headers: Record<string, string> = {
     Accept: "application/json",
-    ...routingHeaders(config)
+    // CapacitorHttp goes out through the platform's own HTTP client, which never preflights, so the
+    // routing hint the browser has to withhold is safe to send from the packaged Android app.
+    ...routingHeaders(config, { preflight: !Capacitor.isNativePlatform() })
   }
   if (hasCredentials(config)) {
     headers.Authorization = authHeader(config)

--- a/web/src/components/session-list.tsx
+++ b/web/src/components/session-list.tsx
@@ -216,7 +216,10 @@ export function SessionSidebar({
       </div>
       <div className="sidebar-sessions" ref={sidebarSessionsRef} onScroll={onScroll}>
         {groups.length === 0 ? <p className="subtle sidebar-empty">{offline ? t('sessions.offlineHint') : t('sessions.emptyTitle')}</p> : groups.map((group) => (
-          <section key={group.directory} className="sidebar-group">
+          // Groups only merge runs of adjacent sessions, and the list is ordered by activity, so one
+          // directory legitimately produces several groups. Keying on the directory made those
+          // collide, and React reserves the right to drop or duplicate children when it happens.
+          <section key={`${group.directory}:${group.sessions[0].id}`} className="sidebar-group">
             <div className="sidebar-group-label" title={group.directory}><FolderIcon size={12} /><span>{projectLabel(group.directory)}</span><span className="sidebar-group-count">{group.sessions.length}</span></div>
             {group.sessions.map((session) => <SessionCard key={session.id} session={session} {...sessionCardProps} />)}
           </section>

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -114,6 +114,7 @@ type TranslationKey =
   | 'detail.nothingToUndo'
   | 'detail.nothingToRedo'
   | 'detail.revertToMessage'
+  | 'detail.turnFailed'
   | 'detail.undoConfirm'
   | 'detail.revertConfirm'
   | 'detail.send'
@@ -410,6 +411,7 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'detail.nothingToUndo': 'Nothing to undo in this session.',
     'detail.nothingToRedo': 'Nothing to redo in this session.',
     'detail.revertToMessage': 'Revert to this message',
+    'detail.turnFailed': 'The reply failed:',
     'detail.undoConfirm': 'Undo the last turn and restore its file changes?',
     'detail.revertConfirm': 'Revert the conversation and file changes to this message?',
     'detail.send': 'Send',
@@ -705,6 +707,7 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'detail.nothingToUndo': 'Non c’è nulla da annullare in questa sessione.',
     'detail.nothingToRedo': 'Non c’è nulla da ripristinare in questa sessione.',
     'detail.revertToMessage': 'Ripristina fino a questo messaggio',
+    'detail.turnFailed': 'La risposta è fallita:',
     'detail.undoConfirm': 'Annullare l’ultimo turno e ripristinare le sue modifiche ai file?',
     'detail.revertConfirm': 'Ripristinare conversazione e modifiche ai file fino a questo messaggio?',
     'detail.send': 'Invia',
@@ -1000,6 +1003,7 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'detail.nothingToUndo': '此工作階段沒有可復原的內容。',
     'detail.nothingToRedo': '此工作階段沒有可重做的內容。',
     'detail.revertToMessage': '還原到這則訊息',
+    'detail.turnFailed': '回覆失敗：',
     'detail.undoConfirm': '要復原上一個回合及其檔案變更嗎？',
     'detail.revertConfirm': '要將對話和檔案變更還原到這則訊息嗎？',
     'detail.send': '傳送',
@@ -1244,6 +1248,7 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'detail.nothingToUndo': '此会话没有可撤销的内容。',
     'detail.nothingToRedo': '此会话没有可重做的内容。',
     'detail.revertToMessage': '还原到这条消息',
+    'detail.turnFailed': '回复失败：',
     'detail.undoConfirm': '要撤销上一轮及其文件更改吗？',
     'detail.revertConfirm': '要将对话和文件更改还原到这条消息吗？',
     'detail.send': '发送',

--- a/web/src/serverConfig.ts
+++ b/web/src/serverConfig.ts
@@ -22,6 +22,27 @@ export function baseUrl(config: ServerConfig): string {
   return agentID ? `${machine}/v1/agents/${encodeURIComponent(agentID)}` : machine
 }
 
+/**
+ * The daemon corrects a stale or wrongly-scoped agent id from this header, so it is what keeps a
+ * profile pointed at the harness the user chose even when the path scope cannot be trusted. It lives
+ * here rather than beside either transport because the browser and the desktop app have separate
+ * request paths, and a header only one of them sent is how the desktop app came to route every
+ * server to the daemon's primary agent.
+ *
+ * A direct OpenCode server does not know the header and may reject it during CORS preflight, so a
+ * profile with no agent id — which is what a pre-daemon OpenCode connection looks like — sends none
+ * from the browser. Nothing preflights a request made from the desktop app's main process or from a
+ * native HTTP client, and a server that does not know the header simply ignores it, so those pass
+ * `preflight: false` and keep the hint that tells a daemon which harness was asked for.
+ */
+export function routingHeaders(
+  config: Pick<ServerConfig, "backend" | "agentId">,
+  { preflight = true }: { preflight?: boolean } = {}
+): Record<string, string> {
+  if (preflight && config.backend === "opencode" && !config.agentId?.trim()) return {}
+  return { "X-Harness-Backend": config.backend }
+}
+
 /** Useful when a caller already has a path and does not build through baseUrl. */
 export function agentScopedPath(config: ServerConfig, path: string): string {
   const agentID = config.agentId?.trim()

--- a/web/src/settings-regression.test.mjs
+++ b/web/src/settings-regression.test.mjs
@@ -9,6 +9,9 @@ const i18n = readFileSync(new URL('./i18n.ts', import.meta.url), 'utf8')
 const styles = readFileSync(new URL('./styles.css', import.meta.url), 'utf8')
 const shell = readFileSync(new URL('./components/shell.tsx', import.meta.url), 'utf8')
 const panels = readFileSync(new URL('./components/panels.tsx', import.meta.url), 'utf8')
+const serverConfig = readFileSync(new URL('./serverConfig.ts', import.meta.url), 'utf8')
+const desktopRequestTransport = readFileSync(new URL('../electron/request-transport.ts', import.meta.url), 'utf8')
+const desktopEventTransport = readFileSync(new URL('../electron/event-transport.ts', import.meta.url), 'utf8')
 
 const testConnection = app.match(/async function testConnection[\s\S]*?async function refreshSessions/)
 assert.ok(testConnection, 'testConnection function should be present')
@@ -80,11 +83,17 @@ assert.match(panels, /setName\(event\.target\.value\)[\s\S]*?setNameEdited\(true
 // Agent-scoped URLs are the primary routing contract. The backend header is a compatibility guard
 // for profiles saved by older builds with no agentId, or with an agentId that points at the old primary.
 // A raw OpenCode server must not receive the custom header because its CORS policy does not know it.
-assert.ok(api.includes('function routingHeaders(config: ServerConfig)'), 'API requests should centralize the compatibility routing hint')
-assert.ok(api.includes('return { "X-Harness-Backend": config.backend }'), 'daemon requests should identify the selected harness backend')
-assert.ok(api.includes('if (config.backend === "opencode" && !config.agentId) return {}'), 'direct legacy OpenCode servers must not receive the daemon routing header')
+// The rule lives with the URL builders, not with one transport: the browser and the desktop app take
+// separate request paths, and a header only the browser sent is how the desktop app came to route
+// every server to the daemon's primary agent.
+assert.match(serverConfig, /export function routingHeaders\(\s*config: Pick<ServerConfig, "backend" \| "agentId">/, 'the routing hint should be defined once beside the URL builders')
+assert.ok(serverConfig.includes('return { "X-Harness-Backend": config.backend }'), 'daemon requests should identify the selected harness backend')
+assert.ok(serverConfig.includes('if (preflight && config.backend === "opencode" && !config.agentId?.trim()) return {}'), 'direct legacy OpenCode servers must not receive the daemon routing header from the browser')
+assert.equal(/function routingHeaders/.test(api), false, 'api.ts should reuse the shared routing hint rather than defining its own')
 assert.ok(api.includes('...routingHeaders(config)'), 'ordinary API requests should carry the selected harness routing hint')
 assert.match(api, /eventStream\(config: ServerConfig\)[\s\S]*?routingHeaders\(config\)/, 'browser SSE should preserve the selected harness routing hint too')
+assert.ok(desktopRequestTransport.includes('...routingHeaders(profile, { preflight: false })'), 'desktop requests never preflight, so they always carry the routing hint')
+assert.ok(desktopEventTransport.includes('...routingHeaders(profile, { preflight: false })'), 'desktop SSE never preflights, so it always carries the routing hint')
 
 // The server picker used to caption itself with a visually-hidden span, but no rule ever hid it: the
 // caption rendered as stray text above the header. Every class the picker and its actions rely on has

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2249,6 +2249,35 @@ a:focus-visible,
   color: var(--danger);
 }
 
+/* A failed turn stands in for the reply that never arrived, so it reads as part of the transcript
+   rather than as chrome: same bubble, same width, distinguished only by the danger palette. */
+.message-failure {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  margin: 0;
+  margin-top: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid var(--danger-border);
+  border-radius: var(--radius-sm);
+  background: var(--danger-soft);
+  color: var(--danger);
+  font-size: var(--font-sm);
+}
+
+.message-failure:first-child {
+  margin-top: 0;
+}
+
+.message-failure-label {
+  font-weight: 600;
+}
+
+.message-failure-detail {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .message-tool-command,
 .message-tool-output {
   margin: 0;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -154,6 +154,9 @@ export type MessageEnvelope = {
       created: number
       completed?: number
     }
+    /** Present when the turn ended in a provider or harness failure instead of a reply. OpenCode
+     *  nests the readable sentence under `data.message`, often as a JSON string of its own. */
+    error?: { name?: string; message?: string; data?: { message?: string } }
   }
   parts: MessagePart[]
 }

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -9,6 +9,7 @@ const styles = readFileSync(new URL('./styles.css', import.meta.url), 'utf8')
 const shell = readFileSync(new URL('./components/shell.tsx', import.meta.url), 'utf8')
 const panels = readFileSync(new URL('./components/panels.tsx', import.meta.url), 'utf8')
 const sessionList = readFileSync(new URL('./components/session-list.tsx', import.meta.url), 'utf8')
+const i18n = readFileSync(new URL('./i18n.ts', import.meta.url), 'utf8')
 const composerView = readFileSync(new URL('./components/session-composer.tsx', import.meta.url), 'utf8')
 const taskDialog = readFileSync(new URL('./components/task-launch-dialog.tsx', import.meta.url), 'utf8')
 const taskDeskTestPage = readFileSync(new URL('./TaskDeskTestPage.tsx', import.meta.url), 'utf8')
@@ -620,6 +621,22 @@ assert.match(styles, /\.task-launch-context,[\s\S]*?\.task-launch-worktree\s*\{[
 assert.match(styles, /@media \(max-width: 780px\)[\s\S]*?\.task-launch-form\s*\{[^}]*grid-template-columns:\s*1fr/, 'TaskDesk launch must collapse to one mobile form column')
 assert.match(styles, /\.task-launch-check input\[type="checkbox"\]\s*\{[^}]*width:\s*1\.125rem;[^}]*max-width:\s*1\.125rem;[^}]*min-height:\s*1\.125rem/, 'TaskDesk worktree checkbox must never inherit full-width text-input sizing')
 assert.match(styles, /\.task-launch-close\s*\{[^}]*margin-left:\s*auto/, 'TaskDesk close control must stay anchored to the header’s right edge')
+
+// A turn that ends in a provider failure has no text and no parts but the bookkeeping step markers.
+// Filtering those out left the prompt on screen with nothing after it — indistinguishable from a
+// reply that went missing, and on a session where every turn failed, from the app showing only what
+// the user typed. The reason has to survive the content filter and reach a bubble.
+assert.match(app, /function messageFailure\(message: MessageEnvelope\): string \| undefined/, 'a failed turn should have one place that reads its reason')
+assert.match(app, /messageFailure\(message\) \|\| message\.parts\.some\(\(part\) => !isTurnScaffolding\(part\)\)/, 'the content filter must keep a message whose only content is its failure')
+assert.ok(app.includes('<MessageFailureView messages={[message]} t={t} />'), 'a standalone bubble should render its own failure')
+assert.ok(app.includes('<MessageFailureView messages={[...messagesByID.values()]} t={t} />'), 'a merged run should render the failures of every message in it')
+assert.match(app, /function collapseRepeatedFailures/, 'retried failures should collapse instead of repeating one reason per attempt')
+assert.match(styles, /\.message-failure\s*\{[^}]*background:\s*var\(--danger-soft\)/, 'a failed turn should read as a failure rather than as ordinary reply text')
+assert.ok(i18n.includes("'detail.turnFailed'"), 'the failed-turn label should be translated')
+
+// Groups merge only runs of adjacent same-directory sessions, so one directory can produce several
+// groups and keying them by directory alone lets React drop or duplicate them.
+assert.match(sessionList, /key=\{`\$\{group\.directory\}:\$\{group\.sessions\[0\]\.id\}`\}/, 'sidebar groups need a key unique per group, not per directory')
 
 console.log('ui regression tests passed')
 


### PR DESCRIPTION
Three separate causes were producing the same symptom — a session that looked emptier than it was — plus a routing regression that made every Desktop server show one agent's sessions. All four were reproduced against a live machine daemon before being fixed, and verified there afterwards.

## Task session history after a daemon restart

Opening a task session showed the one prompt recorded when the task was launched, and nothing else, until a new message streamed in and filled the rest.

`reconcileAll()` adopts every task session at startup so a thread another client holds open can be prompted without `session/load`, and `adoptTaskSession` also marked it `#loaded`. That flag means "the transcript in memory is complete", so `messages()` served the snapshot and the harness's own rollout was never read. Adoption now lives in its own set: it grants the right to prompt, and `#journalBacked()` keeps history coming from the harness until this bridge runs a turn of its own.

Reported against Codex. PI was unaffected only because its loader is marked authoritative and bypasses that path — which is why this read as a PI bug that had already been fixed. Claude Code, which keeps no journal, now replays an adopted session over ACP; adoption previously prevented that outright, leaving no path back to the transcript at all.

This also serializes overlapping loads of one session. A transcript-only load and a config-options load both blank `#messages` before replaying and merge the replay into what they captured first, so whichever finished last won. The client asks for both on every open, so the two raced routinely.

## Desktop agent routing

Every saved server in the packaged Windows app listed the same sessions: the daemon's primary agent, which on a machine with Codex installed is Codex.

`validateDesktopProfile` built its profile object without `agentId`, so main held a machine-root target for every profile and the daemon routes an unscoped request to its primary. The commit that introduced agent routing added the field to the IPC contract and the transport but never to the registry, and the transport test injected an agent id directly — so the gap was invisible to CI. The profile store written by the installed app on my machine had `agentId` undefined on all five profiles.

`routingHeaders` also moves next to the URL builders and is now shared by the browser, Desktop and Android request paths. A header only the browser sent is precisely how the two clients came to disagree. Withholding it from an unscoped OpenCode profile exists to survive a CORS preflight, which only a browser performs, so the native paths pass `preflight: false` and keep the hint — which is what lets a legacy OpenCode profile pointed at a daemon reach OpenCode rather than the primary agent.

Restoring the scope meant exempting the routes the daemon answers itself (`/v1/machine`, `/v1/projects`, `/v1/tasks/…`, and any already-scoped `/v1/agents/…`), since prefixing those with the profile's agent aims them at a bridge where they do not exist. Without that exemption, fixing the routing would have broken TaskDesk on the Desktop.

Existing profiles repair themselves on next launch; no reconfiguration needed.

## Failed turns

An OpenCode session that looked like it was hiding its replies was showing them faithfully — both turns had failed, one on a context-length limit and one because the model was unloaded. There was nowhere to put that: a live ACP failure was announced once and lost on reopen, the OMP and PI loaders dropped a journalled failure for having no content, and `info.error` was not in the client's message type at all. 43 such turns were hidden across the journals on this machine.

A prompt followed by nothing reads as a reply that went missing. Same symptom as a transcript that failed to load, entirely different cause — which is what made two reports look like one bug.

The reason is now carried on the message, persisted in the snapshot, and rendered in the bubble. Consecutive identical failures collapse, since a harness that retries a failing turn records one failed message per attempt.

## Also fixed

A duplicate React key in the session sidebar: groups merge only runs of adjacent same-directory sessions and the list is ordered by activity, so one directory legitimately produces several groups.

## Validation

- bridge suite, 241 tests; web type-check and production build; all web regression suites
- new bridge tests confirmed to fail without the fix (3 of 5)
- against a live daemon with Codex CLI, Claude Code, Oh My Pi, PI and OpenCode: the five profiles return 25/8/23/37/19 distinct sessions from both Web and Desktop, where every one previously returned Codex's 25
- session `01a0100d` went from 1 message to 4, and to 6 after a live turn, with no duplication after a further daemon restart
- launching the Desktop app rewrote the stored profiles with their agent ids restored, leaving the two genuinely direct OpenCode servers unscoped

Prepared as 2.11.1 with release notes in `docs/RELEASE_2.11.1.md`.
