### PR TITLE
Behavioural regression coverage for #240 and #233

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -66,6 +66,8 @@ jobs:
           npm run test:machine-payload
           npm run test:platform
           npm run test:completion-audio
+          npm run test:completion-timing
+          npm run test:native-response
         working-directory: web
 
       - name: Run bridge tests

--- a/web/package.json
+++ b/web/package.json
@@ -40,6 +40,8 @@
     "test:machine-payload": "node --experimental-strip-types src/machine-payload.test.mjs",
     "test:platform": "node src/platform-regression.test.mjs",
     "test:completion-audio": "node src/completion-audio-regression.test.mjs",
+    "test:completion-timing": "node --experimental-strip-types src/completion-audio-timing.test.mjs",
+    "test:native-response": "node --experimental-strip-types src/native-response.test.mjs",
     "test:desktop": "npm run build:electron && node --test electron/*.test.mjs",
     "test:desktop:menu": "npm run build:electron && electron scripts/menu-smoke.mjs"
   },

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,5 +1,6 @@
 import { Capacitor, CapacitorHttp } from "@capacitor/core"
 import { desktopRequest, isDesktopPlatform } from "./desktopBridge"
+import { normalizeNativeResponseData } from "./nativeResponse"
 import { streamURL } from "./opencode-events"
 import { authHeader, baseUrl, hasCredentials, isValidServerConfig, routingHeaders } from "./serverConfig"
 import type { AttachmentPart } from "./attachments"
@@ -81,23 +82,6 @@ function normalizeHeaders(headers: Record<string, unknown> | undefined): Record<
   return Object.fromEntries(
     Object.entries(headers).map(([key, value]) => [key.toLowerCase(), Array.isArray(value) ? value.join(", ") : String(value)])
   )
