### PR TITLE
feat(taskdesk): complete task-first v3 workspace

### DIFF
--- a/bridge/src/task-launch-server.js
+++ b/bridge/src/task-launch-server.js
@@ -2,6 +2,7 @@ import http from "node:http"
 import { authenticateDaemonRequest, writeJSON } from "./http-policy.js"
 
 const TASK_LAUNCH_ROUTE = /^\/v1\/tasks\/([^/]+)\/launch$/
+const TASK_CONTINUE_ROUTE = /^\/v1\/tasks\/([^/]+)\/continue$/
 const TASK_WORKTREE_ROUTE = /^\/v1\/tasks\/([^/]+)\/worktree$/
 const TASK_WORKTREE_CLEANUP_ROUTE = /^\/v1\/tasks\/([^/]+)\/worktree\/cleanup$/
 const LAUNCH_STATUS = new Map([
@@ -18,6 +19,15 @@ const LAUNCH_STATUS = new Map([
   ["worktree_missing", 409]
 ])
 
+async function readJSONBody(request) {
+  let body = ""
+  for await (const chunk of request) {
+    body += chunk
+    if (body.length > 1_000_000) throw new Error("Request body is too large")
+  }
+  return body ? JSON.parse(body) : {}
+}
+
 export function launchStatus(error) {
   return LAUNCH_STATUS.get(error?.code) ?? 500
 }
@@ -26,24 +36,31 @@ export function createTaskLaunchServer({ innerServer, config, taskRunController,
   return createServer(async (request, response) => {
     const requestURL = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`)
     const launchMatch = TASK_LAUNCH_ROUTE.exec(requestURL.pathname)
+    const continueMatch = TASK_CONTINUE_ROUTE.exec(requestURL.pathname)
     const worktreeMatch = TASK_WORKTREE_ROUTE.exec(requestURL.pathname)
     const cleanupMatch = TASK_WORKTREE_CLEANUP_ROUTE.exec(requestURL.pathname)
     const inspect = worktreeMatch && request.method === "GET"
     const cleanup = cleanupMatch && request.method === "POST"
-    if (!launchMatch && !inspect && !cleanup) {
+    if (!launchMatch && !continueMatch && !inspect && !cleanup) {
       innerServer.emit("request", request, response)
       return
     }
 
     if (!authenticateDaemonRequest(request, response, config)) return
     try {
-      if (launchMatch) {
+      if (launchMatch || continueMatch) {
         if (request.method !== "POST") {
           response.writeHead(405, { Allow: "POST, OPTIONS" })
           response.end()
           return
         }
-        writeJSON(response, 200, await taskRunController.launch(decodeURIComponent(launchMatch[1])))
+        const taskID = decodeURIComponent((launchMatch ?? continueMatch)[1])
+        if (continueMatch) {
+          const body = await readJSONBody(request)
+          writeJSON(response, 200, await taskRunController.continue(taskID, body.prompt))
+        } else {
+          writeJSON(response, 200, await taskRunController.launch(taskID))
+        }
         return
       }
       if (inspect) {

--- a/bridge/src/task-run-controller.js
+++ b/bridge/src/task-run-controller.js
@@ -31,7 +31,7 @@ export class TaskRunController {
     const service = this.acpService?.(task.agentId)
     if (!service) return
     const title = task.prompt?.trim().split("\n")[0].slice(0, 60)
-    try { await service.adoptTaskSession(task.run.sessionId, { title, prompt: task.prompt }) } catch {}
+    try { await service.adoptTaskSession(task.run.sessionId, { title, prompt: task.run?.prompt || task.prompt }) } catch {}
   }
 
   async reconcileAll() {
@@ -70,31 +70,54 @@ export class TaskRunController {
     return { task: updated, cleanup }
   }
 
-  async launch(taskID) {
+  async launch(taskID, options = {}) {
     await this.#awaitReconciliation()
     const task = await this.taskStore.get(taskID)
     if (!task) throw taskLaunchError("unknown_task", `Unknown task: ${taskID}`)
-    if (task.status !== "draft") throw taskLaunchError("invalid_state", "Only draft tasks can be launched")
-    if (task.project?.kind === "git" && task.workspace?.mode !== "worktree") throw taskLaunchError("workspace_required", "Git tasks must prepare an isolated worktree before launch")
+    if (!["draft", "completed", "failed", "cancelled"].includes(task.status)) {
+      throw taskLaunchError("invalid_state", "Only draft or terminal tasks can start a run")
+    }
     if (!task.workspace?.path) throw taskLaunchError("workspace_required", "Task workspace is not prepared")
 
-    const run = { id: this.runIDFactory(), agentId: task.agentId, sessionId: null, transport: null, directory: task.workspace.path, startedAt: this.clock() }
+    const requestedPrompt = typeof options.prompt === "string" ? options.prompt.trim() : ""
+    const runPrompt = requestedPrompt || task.prompt
+    if (!runPrompt) throw taskLaunchError("invalid_state", "A run prompt is required")
+
+    const run = {
+      id: this.runIDFactory(),
+      agentId: task.agentId,
+      sessionId: null,
+      transport: null,
+      directory: task.workspace.path,
+      prompt: runPrompt,
+      startedAt: this.clock()
+    }
     let current = await this.taskStore.setRunState(taskID, { status: "starting", run })
+    const currentForRun = () => ({ ...current, prompt: runPrompt })
     try {
-      const session = await this.taskLauncher.createSession(current)
+      const session = await this.taskLauncher.createSession(currentForRun())
       const linkedRun = { ...run, sessionId: session.sessionId, transport: session.transport }
       current = await this.taskStore.setRunState(taskID, { status: "starting", run: linkedRun, expectedRunId: run.id })
-      // A transport may complete or fail synchronously as startPrompt attaches its callbacks.
-      // Persist running first, so those callbacks can make a legal running -> terminal transition.
       current = await this.taskStore.setRunState(taskID, { status: "running", run: linkedRun, expectedRunId: linkedRun.id })
       const onFailed = (error) => void this.#terminal(taskID, linkedRun, "failed", error)
       onFailed.onFailed = onFailed
       onFailed.onCompleted = () => void this.#terminal(taskID, linkedRun, "completed")
-      await this.taskLauncher.startPrompt(current, session, onFailed)
+      await this.taskLauncher.startPrompt(currentForRun(), session, onFailed)
       return current
     } catch (error) {
       await this.#terminal(taskID, current.run ?? run, "failed", error)
       throw error
     }
+  }
+
+  async continue(taskID, prompt) {
+    const text = typeof prompt === "string" ? prompt.trim() : ""
+    if (!text) throw taskLaunchError("invalid_state", "A continuation prompt is required")
+    const task = await this.taskStore.get(taskID)
+    if (!task) throw taskLaunchError("unknown_task", `Unknown task: ${taskID}`)
+    if (!["completed", "failed", "cancelled"].includes(task.status)) {
+      throw taskLaunchError("invalid_state", "Only a terminal task can start another run")
+    }
+    return this.launch(taskID, { prompt: text })
   }
 }

--- a/bridge/src/task-run-store.js
+++ b/bridge/src/task-run-store.js
@@ -1,5 +1,14 @@
 import { TaskStore } from "./task-store.js"
 
+function updateRunHistory(task, run) {
+  const runs = Array.isArray(task.runs) ? task.runs.map((entry) => structuredClone(entry)) : []
+  if (!run?.id) return runs
+  const index = runs.findIndex((entry) => entry?.id === run.id)
+  if (index >= 0) runs[index] = structuredClone(run)
+  else runs.push(structuredClone(run))
+  return runs
+}
+
 export class TaskRunStore extends TaskStore {
   async setRunState(taskID, { status, run, error = null, expectedRunId }) {
     await this.load()
@@ -8,8 +17,8 @@ export class TaskRunStore extends TaskStore {
     const task = this.tasks[index]
 
     if (expectedRunId !== undefined && task.run?.id !== expectedRunId) return structuredClone(task)
-    if (status === "starting" && task.status !== "draft" && task.status !== "starting") {
-      throw new Error("Only draft tasks can start a run")
+    if (status === "starting" && !["draft", "starting", "completed", "failed", "cancelled"].includes(task.status)) {
+      throw new Error("Task cannot start a new run from its current state")
     }
     if (status === "running" && task.status !== "starting") throw new Error("Task is not starting")
     if (status === "running" && !run?.sessionId) throw new Error("Running task requires a session id")
@@ -22,10 +31,12 @@ export class TaskRunStore extends TaskStore {
     if ((status === "completed" || status === "failed") && nextRun && !nextRun.finishedAt) {
       nextRun.finishedAt = this.clock()
     }
+    const runs = updateRunHistory(task, nextRun)
     const updated = {
       ...task,
       status,
       run: nextRun,
+      runs,
       error: error ? { message: error instanceof Error ? error.message : String(error) } : null,
       updatedAt: this.clock()
     }

--- a/bridge/src/task-store.js
+++ b/bridge/src/task-store.js
@@ -13,6 +13,16 @@ function taskError(code, message) {
   return error
 }
 
+function normalizeTaskHistory(task) {
+  if (!task || typeof task !== "object") return task
+  const runs = Array.isArray(task.runs)
+    ? task.runs
+    : task.run
+      ? [task.run]
+      : []
+  return { ...task, runs }
+}
+
 export class TaskStore {
   constructor({ machineID, stateDirectory, idFactory = randomUUID, clock = () => new Date().toISOString(), warn = (message) => process.stderr.write(`${message}\n`) }) {
     this.machineID = machineID
@@ -29,7 +39,8 @@ export class TaskStore {
     if (this.loaded) return
     try {
       const parsed = JSON.parse(await readFile(this.file, "utf8"))
-      this.tasks = Array.isArray(parsed?.tasks) ? parsed.tasks : []
+      const tasks = Array.isArray(parsed?.tasks) ? parsed.tasks : []
+      this.tasks = tasks.map(normalizeTaskHistory)
     } catch (error) {
       if (error?.code === "ENOENT") {
         this.tasks = []
@@ -80,6 +91,8 @@ export class TaskStore {
       status: "draft",
       workspace: { mode: "project", path: project.path },
       run: null,
+      runs: [],
+      error: null,
       createdAt: timestamp,
       updatedAt: timestamp
     }

--- a/bridge/test/task-launch-server.test.js
+++ b/bridge/test/task-launch-server.test.js
@@ -32,6 +32,34 @@ test("POST launch returns the persisted running task", async () => {
   }
 })
 
+test("POST continue forwards the new run prompt", async () => {
+  const innerServer = new EventEmitter()
+  const calls = []
+  const server = createTaskLaunchServer({
+    innerServer,
+    config: { username: "", password: "", corsOrigins: [] },
+    taskRunController: {
+      async continue(id, prompt) {
+        calls.push([id, prompt])
+        return { id, status: "running", run: { id: "run-2", sessionId: "session-2", prompt } }
+      }
+    }
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/tasks/task-1/continue`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: "Add tests" })
+    })
+    assert.equal(response.status, 200)
+    assert.equal((await response.json()).run.sessionId, "session-2")
+    assert.deepEqual(calls, [["task-1", "Add tests"]])
+  } finally {
+    await close(server)
+  }
+})
+
 test("launch maps coded missing tasks to 404 and delegates unrelated routes", async () => {
   const innerServer = new EventEmitter()
   let delegated = false

--- a/bridge/test/task-run-controller.test.js
+++ b/bridge/test/task-run-controller.test.js
@@ -11,6 +11,7 @@ function draft(overrides = {}) {
     project: { kind: "git", path: "/repo" },
     workspace: { mode: "worktree", path: "/state/worktrees/task-1" },
     run: null,
+    runs: [],
     ...overrides
   }
 }
@@ -31,7 +32,7 @@ test("launch persists run identity before starting the prompt and ends running",
       calls.push(["session", task.status])
       return { sessionId: "session-1", transport: "acp", directory: task.workspace.path }
     },
-    async startPrompt(task, session) { calls.push(["prompt", task.status, session.sessionId]) }
+    async startPrompt(task, session) { calls.push(["prompt", task.status, session.sessionId, task.prompt]) }
   }
   const controller = new TaskRunController({ taskStore: store, taskLauncher: launcher, runIDFactory: () => "run-1", clock: () => "2026-08-13T18:00:00.000Z" })
 
@@ -44,7 +45,7 @@ test("launch persists run identity before starting the prompt and ends running",
     ["session", "starting"],
     ["state", "starting", "session-1"],
     ["state", "running", "session-1"],
-    ["prompt", "running", "session-1"]
+    ["prompt", "running", "session-1", "Fix it"]
   ])
 })
 
@@ -71,9 +72,67 @@ test("a synchronous prompt completion cannot race the starting to running transi
   assert.equal(current.status, "completed")
 })
 