-}
-
-/**
- * CapacitorHttp normally decodes JSON, but native engines can still hand a JSON response back as a
- * string depending on the server headers and platform. The browser path always calls response.json(),
- * so returning the string unchanged makes Android the only client that can turn a session array into
- * an iterable string. Parse JSON-looking native strings here while preserving ordinary text bodies.
- */
-function normalizeNativeResponseData(data: unknown): unknown {
-  if (typeof data !== "string") return data
-  const trimmed = data.trim()
-  if (!trimmed || (trimmed[0] !== "{" && trimmed[0] !== "[")) return data
-  try {
-    return JSON.parse(trimmed)
-  } catch {
-    return data
-  }
 }
 
 type ConfigProvidersResponse = {

--- a/web/src/completion-audio-regression.test.mjs
+++ b/web/src/completion-audio-regression.test.mjs
@@ -11,7 +11,7 @@ assert.match(source, /\/abort/, "abort must cancel an armed completion")
 assert.match(source, /\/session\/status/, "session status is the authoritative completion source")
 assert.match(source, /WORKING_STATES = new Set\(\["busy", "retry", "waiting"\]\)/)
 assert.match(source, /if \(!entry\.sawWorking && !entry\.sawAssistantActivity\) continue/, "idle before work starts must not play")
-assert.match(source, /noteSuppressedAssistantAudioRequest\(\)/, "the old first-fragment sound request must be suppressed")
+assert.match(source, /noteAssistantActivity\(\)/, "the old first-fragment sound request must be suppressed")
 assert.match(source, /primePlayback\(\)/, "playback must be primed at user submission time for native WebView")
 assert.match(source, /CapacitorHttp\.request = async/, "native HTTP status polling must drive the same completion tracker")
 

--- a/web/src/completion-audio-timing.test.mjs
+++ b/web/src/completion-audio-timing.test.mjs
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import {
+  armCompletionAudio,
+  cancelCompletionAudio,
+  noteAssistantActivity,
+  observeCompletionStatuses,
+  resetCompletionAudioForTests
+} from './completion-audio.ts'
+
+// Issue #233: the sound used to be tied to the first assistant fragment, so it played when the reply
+// started rather than when the harness finished. These check the timing rules themselves rather than
+// the shape of the source, so renaming a helper cannot make them pass vacuously.
+//
+// observeCompletionStatuses returns the sessions it completed; an empty result is "no sound".
+
+const idle = (id) => ({ [id]: { type: 'idle' } })
+const busy = (id) => ({ [id]: { type: 'busy' } })
+
+function scenario(name, run) {
+  resetCompletionAudioForTests()
+  run()
+  console.log(`  ok ${name}`)
+}
+
+scenario('a submitted prompt makes no sound on its own', () => {
+  armCompletionAudio('ses_1')
+  // The status poll that lands before the harness has picked the turn up still reads idle. Playing
+  // here is the "sound at send time" the issue reported.
+  assert.deepEqual(observeCompletionStatuses(idle('ses_1')), [])
+})
+
+scenario('the first assistant fragment does not play the sound', () => {
+  armCompletionAudio('ses_1')
+  // A working status is never terminal on its own, however many times it is observed.
+  assert.deepEqual(observeCompletionStatuses(busy('ses_1')), [])
+  noteAssistantActivity()
+  // Output has started and the session is still working: this is exactly the moment the old
+  // implementation played.
+  assert.deepEqual(observeCompletionStatuses(busy('ses_1')), [])
+  assert.deepEqual(observeCompletionStatuses(busy('ses_1')), [])
+})
+
+scenario('the sound plays when the session goes from working to idle', () => {
+  armCompletionAudio('ses_1')
+  observeCompletionStatuses(busy('ses_1'))
+  noteAssistantActivity()
+  assert.deepEqual(observeCompletionStatuses(idle('ses_1')), ['ses_1'])
+})
+
+scenario('the sound plays exactly once, however often the status is polled', () => {
+  armCompletionAudio('ses_1')
+  observeCompletionStatuses(busy('ses_1'))
+  assert.deepEqual(observeCompletionStatuses(idle('ses_1')), ['ses_1'])
+  assert.deepEqual(observeCompletionStatuses(idle('ses_1')), [])
+  assert.deepEqual(observeCompletionStatuses(idle('ses_1')), [])
+})
+
+scenario('retry and waiting count as working, so a retried turn plays once at the end', () => {
+  armCompletionAudio('ses_1')
+  assert.deepEqual(observeCompletionStatuses({ ses_1: { type: 'waiting' } }), [])
+  assert.deepEqual(observeCompletionStatuses({ ses_1: { type: 'retry' } }), [])
+  assert.deepEqual(observeCompletionStatuses({ ses_1: { type: 'busy' } }), [])
+  assert.deepEqual(observeCompletionStatuses(idle('ses_1')), ['ses_1'])
+})
+
+scenario('aborting a turn cancels the sound', () => {
+  armCompletionAudio('ses_1')
+  observeCompletionStatuses(busy('ses_1'))
+  noteAssistantActivity()
+  cancelCompletionAudio('ses_1')
+  assert.deepEqual(observeCompletionStatuses(idle('ses_1')), [])
+})
+
+scenario('a submission that failed cancels the sound', () => {
+  // What the transport does when the prompt request errors or answers >= 400.
+  armCompletionAudio('ses_1')
+  cancelCompletionAudio('ses_1')
+  assert.deepEqual(observeCompletionStatuses(idle('ses_1')), [])
+})
+
+scenario('a status poll that omits the armed session decides nothing', () => {
+  armCompletionAudio('ses_1')
+  observeCompletionStatuses(busy('ses_1'))
+  assert.deepEqual(observeCompletionStatuses({ ses_other: { type: 'idle' } }), [])
+  assert.deepEqual(observeCompletionStatuses(idle('ses_1')), ['ses_1'])
+})
+
+scenario('a harness that never reports working still completes once output was seen', () => {
+  armCompletionAudio('ses_1')
+  noteAssistantActivity()
+  assert.deepEqual(observeCompletionStatuses(idle('ses_1')), ['ses_1'])
+})
+
+scenario('two sessions complete independently', () => {
+  armCompletionAudio('ses_1')
+  armCompletionAudio('ses_2')
+  observeCompletionStatuses({ ses_1: { type: 'busy' }, ses_2: { type: 'busy' } })
+  assert.deepEqual(observeCompletionStatuses({ ses_1: { type: 'idle' }, ses_2: { type: 'busy' } }), ['ses_1'])
+  assert.deepEqual(observeCompletionStatuses({ ses_1: { type: 'idle' }, ses_2: { type: 'idle' } }), ['ses_2'])
+})
+
+scenario('assistant activity is attributed to the session most likely producing it', () => {
+  armCompletionAudio('ses_old')
+  armCompletionAudio('ses_new')
+  // Only ses_old is working, so a fragment belongs to it rather than to the more recently armed one.
+  observeCompletionStatuses({ ses_old: { type: 'busy' } })
+  noteAssistantActivity()
+  assert.deepEqual(observeCompletionStatuses({ ses_old: { type: 'idle' } }), ['ses_old'])
+  // ses_new never worked and never produced output, so its idle status still plays nothing.
+  assert.deepEqual(observeCompletionStatuses({ ses_new: { type: 'idle' } }), [])
+})
+
+resetCompletionAudioForTests()
+
+// The rules above only matter if the transports are still wired to them, and that wiring needs a
+// Vite environment to install, so it stays asserted at the source level.
+const source = readFileSync(new URL('./completion-audio.ts', import.meta.url), 'utf8')
+assert.match(source, /if \(armedSessionID && !response\.ok\) cancelCompletionAudio\(armedSessionID\)/, 'a rejected prompt must cancel the armed sound in the browser transport')
+assert.match(source, /if \(armedSessionID && response\.status >= 400\) cancelCompletionAudio\(armedSessionID\)/, 'a rejected prompt must cancel the armed sound in the native transport')
+assert.match(source, /catch \(error\) \{\s*if \(armedSessionID\) cancelCompletionAudio\(armedSessionID\)/, 'a prompt that never reached the server must cancel the armed sound')
+assert.match(source, /noteAssistantActivity\(\)\s*\n\s*return Promise\.resolve\(\)/, 'the premature playback request must be recorded as activity and swallowed')
+
+console.log('completion audio timing tests passed')

--- a/web/src/completion-audio.ts
+++ b/web/src/completion-audio.ts
@@ -88,7 +88,13 @@ export function cancelCompletionAudio(sessionID: string): void {
   armed.delete(sessionID)
 }
 
-export function observeCompletionStatuses(statuses: Record<string, SessionStatus>): void {
+/**
+ * Returns the sessions this observation completed, in the order they played. The transport callers
+ * ignore it; it is what makes the timing rules — armed but idle plays nothing, working then idle
+ * plays once, an aborted or failed turn plays never — checkable without a DOM to hear through.
+ */
+export function observeCompletionStatuses(statuses: Record<string, SessionStatus>): string[] {
+  const completed: string[] = []
   for (const [sessionID, entry] of armed) {
     const sessionStatus = statuses[sessionID]
     if (!sessionStatus) continue
@@ -98,11 +104,18 @@ export function observeCompletionStatuses(statuses: Record<string, SessionStatus
     }
     if (!entry.sawWorking && !entry.sawAssistantActivity) continue
     armed.delete(sessionID)
+    completed.push(sessionID)
     playCompletion()
   }
+  return completed
 }
 
-function noteSuppressedAssistantAudioRequest(): void {
+/**
+ * The first assistant fragment. It is evidence that the turn produced output — which is what lets a
+ * harness that never reports a working status still complete — and explicitly not a reason to play:
+ * the sound waits for the status to come back idle.
+ */
+export function noteAssistantActivity(): void {
   const entry = mostLikelyActiveCompletion()
   if (entry) entry.sawAssistantActivity = true
 }
@@ -190,7 +203,7 @@ export function installCompletionAudioGuard(): void {
     // App.tsx currently requests its completion sound as soon as the first assistant fragment
     // arrives. Suppress that premature playback and use it only as evidence that assistant output
     // has started; the authoritative playback happens after session/status returns to idle.
-    noteSuppressedAssistantAudioRequest()
+    noteAssistantActivity()
     return Promise.resolve()
   }
 

--- a/web/src/native-response.test.mjs
+++ b/web/src/native-response.test.mjs
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { normalizeNativeResponseData } from './nativeResponse.ts'
+
+// Issue #240: an OpenCode server on Linux passed the Android connection test and then listed no
+// sessions, because CapacitorHttp had handed the session array back as a string and the client
+// treated that string as the typed array. The five shapes below are the ones a native engine can
+// produce for the same endpoint, and each has to survive the transport as the caller expects it.
+
+// An already-parsed object comes back identical, by reference — re-encoding it would be a needless
+// copy on every native response.
+const object = { machine: { id: 'machine_1' }, agents: [] }
+assert.equal(normalizeNativeResponseData(object), object)
+
+// An already-parsed array likewise: this is the shape the browser path produces for /session.
+const array = [{ id: 'ses_1' }, { id: 'ses_2' }]
+assert.equal(normalizeNativeResponseData(array), array)
+
+// A stringified object is decoded, so machine discovery reads fields rather than characters.
+assert.deepEqual(
+  normalizeNativeResponseData('{"machine":{"id":"machine_1"},"agents":[]}'),
+  { machine: { id: 'machine_1' }, agents: [] }
+)
+
+// A stringified array is decoded into a real array. This is the failure in #240: left as a string,
+// `.map`/`.filter` are absent and iterating yields single characters, so the session list came out
+// empty rather than erroring in a way anyone could see.
+const sessions = normalizeNativeResponseData('[{"id":"ses_1"},{"id":"ses_2"}]')
+assert.ok(Array.isArray(sessions), 'a stringified session array must arrive as an array')
+assert.deepEqual(sessions.map((session) => session.id), ['ses_1', 'ses_2'])
+
+// A non-JSON string is a plain-text body — usually a server error — and must reach the caller
+// verbatim, because the message is the only thing it carries.
+assert.equal(normalizeNativeResponseData('Unauthorized'), 'Unauthorized')
+assert.equal(normalizeNativeResponseData('OpenCode is not running on this host'), 'OpenCode is not running on this host')
+
+// Leading whitespace is not a reason to refuse to decode, and it must not be trimmed out of a body
+// that is not JSON at all.
+assert.deepEqual(normalizeNativeResponseData('  \n{"ok":true}\n '), { ok: true })
+assert.equal(normalizeNativeResponseData('  not json  '), '  not json  ')
+
+// A truncated or malformed payload is returned untouched rather than throwing: a transport that
+// threw here would surface as an unreachable server instead of a bad response.
+assert.equal(normalizeNativeResponseData('{"id":'), '{"id":')
+assert.equal(normalizeNativeResponseData('[{"id":"ses_1"}'), '[{"id":"ses_1"}')
+
+// Empty and non-string bodies pass through, including the `true` the transport substitutes for 204.
+assert.equal(normalizeNativeResponseData(''), '')
+assert.equal(normalizeNativeResponseData('   '), '   ')
+assert.equal(normalizeNativeResponseData(true), true)
+assert.equal(normalizeNativeResponseData(0), 0)
+assert.equal(normalizeNativeResponseData(null), null)
+assert.equal(normalizeNativeResponseData(undefined), undefined)
+
+// A bare JSON scalar is not decoded: only object and array bodies are ambiguous between "already
+// parsed" and "handed back as text", and treating `"12"` as a number would change a text body.
+assert.equal(normalizeNativeResponseData('12'), '12')
+assert.equal(normalizeNativeResponseData('"quoted"'), '"quoted"')
+
+// The normalizer must stay on the native branch and stay out of the browser and desktop paths, which
+// decode their own bodies — applying it twice is harmless but applying it there hides a real
+// difference between the transports.
+const api = readFileSync(new URL('./api.ts', import.meta.url), 'utf8')
+assert.match(
+  api,
+  /if \(Capacitor\.isNativePlatform\(\)\) \{[\s\S]*?normalizeNativeResponseData\(response\.data\) as T/,
+  'the native branch must normalize its response body'
+)
+assert.equal(
+  (api.match(/normalizeNativeResponseData\(/g) ?? []).length,
+  1,
+  'only the native branch should normalize; the browser and desktop paths decode their own bodies'
+)
+
+console.log('native response normalization tests passed')

--- a/web/src/nativeResponse.ts
+++ b/web/src/nativeResponse.ts
@@ -1,0 +1,21 @@
+/**
+ * CapacitorHttp normally decodes JSON, but native engines can still hand a JSON response back as a
+ * string depending on the server headers and platform. The browser path always calls
+ * `response.json()`, so returning the string unchanged makes Android the only client that can turn a
+ * session array into an iterable string — which is how a working OpenCode server passed the
+ * connection test and then listed no sessions at all.
+ *
+ * Kept free of Capacitor imports so the rule can be exercised directly: what has to hold is that a
+ * JSON-looking string is decoded and everything else — an already-parsed body, a plain-text error,
+ * a malformed payload — comes back untouched.
+ */
+export function normalizeNativeResponseData(data: unknown): unknown {
+  if (typeof data !== "string") return data
+  const trimmed = data.trim()
+  if (!trimmed || (trimmed[0] !== "{" && trimmed[0] !== "[")) return data
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return data
+  }
+}

--- a/web/src/platform-regression.test.mjs
+++ b/web/src/platform-regression.test.mjs
@@ -15,8 +15,10 @@ assert.match(api, /if \(isDesktopPlatform\(\)\)/, 'Electron must select desktop 
 assert.match(api, /desktopRequest\(config,/, 'Desktop request must resolve profile only after synchronization finishes')
 assert.doesNotMatch(api, /desktopProfileID\(config\)/, 'API must not resolve an unacknowledged desktop profile before waiting for synchronization')
 assert.match(desktopBridge, /profileId: string/, 'Desktop stream adapter must accept profile ID, not URL')
-assert.match(api, /function normalizeNativeResponseData\(data: unknown\): unknown/, 'Native transport must normalize stringified JSON payloads')
-assert.match(api, /return JSON\.parse\(trimmed\)/, 'Native JSON normalizer must parse JSON-looking strings')
+// What this suite is about is transport selection, so it checks that the native branch is the one
+// wired to the normalizer. The rule the normalizer implements is exercised for real in
+// native-response.test.mjs rather than asserted against the text of its own source.
+assert.match(api, /from "\.\/nativeResponse"/, 'Native normalization must come from the module that is unit tested')
 assert.match(api, /normalizeNativeResponseData\(response\.data\) as T/, 'Capacitor responses must use native JSON normalization before reaching API callers')
 assert.match(machineClient, /if \(typeof parsed === "string"\)/, 'native machine discovery must accept a JSON string payload')
 assert.match(machineClient, /parsed = JSON\.parse\(parsed\)/, 'stringified machine discovery payloads must be decoded')


### PR DESCRIPTION
Both issues were already fixed — #240 by `8d01021` and #233 by `d06fbc6` + `32fcdc7`, all on 2026-08-18 within an hour of being filed, and all ancestors of `main` and `v3/taskdesk`. What was missing is the coverage each issue asked for. What existed asserted that the source files *contain* certain strings: rename a function and the tests break, get its logic wrong and they pass.

Closes #240
Closes #233

## #240 — five native response shapes

`normalizeNativeResponseData` moves into its own Capacitor-free module so a test can import it, following the same pattern as `serverConfig.ts` and `machinePayload.ts`. The test drives the five shapes the issue named and asserts the consequence rather than the shape — a stringified session array has to arrive as something `.map` works on, which is exactly the failure #240 described. Also covered: leading whitespace, a truncated payload returned untouched instead of throwing, the `true` the transport substitutes for 204, and a bare JSON scalar left alone, since only object and array bodies are ambiguous between "already parsed" and "handed back as text".

`platform-regression.test.mjs` keeps one assertion — that the native branch is the one wired to the module — which is what that suite is about.

## #233 — first token versus real completion

Two seams, both meaningful outside the tests:

- `observeCompletionStatuses` returns the sessions it completed. That is the decision the module makes, and it is what lets the timing be checked without a DOM to hear the sound through. The transport callers ignore it.
- the first-fragment event becomes `noteAssistantActivity`, named for what it means rather than for what it suppresses.

The test walks the sequences the issue described: armed but still idle plays nothing, a working status is never terminal however often it is polled, working → idle plays exactly once, further polls play nothing, abort and a failed submission play never, and a harness that never reports a working status still completes once output was seen. Plus two concurrent sessions completing independently, and a fragment attributed to the session most likely to have produced it.

**Verified against mutation.** Removing the armed-but-never-worked guard, and treating a working status as terminal, each fail at the assertion written for them — the first version of the first-token test passed under the second mutation for the wrong reason, so it was tightened until it did not.

The transports install through Vite-only globals, so their cancel-on-failure paths stay asserted at the source level — in the same file, marked as such rather than left to look like behavioural coverage.

## CI

The PR check job names each web suite explicitly, so both new files are registered in `web/package.json` and added to the regression step. A regression test nothing executes is not coverage.

## One thing still unverified

2.11.1 changed the Android request path: it now sends `X-Harness-Backend` even for an unscoped OpenCode profile, because nothing preflights a native request. That is harmless toward a direct OpenCode server, which ignores the header, and it is what lets a legacy profile pointed at a daemon reach OpenCode rather than the primary agent — but it sits on the code path #240 is about and I have only exercised it on desktop and in the browser. The debug APK builds in CI; building is not the same as running it against a real OpenCode host.

## Validation

- full web regression suite, including both new files; web type-check and production build
- bridge suite unaffected, 241 tests