-test("Git tasks cannot launch from the primary checkout", async () => {
-  const controller = new TaskRunController({ taskStore: { async get() { return draft({ workspace: { mode: "project", path: "/repo" } }) } }, taskLauncher: {} })
-  await assert.rejects(() => controller.launch("task-1"), /isolated worktree/)
+test("Git tasks can intentionally launch from the project checkout", async () => {
+  let current = draft({ workspace: { mode: "project", path: "/repo" } })
+  const store = {
+    async get() { return structuredClone(current) },
+    async setRunState(_id, update) {
+      current = { ...current, status: update.status, run: structuredClone(update.run) }
+      return structuredClone(current)
+    }
+  }
+  const controller = new TaskRunController({
+    taskStore: store,
+    taskLauncher: {
+      async createSession(task) {
+        assert.equal(task.workspace.mode, "project")
+        assert.equal(task.workspace.path, "/repo")
+        return { sessionId: "session-project", transport: "acp" }
+      },
+      async startPrompt() {}
+    },
+    runIDFactory: () => "run-project"
+  })
+  const launched = await controller.launch("task-1")
+  assert.equal(launched.status, "running")
+  assert.equal(launched.run.directory, "/repo")
+})
+
+test("a terminal task can continue with a new run and prompt", async () => {
+  let current = draft({
+    status: "completed",
+    run: { id: "run-1", sessionId: "session-1", transport: "acp", directory: "/state/worktrees/task-1" },
+    runs: [{ id: "run-1", sessionId: "session-1", transport: "acp", directory: "/state/worktrees/task-1" }]
+  })
+  let createdPrompt
+  let sentPrompt
+  const store = {
+    async list() { return [] },
+    async get() { return structuredClone(current) },
+    async setRunState(_id, update) {
+      current = { ...current, status: update.status, run: structuredClone(update.run) }
+      return structuredClone(current)
+    }
+  }
+  const controller = new TaskRunController({
+    taskStore: store,
+    taskLauncher: {
+      async createSession(task) {
+        createdPrompt = task.prompt
+        return { sessionId: "session-2", transport: "acp", directory: task.workspace.path }
+      },
+      async startPrompt(task) { sentPrompt = task.prompt }
+    },
+    runIDFactory: () => "run-2"
+  })
+
+  const continued = await controller.continue("task-1", "Now add regression tests")
+  assert.equal(continued.status, "running")
+  assert.equal(continued.run.id, "run-2")
+  assert.equal(continued.run.sessionId, "session-2")
+  assert.equal(continued.run.prompt, "Now add regression tests")
+  assert.equal(createdPrompt, "Now add regression tests")
+  assert.equal(sentPrompt, "Now add regression tests")
 })
 
 test("launch failures persist failed state", async () => {

--- a/bridge/test/task-store.test.js
+++ b/bridge/test/task-store.test.js
@@ -27,6 +27,8 @@ test("persists machine-scoped draft tasks with project, agent and workspace iden
       status: "draft",
       workspace: { mode: "project", path: "/work/repo" },
       run: null,
+      runs: [],
+      error: null,
       createdAt: "2026-08-13T13:00:00.000Z",
       updatedAt: "2026-08-13T13:00:00.000Z"
     })
@@ -37,6 +39,25 @@ test("persists machine-scoped draft tasks with project, agent and workspace iden
     assert.equal(disk.version, 1)
     assert.equal(disk.machineId, "machine-1")
     assert.deepEqual(disk.tasks, [created])
+  } finally {
+    await rm(stateDirectory, { recursive: true, force: true })
+  }
+})
+
+test("legacy single-run tasks load with a compatible runs history", async () => {
+  const stateDirectory = await mkdtemp(path.join(os.tmpdir(), "harness-task-history-"))
+  try {
+    const store = new TaskStore({ machineID: "machine-1", stateDirectory })
+    await mkdir(stateDirectory, { recursive: true })
+    const legacyRun = { id: "run-1", sessionId: "session-1", startedAt: "2026-08-13T13:00:00.000Z" }
+    await writeFile(store.file, JSON.stringify({
+      version: 1,
+      machineId: "machine-1",
+      tasks: [{ id: "task-1", status: "completed", run: legacyRun }]
+    }), "utf8")
+    const [loaded] = await store.list()
+    assert.deepEqual(loaded.runs, [legacyRun])
+    assert.deepEqual(loaded.run, legacyRun)
   } finally {
     await rm(stateDirectory, { recursive: true, force: true })
   }

--- a/web/src/components/standalone-universal-workspace.tsx
+++ b/web/src/components/standalone-universal-workspace.tsx
@@ -4,7 +4,7 @@ import {
   createWorkspaceMachine,
   type WorkspaceMachine
 } from "../workspaceMachines"
-import { UniversalWorkspace } from "./universal-workspace"
+import { TaskDeskV3 } from "./taskdesk-v3"
 
 type Props = {
   machines: WorkspaceMachine[]
@@ -68,119 +68,45 @@ function MachineEditor({ machine, isNew, onCancel, onSave }: MachineEditorProps)
   return (
     <div className="uw-machine-editor">
       <div className="uw-machine-editor-grid">
-        <label>
-          <span>Name</span>
-          <input value={name} onChange={(event) => setName(event.target.value)} placeholder="My workstation" />
-        </label>
-        <label>
-          <span>Host</span>
-          <input value={host} onChange={(event) => setHost(event.target.value)} placeholder="192.168.1.20 or localhost" spellCheck={false} />
-        </label>
-        <label>
-          <span>Port</span>
-          <input value={port} onChange={(event) => setPort(event.target.value.replace(/\D/g, ""))} inputMode="numeric" />
-        </label>
-        <label>
-          <span>Username</span>
-          <input value={username} onChange={(event) => setUsername(event.target.value)} autoComplete="username" />
-        </label>
-        <label className="uw-machine-editor-wide">
-          <span>Password</span>
-          <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} autoComplete="current-password" />
-        </label>
+        <label><span>Name</span><input value={name} onChange={(event) => setName(event.target.value)} placeholder="My workstation" /></label>
+        <label><span>Host</span><input value={host} onChange={(event) => setHost(event.target.value)} placeholder="192.168.1.20 or localhost" spellCheck={false} /></label>
+        <label><span>Port</span><input value={port} onChange={(event) => setPort(event.target.value.replace(/\D/g, ""))} inputMode="numeric" /></label>
+        <label><span>Username</span><input value={username} onChange={(event) => setUsername(event.target.value)} autoComplete="username" /></label>
+        <label className="uw-machine-editor-wide"><span>Password</span><input type="password" value={password} onChange={(event) => setPassword(event.target.value)} autoComplete="current-password" /></label>
       </div>
-
-      {testResult ? (
-        <div className={`uw-machine-test-result ${testResult.ok ? "ok" : "error"}`}>{testResult.text}</div>
-      ) : null}
-
+      {testResult ? <div className={`uw-machine-test-result ${testResult.ok ? "ok" : "error"}`}>{testResult.text}</div> : null}
       <div className="uw-machine-editor-actions">
         <button type="button" className="uw-manager-button" onClick={onCancel}>Cancel</button>
-        <button type="button" className="uw-manager-button" disabled={!valid || testing} onClick={() => void testConnection()}>
-          {testing ? "Testing..." : "Test connection"}
-        </button>
-        <button type="button" className="uw-manager-button primary" disabled={!valid} onClick={() => valid && onSave(nextMachine())}>
-          {isNew ? "Add machine" : "Save machine"}
-        </button>
+        <button type="button" className="uw-manager-button" disabled={!valid || testing} onClick={() => void testConnection()}>{testing ? "Testing..." : "Test connection"}</button>
+        <button type="button" className="uw-manager-button primary" disabled={!valid} onClick={() => valid && onSave(nextMachine())}>{isNew ? "Add machine" : "Save machine"}</button>
       </div>
     </div>
   )
 }
 
-function MachineManager({
-  machines,
-  onClose,
-  onPersist
-}: {
-  machines: WorkspaceMachine[]
-  onClose: () => void
-  onPersist: (machines: WorkspaceMachine[]) => void
-}) {
+function MachineManager({ machines, onClose, onPersist }: { machines: WorkspaceMachine[]; onClose: () => void; onPersist: (machines: WorkspaceMachine[]) => void }) {
   const [editingID, setEditingID] = useState<string | null>(machines.length === 0 ? "new" : null)
-  const draft = useMemo(() => editingID === "new"
-    ? createWorkspaceMachine()
-    : machines.find((machine) => machine.id === editingID) || null, [editingID, machines])
-
+  const draft = useMemo(() => editingID === "new" ? createWorkspaceMachine() : machines.find((machine) => machine.id === editingID) || null, [editingID, machines])
   const save = (machine: WorkspaceMachine) => {
     if (editingID === "new") onPersist([...machines, machine])
     else onPersist(machines.map((candidate) => candidate.id === machine.id ? machine : candidate))
     setEditingID(null)
   }
-
   const remove = (machine: WorkspaceMachine) => {
     if (!window.confirm(`Remove "${machine.name}" from this workspace?`)) return
     onPersist(machines.filter((candidate) => candidate.id !== machine.id))
     if (editingID === machine.id) setEditingID(null)
   }
-
   return (
     <div className="uw-manager-backdrop" role="presentation" onMouseDown={onClose}>
       <section className="uw-machine-manager" role="dialog" aria-modal="true" aria-label="Machines" onMouseDown={(event) => event.stopPropagation()}>
-        <header className="uw-machine-manager-header">
-          <div>
-            <h2>Machines</h2>
-            <p>Configure the machine daemons aggregated by Universal Workspace. Classic connections are separate.</p>
-          </div>
-          <button type="button" className="uw-manager-close" onClick={onClose} aria-label="Close">×</button>
-        </header>
-
+        <header className="uw-machine-manager-header"><div><h2>Machines</h2><p>Configure machine daemons used by TaskDesk. Classic connections remain separate.</p></div><button type="button" className="uw-manager-close" onClick={onClose} aria-label="Close">×</button></header>
         <div className="uw-machine-manager-body">
-          {machines.length === 0 && editingID !== "new" ? (
-            <div className="uw-machine-manager-empty">
-              <strong>No machines configured</strong>
-              <span>Add a Harness machine daemon to start aggregating native sessions.</span>
-            </div>
-          ) : null}
-
-          {machines.map((machine) => (
-            <div className="uw-machine-config-card" key={machine.id}>
-              <div className="uw-machine-config-main">
-                <strong>{machine.name}</strong>
-                <span>{machine.config.host}:{machine.config.port}</span>
-                <small>{machine.config.username || "No username"}</small>
-              </div>
-              <div className="uw-machine-config-actions">
-                <button type="button" className="uw-manager-button" onClick={() => setEditingID(machine.id)}>Edit</button>
-                <button type="button" className="uw-manager-button danger" onClick={() => remove(machine)}>Remove</button>
-              </div>
-            </div>
-          ))}
-
-          {draft ? (
-            <MachineEditor
-              key={draft.id}
-              machine={draft}
-              isNew={editingID === "new"}
-              onCancel={() => setEditingID(null)}
-              onSave={save}
-            />
-          ) : null}
+          {machines.length === 0 && editingID !== "new" ? <div className="uw-machine-manager-empty"><strong>No machines configured</strong><span>Add a Harness machine daemon to use TaskDesk.</span></div> : null}
+          {machines.map((machine) => <div className="uw-machine-config-card" key={machine.id}><div className="uw-machine-config-main"><strong>{machine.name}</strong><span>{machine.config.host}:{machine.config.port}</span><small>{machine.config.username || "No username"}</small></div><div className="uw-machine-config-actions"><button type="button" className="uw-manager-button" onClick={() => setEditingID(machine.id)}>Edit</button><button type="button" className="uw-manager-button danger" onClick={() => remove(machine)}>Remove</button></div></div>)}
+          {draft ? <MachineEditor key={draft.id} machine={draft} isNew={editingID === "new"} onCancel={() => setEditingID(null)} onSave={save} /> : null}
         </div>
-
-        <footer className="uw-machine-manager-footer">
-          <span>{machines.length} machine{machines.length === 1 ? "" : "s"} configured</span>
-          <button type="button" className="uw-manager-button primary" onClick={() => setEditingID("new")}>+ Add machine</button>
-        </footer>
+        <footer className="uw-machine-manager-footer"><span>{machines.length} machine{machines.length === 1 ? "" : "s"} configured</span><button type="button" className="uw-manager-button primary" onClick={() => setEditingID("new")}>+ Add machine</button></footer>
       </section>
     </div>
   )
@@ -189,38 +115,19 @@ function MachineManager({
 export function StandaloneUniversalWorkspace({ machines, onPersistMachines, legacyView }: Props) {
   const [managerOpen, setManagerOpen] = useState(machines.length === 0)
   const [activeMachineID, setActiveMachineID] = useState(machines[0]?.id || "")
-
-  const activeID = machines.some((machine) => machine.id === activeMachineID)
-    ? activeMachineID
-    : machines[0]?.id || ""
+  const activeID = machines.some((machine) => machine.id === activeMachineID) ? activeMachineID : machines[0]?.id || ""
 
   return (
     <div className="uw-standalone-host">
-      <UniversalWorkspace
-        profiles={machines}
-        activeProfileID={activeID}
-        onPersistProfiles={(nextMachines, nextActiveID) => {
-          onPersistMachines(nextMachines as WorkspaceMachine[])
-          setActiveMachineID(nextActiveID)
-        }}
+      <TaskDeskV3
+        machines={machines}
+        activeMachineID={activeID}
+        onActiveMachineID={setActiveMachineID}
+        onPersistMachines={onPersistMachines}
+        onManageMachines={() => setManagerOpen(true)}
         legacyView={legacyView}
       />
-
-      <button type="button" className="uw-machine-manager-trigger" onClick={() => setManagerOpen(true)} title="Manage machines">
-        Machines
-        <span>{machines.length}</span>
-      </button>
-
-      {managerOpen ? (
-        <MachineManager
-          machines={machines}
-          onClose={() => setManagerOpen(false)}
-          onPersist={(nextMachines) => {
-            onPersistMachines(nextMachines)
-            if (!nextMachines.some((machine) => machine.id === activeID)) setActiveMachineID(nextMachines[0]?.id || "")
-          }}
-        />
-      ) : null}
+      {managerOpen ? <MachineManager machines={machines} onClose={() => setManagerOpen(false)} onPersist={(nextMachines) => { onPersistMachines(nextMachines); if (!nextMachines.some((machine) => machine.id === activeID)) setActiveMachineID(nextMachines[0]?.id || "") }} /> : null}
     </div>
   )
 }

--- a/web/src/components/taskdesk-v3.tsx
+++ b/web/src/components/taskdesk-v3.tsx
@@ -1,0 +1,644 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
+import ReactMarkdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+import { api } from "../api"
+import { discoverMachine, selectableMachineAgents } from "../machineClient"
+import {
+  taskClient,
+  type MachineProject,
+  type MachineTask,
+  type MachineTaskRun,
+  type TaskWorkspaceInspection
+} from "../taskClient"
+import {
+  agentLabel,
+  modelLabel,
+  normalizeTaskStatus,
+  sortTasksByActivity,
+  taskStatusLabel,
+  taskTitle,
+  type TaskDeskTaskStatus
+} from "../taskdeskHomeModel"
+import type {
+  DiffFile,
+  MachineAgentHost,
+  MachineSnapshot,
+  MessageEnvelope,
+  ModelOption,
+  PermissionRequest,
+  QuestionRequest,
+  ServerConfig,
+  TodoItem,
+  VcsStatus
+} from "../types"
+import type { WorkspaceMachine } from "../workspaceMachines"
+import {
+  ChatIcon,
+  CloseIcon,
+  FolderIcon,
+  LoadingIcon,
+  PlusIcon,
+  RefreshIcon,
+  SearchIcon,
+  ServerIcon
+} from "../Icons"
+import { UniversalWorkspace } from "./universal-workspace"
+
+const REFRESH_MS = 4_000
+const DETAIL_REFRESH_MS = 2_500
+const REMARK_PLUGINS = [remarkGfm]
+
+const HARNESS_ICON_FILES: Record<string, string> = {
+  codex: "codex.svg",
+  claude: "claude.svg",
+  opencode: "opencode.svg",
+  omp: "omp.svg",
+  pi: "pi.svg"
+}
+
+type TaskDeskView = "overview" | "tasks" | "sessions" | "projects" | "needs" | "agents" | "machines" | "classic"
+type TaskFilter = "all" | "running" | "waiting" | "completed" | "failed"
+type DetailTab = "overview" | "conversation" | "diff" | "runs"
+
+type RuntimeMachine = {
+  key: string
+  machine: WorkspaceMachine
+  snapshot: MachineSnapshot | null
+  projects: MachineProject[]
+  tasks: MachineTask[]
+  agents: MachineAgentHost[]
+  state: "online" | "offline" | "loading"
+  error?: string
+}
+
+type TaskRecord = {
+  key: string
+  runtime: RuntimeMachine
+  task: MachineTask
+}
+
+type AttentionItem =
+  | { key: string; type: "permission"; runtime: RuntimeMachine; agent: MachineAgentHost; request: PermissionRequest; task?: MachineTask }
+  | { key: string; type: "question"; runtime: RuntimeMachine; agent: MachineAgentHost; request: QuestionRequest; task?: MachineTask }
+
+type TaskDetail = {
+  ownerKey: string | null
+  loading: boolean
+  messages: MessageEnvelope[]
+  diff: DiffFile[]
+  todos: TodoItem[]
+  vcs: VcsStatus | null
+  result: TaskWorkspaceInspection | null
+  error: string | null
+}
+
+type Props = {
+  machines: WorkspaceMachine[]
+  activeMachineID: string
+  onActiveMachineID: (id: string) => void
+  onPersistMachines: (machines: WorkspaceMachine[]) => void
+  onManageMachines: () => void
+  legacyView: ReactNode
+}
+
+function supportedBackend(value: string, fallback: ServerConfig["backend"]): ServerConfig["backend"] {
+  return value === "opencode" || value === "omp" || value === "pi" || value === "claude" || value === "codex"
+    ? value
+    : fallback
+}
+
+function configForAgent(runtime: RuntimeMachine, agent: MachineAgentHost): ServerConfig {
+  return {
+    ...runtime.machine.config,
+    backend: supportedBackend(agent.backend, runtime.machine.config.backend),
+    agentId: agent.id
+  }
+}
+
+function harnessIconUrl(backend: string): string | undefined {
+  const file = HARNESS_ICON_FILES[backend.toLowerCase()]
+  return file ? `${import.meta.env.BASE_URL}harness-icons/${file}` : undefined
+}
+
+function HarnessBadge({ agent }: { agent: MachineAgentHost }) {
+  const source = harnessIconUrl(agent.backend)
+  return (
+    <span className="td3-agent-badge" title={`${agent.label} · ${agent.transport}`}>
+      {source ? <img src={source} alt="" aria-hidden="true" /> : <span>{agent.label.slice(0, 2).toUpperCase()}</span>}
+      <b>{agent.label}</b>
+      <i className={`td3-agent-state td3-agent-state-${agent.state}`} />
+    </span>
+  )
+}
+
+function runSessionID(run?: MachineTaskRun | null): string | null {
+  return run?.sessionId || run?.sessionID || null
+}
+
+function formatRelative(value?: string): string {
+  if (!value) return ""
+  const timestamp = Date.parse(value)
+  if (!Number.isFinite(timestamp)) return value
+  const delta = Math.max(0, Date.now() - timestamp)
+  if (delta < 60_000) return "now"
+  if (delta < 3_600_000) return `${Math.max(1, Math.round(delta / 60_000))}m ago`
+  if (delta < 86_400_000) return `${Math.round(delta / 3_600_000)}h ago`
+  return `${Math.round(delta / 86_400_000)}d ago`
+}
+
+function formatDate(value?: string): string {
+  if (!value) return "Unknown"
+  const timestamp = Date.parse(value)
+  return Number.isFinite(timestamp)
+    ? new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(timestamp)
+    : value
+}
+
+function extractText(message: MessageEnvelope): string {
+  return message.parts
+    .filter((part) => part.type === "text" && part.text)
+    .map((part) => part.text || "")
+    .join("\n")
+    .trim()
+}
+
+function latestAssistantText(messages: MessageEnvelope[]): string {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index].info.role === "user") continue
+    const text = extractText(messages[index])
+    if (text) return text
+  }
+  return ""
+}
+
+function taskWorkspaceLabel(task: MachineTask): string {
+  return task.workspace?.mode === "worktree" ? "Isolated worktree" : "Project directory"
+}
+
+function taskStatusTone(status: string): TaskDeskTaskStatus {
+  return normalizeTaskStatus(status)
+}
+
+function filterMatches(status: string, filter: TaskFilter): boolean {
+  if (filter === "all") return true
+  const normalized = normalizeTaskStatus(status)
+  if (filter === "running") return normalized === "running" || normalized === "preparing" || normalized === "queued"
+  return normalized === filter
+}
+
+function taskRunHistory(task: MachineTask): MachineTaskRun[] {
+  if (Array.isArray(task.runs) && task.runs.length) return task.runs
+  return task.run ? [task.run] : []
+}
+
+function emptyDetail(ownerKey: string | null = null, loading = false): TaskDetail {
+  return { ownerKey, loading, messages: [], diff: [], todos: [], vcs: null, result: null, error: null }
+}
+
+function taskForSession(runtime: RuntimeMachine, sessionID: string): MachineTask | undefined {
+  return runtime.tasks.find((task) => taskRunHistory(task).some((run) => runSessionID(run) === sessionID))
+}
+
+function NewTaskModal({
+  runtimes,
+  initialMachineID,
+  onClose,
+  onCreated
+}: {
+  runtimes: RuntimeMachine[]
+  initialMachineID: string
+  onClose: () => void
+  onCreated: (runtime: RuntimeMachine, task: MachineTask) => void
+}) {
+  const online = runtimes.filter((runtime) => runtime.state === "online" && runtime.snapshot)
+  const first = online.find((runtime) => runtime.machine.id === initialMachineID) || online[0]
+  const [machineID, setMachineID] = useState(first?.machine.id || "")
+  const runtime = online.find((candidate) => candidate.machine.id === machineID) || first
+  const agents = runtime?.agents || []
+  const [projectID, setProjectID] = useState(runtime?.projects[0]?.id || "")
+  const [agentID, setAgentID] = useState(agents[0]?.id || "")
+  const [models, setModels] = useState<ModelOption[]>([])
+  const [modelKey, setModelKey] = useState("")
+  const [modelsLoading, setModelsLoading] = useState(false)
+  const [prompt, setPrompt] = useState("")
+  const [isolated, setIsolated] = useState(true)
+  const [starting, setStarting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const modelGeneration = useRef(0)
+
+  useEffect(() => {
+    if (!runtime) return
+    if (!runtime.projects.some((project) => project.id === projectID)) setProjectID(runtime.projects[0]?.id || "")
+    if (!runtime.agents.some((agent) => agent.id === agentID)) setAgentID(runtime.agents[0]?.id || "")
+  }, [machineID])
+
+  useEffect(() => {
+    if (!runtime || !agentID) {
+      setModels([])
+      setModelKey("")
+      return
+    }
+    const generation = ++modelGeneration.current
+    setModelsLoading(true)
+    setError(null)
+    void taskClient.listAgentModels(runtime.machine.config, agentID).then((catalog) => {
+      if (generation !== modelGeneration.current) return
+      setModels(catalog.models)
+      const selected = catalog.models.find((model) => model.isDefault) || catalog.models[0]
+      setModelKey(selected ? `${selected.providerID}|${selected.modelID}|${selected.variant || ""}` : "")
+    }).catch((reason) => {
+      if (generation === modelGeneration.current) {
+        setModels([])
+        setModelKey("")
+        setError(reason instanceof Error ? reason.message : String(reason))
+      }
+    }).finally(() => {
+      if (generation === modelGeneration.current) setModelsLoading(false)
+    })
+  }, [runtime?.machine.id, agentID])
+
+  const project = runtime?.projects.find((candidate) => candidate.id === projectID)
+  const agent = agents.find((candidate) => candidate.id === agentID)
+  const model = models.find((candidate) => `${candidate.providerID}|${candidate.modelID}|${candidate.variant || ""}` === modelKey)
+  const canStart = Boolean(runtime && project && agent && prompt.trim()) && !starting && !modelsLoading
+
+  async function start() {
+    if (!runtime || !project || !agent || !canStart) return
+    setStarting(true)
+    setError(null)
+    try {
+      let task = await taskClient.createTask(runtime.machine.config, {
+        projectId: project.id,
+        agentId: agent.id,
+        prompt: prompt.trim(),
+        model: model ? { providerID: model.providerID, modelID: model.modelID, variant: model.variant } : undefined
+      })
+      if (isolated && project.kind === "git") task = await taskClient.prepareWorktree(runtime.machine.config, task.id)
+      task = await taskClient.launch(runtime.machine.config, task.id)
+      onCreated(runtime, task)
+      onClose()
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason))
+    } finally {
+      setStarting(false)
+    }
+  }
+
+  return (
+    <div className="td3-modal-backdrop" role="presentation" onMouseDown={onClose}>
+      <section className="td3-modal td3-new-task" role="dialog" aria-modal="true" aria-label="New Task" onMouseDown={(event) => event.stopPropagation()}>
+        <header>
+          <div><small>TaskDesk</small><h2>New Task</h2><p>Create durable agent work with an explicit machine, project, model and workspace.</p></div>
+          <button type="button" onClick={onClose} aria-label="Close"><CloseIcon size={17} /></button>
+        </header>
+        <div className="td3-modal-body td3-form-grid">
+          <label><span>Machine</span><select value={runtime?.machine.id || ""} onChange={(event) => setMachineID(event.target.value)}>{online.map((item) => <option key={item.machine.id} value={item.machine.id}>{item.snapshot?.machine.name || item.machine.name}</option>)}</select></label>
+          <label><span>Project</span><select value={projectID} onChange={(event) => setProjectID(event.target.value)}>{runtime?.projects.map((item) => <option key={item.id} value={item.id}>{item.name}</option>)}</select></label>
+          <label><span>Agent</span><select value={agentID} onChange={(event) => setAgentID(event.target.value)}>{agents.map((item) => <option key={item.id} value={item.id}>{item.label}</option>)}</select></label>
+          <label><span>Model</span><select value={modelKey} onChange={(event) => setModelKey(event.target.value)} disabled={modelsLoading}>{modelsLoading ? <option value="">Loading models...</option> : null}{!modelsLoading && models.length === 0 ? <option value="">Agent default</option> : null}{models.map((item) => { const key = `${item.providerID}|${item.modelID}|${item.variant || ""}`; return <option key={key} value={key}>{item.modelName}{item.variant ? ` (${item.variant})` : ""}</option> })}</select></label>
+          <label className="td3-form-wide"><span>Task</span><textarea rows={7} value={prompt} onChange={(event) => setPrompt(event.target.value)} placeholder="Describe the outcome you want the agent to deliver..." autoFocus /></label>
+          <label className="td3-workspace-choice td3-form-wide">
+            <input type="checkbox" checked={isolated} onChange={(event) => setIsolated(event.target.checked)} disabled={project?.kind !== "git"} />
+            <span><strong>Use an isolated Git worktree</strong><small>{project?.kind === "git" ? "Recommended. The task gets its own branch and working directory." : "This project is not Git-backed, so it runs in the project directory."}</small></span>
+          </label>
+          {!isolated && project?.kind === "git" ? <div className="td3-inline-warning td3-form-wide">This task will edit the selected project checkout directly.</div> : null}
+          {error ? <div className="td3-inline-error td3-form-wide">{error}</div> : null}
+        </div>
+        <footer><button type="button" className="td3-button" onClick={onClose}>Cancel</button><button type="button" className="td3-button primary" disabled={!canStart} onClick={() => void start()}>{starting ? <LoadingIcon size={15} /> : <PlusIcon size={15} />}{starting ? "Starting task..." : "Start Task"}</button></footer>
+      </section>
+    </div>
+  )
+}
+
+function ContinueTaskModal({ record, onClose, onContinued }: { record: TaskRecord; onClose: () => void; onContinued: (task: MachineTask) => void }) {
+  const [prompt, setPrompt] = useState("")
+  const [working, setWorking] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  async function submit() {
+    if (!prompt.trim() || working) return
+    setWorking(true)
+    setError(null)
+    try {
+      onContinued(await taskClient.continueTask(record.runtime.machine.config, record.task.id, prompt.trim()))
+      onClose()
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason))
+    } finally {
+      setWorking(false)
+    }
+  }
+  return (
+    <div className="td3-modal-backdrop" role="presentation" onMouseDown={onClose}>
+      <section className="td3-modal td3-continue-modal" role="dialog" aria-modal="true" aria-label="Continue Task" onMouseDown={(event) => event.stopPropagation()}>
+        <header><div><small>New Run</small><h2>Continue Task</h2><p>{taskTitle(record.task)}</p></div><button type="button" onClick={onClose}><CloseIcon size={17} /></button></header>
+        <div className="td3-modal-body"><label className="td3-stack-field"><span>What should the next Run do?</span><textarea rows={7} value={prompt} onChange={(event) => setPrompt(event.target.value)} placeholder="Continue from the current workspace state and..." autoFocus /></label>{error ? <div className="td3-inline-error">{error}</div> : null}</div>
+        <footer><button type="button" className="td3-button" onClick={onClose}>Cancel</button><button type="button" className="td3-button primary" disabled={!prompt.trim() || working} onClick={() => void submit()}>{working ? <LoadingIcon size={15} /> : null}{working ? "Starting..." : "Start new Run"}</button></footer>
+      </section>
+    </div>
+  )
+}
+
+function QuestionAttentionCard({ item, onResolved, onOpenSession }: { item: Extract<AttentionItem, { type: "question" }>; onResolved: () => void; onOpenSession: () => void }) {
+  const [answers, setAnswers] = useState<Record<number, string[]>>({})
+  const [sending, setSending] = useState(false)
+  const config = configForAgent(item.runtime, item.agent)
+  async function reply() {
+    setSending(true)
+    try {
+      const payload = item.request.questions.map((_question, index) => answers[index] || [])
+      await api.replyQuestion(config, item.request.id, payload, item.task?.workspace.path)
+      onResolved()
+    } finally {
+      setSending(false)
+    }
+  }
+  return (
+    <article className="td3-attention-card">
+      <header><span className="td3-attention-icon">?</span><div><strong>Question</strong><small>{item.task ? taskTitle(item.task) : item.agent.label}</small></div></header>
+      {item.request.questions.map((question, index) => <div className="td3-question" key={`${item.request.id}-${index}`}><p>{question.question}</p><div>{question.options.map((option) => { const selected = answers[index]?.includes(option.label) || false; return <button type="button" key={option.label} className={selected ? "selected" : ""} onClick={() => setAnswers((current) => ({ ...current, [index]: question.multiple ? (selected ? (current[index] || []).filter((value) => value !== option.label) : [...(current[index] || []), option.label]) : [option.label] }))}>{option.label}</button> })}</div></div>)}
+      <footer><button type="button" className="td3-link-button" onClick={onOpenSession}>Open session</button><button type="button" className="td3-button primary" disabled={sending} onClick={() => void reply()}>{sending ? "Sending..." : "Answer"}</button></footer>
+    </article>
+  )
+}
+
+export function TaskDeskV3({ machines, activeMachineID, onActiveMachineID, onPersistMachines, onManageMachines, legacyView }: Props) {
+  const [view, setView] = useState<TaskDeskView>("tasks")
+  const [runtimes, setRuntimes] = useState<RuntimeMachine[]>([])
+  const [filter, setFilter] = useState<TaskFilter>("all")
+  const [query, setQuery] = useState("")
+  const [machineScope, setMachineScope] = useState(activeMachineID || "all")
+  const [selectedKey, setSelectedKey] = useState<string | null>(null)
+  const [detailTab, setDetailTab] = useState<DetailTab>("overview")
+  const [detail, setDetail] = useState<TaskDetail>(() => emptyDetail())
+  const [attention, setAttention] = useState<AttentionItem[]>([])
+  const [newTaskOpen, setNewTaskOpen] = useState(false)
+  const [continueOpen, setContinueOpen] = useState(false)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [actionBusy, setActionBusy] = useState(false)
+  const refreshInFlight = useRef(false)
+  const detailInFlight = useRef(false)
+  const detailGeneration = useRef(0)
+
+  useEffect(() => {
+    if (activeMachineID && machines.some((machine) => machine.id === activeMachineID)) setMachineScope(activeMachineID)
+  }, [activeMachineID])
+
+  const refresh = useCallback(async (silent = false) => {
+    if (refreshInFlight.current) return
+    refreshInFlight.current = true
+    try {
+      const next = await Promise.all(machines.map(async (machine): Promise<RuntimeMachine> => {
+        try {
+          const snapshot = await discoverMachine(machine.config)
+          if (!snapshot) return { key: machine.id, machine, snapshot: null, projects: [], tasks: [], agents: [], state: "offline", error: "Not a Harness machine daemon" }
+          const [projects, tasks] = await Promise.all([
+            taskClient.listProjects(machine.config).catch(() => []),
+            taskClient.listTasks(machine.config).catch(() => [])
+          ])
+          return { key: machine.id, machine, snapshot, projects, tasks: sortTasksByActivity(tasks), agents: selectableMachineAgents(snapshot), state: "online" }
+        } catch (reason) {
+          return { key: machine.id, machine, snapshot: null, projects: [], tasks: [], agents: [], state: "offline", error: reason instanceof Error ? reason.message : String(reason) }
+        }
+      }))
+      setRuntimes(next)
+
+      const nextAttention = (await Promise.all(next.filter((runtime) => runtime.state === "online").flatMap((runtime) => runtime.agents.map(async (agent) => {
+        const config = configForAgent(runtime, agent)
+        const [questions, permissions] = await Promise.all([
+          api.loadQuestions(config).catch(() => []),
+          api.loadPermissions(config).catch(() => [])
+        ])
+        return [
+          ...permissions.map((request): AttentionItem => ({ key: `${runtime.key}|${agent.id}|permission|${request.id}`, type: "permission", runtime, agent, request, task: taskForSession(runtime, request.sessionID) })),
+          ...questions.map((request): AttentionItem => ({ key: `${runtime.key}|${agent.id}|question|${request.id}`, type: "question", runtime, agent, request, task: taskForSession(runtime, request.sessionID) }))
+        ]
+      })))).flat()
+      setAttention(nextAttention)
+
+      const records = next.flatMap((runtime) => runtime.tasks.map((task) => ({ key: `${runtime.key}|${task.id}`, runtime, task })))
+      setSelectedKey((current) => current && records.some((record) => record.key === current) ? current : records[0]?.key || null)
+    } finally {
+      refreshInFlight.current = false
+    }
+  }, [machines])
+
+  useEffect(() => {
+    void refresh(false)
+    const timer = window.setInterval(() => void refresh(true), REFRESH_MS)
+    return () => window.clearInterval(timer)
+  }, [refresh])
+
+  const records = useMemo(() => runtimes.flatMap((runtime) => runtime.tasks.map((task) => ({ key: `${runtime.key}|${task.id}`, runtime, task }))), [runtimes])
+  const selected = records.find((record) => record.key === selectedKey) || null
+
+  const loadDetail = useCallback(async (record: TaskRecord, silent = false) => {
+    if (detailInFlight.current && silent) return
+    detailInFlight.current = true
+    const generation = ++detailGeneration.current
+    if (!silent) setDetail(emptyDetail(record.key, true))
+    const agent = record.runtime.agents.find((candidate) => candidate.id === record.task.agentId)
+    const sessionID = runSessionID(record.task.run)
+    try {
+      const resultPromise = taskClient.inspectResult(record.runtime.machine.config, record.task.id).catch(() => null)
+      if (!agent || !sessionID) {
+        const result = await resultPromise
+        if (generation === detailGeneration.current) setDetail({ ...emptyDetail(record.key), result })
+        return
+      }
+      const config = configForAgent(record.runtime, agent)
+      const directory = record.task.run?.directory || record.task.workspace.path
+      const [messages, diff, todos, vcs, result] = await Promise.all([
+        api.loadMessages(config, sessionID, directory).catch(() => []),
+        api.loadDiff(config, sessionID, directory).catch(() => []),
+        api.loadTodo(config, sessionID, directory).catch(() => []),
+        api.loadVcs(config, directory).catch(() => null),
+        resultPromise
+      ])
+      if (generation !== detailGeneration.current) return
+      setDetail({ ownerKey: record.key, loading: false, messages, diff, todos, vcs, result, error: null })
+    } catch (reason) {
+      if (generation === detailGeneration.current) setDetail({ ...emptyDetail(record.key), error: reason instanceof Error ? reason.message : String(reason) })
+    } finally {
+      detailInFlight.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    detailGeneration.current += 1
+    detailInFlight.current = false
+    if (!selected) {
+      setDetail(emptyDetail())
+      return
+    }
+    setDetail(emptyDetail(selected.key, true))
+    void loadDetail(selected, false)
+    const timer = window.setInterval(() => void loadDetail(selected, true), DETAIL_REFRESH_MS)
+    return () => window.clearInterval(timer)
+  }, [selected?.key, selected?.task.updatedAt, loadDetail])
+
+  const scopedRecords = useMemo(() => records.filter((record) => machineScope === "all" || record.runtime.machine.id === machineScope), [records, machineScope])
+  const filteredRecords = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    return scopedRecords.filter((record) => {
+      if (!filterMatches(record.task.status, filter)) return false
+      if (!needle) return true
+      return [taskTitle(record.task), record.task.prompt, record.task.project?.name, agentLabel(record.runtime.agents, record.task.agentId), modelLabel(record.task), record.runtime.snapshot?.machine.name, record.runtime.machine.name].some((value) => value?.toLowerCase().includes(needle))
+    })
+  }, [scopedRecords, filter, query])
+
+  const counts = useMemo(() => ({
+    tasks: records.length,
+    running: records.filter((record) => ["running", "preparing", "queued"].includes(normalizeTaskStatus(record.task.status))).length,
+    waiting: records.filter((record) => normalizeTaskStatus(record.task.status) === "waiting").length,
+    completed: records.filter((record) => normalizeTaskStatus(record.task.status) === "completed").length,
+    failed: records.filter((record) => normalizeTaskStatus(record.task.status) === "failed").length,
+    machines: runtimes.filter((runtime) => runtime.state === "online").length,
+    agents: runtimes.reduce((sum, runtime) => sum + runtime.agents.length, 0)
+  }), [records, runtimes])
+
+  const selectedRuntime = runtimes.find((runtime) => runtime.machine.id === machineScope) || runtimes.find((runtime) => runtime.machine.id === activeMachineID) || runtimes[0]
+  const selectedAgent = selected?.runtime.agents.find((agent) => agent.id === selected.task.agentId)
+  const selectedSessionID = selected ? runSessionID(selected.task.run) : null
+  const detailReady = selected && detail.ownerKey === selected.key && !detail.loading
+  const summary = detailReady ? latestAssistantText(detail.messages) : ""
+
+  async function refreshAndReselect(taskID?: string, machineID?: string) {
+    await refresh(true)
+    if (taskID && machineID) setSelectedKey(`${machineID}|${taskID}`)
+  }
+
+  async function finishSelected() {
+    if (!selected || actionBusy) return
+    setActionBusy(true)
+    setActionError(null)
+    try {
+      const response = await taskClient.finish(selected.runtime.machine.config, selected.task.id)
+      await refreshAndReselect(response.task.id, selected.runtime.machine.id)
+    } catch (reason) {
+      setActionError(reason instanceof Error ? reason.message : String(reason))
+    } finally {
+      setActionBusy(false)
+    }
+  }
+
+  async function cleanupSelected() {
+    if (!selected || actionBusy) return
+    if (!window.confirm("Release this task's isolated worktree? Uncommitted changes are protected and will make the daemon refuse cleanup.")) return
+    setActionBusy(true)
+    setActionError(null)
+    try {
+      const response = await taskClient.cleanupWorkspace(selected.runtime.machine.config, selected.task.id)
+      await refreshAndReselect(response.task.id, selected.runtime.machine.id)
+    } catch (reason) {
+      setActionError(reason instanceof Error ? reason.message : String(reason))
+    } finally {
+      setActionBusy(false)
+    }
+  }
+
+  if (view === "sessions") {
+    return (
+      <div className="td3-session-mode">
+        <button type="button" className="td3-return-button" onClick={() => setView("tasks")}>← Tasks</button>
+        <UniversalWorkspace
+          profiles={machines}
+          activeProfileID={activeMachineID}
+          onPersistProfiles={(nextMachines, nextActiveID) => {
+            onPersistMachines(nextMachines as WorkspaceMachine[])
+            onActiveMachineID(nextActiveID)
+          }}
+          legacyView={legacyView}
+        />
+      </div>
+    )
+  }
+
+  if (view === "classic") return <div className="td3-classic-mode"><button type="button" className="td3-return-button" onClick={() => setView("tasks")}>← TaskDesk</button>{legacyView}</div>
+
+  const nav = (
+    <aside className="td3-sidebar">
+      <div className="td3-brand"><span>TD</span><div><strong>TaskDesk v3</strong><small>Harness Remote</small></div></div>
+      <nav>
+        <button className={view === "overview" ? "active" : ""} onClick={() => setView("overview")}><span>⌂</span>Overview</button>
+        <button className={view === "tasks" ? "active" : ""} onClick={() => setView("tasks")}><span>☷</span>Tasks<b>{counts.tasks}</b></button>
+        <button onClick={() => setView("sessions")}><ChatIcon size={16} />Sessions</button>
+        <button className={view === "projects" ? "active" : ""} onClick={() => setView("projects")}><FolderIcon size={16} />Projects</button>
+        <button className={view === "needs" ? "active" : ""} onClick={() => setView("needs")}><span>!</span>Needs You{attention.length ? <b className="attention">{attention.length}</b> : null}</button>
+        <button className={view === "agents" ? "active" : ""} onClick={() => setView("agents")}><span>◇</span>Agents</button>
+        <button className={view === "machines" ? "active" : ""} onClick={() => setView("machines")}><ServerIcon size={16} />Machines</button>
+      </nav>
+      <div className="td3-sidebar-bottom"><button onClick={() => setView("classic")}>Classic 2.x</button><button onClick={onManageMachines}>Manage machines</button></div>
+    </aside>
+  )
+
+  const topbar = (
+    <header className="td3-topbar">
+      <div className="td3-machine-selector"><ServerIcon size={16} /><select value={machineScope} onChange={(event) => { const value = event.target.value; setMachineScope(value); if (value !== "all") onActiveMachineID(value) }}><option value="all">All machines</option>{runtimes.map((runtime) => <option key={runtime.machine.id} value={runtime.machine.id}>{runtime.snapshot?.machine.name || runtime.machine.name}</option>)}</select><span className={`td3-online-dot ${selectedRuntime?.state === "online" ? "online" : "offline"}`} /><small>{selectedRuntime?.state === "online" ? "Online" : "Offline"}</small></div>
+      <div className="td3-agent-strip">{selectedRuntime?.agents.slice(0, 5).map((agent) => <HarnessBadge key={agent.id} agent={agent} />)}</div>
+      <div className="td3-global-search"><SearchIcon size={16} /><input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search tasks, projects, agents..." /></div>
+      <button type="button" className="td3-button primary" onClick={() => setNewTaskOpen(true)} disabled={!runtimes.some((runtime) => runtime.state === "online")}><PlusIcon size={15} />New Task</button>
+      <button type="button" className="td3-button" onClick={() => setView("sessions")}><PlusIcon size={15} />New Session</button>
+    </header>
+  )
+
+  return (
+    <div className="td3-shell">
+      {nav}
+      <div className="td3-workspace">
+        {topbar}
+
+        {view === "overview" ? (
+          <main className="td3-overview">
+            <section className="td3-page-heading"><div><small>Control plane</small><h1>Overview</h1><p>Durable Tasks, native Sessions and every coding harness in one place.</p></div><button type="button" className="td3-button" onClick={() => void refresh(true)}><RefreshIcon size={15} />Refresh</button></section>
+            <section className="td3-kpis"><article><span>Running</span><strong>{counts.running}</strong><small>active task runs</small></article><article><span>Needs You</span><strong>{attention.length}</strong><small>questions and permissions</small></article><article><span>Machines</span><strong>{counts.machines}/{runtimes.length}</strong><small>online</small></article><article><span>Agents</span><strong>{counts.agents}</strong><small>available harnesses</small></article></section>
+            <div className="td3-overview-grid">
+              <section className="td3-panel"><header><div><h2>Recent Tasks</h2><p>Most recently active durable work.</p></div><button onClick={() => setView("tasks")}>View all</button></header>{records.slice(0, 6).map((record) => <button className="td3-recent-task" key={record.key} onClick={() => { setSelectedKey(record.key); setView("tasks") }}><span className={`td3-status-dot td3-status-${taskStatusTone(record.task.status)}`} /><div><strong>{taskTitle(record.task)}</strong><small>{record.task.project.name} · {agentLabel(record.runtime.agents, record.task.agentId)}</small></div><time>{formatRelative(record.task.updatedAt)}</time></button>)}</section>
+              <section className="td3-panel"><header><div><h2>Needs You</h2><p>Agent questions and permission requests.</p></div><button onClick={() => setView("needs")}>View all</button></header>{attention.length === 0 ? <div className="td3-empty-mini">Nothing needs your attention.</div> : attention.slice(0, 5).map((item) => <button className="td3-attention-row" key={item.key} onClick={() => setView("needs")}><span>{item.type === "permission" ? "!" : "?"}</span><div><strong>{item.type === "permission" ? "Permission request" : "Question"}</strong><small>{item.task ? taskTitle(item.task) : item.agent.label}</small></div></button>)}</section>
+            </div>
+          </main>
+        ) : null}
+
+        {view === "tasks" ? (
+          <main className="td3-tasks-layout">
+            <section className="td3-task-list-pane">
+              <div className="td3-page-heading compact"><div><small>Durable work</small><h1>Tasks</h1><p>Tasks survive individual sessions and can accumulate multiple Runs.</p></div><button type="button" className="td3-button" onClick={() => void refresh(true)}><RefreshIcon size={15} /></button></div>
+              <div className="td3-filters">{(["all", "running", "waiting", "completed", "failed"] as TaskFilter[]).map((item) => <button key={item} className={filter === item ? "active" : ""} onClick={() => setFilter(item)}>{item[0].toUpperCase() + item.slice(1)}<span>{item === "all" ? scopedRecords.length : scopedRecords.filter((record) => filterMatches(record.task.status, item)).length}</span></button>)}</div>
+              <div className="td3-task-table-head"><span>Task</span><span>Project</span><span>Agent</span><span>Model</span><span>Workspace</span><span>Status</span><span>Activity</span></div>
+              <div className="td3-task-list">{filteredRecords.length === 0 ? <div className="td3-empty-state"><strong>No tasks match this view.</strong><span>Change filters or start a new Task.</span></div> : filteredRecords.map((record) => { const agent = record.runtime.agents.find((candidate) => candidate.id === record.task.agentId); const tone = taskStatusTone(record.task.status); return <button type="button" className={`td3-task-row${record.key === selectedKey ? " selected" : ""}`} key={record.key} onClick={() => { setSelectedKey(record.key); setDetailTab("overview"); setActionError(null) }}><span className="td3-task-title"><i className={`td3-status-dot td3-status-${tone}`} /><span><strong>{taskTitle(record.task)}</strong><small>{record.task.prompt.split(/\r?\n/).slice(1).join(" ").slice(0, 100) || record.runtime.snapshot?.machine.name || record.runtime.machine.name}</small></span></span><span>{record.task.project?.name || record.task.projectId}</span><span>{agent ? <HarnessBadge agent={agent} /> : record.task.agentId}</span><span>{modelLabel(record.task)}</span><span>{taskWorkspaceLabel(record.task)}</span><span><b className={`td3-status-pill td3-status-${tone}`}>{taskStatusLabel(record.task.status)}</b></span><time>{formatRelative(record.task.updatedAt)}</time></button> })}</div>
+            </section>
+
+            <aside className="td3-task-detail">
+              {!selected ? <div className="td3-empty-state"><strong>Select a Task</strong><span>Task metadata, Run history, result and changed files appear here.</span></div> : (
+                <>
+                  <header className="td3-detail-header"><div><div className="td3-detail-title-line"><h2>{taskTitle(selected.task)}</h2><b className={`td3-status-pill td3-status-${taskStatusTone(selected.task.status)}`}>{taskStatusLabel(selected.task.status)}</b></div><p>{selected.task.prompt}</p></div></header>
+                  <section className="td3-detail-meta"><span><small>Project</small><b>{selected.task.project.name}</b></span><span><small>Agent</small><b>{selectedAgent?.label || selected.task.agentId}</b></span><span><small>Model</small><b>{modelLabel(selected.task)}</b></span><span><small>Workspace</small><b>{taskWorkspaceLabel(selected.task)}</b></span><span><small>Machine</small><b>{selected.runtime.snapshot?.machine.name || selected.runtime.machine.name}</b></span><span><small>Run</small><b>{selected.task.run?.id || "Not started"}</b></span><span><small>Session</small><b>{selectedSessionID || "None"}</b></span><span><small>Branch</small><b>{selected.task.workspace.branch || detail.vcs?.branch || "Project checkout"}</b></span></section>
+                  <nav className="td3-detail-tabs">{(["overview", "conversation", "diff", "runs"] as DetailTab[]).map((tab) => <button key={tab} className={detailTab === tab ? "active" : ""} onClick={() => setDetailTab(tab)}>{tab[0].toUpperCase() + tab.slice(1)}{tab === "diff" && detail.diff.length ? <span>{detail.diff.length}</span> : null}</button>)}</nav>
+                  <div className="td3-detail-body">
+                    {detail.loading && detail.ownerKey === selected.key ? <div className="td3-detail-loading"><LoadingIcon size={22} /><strong>Loading Task...</strong></div> : null}
+                    {!detail.loading && detailTab === "overview" ? <><section className="td3-relationship"><h3>Task → Run → Session</h3><div><article><small>Task</small><strong>{taskTitle(selected.task)}</strong><span>Durable work item</span></article><i>→</i><article><small>Run</small><strong>{selected.task.run?.id || "Not started"}</strong><span>{selected.task.run?.startedAt ? `Started ${formatRelative(selected.task.run.startedAt)}` : "No Run yet"}</span></article><i>→</i><article><small>Session</small><strong>{selectedSessionID || "None"}</strong><span>{selectedAgent?.label || selected.task.agentId}</span></article></div></section><div className="td3-detail-cards"><section><header><h3>Result Summary</h3></header>{summary ? <div className="td3-markdown"><ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{summary}</ReactMarkdown></div> : <p className="td3-muted">No assistant result is available yet.</p>}{selected.task.error?.message ? <div className="td3-inline-error">{selected.task.error.message}</div> : null}</section><section><header><h3>Workspace result</h3></header><dl><dt>Changed files</dt><dd>{detail.diff.length || detail.result?.changeCount || 0}</dd><dt>Commits ahead</dt><dd>{detail.result?.commitsAhead ?? "-"}</dd><dt>Commits behind</dt><dd>{detail.result?.commitsBehind ?? "-"}</dd><dt>Dirty</dt><dd>{detail.result?.dirty ? "Yes" : "No"}</dd></dl>{detail.todos.length ? <div className="td3-todo-summary"><strong>Agent plan</strong>{detail.todos.slice(0, 5).map((todo) => <span key={todo.id}>{todo.status === "completed" ? "✓" : "•"} {todo.content}</span>)}</div> : null}</section></div></> : null}
+                    {!detail.loading && detailTab === "conversation" ? <div className="td3-conversation">{detail.messages.length === 0 ? <div className="td3-empty-state"><span>No conversation is available for this Run.</span></div> : detail.messages.map((message) => { const text = extractText(message); return text ? <article key={message.info.id} className={message.info.role === "user" ? "user" : "assistant"}><header><strong>{message.info.role === "user" ? "You" : selectedAgent?.label || "Agent"}</strong></header><div className="td3-markdown"><ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{text}</ReactMarkdown></div></article> : null })}</div> : null}
+                    {!detail.loading && detailTab === "diff" ? <div className="td3-diff-list">{detail.diff.length === 0 ? <div className="td3-empty-state"><span>No changed files were reported by the current Session.</span></div> : detail.diff.map((file) => <details key={file.file}><summary><code>{file.file}</code><span><b>+{file.additions}</b><i>-{file.deletions}</i></span></summary>{file.patch ? <pre>{file.patch}</pre> : <p>No patch text available.</p>}</details>)}</div> : null}
+                    {!detail.loading && detailTab === "runs" ? <div className="td3-runs"><header><h3>Run history</h3><p>Each continuation creates a new native Session while the Task remains the durable unit.</p></header>{taskRunHistory(selected.task).length === 0 ? <div className="td3-empty-state"><span>This Task has not started a Run yet.</span></div> : [...taskRunHistory(selected.task)].reverse().map((run, index) => <article key={run.id || index}><span className="td3-run-index">#{taskRunHistory(selected.task).length - index}</span><div><strong>{run.id || "Run"}</strong><small>{run.prompt || (index === taskRunHistory(selected.task).length - 1 ? selected.task.prompt : "Continuation")}</small></div><dl><dt>Session</dt><dd>{runSessionID(run) || "-"}</dd><dt>Started</dt><dd>{formatDate(run.startedAt)}</dd><dt>Finished</dt><dd>{formatDate(run.finishedAt)}</dd></dl></article>)}</div> : null}
+                    {detail.error ? <div className="td3-inline-error">{detail.error}</div> : null}
+                  </div>
+                  <footer className="td3-detail-actions">{selectedSessionID ? <button type="button" className="td3-button" onClick={() => setView("sessions")}>Open Session</button> : null}{["completed", "failed", "cancelled"].includes(normalizeTaskStatus(selected.task.status)) ? <button type="button" className="td3-button primary" onClick={() => setContinueOpen(true)}>Continue</button> : null}{!["running", "preparing", "queued"].includes(normalizeTaskStatus(selected.task.status)) ? <button type="button" className="td3-button" disabled={actionBusy} onClick={() => void finishSelected()}>Review / Finish</button> : null}{selected.task.workspace.mode === "worktree" && !["running", "preparing", "queued"].includes(normalizeTaskStatus(selected.task.status)) ? <button type="button" className="td3-button danger" disabled={actionBusy} onClick={() => void cleanupSelected()}>Cleanup</button> : null}{actionError ? <span className="td3-action-error">{actionError}</span> : null}</footer>
+                </>
+              )}
+            </aside>
+          </main>
+        ) : null}
+
+        {view === "projects" ? <main className="td3-simple-page"><section className="td3-page-heading"><div><small>Machine catalog</small><h1>Projects</h1><p>Projects are daemon-known roots used by Tasks. Arbitrary session folders stay separate.</p></div></section><div className="td3-card-grid">{runtimes.flatMap((runtime) => runtime.projects.map((project) => <article key={`${runtime.key}|${project.id}`}><FolderIcon size={20} /><div><h3>{project.name}</h3><code>{project.path}</code><span>{runtime.snapshot?.machine.name || runtime.machine.name} · {project.kind}</span></div><button onClick={() => { setMachineScope(runtime.machine.id); onActiveMachineID(runtime.machine.id); setView("tasks"); setNewTaskOpen(true) }}>New Task</button></article>))}</div></main> : null}
+
+        {view === "agents" ? <main className="td3-simple-page"><section className="td3-page-heading"><div><small>Harnesses</small><h1>Agents</h1><p>Native coding harnesses discovered behind each machine daemon.</p></div></section><div className="td3-card-grid">{runtimes.flatMap((runtime) => runtime.agents.map((agent) => <article key={`${runtime.key}|${agent.id}`}><HarnessBadge agent={agent} /><div><h3>{agent.label}</h3><span>{runtime.snapshot?.machine.name || runtime.machine.name}</span><code>{agent.backend} · {agent.transport}</code></div></article>))}</div></main> : null}
+
+        {view === "machines" ? <main className="td3-simple-page"><section className="td3-page-heading"><div><small>Fleet</small><h1>Machines</h1><p>Execution, credentials and source code stay local to each configured machine.</p></div><button className="td3-button primary" onClick={onManageMachines}>Manage machines</button></section><div className="td3-card-grid">{runtimes.map((runtime) => <article key={runtime.key}><ServerIcon size={22} /><div><h3>{runtime.snapshot?.machine.name || runtime.machine.name}</h3><code>{runtime.machine.config.host}:{runtime.machine.config.port}</code><span>{runtime.agents.length} agents · {runtime.tasks.length} tasks</span>{runtime.error ? <small className="td3-card-error">{runtime.error}</small> : null}</div><b className={`td3-machine-state ${runtime.state}`}>{runtime.state}</b></article>)}</div></main> : null}
+
+        {view === "needs" ? <main className="td3-simple-page"><section className="td3-page-heading"><div><small>Attention inbox</small><h1>Needs You</h1><p>Questions and permission requests from native harness Sessions.</p></div></section><div className="td3-attention-list">{attention.length === 0 ? <div className="td3-empty-state"><strong>Nothing needs you right now.</strong></div> : attention.map((item) => item.type === "permission" ? <article className="td3-attention-card" key={item.key}><header><span className="td3-attention-icon warning">!</span><div><strong>Permission request</strong><small>{item.task ? taskTitle(item.task) : item.agent.label}</small></div></header><p>{item.request.permission}</p>{item.request.patterns?.length ? <code>{item.request.patterns.join(", ")}</code> : null}<footer><button className="td3-button danger" onClick={() => void api.replyPermission(configForAgent(item.runtime, item.agent), item.request.id, "reject", item.task?.workspace.path).then(() => refresh(true))}>Reject</button><button className="td3-button" onClick={() => void api.replyPermission(configForAgent(item.runtime, item.agent), item.request.id, "once", item.task?.workspace.path).then(() => refresh(true))}>Once</button><button className="td3-button primary" onClick={() => void api.replyPermission(configForAgent(item.runtime, item.agent), item.request.id, "always", item.task?.workspace.path).then(() => refresh(true))}>Always</button></footer></article> : <QuestionAttentionCard key={item.key} item={item} onResolved={() => void refresh(true)} onOpenSession={() => setView("sessions")} />)}</div></main> : null}
+      </div>
+
+      {newTaskOpen ? <NewTaskModal runtimes={runtimes} initialMachineID={machineScope === "all" ? activeMachineID : machineScope} onClose={() => setNewTaskOpen(false)} onCreated={(runtime, task) => { setMachineScope(runtime.machine.id); onActiveMachineID(runtime.machine.id); setSelectedKey(`${runtime.key}|${task.id}`); void refreshAndReselect(task.id, runtime.machine.id) }} /> : null}
+      {continueOpen && selected ? <ContinueTaskModal record={selected} onClose={() => setContinueOpen(false)} onContinued={(task) => void refreshAndReselect(task.id, selected.runtime.machine.id)} /> : null}
+    </div>
+  )
+}

--- a/web/src/components/taskdesk-v3.tsx
+++ b/web/src/components/taskdesk-v3.tsx
@@ -383,7 +383,7 @@ export function TaskDeskV3({ machines, activeMachineID, onActiveMachineID, onPer
     if (activeMachineID && machines.some((machine) => machine.id === activeMachineID)) setMachineScope(activeMachineID)
   }, [activeMachineID])
 
-  const refresh = useCallback(async (silent = false) => {
+  const refresh = useCallback(async (_silent = false) => {
     if (refreshInFlight.current) return
     refreshInFlight.current = true
     try {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -28,6 +28,7 @@ import "./v3-polish.css"
 import "./universal-workspace.css"
 import "./universal-workspace-readable.css"
 import "./universal-workspace-readable-fixes.css"
+import "./taskdesk-v3.css"
 
 installCompletionAudioGuard()
 

--- a/web/src/taskClient.ts
+++ b/web/src/taskClient.ts
@@ -22,6 +22,19 @@ export type TaskWorkspace = {
   source?: string
 }
 
+export type MachineTaskRun = {
+  id?: string
+  agentId?: string
+  sessionId?: string | null
+  sessionID?: string | null
+  status?: string
+  transport?: string | null
+  directory?: string
+  prompt?: string
+  startedAt?: string
+  finishedAt?: string
+}
+
 export type MachineTask = {
   id: string
   machineId: string
@@ -32,9 +45,39 @@ export type MachineTask = {
   model?: ModelSelection | null
   status: string
   workspace: TaskWorkspace
-  run: null | { id?: string; sessionId?: string; sessionID?: string; status?: string }
+  run: null | MachineTaskRun
+  runs?: MachineTaskRun[]
+  error?: { message?: string } | null
   createdAt: string
   updatedAt: string
+}
+
+export type TaskWorkspaceInspection = {
+  managed: boolean
+  dirty: boolean
+  changeCount: number
+  commitsAhead?: number
+  commitsBehind?: number
+  mergedIntoSource?: boolean
+  branchMissing?: boolean
+  sourceHead?: string
+  branchHead?: string
+}
+
+export type TaskCleanup = {
+  removed: boolean
+  branchDeleted: boolean
+}
+
+export type TaskCleanupResponse = {
+  task: MachineTask
+  cleanup: TaskCleanup
+}
+
+export type TaskFinishResponse = {
+  task: MachineTask
+  result: TaskWorkspaceInspection
+  cleanup: TaskCleanup
 }
 
 export type AgentModelCatalog = {
@@ -189,5 +232,25 @@ export const taskClient = {
 
   launch(config: ServerConfig, taskId: string): Promise<MachineTask> {
     return machineRequest<MachineTask>(config, `/v1/tasks/${encodeURIComponent(taskId)}/launch`, { method: "POST", body: {} })
+  },
+
+  continueTask(config: ServerConfig, taskId: string, prompt: string): Promise<MachineTask> {
+    return machineRequest<MachineTask>(config, `/v1/tasks/${encodeURIComponent(taskId)}/continue`, { method: "POST", body: { prompt } })
+  },
+
+  inspectResult(config: ServerConfig, taskId: string): Promise<TaskWorkspaceInspection> {
+    return machineRequest<TaskWorkspaceInspection>(config, `/v1/tasks/${encodeURIComponent(taskId)}/result`)
+  },
+
+  inspectWorkspace(config: ServerConfig, taskId: string): Promise<TaskWorkspaceInspection> {
+    return machineRequest<TaskWorkspaceInspection>(config, `/v1/tasks/${encodeURIComponent(taskId)}/worktree`)
+  },
+
+  cleanupWorkspace(config: ServerConfig, taskId: string): Promise<TaskCleanupResponse> {
+    return machineRequest<TaskCleanupResponse>(config, `/v1/tasks/${encodeURIComponent(taskId)}/worktree/cleanup`, { method: "POST", body: {} })
+  },
+
+  finish(config: ServerConfig, taskId: string): Promise<TaskFinishResponse> {
+    return machineRequest<TaskFinishResponse>(config, `/v1/tasks/${encodeURIComponent(taskId)}/finish`, { method: "POST", body: {} })
   }
 }

--- a/web/src/taskdesk-home.test.mjs
+++ b/web/src/taskdesk-home.test.mjs
@@ -56,16 +56,7 @@ test("TaskDesk sorts Tasks by durable task activity rather than session order", 
   assert.deepEqual(sortTasksByActivity([older, newer]).map((item) => item.id), ["newer", "older"])
 })
 
-test("Universal workspace cannot starve initial loading with overlapping polls", () => {
-  const source = readFileSync(new URL("./components/universal-workspace.tsx", import.meta.url), "utf8")
-  assert.match(source, /const AGENT_SESSION_LOAD_TIMEOUT_MS = 12_000/)
-  assert.match(source, /const refreshInFlight = useRef\(false\)/)
-  assert.match(source, /if \(refreshInFlight\.current\) return/)
-  assert.match(source, /await withTimeout\(Promise\.all\(\[/)
-  assert.match(source, /refreshInFlight\.current = false/)
-})
-
-test("Universal workspace machine configuration is independent from Classic profiles", () => {
+test("TaskDesk machine configuration remains independent from Classic profiles", () => {
   const main = readFileSync(new URL("./main.tsx", import.meta.url), "utf8")
   const machineStorage = readFileSync(new URL("./workspaceMachines.ts", import.meta.url), "utf8")
   const standalone = readFileSync(new URL("./components/standalone-universal-workspace.tsx", import.meta.url), "utf8")
@@ -75,8 +66,75 @@ test("Universal workspace machine configuration is independent from Classic prof
   assert.match(taskDeskBoundary[0], /loadWorkspaceMachines/)
   assert.doesNotMatch(taskDeskBoundary[0], /loadServerProfiles/)
   assert.match(machineStorage, /harness-remote\.workspace\.machines\.v1/)
+  assert.match(standalone, /<TaskDeskV3/)
   assert.match(standalone, /\+ Add machine/)
-  assert.match(standalone, /Classic connections are separate/)
+})
+
+test("TaskDesk v3 exposes Tasks as a separate durable product surface", () => {
+  const source = readFileSync(new URL("./components/taskdesk-v3.tsx", import.meta.url), "utf8")
+
+  assert.match(source, /type TaskDeskView = "overview" \| "tasks" \| "sessions"/)
+  assert.match(source, />Tasks</)
+  assert.match(source, />Sessions</)
+  assert.match(source, /Task → Run → Session/)
+  assert.match(source, /Run history/)
+  assert.match(source, /taskRunHistory\(selected\.task\)/)
+  assert.match(source, /<UniversalWorkspace/)
+})
+
+test("TaskDesk v3 New Task uses real machine task APIs and explicit workspace choice", () => {
+  const source = readFileSync(new URL("./components/taskdesk-v3.tsx", import.meta.url), "utf8")
+
+  assert.match(source, /taskClient\.createTask/)
+  assert.match(source, /taskClient\.prepareWorktree/)
+  assert.match(source, /taskClient\.launch/)
+  assert.match(source, /Use an isolated Git worktree/)
+  assert.match(source, /Project directory/)
+  assert.match(source, /Machine -> Project -> Agent -> Model -> Workspace -> Task|machine, project, model and workspace/i)
+})
+
+test("TaskDesk v3 Task detail uses the native Run session and lifecycle APIs", () => {
+  const source = readFileSync(new URL("./components/taskdesk-v3.tsx", import.meta.url), "utf8")
+  const client = readFileSync(new URL("./taskClient.ts", import.meta.url), "utf8")
+
+  assert.match(source, /api\.loadMessages\(config, sessionID, directory\)/)
+  assert.match(source, /api\.loadDiff\(config, sessionID, directory\)/)
+  assert.match(source, /taskClient\.inspectResult/)
+  assert.match(source, /taskClient\.finish/)
+  assert.match(source, /taskClient\.cleanupWorkspace/)
+  assert.match(source, /taskClient\.continueTask/)
+  assert.match(client, /\/v1\/tasks\/\$\{encodeURIComponent\(taskId\)\}\/continue/)
+  assert.match(client, /\/v1\/tasks\/\$\{encodeURIComponent\(taskId\)\}\/finish/)
+  assert.match(client, /\/v1\/tasks\/\$\{encodeURIComponent\(taskId\)\}\/result/)
+})
+
+test("TaskDesk v3 protects Task detail from stale asynchronous responses", () => {
+  const source = readFileSync(new URL("./components/taskdesk-v3.tsx", import.meta.url), "utf8")
+
+  assert.match(source, /const detailGeneration = useRef\(0\)/)
+  assert.match(source, /const generation = \+\+detailGeneration\.current/)
+  assert.match(source, /if \(generation !== detailGeneration\.current\) return/)
+  assert.match(source, /ownerKey: record\.key/)
+  assert.match(source, /detail\.ownerKey === selected\.key/)
+})
+
+test("TaskDesk v3 aggregates native questions and permissions into Needs You", () => {
+  const source = readFileSync(new URL("./components/taskdesk-v3.tsx", import.meta.url), "utf8")
+
+  assert.match(source, /api\.loadQuestions\(config\)/)
+  assert.match(source, /api\.loadPermissions\(config\)/)
+  assert.match(source, /api\.replyPermission/)
+  assert.match(source, /api\.replyQuestion/)
+  assert.match(source, />Needs You</)
+})
+
+test("Universal workspace cannot starve initial loading with overlapping polls", () => {
+  const source = readFileSync(new URL("./components/universal-workspace.tsx", import.meta.url), "utf8")
+  assert.match(source, /const AGENT_SESSION_LOAD_TIMEOUT_MS = 12_000/)
+  assert.match(source, /const refreshInFlight = useRef\(false\)/)
+  assert.match(source, /if \(refreshInFlight\.current\) return/)
+  assert.match(source, /await withTimeout\(Promise\.all\(\[/)
+  assert.match(source, /refreshInFlight\.current = false/)
 })
 
 test("Universal workspace counts and projects follow the selected machine scope", () => {

--- a/web/src/taskdesk-v3.css
+++ b/web/src/taskdesk-v3.css
@@ -1,0 +1,287 @@
+.td3-shell {
+  --td3-bg: #070c14;
+  --td3-panel: #0b121d;
+  --td3-panel-2: #0f1825;
+  --td3-panel-3: #131e2e;
+  --td3-border: rgba(148, 163, 184, 0.13);
+  --td3-border-strong: rgba(148, 163, 184, 0.24);
+  --td3-text: #edf3fb;
+  --td3-muted: #8e9bad;
+  --td3-muted-2: #657389;
+  --td3-blue: #4f7cff;
+  --td3-green: #4ade80;
+  --td3-yellow: #fbbf24;
+  --td3-red: #f87171;
+  width: 100%;
+  height: 100vh;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 190px minmax(0, 1fr);
+  overflow: hidden;
+  color: var(--td3-text);
+  background: radial-gradient(circle at 58% -20%, rgba(79, 124, 255, .11), transparent 35%), var(--td3-bg);
+  font: 13px/1.45 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.td3-shell *, .td3-shell *::before, .td3-shell *::after { box-sizing: border-box; }
+.td3-shell button, .td3-shell input, .td3-shell textarea, .td3-shell select { font: inherit; }
+.td3-shell button { color: inherit; }
+
+.td3-sidebar {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--td3-border);
+  background: rgba(7, 12, 20, .94);
+}
+
+.td3-brand {
+  height: 74px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 15px;
+  border-bottom: 1px solid rgba(148, 163, 184, .08);
+}
+.td3-brand > span {
+  width: 34px; height: 34px; display: grid; place-items: center;
+  border: 1px solid rgba(90, 131, 255, .42); border-radius: 10px;
+  color: #dbe7ff; background: linear-gradient(145deg, rgba(63, 108, 228, .35), rgba(27, 50, 111, .45));
+  font-size: 11px; font-weight: 800; letter-spacing: .04em;
+}
+.td3-brand > div { min-width: 0; display: flex; flex-direction: column; }
+.td3-brand strong { font-size: 14px; }
+.td3-brand small { margin-top: 2px; color: var(--td3-muted); font-size: 11px; }
+
+.td3-sidebar nav { display: grid; gap: 4px; padding: 14px 10px; }
+.td3-sidebar nav button, .td3-sidebar-bottom button {
+  width: 100%; min-height: 38px; display: grid; grid-template-columns: 20px minmax(0,1fr) auto;
+  align-items: center; gap: 8px; padding: 0 10px; border: 1px solid transparent; border-radius: 9px;
+  color: #aab6c7; background: transparent; text-align: left; cursor: pointer;
+}
+.td3-sidebar nav button:hover, .td3-sidebar-bottom button:hover { color: #eef4fc; background: rgba(255,255,255,.035); }
+.td3-sidebar nav button.active { color: #fff; border-color: rgba(79,124,255,.25); background: rgba(79,124,255,.14); box-shadow: inset 2px 0 0 var(--td3-blue); }
+.td3-sidebar nav button > span:first-child { width: 18px; text-align: center; color: #8290a4; }
+.td3-sidebar nav button b { min-width: 20px; padding: 1px 6px; border-radius: 999px; color: #8f9db1; background: rgba(255,255,255,.05); text-align: center; font-size: 11px; }
+.td3-sidebar nav button b.attention { color: #ffd195; background: rgba(234, 88, 12, .17); }
+.td3-sidebar-bottom { margin-top: auto; display: grid; gap: 3px; padding: 10px; border-top: 1px solid var(--td3-border); }
+.td3-sidebar-bottom button { grid-template-columns: 1fr; font-size: 12px; }
+
+.td3-workspace { min-width: 0; min-height: 0; display: flex; flex-direction: column; overflow: hidden; }
+.td3-topbar {
+  height: 66px; flex: none; display: grid; grid-template-columns: minmax(250px, auto) minmax(260px, 1fr) minmax(220px, 360px) auto auto;
+  align-items: center; gap: 10px; padding: 0 14px; border-bottom: 1px solid var(--td3-border);
+  background: rgba(8, 14, 23, .9); backdrop-filter: blur(18px); z-index: 5;
+}
+.td3-machine-selector { min-width: 0; display: flex; align-items: center; gap: 7px; }
+.td3-machine-selector select { min-width: 110px; max-width: 185px; height: 36px; padding: 0 28px 0 10px; border: 1px solid var(--td3-border); border-radius: 9px; outline: 0; color: #e5ecf6; background: #101927; }
+.td3-online-dot { width: 8px; height: 8px; flex: none; border-radius: 50%; background: #64748b; }
+.td3-online-dot.online { background: var(--td3-green); box-shadow: 0 0 0 3px rgba(74,222,128,.08); }
+.td3-online-dot.offline { background: var(--td3-red); }
+.td3-machine-selector small { color: var(--td3-muted); font-size: 11px; }
+.td3-agent-strip { min-width: 0; display: flex; gap: 5px; overflow: hidden; }
+.td3-agent-badge { min-width: 0; height: 31px; display: inline-flex; align-items: center; gap: 6px; padding: 0 8px; border: 1px solid var(--td3-border); border-radius: 8px; color: #cdd7e5; background: rgba(255,255,255,.025); white-space: nowrap; }
+.td3-agent-badge img { width: 18px; height: 18px; display: block; object-fit: contain; border-radius: 4px; }
+.td3-agent-badge > span { font-size: 9px; font-weight: 800; }
+.td3-agent-badge b { overflow: hidden; text-overflow: ellipsis; font-size: 11px; font-weight: 650; }
+.td3-agent-state { width: 6px; height: 6px; flex: none; border-radius: 50%; background: #64748b; }
+.td3-agent-state-available, .td3-agent-state-configured { background: var(--td3-green); }
+.td3-global-search { min-width: 0; height: 36px; display: flex; align-items: center; gap: 8px; padding: 0 10px; border: 1px solid var(--td3-border); border-radius: 9px; color: var(--td3-muted); background: rgba(15,24,37,.85); }
+.td3-global-search input { width: 100%; min-width: 0; border: 0; outline: 0; color: var(--td3-text); background: transparent; font-size: 12px; }
+
+.td3-button { min-height: 34px; display: inline-flex; align-items: center; justify-content: center; gap: 6px; padding: 0 11px; border: 1px solid var(--td3-border); border-radius: 9px; outline: 0; color: #d7e0eb; background: #101927; cursor: pointer; white-space: nowrap; }
+.td3-button:hover:not(:disabled) { border-color: var(--td3-border-strong); background: #152133; }
+.td3-button:disabled { opacity: .45; cursor: default; }
+.td3-button.primary { border-color: rgba(103,139,255,.5); color: #fff; background: linear-gradient(180deg,#5680ff,#3d68e8); }
+.td3-button.danger { border-color: rgba(248,113,113,.28); color: #fca5a5; background: rgba(127,29,29,.13); }
+
+.td3-page-heading { display: flex; align-items: flex-end; justify-content: space-between; gap: 20px; padding: 22px 24px 17px; }
+.td3-page-heading.compact { padding: 19px 18px 14px; }
+.td3-page-heading small { color: #71819a; font-size: 10px; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+.td3-page-heading h1 { margin: 2px 0 3px; font-size: 23px; line-height: 1.15; letter-spacing: -.025em; }
+.td3-page-heading p { max-width: 680px; margin: 0; color: var(--td3-muted); font-size: 12.5px; }
+
+.td3-overview, .td3-simple-page { min-height: 0; flex: 1; overflow: auto; }
+.td3-kpis { display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); gap: 10px; padding: 0 24px 18px; }
+.td3-kpis article { min-height: 104px; display: flex; flex-direction: column; justify-content: center; padding: 14px 16px; border: 1px solid var(--td3-border); border-radius: 12px; background: linear-gradient(145deg,rgba(18,29,45,.82),rgba(10,17,28,.82)); }
+.td3-kpis span { color: var(--td3-muted); font-size: 11px; }
+.td3-kpis strong { margin: 3px 0; font-size: 26px; letter-spacing: -.03em; }
+.td3-kpis small { color: var(--td3-muted-2); font-size: 11px; }
+.td3-overview-grid { display: grid; grid-template-columns: minmax(0,1.25fr) minmax(300px,.75fr); gap: 12px; padding: 0 24px 24px; }
+.td3-panel { min-width: 0; border: 1px solid var(--td3-border); border-radius: 12px; background: rgba(11,18,29,.78); overflow: hidden; }
+.td3-panel > header { min-height: 64px; display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 0 15px; border-bottom: 1px solid rgba(148,163,184,.08); }
+.td3-panel h2 { margin: 0; font-size: 14px; }
+.td3-panel header p { margin: 2px 0 0; color: var(--td3-muted); font-size: 11px; }
+.td3-panel header button { border: 0; color: #78a0ff; background: transparent; cursor: pointer; font-size: 11px; }
+.td3-recent-task, .td3-attention-row { width: 100%; min-height: 60px; display: grid; grid-template-columns: auto minmax(0,1fr) auto; align-items: center; gap: 10px; padding: 9px 14px; border: 0; border-bottom: 1px solid rgba(148,163,184,.06); color: inherit; background: transparent; text-align: left; cursor: pointer; }
+.td3-recent-task:hover, .td3-attention-row:hover { background: rgba(255,255,255,.025); }
+.td3-recent-task div, .td3-attention-row div { min-width: 0; display: flex; flex-direction: column; }
+.td3-recent-task strong, .td3-attention-row strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; }
+.td3-recent-task small, .td3-attention-row small { color: var(--td3-muted); font-size: 11px; }
+.td3-recent-task time { color: var(--td3-muted-2); font-size: 10.5px; }
+.td3-attention-row { grid-template-columns: 28px minmax(0,1fr); }
+.td3-attention-row > span { width: 26px; height: 26px; display: grid; place-items: center; border-radius: 50%; color: #fbd38d; background: rgba(234,88,12,.13); font-weight: 800; }
+.td3-empty-mini { padding: 22px 15px; color: var(--td3-muted); font-size: 12px; }
+
+.td3-tasks-layout { min-height: 0; flex: 1; display: grid; grid-template-columns: minmax(620px, 1.2fr) minmax(430px, .8fr); overflow: hidden; }
+.td3-task-list-pane { min-width: 0; min-height: 0; display: flex; flex-direction: column; border-right: 1px solid var(--td3-border); }
+.td3-filters { display: flex; gap: 6px; padding: 0 18px 12px; overflow-x: auto; }
+.td3-filters button { min-height: 30px; display: inline-flex; align-items: center; gap: 6px; padding: 0 10px; border: 1px solid var(--td3-border); border-radius: 999px; color: var(--td3-muted); background: rgba(255,255,255,.018); cursor: pointer; font-size: 11px; white-space: nowrap; }
+.td3-filters button.active { color: #fff; border-color: rgba(79,124,255,.35); background: rgba(79,124,255,.14); }
+.td3-filters span { min-width: 17px; padding: 1px 5px; border-radius: 999px; color: #b5c1d1; background: rgba(255,255,255,.05); text-align: center; font-size: 10px; }
+.td3-task-table-head, .td3-task-row { display: grid; grid-template-columns: minmax(235px,2.1fr) minmax(90px,.8fr) minmax(115px,.95fr) minmax(100px,.85fr) minmax(110px,.9fr) 86px 72px; gap: 10px; align-items: center; }
+.td3-task-table-head { min-height: 34px; padding: 0 15px; border-top: 1px solid rgba(148,163,184,.07); border-bottom: 1px solid rgba(148,163,184,.09); color: #708096; background: rgba(255,255,255,.015); font-size: 10px; font-weight: 700; }
+.td3-task-list { min-height: 0; flex: 1; overflow: auto; }
+.td3-task-row { width: 100%; min-height: 65px; padding: 8px 15px; border: 0; border-bottom: 1px solid rgba(148,163,184,.065); color: #bdc8d6; background: transparent; text-align: left; cursor: pointer; font-size: 11.5px; }
+.td3-task-row:hover { background: rgba(255,255,255,.025); }
+.td3-task-row.selected { background: linear-gradient(90deg,rgba(79,124,255,.14),rgba(79,124,255,.035)); box-shadow: inset 2px 0 0 var(--td3-blue); }
+.td3-task-title { min-width: 0; display: grid; grid-template-columns: 11px minmax(0,1fr); align-items: center; gap: 9px; }
+.td3-task-title > span { min-width: 0; display: flex; flex-direction: column; }
+.td3-task-title strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: #eef3fa; font-size: 12.5px; }
+.td3-task-title small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; margin-top: 2px; color: #768498; font-size: 10.5px; }
+.td3-task-row > span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.td3-task-row .td3-agent-badge { max-width: 100%; height: 29px; padding-inline: 6px; }
+.td3-task-row .td3-agent-badge b { font-size: 10.5px; }
+.td3-task-row time { color: #78869a; font-size: 10.5px; }
+.td3-status-dot { width: 9px; height: 9px; display: inline-block; border: 2px solid #64748b; border-radius: 50%; }
+.td3-status-dot.td3-status-running, .td3-status-dot.td3-status-preparing, .td3-status-dot.td3-status-queued { border-color: #5b82ff; box-shadow: 0 0 8px rgba(79,124,255,.35); }
+.td3-status-dot.td3-status-waiting { border-color: #fbbf24; }
+.td3-status-dot.td3-status-completed { border-color: #4ade80; }
+.td3-status-dot.td3-status-failed, .td3-status-dot.td3-status-cancelled { border-color: #f87171; }
+.td3-status-pill { display: inline-flex; align-items: center; justify-content: center; min-height: 23px; padding: 0 7px; border-radius: 7px; font-size: 10px; font-weight: 750; }
+.td3-status-pill.td3-status-running, .td3-status-pill.td3-status-preparing, .td3-status-pill.td3-status-queued { color: #a9bcff; background: rgba(79,124,255,.14); }
+.td3-status-pill.td3-status-waiting { color: #fcd98f; background: rgba(180,105,0,.17); }
+.td3-status-pill.td3-status-completed { color: #89e9ad; background: rgba(34,197,94,.12); }
+.td3-status-pill.td3-status-failed, .td3-status-pill.td3-status-cancelled { color: #fca5a5; background: rgba(239,68,68,.12); }
+
+.td3-task-detail { min-width: 0; min-height: 0; display: flex; flex-direction: column; background: rgba(8,14,23,.58); }
+.td3-detail-header { min-height: 105px; padding: 17px 18px 13px; border-bottom: 1px solid var(--td3-border); }
+.td3-detail-title-line { display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; }
+.td3-detail-title-line h2 { margin: 0; font-size: 17px; line-height: 1.25; letter-spacing: -.02em; }
+.td3-detail-header p { max-height: 42px; margin: 7px 0 0; overflow: hidden; color: var(--td3-muted); display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; font-size: 11.5px; }
+.td3-detail-meta { display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); gap: 1px; padding: 10px 12px; border-bottom: 1px solid rgba(148,163,184,.08); background: rgba(255,255,255,.012); }
+.td3-detail-meta span { min-width: 0; display: flex; flex-direction: column; padding: 5px 7px; }
+.td3-detail-meta small { color: #67758a; font-size: 9.5px; }
+.td3-detail-meta b { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; margin-top: 1px; color: #c4cfdd; font-size: 10.5px; font-weight: 650; }
+.td3-detail-tabs { height: 40px; display: flex; gap: 18px; padding: 0 17px; border-bottom: 1px solid rgba(148,163,184,.08); }
+.td3-detail-tabs button { position: relative; border: 0; color: #7d8a9d; background: transparent; cursor: pointer; font-size: 11px; }
+.td3-detail-tabs button.active { color: #eef3fa; }
+.td3-detail-tabs button.active::after { content:""; position:absolute; left:0; right:0; bottom:-1px; height:2px; background:var(--td3-blue); }
+.td3-detail-tabs button span { margin-left: 4px; padding: 1px 5px; border-radius: 999px; background: rgba(255,255,255,.05); font-size: 9px; }
+.td3-detail-body { min-height: 0; flex: 1; overflow: auto; padding: 13px; }
+.td3-detail-loading { min-height: 180px; display: flex; align-items: center; justify-content: center; gap: 8px; color: var(--td3-muted); }
+.td3-relationship { padding: 12px; border: 1px solid var(--td3-border); border-radius: 11px; background: rgba(15,24,37,.65); }
+.td3-relationship h3 { margin: 0 0 10px; font-size: 12px; }
+.td3-relationship > div { display: grid; grid-template-columns: minmax(0,1fr) 20px minmax(0,1fr) 20px minmax(0,1fr); align-items: center; gap: 5px; }
+.td3-relationship article { min-width: 0; min-height: 78px; display: flex; flex-direction: column; justify-content: center; padding: 9px; border: 1px solid rgba(148,163,184,.1); border-radius: 9px; background: rgba(255,255,255,.02); }
+.td3-relationship article small { color: #7793d8; font-size: 9px; text-transform: uppercase; letter-spacing: .08em; }
+.td3-relationship article strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; margin: 2px 0; font-size: 11px; }
+.td3-relationship article span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--td3-muted); font-size: 9.5px; }
+.td3-relationship > div > i { color: #60708a; text-align: center; font-style: normal; }
+.td3-detail-cards { display: grid; grid-template-columns: 1.12fr .88fr; gap: 10px; margin-top: 10px; }
+.td3-detail-cards > section { min-width: 0; padding: 12px; border: 1px solid var(--td3-border); border-radius: 11px; background: rgba(15,24,37,.55); }
+.td3-detail-cards h3 { margin: 0 0 9px; font-size: 12px; }
+.td3-detail-cards dl { display: grid; grid-template-columns: 1fr auto; gap: 6px 10px; margin: 0; }
+.td3-detail-cards dt { color: var(--td3-muted); font-size: 10.5px; }
+.td3-detail-cards dd { margin: 0; color: #dbe5f1; font-size: 10.5px; font-weight: 650; }
+.td3-muted { color: var(--td3-muted); font-size: 11px; }
+.td3-todo-summary { display: grid; gap: 5px; margin-top: 12px; padding-top: 10px; border-top: 1px solid rgba(148,163,184,.08); }
+.td3-todo-summary strong { font-size: 10.5px; }
+.td3-todo-summary span { color: #9eabbc; font-size: 10px; }
+.td3-markdown { color: #c7d1de; font-size: 11.5px; line-height: 1.6; }
+.td3-markdown > :first-child { margin-top: 0; } .td3-markdown > :last-child { margin-bottom: 0; }
+.td3-markdown p { margin: 5px 0; }
+.td3-markdown code { padding: 1px 4px; border-radius: 4px; color: #dbe7f5; background: rgba(255,255,255,.05); font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.td3-conversation { display: grid; gap: 13px; }
+.td3-conversation article { padding: 11px 12px; border: 1px solid rgba(148,163,184,.09); border-radius: 10px; background: rgba(255,255,255,.018); }
+.td3-conversation article.user { background: rgba(79,124,255,.055); }
+.td3-conversation header { margin-bottom: 5px; color: #e2eaf5; font-size: 11px; }
+.td3-diff-list { display: grid; gap: 7px; }
+.td3-diff-list details { border: 1px solid var(--td3-border); border-radius: 9px; background: rgba(255,255,255,.018); overflow: hidden; }
+.td3-diff-list summary { min-height: 38px; display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 0 10px; cursor: pointer; }
+.td3-diff-list summary code { min-width: 0; overflow: hidden; text-overflow: ellipsis; color: #cbd7e5; white-space: nowrap; font-size: 10.5px; }
+.td3-diff-list summary span { display: flex; gap: 6px; font-size: 10px; } .td3-diff-list summary b { color:#72dc9a; } .td3-diff-list summary i { color:#f59a9a; font-style:normal; }
+.td3-diff-list pre { max-height: 360px; margin: 0; overflow: auto; padding: 10px; border-top: 1px solid var(--td3-border); color: #9fabbd; background: #070c13; font: 10px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; white-space: pre-wrap; }
+.td3-runs > header h3 { margin: 0; font-size: 13px; } .td3-runs > header p { margin: 3px 0 12px; color:var(--td3-muted); font-size:10.5px; }
+.td3-runs > article { display: grid; grid-template-columns: 32px minmax(0,1fr) minmax(190px,.8fr); gap: 10px; padding: 11px; border: 1px solid var(--td3-border); border-radius: 10px; margin-bottom: 7px; background: rgba(255,255,255,.018); }
+.td3-run-index { width: 29px; height: 29px; display:grid; place-items:center; border-radius:50%; color:#9eb5ff; background:rgba(79,124,255,.12); font-size:10px; font-weight:700; }
+.td3-runs article > div { min-width:0; display:flex; flex-direction:column; } .td3-runs article strong { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-size:11px; } .td3-runs article small { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--td3-muted); font-size:10px; }
+.td3-runs dl { display:grid; grid-template-columns:auto 1fr; gap:2px 7px; margin:0; font-size:9.5px; } .td3-runs dt { color:var(--td3-muted-2); } .td3-runs dd { min-width:0; margin:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:#aeb9c8; }
+.td3-detail-actions { min-height: 57px; display: flex; align-items: center; gap: 7px; padding: 9px 13px; border-top: 1px solid var(--td3-border); background: rgba(8,14,23,.92); }
+.td3-action-error { min-width: 0; margin-left: auto; overflow: hidden; color: #fca5a5; text-overflow: ellipsis; white-space: nowrap; font-size: 10.5px; }
+
+.td3-simple-page .td3-card-grid { display: grid; grid-template-columns: repeat(auto-fill,minmax(270px,1fr)); gap: 10px; padding: 0 24px 24px; }
+.td3-card-grid article { min-width: 0; min-height: 105px; display: flex; align-items: flex-start; gap: 11px; padding: 14px; border: 1px solid var(--td3-border); border-radius: 11px; background: rgba(12,19,31,.74); }
+.td3-card-grid article > div { min-width:0; display:flex; flex:1; flex-direction:column; gap:3px; }
+.td3-card-grid h3 { margin:0; font-size:13px; } .td3-card-grid code { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:#9eacc0; font-size:10px; } .td3-card-grid span { color:var(--td3-muted); font-size:10.5px; }
+.td3-card-grid article > button { margin-left:auto; border:0; color:#8eacff; background:transparent; cursor:pointer; font-size:10.5px; }
+.td3-machine-state { margin-left:auto; padding:3px 7px; border-radius:999px; color:#fca5a5; background:rgba(239,68,68,.1); font-size:9.5px; text-transform:capitalize; } .td3-machine-state.online { color:#86efac; background:rgba(34,197,94,.1); }
+.td3-card-error { color:#fca5a5 !important; }
+
+.td3-attention-list { display: grid; grid-template-columns: repeat(auto-fill,minmax(340px,1fr)); align-items:start; gap:10px; padding:0 24px 24px; }
+.td3-attention-card { min-width:0; padding:13px; border:1px solid var(--td3-border); border-radius:11px; background:rgba(12,19,31,.74); }
+.td3-attention-card > header { display:flex; align-items:center; gap:9px; } .td3-attention-card header > div { min-width:0; display:flex; flex-direction:column; } .td3-attention-card header strong { font-size:12px; } .td3-attention-card header small { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--td3-muted); font-size:10px; }
+.td3-attention-icon { width:27px; height:27px; display:grid; place-items:center; border-radius:50%; color:#9eb5ff; background:rgba(79,124,255,.13); font-weight:800; } .td3-attention-icon.warning { color:#fbd38d; background:rgba(234,88,12,.14); }
+.td3-attention-card > p { color:#c1ccda; font-size:11px; } .td3-attention-card > code { display:block; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; padding:6px 8px; border-radius:7px; color:#aebbd0; background:rgba(0,0,0,.18); font-size:9.5px; }
+.td3-attention-card footer { display:flex; justify-content:flex-end; gap:6px; margin-top:11px; }
+.td3-question { margin-top:10px; } .td3-question p { margin:0 0 6px; color:#cbd5e1; font-size:11px; } .td3-question > div { display:flex; flex-wrap:wrap; gap:5px; } .td3-question button { min-height:28px; padding:0 8px; border:1px solid var(--td3-border); border-radius:7px; color:#aeb9c8; background:rgba(255,255,255,.02); cursor:pointer; font-size:10px; } .td3-question button.selected { color:#fff; border-color:rgba(79,124,255,.35); background:rgba(79,124,255,.13); }
+.td3-link-button { margin-right:auto; border:0; color:#8cacff; background:transparent; cursor:pointer; font-size:10.5px; }
+
+.td3-empty-state { min-height:150px; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:5px; padding:20px; color:var(--td3-muted); text-align:center; } .td3-empty-state strong { color:#d8e1ec; font-size:13px; } .td3-empty-state span { font-size:11px; }
+.td3-inline-error, .td3-inline-warning { padding:8px 10px; border:1px solid rgba(248,113,113,.22); border-radius:8px; color:#fecaca; background:rgba(127,29,29,.14); font-size:10.5px; }
+.td3-inline-warning { border-color:rgba(251,191,36,.2); color:#fde7a6; background:rgba(120,72,0,.12); }
+
+.td3-modal-backdrop { position:fixed; inset:0; z-index:1000; display:grid; place-items:center; padding:18px; background:rgba(2,6,12,.76); backdrop-filter:blur(8px); }
+.td3-modal { width:min(720px,100%); max-height:min(760px,calc(100vh - 32px)); display:flex; flex-direction:column; border:1px solid var(--td3-border-strong); border-radius:15px; color:var(--td3-text); background:#0c1420; box-shadow:0 28px 100px rgba(0,0,0,.5); overflow:hidden; font:13px/1.45 Inter,ui-sans-serif,system-ui,sans-serif; }
+.td3-modal > header { min-height:78px; display:flex; align-items:flex-start; justify-content:space-between; gap:15px; padding:15px 17px; border-bottom:1px solid var(--td3-border); } .td3-modal header small { color:#7184a0; font-size:9.5px; font-weight:800; letter-spacing:.1em; text-transform:uppercase; } .td3-modal header h2 { margin:2px 0; font-size:18px; } .td3-modal header p { margin:0; color:var(--td3-muted); font-size:11px; } .td3-modal header > button { width:30px; height:30px; display:grid; place-items:center; border:1px solid var(--td3-border); border-radius:8px; color:#9ba8ba; background:transparent; cursor:pointer; }
+.td3-modal-body { min-height:0; overflow:auto; padding:15px 17px; }
+.td3-form-grid { display:grid; grid-template-columns:1fr 1fr; gap:12px; }
+.td3-form-grid label, .td3-stack-field { display:flex; flex-direction:column; gap:5px; } .td3-form-grid label > span, .td3-stack-field > span { color:#91a0b4; font-size:10.5px; font-weight:650; }
+.td3-form-grid select, .td3-form-grid textarea, .td3-stack-field textarea { width:100%; border:1px solid var(--td3-border); border-radius:9px; outline:0; color:#e9eef6; background:#101a28; font-size:12px; } .td3-form-grid select { height:38px; padding:0 9px; } .td3-form-grid textarea, .td3-stack-field textarea { min-height:120px; padding:10px; resize:vertical; line-height:1.55; }
+.td3-form-wide { grid-column:1/-1; }
+.td3-workspace-choice { flex-direction:row !important; align-items:flex-start; gap:9px !important; padding:10px; border:1px solid var(--td3-border); border-radius:9px; background:rgba(255,255,255,.018); } .td3-workspace-choice input { margin-top:2px; } .td3-workspace-choice > span { display:flex; flex-direction:column; gap:2px; } .td3-workspace-choice strong { color:#dbe4ef; font-size:11px; } .td3-workspace-choice small { color:var(--td3-muted); font-size:10px; }
+.td3-modal > footer { min-height:58px; display:flex; align-items:center; justify-content:flex-end; gap:7px; padding:9px 17px; border-top:1px solid var(--td3-border); background:rgba(7,12,20,.4); }
+.td3-continue-modal { width:min(590px,100%); }
+
+.td3-session-mode, .td3-classic-mode { width:100%; height:100vh; position:relative; overflow:hidden; background:#070c14; }
+.td3-return-button { position:fixed; top:11px; left:12px; z-index:80; min-height:34px; padding:0 10px; border:1px solid rgba(148,163,184,.22); border-radius:8px; color:#d7e0eb; background:rgba(10,17,28,.94); cursor:pointer; box-shadow:0 8px 24px rgba(0,0,0,.25); font-size:11px; }
+
+@media (max-width: 1220px) {
+  .td3-shell { grid-template-columns: 166px minmax(0,1fr); }
+  .td3-topbar { grid-template-columns: minmax(220px,auto) minmax(180px,1fr) minmax(190px,300px) auto; }
+  .td3-topbar > .td3-button:last-child { display:none; }
+  .td3-task-table-head, .td3-task-row { grid-template-columns:minmax(210px,2fr) minmax(80px,.75fr) minmax(105px,.9fr) minmax(90px,.8fr) 80px 68px; }
+  .td3-task-table-head > span:nth-child(5), .td3-task-row > span:nth-child(5) { display:none; }
+}
+
+@media (max-width: 980px) {
+  .td3-shell { grid-template-columns: 64px minmax(0,1fr); }
+  .td3-brand { padding:0 14px; } .td3-brand > div { display:none; }
+  .td3-sidebar nav button { grid-template-columns: 1fr; justify-items:center; padding:0; font-size:0; } .td3-sidebar nav button > svg, .td3-sidebar nav button > span:first-child { font-size:15px; } .td3-sidebar nav button b { position:absolute; margin:0 0 25px 27px; font-size:8px; min-width:14px; padding:0 3px; }
+  .td3-sidebar-bottom button { font-size:0; min-height:34px; } .td3-sidebar-bottom button::after { content:"•••"; font-size:12px; }
+  .td3-topbar { grid-template-columns:minmax(185px,auto) minmax(160px,1fr) auto; }
+  .td3-agent-strip { display:none; } .td3-topbar > .td3-button:last-child { display:none; }
+  .td3-tasks-layout { grid-template-columns:minmax(0,1fr); }
+  .td3-task-detail { position:absolute; inset:66px 0 0 64px; z-index:10; border-left:1px solid var(--td3-border); }
+  .td3-task-list-pane:has(.td3-task-row.selected) + .td3-task-detail .td3-empty-state { display:none; }
+  .td3-overview-grid, .td3-kpis { grid-template-columns:1fr 1fr; }
+}
+
+@media (max-width: 680px) {
+  .td3-shell { grid-template-columns: 1fr; }
+  .td3-sidebar { position:fixed; left:0; right:0; bottom:0; z-index:50; height:57px; display:block; border-top:1px solid var(--td3-border); border-right:0; background:rgba(7,12,20,.96); }
+  .td3-brand, .td3-sidebar-bottom { display:none; }
+  .td3-sidebar nav { height:100%; grid-template-columns:repeat(6,1fr); gap:0; padding:4px; } .td3-sidebar nav button { min-height:48px; } .td3-sidebar nav button:nth-child(n+7) { display:none; }
+  .td3-workspace { padding-bottom:57px; }
+  .td3-topbar { height:auto; min-height:62px; grid-template-columns:minmax(0,1fr) auto; padding:8px; } .td3-global-search { display:none; } .td3-topbar > .td3-button:last-child { display:none; }
+  .td3-machine-selector small { display:none; }
+  .td3-page-heading { padding:16px 12px 12px; } .td3-page-heading h1 { font-size:20px; }
+  .td3-kpis { grid-template-columns:1fr 1fr; padding:0 12px 12px; } .td3-kpis article { min-height:82px; padding:10px; } .td3-kpis strong { font-size:21px; }
+  .td3-overview-grid { grid-template-columns:1fr; padding:0 12px 75px; }
+  .td3-task-table-head { display:none; } .td3-task-row { grid-template-columns:minmax(0,1fr) auto; gap:5px 10px; min-height:92px; padding:10px 12px; } .td3-task-row > span:nth-child(2), .td3-task-row > span:nth-child(4), .td3-task-row > span:nth-child(5) { display:none; } .td3-task-row > span:nth-child(3) { grid-column:1; } .td3-task-row > span:nth-child(6) { grid-column:2; grid-row:1; } .td3-task-row time { grid-column:2; grid-row:2; }
+  .td3-task-detail { inset:0 0 57px 0; z-index:60; }
+  .td3-detail-meta { grid-template-columns:1fr 1fr; } .td3-detail-cards { grid-template-columns:1fr; } .td3-relationship > div { grid-template-columns:1fr; } .td3-relationship > div > i { transform:rotate(90deg); }
+  .td3-detail-actions { overflow-x:auto; }
+  .td3-simple-page .td3-card-grid, .td3-attention-list { grid-template-columns:1fr; padding:0 12px 72px; }
+  .td3-form-grid { grid-template-columns:1fr; } .td3-form-wide { grid-column:auto; }
+}


### PR DESCRIPTION
## What changed

Builds the first end-to-end TaskDesk v3 product flow on top of the unified machine daemon.

- makes Tasks the primary product surface while keeping Sessions and Classic directly accessible;
- adds Overview, Tasks, Projects, Needs You, Agents and Machines views;
- adds the real New Task flow: Machine -> Project -> Agent -> Model -> Workspace -> Task;
- supports isolated Git worktrees and intentional project-directory execution;
- adds Task detail with Task -> Run -> Session relationship, native conversation, diff, todos and VCS context;
- adds result inspection, Review / Finish and safe Cleanup actions;
- adds a Needs You inbox for native questions and permission requests;
- persists Task Run history and migrates existing single-run tasks without dropping data;
- allows terminal Tasks to start a new Run with a fresh native Session through a Continue action;
- keeps multi-machine aggregation and existing Universal Workspace session behavior available;
- keeps Classic 2.x isolated from TaskDesk machine configuration.

## Safety and compatibility

`main` is not touched. This PR targets `v3/taskdesk` only.

Existing persisted Task records with a single `run` are normalized into `runs[]` on load. Existing current-run fields remain present for compatibility.

Workspace cleanup remains daemon-guarded and refuses unsafe active or dirty worktrees.

## Validation in progress

This PR is intentionally draft while GitHub Actions runs the full web type-check/build and bridge regression suite. It should not be merged until those checks are green and the resulting exact SHA is ready for real-harness testing.

Refs #253
Refs #197