### PR TITLE
feat(taskdesk): add multi-harness Task handoff core

### DIFF
--- a/bridge/src/task-context.js
+++ b/bridge/src/task-context.js
@@ -8,10 +8,9 @@ function cleanRole(value, fallback = "continue") {
 }
 
 function runStatus(run, taskStatus) {
-  if (run?.finishedAt) {
-    if (taskStatus === "failed" && run.id) return "failed"
-    return "completed"
-  }
+  const persisted = cleanText(run?.status)
+  if (persisted) return persisted
+  if (run?.finishedAt) return taskStatus === "failed" ? "failed" : "completed"
   return taskStatus || "unknown"
 }
 
@@ -42,7 +41,7 @@ export function summarizeTaskRun(run, taskStatus = "unknown") {
 
 export function buildPersistedTaskContext(task, revision = task?.context?.revision ?? 0) {
   const runs = Array.isArray(task?.runs) ? task.runs : task?.run ? [task.run] : []
-  const runSummaries = runs.map((run) => summarizeTaskRun(run, run?.id === task?.run?.id ? task?.status : run?.finishedAt ? "completed" : "unknown")).filter(Boolean)
+  const runSummaries = runs.map((run) => summarizeTaskRun(run, run?.id === task?.run?.id ? task?.status : run?.status || (run?.finishedAt ? "completed" : "unknown"))).filter(Boolean)
   const latestRun = task?.run ? summarizeTaskRun(task.run, task.status) : null
   const errorMessage = cleanText(task?.error?.message)
   return {
@@ -98,23 +97,14 @@ export function formatTaskHandoff(context, { targetAgentId, role, instruction })
 
   const latest = context.latestRun || context.runSummaries?.at?.(-1)
   if (latest) {
-    lines.push(
-      "",
-      "PREVIOUS STEP",
-      `${latest.agentId || "unknown harness"} / ${latest.role || "continue"} / ${latest.status || "unknown"}`
-    )
+    lines.push("", "PREVIOUS STEP", `${latest.agentId || "unknown harness"} / ${latest.role || "continue"} / ${latest.status || "unknown"}`)
   }
-
-  if (context.latestOutcome?.error) {
-    lines.push("", "LATEST ERROR", context.latestOutcome.error)
-  }
-
+  if (context.latestOutcome?.error) lines.push("", "LATEST ERROR", context.latestOutcome.error)
   if (context.changedFiles?.length) {
     lines.push("", "CHANGED FILES", ...context.changedFiles.map((file) => `- ${file}`))
   } else if (context.workspace?.changeCount) {
     lines.push("", "WORKSPACE CHANGES", `${context.workspace.changeCount} changed file(s) are present in the shared workspace.`)
   }
-
   if (context.runSummaries?.length) {
     lines.push("", "RECENT TASK STEPS")
     for (const run of context.runSummaries.slice(-6)) {
@@ -122,19 +112,6 @@ export function formatTaskHandoff(context, { targetAgentId, role, instruction })
     }
   }
 
-  lines.push(
-    "",
-    "YOUR ROLE",
-    cleanRole(role),
-    "",
-    "TARGET HARNESS",
-    cleanText(targetAgentId) || "unknown",
-    "",
-    "USER INSTRUCTION",
-    cleanText(instruction),
-    "",
-    "Continue from the shared workspace and the transferred Task Context. Inspect the current files before assuming previous work is correct."
-  )
-
+  lines.push("", "YOUR ROLE", cleanRole(role), "", "TARGET HARNESS", cleanText(targetAgentId) || "unknown", "", "USER INSTRUCTION", cleanText(instruction), "", "Continue from the shared workspace and the transferred Task Context. Inspect the current files before assuming previous work is correct.")
   return lines.join("\n")
 }

--- a/bridge/src/task-context.js
+++ b/bridge/src/task-context.js
@@ -1,5 +1,12 @@
 const MAX_OUTCOME_CHARS = 6_000
+const MAX_OBJECTIVE_CHARS = 12_000
+const MAX_RUN_PROMPT_CHARS = 2_000
+const MAX_ERROR_CHARS = 2_000
+const MAX_CONTEXT_RUNS = 12
+const MAX_CHANGED_FILES = 80
+const MAX_CHANGED_FILE_CHARS = 500
 const HANDOFF_OUTCOME_CHARS = 1_600
+const HANDOFF_RECENT_RUNS = 6
 
 function cleanText(value) {
   return typeof value === "string" ? value.trim() : ""
@@ -9,6 +16,10 @@ function boundedText(value, limit = MAX_OUTCOME_CHARS) {
   const text = cleanText(value)
   if (text.length <= limit) return text
   return `…${text.slice(-(limit - 1))}`
+}
+
+export function boundTaskOutcome(value) {
+  return boundedText(value, MAX_OUTCOME_CHARS)
 }
 
 function cleanRole(value, fallback = "continue") {
@@ -42,7 +53,7 @@ export function summarizeTaskRun(run, taskStatus = "unknown") {
     ...(model?.providerID && model?.modelID ? { model } : {}),
     ...(run.sessionId ? { sessionId: run.sessionId } : {}),
     status: runStatus(run, taskStatus),
-    prompt: cleanText(run.prompt),
+    prompt: boundedText(run.prompt, MAX_RUN_PROMPT_CHARS),
     ...(outcome ? { outcome } : {}),
     ...(run.startedAt ? { startedAt: run.startedAt } : {}),
     ...(run.finishedAt ? { finishedAt: run.finishedAt } : {}),
@@ -51,16 +62,20 @@ export function summarizeTaskRun(run, taskStatus = "unknown") {
 }
 
 export function buildPersistedTaskContext(task, revision = task?.context?.revision ?? 0) {
-  const runs = Array.isArray(task?.runs) ? task.runs : task?.run ? [task.run] : []
-  const runSummaries = runs.map((run) => summarizeTaskRun(run, run?.id === task?.run?.id ? task?.status : run?.status || (run?.finishedAt ? "completed" : "unknown"))).filter(Boolean)
+  const allRuns = Array.isArray(task?.runs) ? task.runs : task?.run ? [task.run] : []
+  const recentRuns = allRuns.slice(-MAX_CONTEXT_RUNS)
+  const runSummaries = recentRuns
+    .map((run) => summarizeTaskRun(run, run?.id === task?.run?.id ? task?.status : run?.status || (run?.finishedAt ? "completed" : "unknown")))
+    .filter(Boolean)
   const latestRun = task?.run ? summarizeTaskRun(task.run, task.status) : null
-  const errorMessage = cleanText(task?.error?.message)
+  const errorMessage = boundedText(task?.error?.message, MAX_ERROR_CHARS)
   return {
     version: 1,
     revision: Math.max(0, Number(revision) || 0),
     taskId: task?.id || "",
-    objective: cleanText(task?.prompt),
+    objective: boundedText(task?.prompt, MAX_OBJECTIVE_CHARS),
     currentState: cleanText(task?.status) || "draft",
+    runCount: allRuns.length,
     latestOutcome: latestRun
       ? {
           status: latestRun.status,
@@ -75,20 +90,22 @@ export function buildPersistedTaskContext(task, revision = task?.context?.revisi
 }
 
 export function buildTaskContext(task, { workspace } = {}) {
-  const persisted = task?.context && task.context.version === 1
-    ? task.context
-    : buildPersistedTaskContext(task)
-  const changedFiles = Array.isArray(workspace?.changedFiles)
-    ? workspace.changedFiles.filter((value) => typeof value === "string" && value.trim()).map((value) => value.trim())
+  const revision = Number.isFinite(Number(task?.context?.revision)) ? Number(task.context.revision) : 0
+  const persisted = buildPersistedTaskContext(task, revision)
+  const allChangedFiles = Array.isArray(workspace?.changedFiles)
+    ? workspace.changedFiles.filter((value) => typeof value === "string" && value.trim()).map((value) => boundedText(value, MAX_CHANGED_FILE_CHARS))
     : []
+  const changedFiles = allChangedFiles.slice(0, MAX_CHANGED_FILES)
   return {
-    ...structuredClone(persisted),
+    ...persisted,
     currentState: cleanText(task?.status) || persisted.currentState || "draft",
     latestRun: task?.run ? summarizeTaskRun(task.run, task.status) : null,
     changedFiles,
     workspace: {
       dirty: Boolean(workspace?.dirty),
-      changeCount: Number(workspace?.changeCount) || changedFiles.length
+      changeCount: Number(workspace?.changeCount) || allChangedFiles.length,
+      listedChangeCount: changedFiles.length,
+      truncated: allChangedFiles.length > changedFiles.length
     },
     verification: null,
     unresolved: []
@@ -101,7 +118,7 @@ export function formatTaskHandoff(context, { targetAgentId, role, instruction })
     "The context below was transferred by TaskDesk. It is not native conversational memory from another harness.",
     "",
     "TASK OBJECTIVE",
-    context.objective || "(not recorded)",
+    boundedText(context.objective, MAX_OBJECTIVE_CHARS) || "(not recorded)",
     "",
     "CURRENT STATE",
     context.currentState || "unknown"
@@ -110,17 +127,21 @@ export function formatTaskHandoff(context, { targetAgentId, role, instruction })
   const latest = context.latestRun || context.runSummaries?.at?.(-1)
   if (latest) lines.push("", "PREVIOUS STEP", `${latest.agentId || "unknown harness"} / ${latest.role || "continue"} / ${latest.status || "unknown"}`)
   if (context.latestOutcome?.text) lines.push("", "PREVIOUS RESULT", boundedText(context.latestOutcome.text, HANDOFF_OUTCOME_CHARS))
-  if (context.latestOutcome?.error) lines.push("", "LATEST ERROR", context.latestOutcome.error)
+  if (context.latestOutcome?.error) lines.push("", "LATEST ERROR", boundedText(context.latestOutcome.error, MAX_ERROR_CHARS))
   if (context.changedFiles?.length) {
-    lines.push("", "CHANGED FILES", ...context.changedFiles.map((file) => `- ${file}`))
+    lines.push("", "CHANGED FILES", ...context.changedFiles.map((file) => `- ${boundedText(file, MAX_CHANGED_FILE_CHARS)}`))
+    if (context.workspace?.truncated) lines.push(`- …and ${Math.max(0, Number(context.workspace.changeCount) - context.changedFiles.length)} more changed file(s)`)
   } else if (context.workspace?.changeCount) {
     lines.push("", "WORKSPACE CHANGES", `${context.workspace.changeCount} changed file(s) are present in the shared workspace.`)
   }
   if (context.runSummaries?.length) {
     lines.push("", "RECENT TASK STEPS")
-    for (const run of context.runSummaries.slice(-6)) {
+    for (const run of context.runSummaries.slice(-HANDOFF_RECENT_RUNS)) {
       lines.push(`- Run ${run.sequence || "?"}: ${run.agentId || "unknown"} / ${run.role || "continue"} / ${run.status || "unknown"}`)
       if (run.outcome) lines.push(`  Result: ${boundedText(run.outcome, HANDOFF_OUTCOME_CHARS)}`)
+    }
+    if (Number(context.runCount) > context.runSummaries.length) {
+      lines.push(`- ${Number(context.runCount) - context.runSummaries.length} earlier Task step(s) retained in Task history but omitted from this handoff`)
     }
   }
 

--- a/bridge/src/task-context.js
+++ b/bridge/src/task-context.js
@@ -75,7 +75,6 @@ export function buildPersistedTaskContext(task, revision = task?.context?.revisi
     taskId: task?.id || "",
     objective: boundedText(task?.prompt, MAX_OBJECTIVE_CHARS),
     currentState: cleanText(task?.status) || "draft",
-    runCount: allRuns.length,
     latestOutcome: latestRun
       ? {
           status: latestRun.status,
@@ -92,12 +91,14 @@ export function buildPersistedTaskContext(task, revision = task?.context?.revisi
 export function buildTaskContext(task, { workspace } = {}) {
   const revision = Number.isFinite(Number(task?.context?.revision)) ? Number(task.context.revision) : 0
   const persisted = buildPersistedTaskContext(task, revision)
+  const allRuns = Array.isArray(task?.runs) ? task.runs : task?.run ? [task.run] : []
   const allChangedFiles = Array.isArray(workspace?.changedFiles)
     ? workspace.changedFiles.filter((value) => typeof value === "string" && value.trim()).map((value) => boundedText(value, MAX_CHANGED_FILE_CHARS))
     : []
   const changedFiles = allChangedFiles.slice(0, MAX_CHANGED_FILES)
   return {
     ...persisted,
+    runCount: allRuns.length,
     currentState: cleanText(task?.status) || persisted.currentState || "draft",
     latestRun: task?.run ? summarizeTaskRun(task.run, task.status) : null,
     changedFiles,

--- a/bridge/src/task-context.js
+++ b/bridge/src/task-context.js
@@ -1,5 +1,14 @@
+const MAX_OUTCOME_CHARS = 6_000
+const HANDOFF_OUTCOME_CHARS = 1_600
+
 function cleanText(value) {
   return typeof value === "string" ? value.trim() : ""
+}
+
+function boundedText(value, limit = MAX_OUTCOME_CHARS) {
+  const text = cleanText(value)
+  if (text.length <= limit) return text
+  return `…${text.slice(-(limit - 1))}`
 }
 
 function cleanRole(value, fallback = "continue") {
@@ -24,6 +33,7 @@ export function summarizeTaskRun(run, taskStatus = "unknown") {
         ...(cleanText(run.model.variant) ? { variant: cleanText(run.model.variant) } : {})
       }
     : null
+  const outcome = boundedText(run.outcome)
   return {
     ...(run.id ? { id: run.id } : {}),
     ...(sequence ? { sequence } : {}),
@@ -33,6 +43,7 @@ export function summarizeTaskRun(run, taskStatus = "unknown") {
     ...(run.sessionId ? { sessionId: run.sessionId } : {}),
     status: runStatus(run, taskStatus),
     prompt: cleanText(run.prompt),
+    ...(outcome ? { outcome } : {}),
     ...(run.startedAt ? { startedAt: run.startedAt } : {}),
     ...(run.finishedAt ? { finishedAt: run.finishedAt } : {}),
     ...(Number.isFinite(Number(run.contextRevision)) ? { contextRevision: Number(run.contextRevision) } : {})
@@ -55,6 +66,7 @@ export function buildPersistedTaskContext(task, revision = task?.context?.revisi
           status: latestRun.status,
           agentId: latestRun.agentId,
           role: latestRun.role,
+          ...(latestRun.outcome ? { text: latestRun.outcome } : {}),
           ...(errorMessage ? { error: errorMessage } : {})
         }
       : null,
@@ -96,9 +108,8 @@ export function formatTaskHandoff(context, { targetAgentId, role, instruction })
   ]
 
   const latest = context.latestRun || context.runSummaries?.at?.(-1)
-  if (latest) {
-    lines.push("", "PREVIOUS STEP", `${latest.agentId || "unknown harness"} / ${latest.role || "continue"} / ${latest.status || "unknown"}`)
-  }
+  if (latest) lines.push("", "PREVIOUS STEP", `${latest.agentId || "unknown harness"} / ${latest.role || "continue"} / ${latest.status || "unknown"}`)
+  if (context.latestOutcome?.text) lines.push("", "PREVIOUS RESULT", boundedText(context.latestOutcome.text, HANDOFF_OUTCOME_CHARS))
   if (context.latestOutcome?.error) lines.push("", "LATEST ERROR", context.latestOutcome.error)
   if (context.changedFiles?.length) {
     lines.push("", "CHANGED FILES", ...context.changedFiles.map((file) => `- ${file}`))
@@ -109,6 +120,7 @@ export function formatTaskHandoff(context, { targetAgentId, role, instruction })
     lines.push("", "RECENT TASK STEPS")
     for (const run of context.runSummaries.slice(-6)) {
       lines.push(`- Run ${run.sequence || "?"}: ${run.agentId || "unknown"} / ${run.role || "continue"} / ${run.status || "unknown"}`)
+      if (run.outcome) lines.push(`  Result: ${boundedText(run.outcome, HANDOFF_OUTCOME_CHARS)}`)
     }
   }
 

--- a/bridge/src/task-context.js
+++ b/bridge/src/task-context.js
@@ -1,0 +1,140 @@
+function cleanText(value) {
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function cleanRole(value, fallback = "continue") {
+  const normalized = cleanText(value).toLowerCase().replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "")
+  return normalized || fallback
+}
+
+function runStatus(run, taskStatus) {
+  if (run?.finishedAt) {
+    if (taskStatus === "failed" && run.id) return "failed"
+    return "completed"
+  }
+  return taskStatus || "unknown"
+}
+
+export function summarizeTaskRun(run, taskStatus = "unknown") {
+  if (!run || typeof run !== "object") return null
+  const sequence = Number.isFinite(Number(run.sequence)) ? Number(run.sequence) : undefined
+  const model = run.model && typeof run.model === "object"
+    ? {
+        providerID: cleanText(run.model.providerID),
+        modelID: cleanText(run.model.modelID),
+        ...(cleanText(run.model.variant) ? { variant: cleanText(run.model.variant) } : {})
+      }
+    : null
+  return {
+    ...(run.id ? { id: run.id } : {}),
+    ...(sequence ? { sequence } : {}),
+    agentId: cleanText(run.agentId),
+    role: cleanRole(run.role, sequence === 1 ? "implement" : "continue"),
+    ...(model?.providerID && model?.modelID ? { model } : {}),
+    ...(run.sessionId ? { sessionId: run.sessionId } : {}),
+    status: runStatus(run, taskStatus),
+    prompt: cleanText(run.prompt),
+    ...(run.startedAt ? { startedAt: run.startedAt } : {}),
+    ...(run.finishedAt ? { finishedAt: run.finishedAt } : {}),
+    ...(Number.isFinite(Number(run.contextRevision)) ? { contextRevision: Number(run.contextRevision) } : {})
+  }
+}
+
+export function buildPersistedTaskContext(task, revision = task?.context?.revision ?? 0) {
+  const runs = Array.isArray(task?.runs) ? task.runs : task?.run ? [task.run] : []
+  const runSummaries = runs.map((run) => summarizeTaskRun(run, run?.id === task?.run?.id ? task?.status : run?.finishedAt ? "completed" : "unknown")).filter(Boolean)
+  const latestRun = task?.run ? summarizeTaskRun(task.run, task.status) : null
+  const errorMessage = cleanText(task?.error?.message)
+  return {
+    version: 1,
+    revision: Math.max(0, Number(revision) || 0),
+    taskId: task?.id || "",
+    objective: cleanText(task?.prompt),
+    currentState: cleanText(task?.status) || "draft",
+    latestOutcome: latestRun
+      ? {
+          status: latestRun.status,
+          agentId: latestRun.agentId,
+          role: latestRun.role,
+          ...(errorMessage ? { error: errorMessage } : {})
+        }
+      : null,
+    runSummaries
+  }
+}
+
+export function buildTaskContext(task, { workspace } = {}) {
+  const persisted = task?.context && task.context.version === 1
+    ? task.context
+    : buildPersistedTaskContext(task)
+  const changedFiles = Array.isArray(workspace?.changedFiles)
+    ? workspace.changedFiles.filter((value) => typeof value === "string" && value.trim()).map((value) => value.trim())
+    : []
+  return {
+    ...structuredClone(persisted),
+    currentState: cleanText(task?.status) || persisted.currentState || "draft",
+    latestRun: task?.run ? summarizeTaskRun(task.run, task.status) : null,
+    changedFiles,
+    workspace: {
+      dirty: Boolean(workspace?.dirty),
+      changeCount: Number(workspace?.changeCount) || changedFiles.length
+    },
+    verification: null,
+    unresolved: []
+  }
+}
+
+export function formatTaskHandoff(context, { targetAgentId, role, instruction }) {
+  const lines = [
+    "You are taking over an existing TaskDesk task.",
+    "The context below was transferred by TaskDesk. It is not native conversational memory from another harness.",
+    "",
+    "TASK OBJECTIVE",
+    context.objective || "(not recorded)",
+    "",
+    "CURRENT STATE",
+    context.currentState || "unknown"
+  ]
+
+  const latest = context.latestRun || context.runSummaries?.at?.(-1)
+  if (latest) {
+    lines.push(
+      "",
+      "PREVIOUS STEP",
+      `${latest.agentId || "unknown harness"} / ${latest.role || "continue"} / ${latest.status || "unknown"}`
+    )
+  }
+
+  if (context.latestOutcome?.error) {
+    lines.push("", "LATEST ERROR", context.latestOutcome.error)
+  }
+
+  if (context.changedFiles?.length) {
+    lines.push("", "CHANGED FILES", ...context.changedFiles.map((file) => `- ${file}`))
+  } else if (context.workspace?.changeCount) {
+    lines.push("", "WORKSPACE CHANGES", `${context.workspace.changeCount} changed file(s) are present in the shared workspace.`)
+  }
+
+  if (context.runSummaries?.length) {
+    lines.push("", "RECENT TASK STEPS")
+    for (const run of context.runSummaries.slice(-6)) {
+      lines.push(`- Run ${run.sequence || "?"}: ${run.agentId || "unknown"} / ${run.role || "continue"} / ${run.status || "unknown"}`)
+    }
+  }
+
+  lines.push(
+    "",
+    "YOUR ROLE",
+    cleanRole(role),
+    "",
+    "TARGET HARNESS",
+    cleanText(targetAgentId) || "unknown",
+    "",
+    "USER INSTRUCTION",
+    cleanText(instruction),
+    "",
+    "Continue from the shared workspace and the transferred Task Context. Inspect the current files before assuming previous work is correct."
+  )
+
+  return lines.join("\n")
+}

--- a/bridge/src/task-launch-server.js
+++ b/bridge/src/task-launch-server.js
@@ -3,6 +3,7 @@ import { authenticateDaemonRequest, writeJSON } from "./http-policy.js"
 
 const TASK_LAUNCH_ROUTE = /^\/v1\/tasks\/([^/]+)\/launch$/
 const TASK_CONTINUE_ROUTE = /^\/v1\/tasks\/([^/]+)\/continue$/
+const TASK_CONTEXT_ROUTE = /^\/v1\/tasks\/([^/]+)\/context$/
 const TASK_WORKTREE_ROUTE = /^\/v1\/tasks\/([^/]+)\/worktree$/
 const TASK_WORKTREE_CLEANUP_ROUTE = /^\/v1\/tasks\/([^/]+)\/worktree\/cleanup$/
 const LAUNCH_STATUS = new Map([
@@ -12,6 +13,7 @@ const LAUNCH_STATUS = new Map([
   ["invalid_state", 409],
   ["workspace_required", 409],
   ["unsupported_agent", 409],
+  ["session_unavailable", 409],
   ["task_active", 409],
   ["worktree_dirty", 409],
   ["invalid_worktree", 409],
@@ -37,17 +39,23 @@ export function createTaskLaunchServer({ innerServer, config, taskRunController,
     const requestURL = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`)
     const launchMatch = TASK_LAUNCH_ROUTE.exec(requestURL.pathname)
     const continueMatch = TASK_CONTINUE_ROUTE.exec(requestURL.pathname)
+    const contextMatch = TASK_CONTEXT_ROUTE.exec(requestURL.pathname)
     const worktreeMatch = TASK_WORKTREE_ROUTE.exec(requestURL.pathname)
     const cleanupMatch = TASK_WORKTREE_CLEANUP_ROUTE.exec(requestURL.pathname)
     const inspect = worktreeMatch && request.method === "GET"
     const cleanup = cleanupMatch && request.method === "POST"
-    if (!launchMatch && !continueMatch && !inspect && !cleanup) {
+    const context = contextMatch && request.method === "GET"
+    if (!launchMatch && !continueMatch && !context && !inspect && !cleanup) {
       innerServer.emit("request", request, response)
       return
     }
 
     if (!authenticateDaemonRequest(request, response, config)) return
     try {
+      if (context) {
+        writeJSON(response, 200, await taskRunController.context(decodeURIComponent(contextMatch[1])))
+        return
+      }
       if (launchMatch || continueMatch) {
         if (request.method !== "POST") {
           response.writeHead(405, { Allow: "POST, OPTIONS" })
@@ -55,11 +63,11 @@ export function createTaskLaunchServer({ innerServer, config, taskRunController,
           return
         }
         const taskID = decodeURIComponent((launchMatch ?? continueMatch)[1])
+        const body = await readJSONBody(request)
         if (continueMatch) {
-          const body = await readJSONBody(request)
-          writeJSON(response, 200, await taskRunController.continue(taskID, body.prompt))
+          writeJSON(response, 200, await taskRunController.continue(taskID, body))
         } else {
-          writeJSON(response, 200, await taskRunController.launch(taskID))
+          writeJSON(response, 200, await taskRunController.launch(taskID, body))
         }
         return
       }

--- a/bridge/src/task-launch-server.js
+++ b/bridge/src/task-launch-server.js
@@ -7,6 +7,7 @@ const TASK_CONTEXT_ROUTE = /^\/v1\/tasks\/([^/]+)\/context$/
 const TASK_WORKTREE_ROUTE = /^\/v1\/tasks\/([^/]+)\/worktree$/
 const TASK_WORKTREE_CLEANUP_ROUTE = /^\/v1\/tasks\/([^/]+)\/worktree\/cleanup$/
 const LAUNCH_STATUS = new Map([
+  ["invalid_request", 400],
   ["unknown_task", 404],
   ["unknown_agent", 404],
   ["agent_unavailable", 503],
@@ -18,16 +19,28 @@ const LAUNCH_STATUS = new Map([
   ["worktree_dirty", 409],
   ["invalid_worktree", 409],
   ["worktree_outside_state", 409],
-  ["worktree_missing", 409]
+  ["worktree_missing", 409],
+  ["invalid_project", 409]
 ])
+
+function requestError(message) {
+  const error = new Error(message)
+  error.code = "invalid_request"
+  return error
+}
 
 async function readJSONBody(request) {
   let body = ""
   for await (const chunk of request) {
     body += chunk
-    if (body.length > 1_000_000) throw new Error("Request body is too large")
+    if (body.length > 1_000_000) throw requestError("Request body is too large")
   }
-  return body ? JSON.parse(body) : {}
+  if (!body) return {}
+  try {
+    return JSON.parse(body)
+  } catch {
+    throw requestError("Request body must be valid JSON")
+  }
 }
 
 export function launchStatus(error) {
@@ -64,6 +77,7 @@ export function createTaskLaunchServer({ innerServer, config, taskRunController,
         }
         const taskID = decodeURIComponent((launchMatch ?? continueMatch)[1])
         const body = await readJSONBody(request)
+        if (!body || typeof body !== "object" || Array.isArray(body)) throw requestError("Request body must be a JSON object")
         if (continueMatch) {
           writeJSON(response, 200, await taskRunController.continue(taskID, body))
         } else {

--- a/bridge/src/task-launch-server.js
+++ b/bridge/src/task-launch-server.js
@@ -15,6 +15,7 @@ const LAUNCH_STATUS = new Map([
   ["workspace_required", 409],
   ["unsupported_agent", 409],
   ["session_unavailable", 409],
+  ["model_unavailable", 409],
   ["task_active", 409],
   ["worktree_dirty", 409],
   ["invalid_worktree", 409],

--- a/bridge/src/task-launcher.js
+++ b/bridge/src/task-launcher.js
@@ -41,6 +41,12 @@ function acpModelWireName(model) {
   return model ? `${model.providerID}/${model.modelID}` : undefined
 }
 
+function sameModel(left, right) {
+  if (!left && !right) return true
+  if (!left || !right) return false
+  return left.providerID === right.providerID && left.modelID === right.modelID && (left.variant || "") === (right.variant || "")
+}
+
 function runAgentID(task, run = task?.run) {
   return run?.agentId || task?.agentId
 }
@@ -80,11 +86,7 @@ export class TaskLauncher {
     if (entry.kind === "acp") {
       const service = this.acpService?.(agentID)
       if (service) {
-        const session = await service.createSession({
-          directory: task.workspace.path,
-          title,
-          model: acpModelWireName(model)
-        })
+        const session = await service.createSession({ directory: task.workspace.path, title, model: acpModelWireName(model) })
         if (!session?.id) throw new Error(`Agent ${agentID} did not return a session id`)
         return { sessionId: session.id, transport: "acp", directory: task.workspace.path }
       }
@@ -93,11 +95,7 @@ export class TaskLauncher {
       if (!result?.sessionId) throw new Error(`Agent ${agentID} did not return a session id`)
       const value = acpModelValue(result.configOptions, model)
       if (value) {
-        await entry.host.request("session/set_config_option", {
-          sessionId: result.sessionId,
-          configId: "model",
-          value
-        })
+        await entry.host.request("session/set_config_option", { sessionId: result.sessionId, configId: "model", value })
       }
       return { sessionId: result.sessionId, transport: "acp", directory: task.workspace.path }
     }
@@ -109,13 +107,8 @@ export class TaskLauncher {
       const authorization = basicAuthorization(entry.host.username, entry.host.password)
       const response = await this.fetchImpl(`${base}/session?directory=${encodeURIComponent(task.workspace.path)}`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(authorization ? { Authorization: authorization } : {})
-        },
-        body: JSON.stringify({
-          title
-        })
+        headers: { "Content-Type": "application/json", ...(authorization ? { Authorization: authorization } : {}) },
+        body: JSON.stringify({ title })
       })
       const session = await responseJSON(response, `Creating ${agentID} session`)
       if (!session?.id) throw new Error(`Agent ${agentID} did not return a session id`)
@@ -134,17 +127,18 @@ export class TaskLauncher {
     }
     const entry = await this.#entry(agentID)
     if (!task.workspace?.path) throw taskLaunchError("workspace_required", "Task workspace is not prepared")
+    const modelChanged = !sameModel(previousRun.model ?? null, model)
 
     if (entry.kind === "acp") {
       const service = this.acpService?.(agentID)
       if (service) {
         const adopted = await service.adoptTaskSession(previousRun.sessionId, { title: taskSessionTitle(task) })
         if (adopted === false) throw taskLaunchError("session_unavailable", "The previous native Session can no longer be resumed")
-        if (model) await service.setModel(previousRun.sessionId, acpModelWireName(model))
+        if (modelChanged && model) await service.setModel(previousRun.sessionId, acpModelWireName(model))
         return { sessionId: previousRun.sessionId, transport: "acp", directory: task.workspace.path }
       }
       await entry.host.start()
-      if (model) {
+      if (modelChanged && model) {
         await entry.host.request("session/set_config_option", {
           sessionId: previousRun.sessionId,
           configId: "model",
@@ -173,36 +167,21 @@ export class TaskLauncher {
     if (entry.kind === "acp") {
       const service = this.acpService?.(agentID)
       if (service) {
-        void service.promptAndWait(run.sessionId, task.prompt).then((result) => {
-          onCompleted?.(result)
-        }).catch((error) => {
-          onFailed?.(error)
-        })
+        void service.promptAndWait(run.sessionId, task.prompt).then((result) => onCompleted?.(result)).catch((error) => onFailed?.(error))
         return
       }
       void entry.host.request("session/prompt", {
         sessionId: run.sessionId,
         prompt: [{ type: "text", text: task.prompt }]
-      }, 300_000).then((result) => {
-        onCompleted?.(result)
-      }).catch((error) => {
-        onFailed?.(error)
-      })
+      }, 300_000).then((result) => onCompleted?.(result)).catch((error) => onFailed?.(error))
       return
     }
 
     if (entry.kind === "http") {
       void this.fetchImpl(`${run.base}/session/${encodeURIComponent(run.sessionId)}/message?directory=${encodeURIComponent(task.workspace.path)}`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(run.authorization ? { Authorization: run.authorization } : {})
-        },
-        body: JSON.stringify({
-          parts: [{ type: "text", text: task.prompt }],
-          model: promptModelBody(model),
-          variant: model?.variant || undefined
-        })
+        headers: { "Content-Type": "application/json", ...(run.authorization ? { Authorization: run.authorization } : {}) },
+        body: JSON.stringify({ parts: [{ type: "text", text: task.prompt }], model: promptModelBody(model), variant: model?.variant || undefined })
       }).then((response) => responseJSON(response, `Starting ${agentID} task`))
         .then((result) => onCompleted?.(result))
         .catch((error) => onFailed?.(error))
@@ -215,9 +194,7 @@ export class TaskLauncher {
     const agentID = runAgentID(task, run)
     const entry = this.daemon.hostEntry(agentID)
     if (!entry) return "unknown"
-
-    if (entry.kind === "acp") return "unknown"
-    if (entry.kind !== "http") return "unknown"
+    if (entry.kind === "acp" || entry.kind !== "http") return "unknown"
 
     try {
       await entry.host.start?.()

--- a/bridge/src/task-launcher.js
+++ b/bridge/src/task-launcher.js
@@ -107,6 +107,13 @@ export class TaskLauncher {
     return entry
   }
 
+  async validateModelSelection(agentID, model) {
+    if (!model) return
+    await this.#entry(agentID)
+    if (typeof this.daemon.validateModel !== "function") return
+    await this.daemon.validateModel(agentID, model)
+  }
+
   async createSession(task) {
     const agentID = runAgentID(task)
     const model = runModel(task)

--- a/bridge/src/task-launcher.js
+++ b/bridge/src/task-launcher.js
@@ -1,6 +1,8 @@
 import { taskLaunchError } from "./task-errors.js"
 import { promptModelBody } from "./task-model.js"
 
+const MAX_OUTCOME_CHARS = 6_000
+
 function basicAuthorization(username, password) {
   if (!username && !password) return undefined
   return `Basic ${Buffer.from(`${username ?? ""}:${password ?? ""}`).toString("base64")}`
@@ -60,6 +62,35 @@ function taskSessionTitle(task) {
   return Number(task.run?.sequence) > 1 ? `${base} · Run ${task.run.sequence}` : base
 }
 
+function boundOutcome(value) {
+  const text = typeof value === "string" ? value.trim() : ""
+  if (!text) return undefined
+  return text.length <= MAX_OUTCOME_CHARS ? text : `…${text.slice(-(MAX_OUTCOME_CHARS - 1))}`
+}
+
+function messageText(message) {
+  const parts = Array.isArray(message?.parts) ? message.parts : []
+  return parts.filter((part) => part?.type === "text" && typeof part.text === "string").map((part) => part.text).join("\n").trim()
+}
+
+function latestAssistantOutcome(messages) {
+  for (let index = (messages?.length ?? 0) - 1; index >= 0; index -= 1) {
+    if (messages[index]?.info?.role !== "assistant") continue
+    const text = boundOutcome(messageText(messages[index]))
+    if (text) return text
+  }
+  return undefined
+}
+
+function outcomeFromResult(result) {
+  if (!result || typeof result !== "object") return undefined
+  const direct = boundOutcome(result.outcome || result.text || result.content)
+  if (direct) return direct
+  if (Array.isArray(result.parts)) return boundOutcome(messageText(result))
+  if (result.message && typeof result.message === "object") return outcomeFromResult(result.message)
+  return undefined
+}
+
 export class TaskLauncher {
   constructor({ daemon, fetchImpl = fetch, acpService } = {}) {
     this.daemon = daemon
@@ -94,9 +125,7 @@ export class TaskLauncher {
       const result = await entry.host.request("session/new", { cwd: task.workspace.path, mcpServers: [] })
       if (!result?.sessionId) throw new Error(`Agent ${agentID} did not return a session id`)
       const value = acpModelValue(result.configOptions, model)
-      if (value) {
-        await entry.host.request("session/set_config_option", { sessionId: result.sessionId, configId: "model", value })
-      }
+      if (value) await entry.host.request("session/set_config_option", { sessionId: result.sessionId, configId: "model", value })
       return { sessionId: result.sessionId, transport: "acp", directory: task.workspace.path }
     }
 
@@ -122,9 +151,7 @@ export class TaskLauncher {
     const agentID = runAgentID(task)
     const model = runModel(task)
     if (!previousRun?.sessionId) throw taskLaunchError("session_unavailable", "The previous Task session is unavailable")
-    if (previousRun.agentId && previousRun.agentId !== agentID) {
-      throw taskLaunchError("session_unavailable", "A native Session can only be resumed by the harness that owns it")
-    }
+    if (previousRun.agentId && previousRun.agentId !== agentID) throw taskLaunchError("session_unavailable", "A native Session can only be resumed by the harness that owns it")
     const entry = await this.#entry(agentID)
     if (!task.workspace?.path) throw taskLaunchError("workspace_required", "Task workspace is not prepared")
     const modelChanged = !sameModel(previousRun.model ?? null, model)
@@ -139,11 +166,7 @@ export class TaskLauncher {
       }
       await entry.host.start()
       if (modelChanged && model) {
-        await entry.host.request("session/set_config_option", {
-          sessionId: previousRun.sessionId,
-          configId: "model",
-          value: acpModelWireName(model)
-        })
+        await entry.host.request("session/set_config_option", { sessionId: previousRun.sessionId, configId: "model", value: acpModelWireName(model) })
       }
       return { sessionId: previousRun.sessionId, transport: "acp", directory: task.workspace.path }
     }
@@ -167,13 +190,17 @@ export class TaskLauncher {
     if (entry.kind === "acp") {
       const service = this.acpService?.(agentID)
       if (service) {
-        void service.promptAndWait(run.sessionId, task.prompt).then((result) => onCompleted?.(result)).catch((error) => onFailed?.(error))
+        void service.promptAndWait(run.sessionId, task.prompt).then(async () => {
+          let outcome
+          try { outcome = latestAssistantOutcome(await service.messages(run.sessionId)) } catch {}
+          onCompleted?.({ outcome })
+        }).catch((error) => onFailed?.(error))
         return
       }
       void entry.host.request("session/prompt", {
         sessionId: run.sessionId,
         prompt: [{ type: "text", text: task.prompt }]
-      }, 300_000).then((result) => onCompleted?.(result)).catch((error) => onFailed?.(error))
+      }, 300_000).then((result) => onCompleted?.({ outcome: outcomeFromResult(result) })).catch((error) => onFailed?.(error))
       return
     }
 
@@ -183,7 +210,7 @@ export class TaskLauncher {
         headers: { "Content-Type": "application/json", ...(run.authorization ? { Authorization: run.authorization } : {}) },
         body: JSON.stringify({ parts: [{ type: "text", text: task.prompt }], model: promptModelBody(model), variant: model?.variant || undefined })
       }).then((response) => responseJSON(response, `Starting ${agentID} task`))
-        .then((result) => onCompleted?.(result))
+        .then((result) => onCompleted?.({ outcome: outcomeFromResult(result) }))
         .catch((error) => onFailed?.(error))
     }
   }
@@ -193,8 +220,7 @@ export class TaskLauncher {
     if (!run?.sessionId) return "unknown"
     const agentID = runAgentID(task, run)
     const entry = this.daemon.hostEntry(agentID)
-    if (!entry) return "unknown"
-    if (entry.kind === "acp" || entry.kind !== "http") return "unknown"
+    if (!entry || entry.kind !== "http") return "unknown"
 
     try {
       await entry.host.start?.()

--- a/bridge/src/task-launcher.js
+++ b/bridge/src/task-launcher.js
@@ -41,6 +41,14 @@ function acpModelWireName(model) {
   return model ? `${model.providerID}/${model.modelID}` : undefined
 }
 
+function runAgentID(task, run = task?.run) {
+  return run?.agentId || task?.agentId
+}
+
+function runModel(task, run = task?.run) {
+  return run?.model ?? task?.model ?? null
+}
+
 function taskSessionTitle(task) {
   const base = `Task ${task.id.slice(0, 8)}`
   return Number(task.run?.sequence) > 1 ? `${base} · Run ${task.run.sequence}` : base
@@ -53,30 +61,37 @@ export class TaskLauncher {
     this.acpService = acpService
   }
 
-  async createSession(task) {
-    const entry = this.daemon.hostEntry(task.agentId)
-    if (!entry) throw taskLaunchError("unknown_agent", `Unknown agent: ${task.agentId}`)
-    if (this.daemon.registry.host(task.agentId)?.state === "unavailable") {
-      throw taskLaunchError("agent_unavailable", `Agent ${task.agentId} is unavailable`)
+  async #entry(agentID) {
+    const entry = this.daemon.hostEntry(agentID)
+    if (!entry) throw taskLaunchError("unknown_agent", `Unknown agent: ${agentID}`)
+    if (this.daemon.registry.host(agentID)?.state === "unavailable") {
+      throw taskLaunchError("agent_unavailable", `Agent ${agentID} is unavailable`)
     }
+    return entry
+  }
+
+  async createSession(task) {
+    const agentID = runAgentID(task)
+    const model = runModel(task)
+    const entry = await this.#entry(agentID)
     if (!task.workspace?.path) throw taskLaunchError("workspace_required", "Task workspace is not prepared")
     const title = taskSessionTitle(task)
 
     if (entry.kind === "acp") {
-      const service = this.acpService?.(task.agentId)
+      const service = this.acpService?.(agentID)
       if (service) {
         const session = await service.createSession({
           directory: task.workspace.path,
           title,
-          model: acpModelWireName(task.model)
+          model: acpModelWireName(model)
         })
-        if (!session?.id) throw new Error(`Agent ${task.agentId} did not return a session id`)
+        if (!session?.id) throw new Error(`Agent ${agentID} did not return a session id`)
         return { sessionId: session.id, transport: "acp", directory: task.workspace.path }
       }
       await entry.host.start()
       const result = await entry.host.request("session/new", { cwd: task.workspace.path, mcpServers: [] })
-      if (!result?.sessionId) throw new Error(`Agent ${task.agentId} did not return a session id`)
-      const value = acpModelValue(result.configOptions, task.model)
+      if (!result?.sessionId) throw new Error(`Agent ${agentID} did not return a session id`)
+      const value = acpModelValue(result.configOptions, model)
       if (value) {
         await entry.host.request("session/set_config_option", {
           sessionId: result.sessionId,
@@ -99,28 +114,64 @@ export class TaskLauncher {
           ...(authorization ? { Authorization: authorization } : {})
         },
         body: JSON.stringify({
-          // OpenCode assigns the model to a message, not to a session. Keep the session title
-          // consistent with sessions created for other agents; the UI resolves task metadata
-          // separately when it displays the session's selected model.
           title
         })
       })
-      const session = await responseJSON(response, `Creating ${task.agentId} session`)
-      if (!session?.id) throw new Error(`Agent ${task.agentId} did not return a session id`)
-      // Managed host connection details, especially authorization, are intentionally
-      // kept on this in-memory launch object and must never be persisted on task.run.
+      const session = await responseJSON(response, `Creating ${agentID} session`)
+      if (!session?.id) throw new Error(`Agent ${agentID} did not return a session id`)
       return { sessionId: session.id, transport: "http", directory: task.workspace.path, base, authorization }
     }
 
-    throw taskLaunchError("unsupported_agent", `Agent ${task.agentId} cannot launch tasks`)
+    throw taskLaunchError("unsupported_agent", `Agent ${agentID} cannot launch tasks`)
+  }
+
+  async resumeSession(task, previousRun) {
+    const agentID = runAgentID(task)
+    const model = runModel(task)
+    if (!previousRun?.sessionId) throw taskLaunchError("session_unavailable", "The previous Task session is unavailable")
+    if (previousRun.agentId && previousRun.agentId !== agentID) {
+      throw taskLaunchError("session_unavailable", "A native Session can only be resumed by the harness that owns it")
+    }
+    const entry = await this.#entry(agentID)
+    if (!task.workspace?.path) throw taskLaunchError("workspace_required", "Task workspace is not prepared")
+
+    if (entry.kind === "acp") {
+      const service = this.acpService?.(agentID)
+      if (service) {
+        const adopted = await service.adoptTaskSession(previousRun.sessionId, { title: taskSessionTitle(task) })
+        if (adopted === false) throw taskLaunchError("session_unavailable", "The previous native Session can no longer be resumed")
+        if (model) await service.setModel(previousRun.sessionId, acpModelWireName(model))
+        return { sessionId: previousRun.sessionId, transport: "acp", directory: task.workspace.path }
+      }
+      await entry.host.start()
+      if (model) {
+        await entry.host.request("session/set_config_option", {
+          sessionId: previousRun.sessionId,
+          configId: "model",
+          value: acpModelWireName(model)
+        })
+      }
+      return { sessionId: previousRun.sessionId, transport: "acp", directory: task.workspace.path }
+    }
+
+    if (entry.kind === "http") {
+      await entry.host.start?.()
+      const host = entry.host.readinessHost ?? entry.host.host ?? "127.0.0.1"
+      const base = `http://${httpHost(host)}:${entry.host.port}`
+      const authorization = basicAuthorization(entry.host.username, entry.host.password)
+      return { sessionId: previousRun.sessionId, transport: "http", directory: task.workspace.path, base, authorization }
+    }
+
+    throw taskLaunchError("unsupported_agent", `Agent ${agentID} cannot resume tasks`)
   }
 
   async startPrompt(task, run, { onFailed, onCompleted } = {}) {
-    const entry = this.daemon.hostEntry(task.agentId)
-    if (!entry) throw taskLaunchError("unknown_agent", `Unknown agent: ${task.agentId}`)
+    const agentID = runAgentID(task, run)
+    const model = runModel(task, run)
+    const entry = await this.#entry(agentID)
 
     if (entry.kind === "acp") {
-      const service = this.acpService?.(task.agentId)
+      const service = this.acpService?.(agentID)
       if (service) {
         void service.promptAndWait(run.sessionId, task.prompt).then((result) => {
           onCompleted?.(result)
@@ -141,22 +192,18 @@ export class TaskLauncher {
     }
 
     if (entry.kind === "http") {
-      // prompt_async only acknowledges queueing (204). Provider/authentication failures then land
-      // in OpenCode events and the task remains "running" forever. The normal message endpoint
-      // keeps the same selected model but lets the background request settle as completed or failed.
       void this.fetchImpl(`${run.base}/session/${encodeURIComponent(run.sessionId)}/message?directory=${encodeURIComponent(task.workspace.path)}`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          // Authorization belongs to the ephemeral createSession() result only.
           ...(run.authorization ? { Authorization: run.authorization } : {})
         },
         body: JSON.stringify({
           parts: [{ type: "text", text: task.prompt }],
-          model: promptModelBody(task.model),
-          variant: task.model?.variant || undefined
+          model: promptModelBody(model),
+          variant: model?.variant || undefined
         })
-      }).then((response) => responseJSON(response, `Starting ${task.agentId} task`))
+      }).then((response) => responseJSON(response, `Starting ${agentID} task`))
         .then((result) => onCompleted?.(result))
         .catch((error) => onFailed?.(error))
     }
@@ -165,11 +212,10 @@ export class TaskLauncher {
   async inspectRun(task) {
     const run = task?.run
     if (!run?.sessionId) return "unknown"
-    const entry = this.daemon.hostEntry(task.agentId)
+    const agentID = runAgentID(task, run)
+    const entry = this.daemon.hostEntry(agentID)
     if (!entry) return "unknown"
 
-    // ACP gives us an authoritative completion signal while the prompt request is alive,
-    // but there is no backend-neutral post-restart session status primitive to query here.
     if (entry.kind === "acp") return "unknown"
     if (entry.kind !== "http") return "unknown"
 

--- a/bridge/src/task-run-controller.js
+++ b/bridge/src/task-run-controller.js
@@ -1,6 +1,26 @@
 import { randomUUID } from "node:crypto"
+import { buildTaskContext, formatTaskHandoff } from "./task-context.js"
 import { taskLaunchError } from "./task-errors.js"
+import { normalizeTaskModel } from "./task-model.js"
 import { WorktreeManager } from "./worktree-manager.js"
+
+function requestedAgent(task, options = {}) {
+  const explicit = typeof options.agentId === "string" ? options.agentId.trim() : ""
+  return explicit || task.run?.agentId || task.agentId
+}
+
+function requestedModel(task, targetAgent, options = {}) {
+  if (Object.prototype.hasOwnProperty.call(options, "model")) return normalizeTaskModel(options.model)
+  const previousAgent = task.run?.agentId || task.agentId
+  if (task.run && targetAgent !== previousAgent) return null
+  return normalizeTaskModel(task.run?.model ?? task.model)
+}
+
+function requestedRole(task, options = {}) {
+  const explicit = typeof options.role === "string" ? options.role.trim() : ""
+  if (explicit) return explicit
+  return task.run ? "continue" : "implement"
+}
 
 export class TaskRunController {
   constructor({ taskStore, taskLauncher, worktreeManager, acpService, runIDFactory = randomUUID, clock = () => new Date().toISOString() }) {
@@ -28,7 +48,8 @@ export class TaskRunController {
 
   async #adoptAcpTaskSession(task) {
     if (!task.run?.sessionId || task.run.transport !== "acp") return null
-    const service = this.acpService?.(task.agentId)
+    const agentID = task.run.agentId || task.agentId
+    const service = this.acpService?.(agentID)
     if (!service) return null
     const title = task.prompt?.trim().split("\n")[0].slice(0, 60)
     try {
@@ -36,6 +57,18 @@ export class TaskRunController {
     } catch {
       return null
     }
+  }
+
+  async #contextForTask(task) {
+    let workspace = { managed: task.workspace?.mode === "worktree", dirty: false, changeCount: 0, changedFiles: [] }
+    if (task.workspace?.mode === "worktree" && this.worktreeManager) {
+      try {
+        workspace = await this.worktreeManager.inspect(task.workspace)
+      } catch {
+        // Context remains useful even when the workspace cannot be inspected temporarily.
+      }
+    }
+    return buildTaskContext(task, { workspace })
   }
 
   async reconcileAll() {
@@ -57,11 +90,18 @@ export class TaskRunController {
     }
   }
 
+  async context(taskID) {
+    await this.#awaitReconciliation()
+    const task = await this.taskStore.get(taskID)
+    if (!task) throw taskLaunchError("unknown_task", `Unknown task: ${taskID}`)
+    return this.#contextForTask(task)
+  }
+
   async inspectWorkspace(taskID) {
     await this.#awaitReconciliation()
     const task = await this.taskStore.get(taskID)
     if (!task) throw taskLaunchError("unknown_task", `Unknown task: ${taskID}`)
-    if (task.workspace?.mode !== "worktree") return { managed: false, dirty: false, changeCount: 0 }
+    if (task.workspace?.mode !== "worktree") return { managed: false, dirty: false, changeCount: 0, changedFiles: [] }
     if (!this.worktreeManager) throw new Error("Worktree manager is not configured")
     return this.worktreeManager.inspect(task.workspace)
   }
@@ -88,24 +128,52 @@ export class TaskRunController {
     if (!task.workspace?.path) throw taskLaunchError("workspace_required", "Task workspace is not prepared")
 
     const requestedPrompt = typeof options.prompt === "string" ? options.prompt.trim() : ""
-    const runPrompt = requestedPrompt || task.prompt
-    if (!runPrompt) throw taskLaunchError("invalid_state", "A run prompt is required")
+    const userPrompt = requestedPrompt || task.prompt
+    if (!userPrompt) throw taskLaunchError("invalid_state", "A run prompt is required")
+
+    const previousRun = task.run ? structuredClone(task.run) : null
+    const agentID = requestedAgent(task, options)
+    if (!agentID) throw taskLaunchError("unknown_agent", "A target harness is required")
+    const model = requestedModel(task, agentID, options)
+    const role = requestedRole(task, options)
+    const reuseSession = options.reuseSession === true
+    const previousAgent = previousRun?.agentId || task.agentId
+    if (reuseSession && (!previousRun?.sessionId || agentID !== previousAgent)) {
+      throw taskLaunchError("session_unavailable", "The requested native Session cannot be reused for this Run")
+    }
+
+    const context = await this.#contextForTask(task)
+    const effectivePrompt = previousRun && !reuseSession
+      ? formatTaskHandoff(context, { targetAgentId: agentID, role, instruction: userPrompt })
+      : userPrompt
 
     const previousRunCount = Array.isArray(task.runs) ? task.runs.length : task.run ? 1 : 0
     const run = {
       id: this.runIDFactory(),
       sequence: previousRunCount + 1,
-      agentId: task.agentId,
+      agentId: agentID,
+      model,
+      role,
+      contextRevision: Number(context.revision) || 0,
+      ...(previousRun && !reuseSession ? { handoffFromRunId: previousRun.id ?? null } : {}),
       sessionId: null,
       transport: null,
       directory: task.workspace.path,
-      prompt: runPrompt,
+      prompt: userPrompt,
       startedAt: this.clock()
     }
     let current = await this.taskStore.setRunState(taskID, { status: "starting", run })
-    const currentForRun = () => ({ ...current, prompt: runPrompt })
+    const currentForRun = () => ({
+      ...current,
+      agentId: agentID,
+      model,
+      prompt: effectivePrompt,
+      run: current.run ? { ...current.run, agentId: agentID, model } : current.run
+    })
     try {
-      const session = await this.taskLauncher.createSession(currentForRun())
+      const session = reuseSession
+        ? await this.taskLauncher.resumeSession(currentForRun(), previousRun)
+        : await this.taskLauncher.createSession(currentForRun())
       const linkedRun = { ...run, sessionId: session.sessionId, transport: session.transport }
       current = await this.taskStore.setRunState(taskID, { status: "starting", run: linkedRun, expectedRunId: run.id })
       current = await this.taskStore.setRunState(taskID, { status: "running", run: linkedRun, expectedRunId: linkedRun.id })
@@ -120,14 +188,28 @@ export class TaskRunController {
     }
   }
 
-  async continue(taskID, prompt) {
-    const text = typeof prompt === "string" ? prompt.trim() : ""
+  async continue(taskID, input) {
+    const options = typeof input === "string" ? { prompt: input } : input && typeof input === "object" ? input : {}
+    const text = typeof options.prompt === "string" ? options.prompt.trim() : ""
     if (!text) throw taskLaunchError("invalid_state", "A continuation prompt is required")
+    await this.#awaitReconciliation()
     const task = await this.taskStore.get(taskID)
     if (!task) throw taskLaunchError("unknown_task", `Unknown task: ${taskID}`)
     if (!["completed", "failed", "cancelled"].includes(task.status)) {
       throw taskLaunchError("invalid_state", "Only a terminal task can start another run")
     }
-    return this.launch(taskID, { prompt: text })
+
+    const agentID = requestedAgent(task, options)
+    const previousAgent = task.run?.agentId || task.agentId
+    const explicitFresh = options.mode === "fresh" || options.fresh === true
+    let reuseSession = false
+    if (!explicitFresh && agentID === previousAgent) {
+      if (!task.run?.sessionId) {
+        throw taskLaunchError("session_unavailable", "The previous native Session cannot be resumed. Start a fresh Run explicitly instead.")
+      }
+      reuseSession = true
+    }
+
+    return this.launch(taskID, { ...options, prompt: text, agentId: agentID, reuseSession })
   }
 }

--- a/bridge/src/task-run-controller.js
+++ b/bridge/src/task-run-controller.js
@@ -1,8 +1,11 @@
 import { randomUUID } from "node:crypto"
-import { buildTaskContext, formatTaskHandoff } from "./task-context.js"
+import { boundTaskOutcome, buildTaskContext, formatTaskHandoff } from "./task-context.js"
 import { taskLaunchError } from "./task-errors.js"
 import { normalizeTaskModel } from "./task-model.js"
 import { WorktreeManager } from "./worktree-manager.js"
+
+const MAX_AGENT_ID_CHARS = 160
+const MAX_ROLE_CHARS = 80
 
 function taskRuns(task) {
   if (Array.isArray(task?.runs) && task.runs.length) return task.runs
@@ -22,6 +25,40 @@ function latestRunForAgent(task, agentID, { requireSession = false } = {}) {
     return run
   }
   return null
+}
+
+function validateRunOptions(options) {
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    throw taskLaunchError("invalid_request", "Task Run options must be an object")
+  }
+  if (Object.prototype.hasOwnProperty.call(options, "prompt") && typeof options.prompt !== "string") {
+    throw taskLaunchError("invalid_request", "Task Run prompt must be a string")
+  }
+  if (Object.prototype.hasOwnProperty.call(options, "agentId")) {
+    if (typeof options.agentId !== "string" || !options.agentId.trim()) {
+      throw taskLaunchError("invalid_request", "Target harness must be a non-empty string")
+    }
+    if (options.agentId.trim().length > MAX_AGENT_ID_CHARS) {
+      throw taskLaunchError("invalid_request", "Target harness identifier is too long")
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(options, "role")) {
+    if (typeof options.role !== "string" || !options.role.trim()) {
+      throw taskLaunchError("invalid_request", "Task Run role must be a non-empty string")
+    }
+    if (options.role.trim().length > MAX_ROLE_CHARS) {
+      throw taskLaunchError("invalid_request", "Task Run role is too long")
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(options, "model") && options.model !== null && !normalizeTaskModel(options.model)) {
+    throw taskLaunchError("invalid_request", "Task Run model is malformed")
+  }
+  if (Object.prototype.hasOwnProperty.call(options, "fresh") && typeof options.fresh !== "boolean") {
+    throw taskLaunchError("invalid_request", "Task Run fresh flag must be boolean")
+  }
+  if (Object.prototype.hasOwnProperty.call(options, "mode") && !["fresh", "resume"].includes(options.mode)) {
+    throw taskLaunchError("invalid_request", "Task Run mode must be fresh or resume")
+  }
 }
 
 function requestedAgent(task, options = {}) {
@@ -44,7 +81,7 @@ function requestedRole(task, options = {}) {
 }
 
 function completedRun(run, result) {
-  const outcome = typeof result?.outcome === "string" ? result.outcome.trim() : ""
+  const outcome = boundTaskOutcome(result?.outcome)
   return outcome ? { ...run, outcome } : run
 }
 
@@ -86,20 +123,23 @@ export class TaskRunController {
 
   async #contextForTask(task) {
     let workspace = { managed: task.workspace?.mode === "worktree", dirty: false, changeCount: 0, changedFiles: [] }
-    if (task.workspace?.mode === "worktree" && this.worktreeManager) {
-      try {
+    if (!this.worktreeManager) return buildTaskContext(task, { workspace })
+    try {
+      if (task.workspace?.mode === "worktree") {
         workspace = await this.worktreeManager.inspect(task.workspace)
-      } catch {
-        // Context remains useful even when the workspace cannot be inspected temporarily.
+      } else if (task.workspace?.mode === "project" && task.project?.kind === "git" && typeof this.worktreeManager.inspectProject === "function") {
+        workspace = await this.worktreeManager.inspectProject(task.workspace.path || task.project.path)
       }
+    } catch {
+      // Context remains useful even when Git state cannot be inspected temporarily.
     }
     return buildTaskContext(task, { workspace })
   }
 
   async reconcileAll() {
     for (const task of await this.taskStore.list()) {
-      const adoptedAcpSession = await this.#adoptAcpTaskSession(task)
       if (!["starting", "running"].includes(task.status)) continue
+      const adoptedAcpSession = await this.#adoptAcpTaskSession(task)
       if (!task.run?.id) {
         try { await this.taskStore.setRunState(task.id, { status: "failed", error: new Error("Active task has no persisted run identity") }) } catch {}
         continue
@@ -126,9 +166,15 @@ export class TaskRunController {
     await this.#awaitReconciliation()
     const task = await this.taskStore.get(taskID)
     if (!task) throw taskLaunchError("unknown_task", `Unknown task: ${taskID}`)
-    if (task.workspace?.mode !== "worktree") return { managed: false, dirty: false, changeCount: 0, changedFiles: [] }
-    if (!this.worktreeManager) throw new Error("Worktree manager is not configured")
-    return this.worktreeManager.inspect(task.workspace)
+    if (!this.worktreeManager) {
+      if (task.workspace?.mode === "worktree") throw new Error("Worktree manager is not configured")
+      return { managed: false, dirty: false, changeCount: 0, changedFiles: [] }
+    }
+    if (task.workspace?.mode === "worktree") return this.worktreeManager.inspect(task.workspace)
+    if (task.workspace?.mode === "project" && task.project?.kind === "git" && typeof this.worktreeManager.inspectProject === "function") {
+      return this.worktreeManager.inspectProject(task.workspace.path || task.project.path)
+    }
+    return { managed: false, dirty: false, changeCount: 0, changedFiles: [] }
   }
 
   async cleanupWorkspace(taskID) {
@@ -144,6 +190,7 @@ export class TaskRunController {
   }
 
   async launch(taskID, options = {}) {
+    validateRunOptions(options)
     await this.#awaitReconciliation()
     const task = await this.taskStore.get(taskID)
     if (!task) throw taskLaunchError("unknown_task", `Unknown task: ${taskID}`)
@@ -213,7 +260,8 @@ export class TaskRunController {
   }
 
   async continue(taskID, input) {
-    const options = typeof input === "string" ? { prompt: input } : input && typeof input === "object" ? input : {}
+    const options = typeof input === "string" ? { prompt: input } : input && typeof input === "object" && !Array.isArray(input) ? input : {}
+    validateRunOptions(options)
     const text = typeof options.prompt === "string" ? options.prompt.trim() : ""
     if (!text) throw taskLaunchError("invalid_state", "A continuation prompt is required")
     await this.#awaitReconciliation()
@@ -223,7 +271,11 @@ export class TaskRunController {
 
     const agentID = requestedAgent(task, options)
     const explicitFresh = options.mode === "fresh" || options.fresh === true
+    const explicitResume = options.mode === "resume"
     const reusableRun = latestRunForAgent(task, agentID, { requireSession: true })
+    if (explicitResume && !reusableRun) {
+      throw taskLaunchError("session_unavailable", "No native Session for the selected harness can be resumed. Start a fresh Run instead.")
+    }
     const reuseSession = !explicitFresh && Boolean(reusableRun)
     if (!explicitFresh && agentID === runAgent(task, task.run) && !reusableRun) {
       throw taskLaunchError("session_unavailable", "The previous native Session cannot be resumed. Start a fresh Run explicitly instead.")

--- a/bridge/src/task-run-controller.js
+++ b/bridge/src/task-run-controller.js
@@ -4,22 +4,48 @@ import { taskLaunchError } from "./task-errors.js"
 import { normalizeTaskModel } from "./task-model.js"
 import { WorktreeManager } from "./worktree-manager.js"
 
+function taskRuns(task) {
+  if (Array.isArray(task?.runs) && task.runs.length) return task.runs
+  return task?.run ? [task.run] : []
+}
+
+function runAgent(task, run) {
+  return run?.agentId || task?.agentId || ""
+}
+
+function latestRunForAgent(task, agentID, { requireSession = false } = {}) {
+  const runs = taskRuns(task)
+  for (let index = runs.length - 1; index >= 0; index -= 1) {
+    const run = runs[index]
+    if (runAgent(task, run) !== agentID) continue
+    if (requireSession && !run?.sessionId) continue
+    return run
+  }
+  return null
+}
+
 function requestedAgent(task, options = {}) {
   const explicit = typeof options.agentId === "string" ? options.agentId.trim() : ""
-  return explicit || task.run?.agentId || task.agentId
+  return explicit || runAgent(task, task.run)
 }
 
 function requestedModel(task, targetAgent, options = {}) {
   if (Object.prototype.hasOwnProperty.call(options, "model")) return normalizeTaskModel(options.model)
-  const previousAgent = task.run?.agentId || task.agentId
-  if (task.run && targetAgent !== previousAgent) return null
-  return normalizeTaskModel(task.run?.model ?? task.model)
+  const priorTargetRun = latestRunForAgent(task, targetAgent)
+  if (priorTargetRun?.model) return normalizeTaskModel(priorTargetRun.model)
+  if (targetAgent === task.agentId) return normalizeTaskModel(task.model)
+  return null
 }
 
 function requestedRole(task, options = {}) {
   const explicit = typeof options.role === "string" ? options.role.trim() : ""
   if (explicit) return explicit
   return task.run ? "continue" : "implement"
+}
+
+function completedRun(run, result) {
+  const outcome = typeof result?.outcome === "string" ? result.outcome.trim() : ""
+  return outcome ? { ...run, outcome } : run
 }
 
 export class TaskRunController {
@@ -37,18 +63,17 @@ export class TaskRunController {
 
   async #awaitReconciliation() {
     await this.reconciliation
-    if (this.reconciliationError) {
-      throw taskLaunchError("agent_unavailable", "Task state is unavailable", { cause: this.reconciliationError })
-    }
+    if (this.reconciliationError) throw taskLaunchError("agent_unavailable", "Task state is unavailable", { cause: this.reconciliationError })
   }
 
-  async #terminal(taskID, run, status, error = null) {
-    try { await this.taskStore.setRunState(taskID, { status, run, error, expectedRunId: run?.id }) } catch {}
+  async #terminal(taskID, run, status, error = null, result = null) {
+    const terminalRun = status === "completed" ? completedRun(run, result) : run
+    try { await this.taskStore.setRunState(taskID, { status, run: terminalRun, error, expectedRunId: run?.id }) } catch {}
   }
 
   async #adoptAcpTaskSession(task) {
     if (!task.run?.sessionId || task.run.transport !== "acp") return null
-    const agentID = task.run.agentId || task.agentId
+    const agentID = runAgent(task, task.run)
     const service = this.acpService?.(agentID)
     if (!service) return null
     const title = task.prompt?.trim().split("\n")[0].slice(0, 60)
@@ -122,9 +147,7 @@ export class TaskRunController {
     await this.#awaitReconciliation()
     const task = await this.taskStore.get(taskID)
     if (!task) throw taskLaunchError("unknown_task", `Unknown task: ${taskID}`)
-    if (!["draft", "completed", "failed", "cancelled"].includes(task.status)) {
-      throw taskLaunchError("invalid_state", "Only draft or terminal tasks can start a run")
-    }
+    if (!["draft", "completed", "failed", "cancelled"].includes(task.status)) throw taskLaunchError("invalid_state", "Only draft or terminal tasks can start a run")
     if (!task.workspace?.path) throw taskLaunchError("workspace_required", "Task workspace is not prepared")
 
     const requestedPrompt = typeof options.prompt === "string" ? options.prompt.trim() : ""
@@ -137,17 +160,17 @@ export class TaskRunController {
     const model = requestedModel(task, agentID, options)
     const role = requestedRole(task, options)
     const reuseSession = options.reuseSession === true
-    const previousAgent = previousRun?.agentId || task.agentId
-    if (reuseSession && (!previousRun?.sessionId || agentID !== previousAgent)) {
-      throw taskLaunchError("session_unavailable", "The requested native Session cannot be reused for this Run")
-    }
+    const reusableRun = reuseSession ? latestRunForAgent(task, agentID, { requireSession: true }) : null
+    if (reuseSession && !reusableRun) throw taskLaunchError("session_unavailable", "The requested native Session cannot be reused for this Run")
 
     const context = await this.#contextForTask(task)
-    const effectivePrompt = previousRun && !reuseSession
+    const directNativeContinuation = Boolean(reusableRun && previousRun && reusableRun.id === previousRun.id)
+    const needsHandoffContext = Boolean(previousRun && (!reuseSession || !directNativeContinuation))
+    const effectivePrompt = needsHandoffContext
       ? formatTaskHandoff(context, { targetAgentId: agentID, role, instruction: userPrompt })
       : userPrompt
 
-    const previousRunCount = Array.isArray(task.runs) ? task.runs.length : task.run ? 1 : 0
+    const previousRunCount = taskRuns(task).length
     const run = {
       id: this.runIDFactory(),
       sequence: previousRunCount + 1,
@@ -155,7 +178,8 @@ export class TaskRunController {
       model,
       role,
       contextRevision: Number(context.revision) || 0,
-      ...(previousRun && !reuseSession ? { handoffFromRunId: previousRun.id ?? null } : {}),
+      ...(needsHandoffContext ? { handoffFromRunId: previousRun?.id ?? null } : {}),
+      ...(reusableRun ? { resumedFromRunId: reusableRun.id ?? null } : {}),
       sessionId: null,
       transport: null,
       directory: task.workspace.path,
@@ -172,14 +196,14 @@ export class TaskRunController {
     })
     try {
       const session = reuseSession
-        ? await this.taskLauncher.resumeSession(currentForRun(), previousRun)
+        ? await this.taskLauncher.resumeSession(currentForRun(), reusableRun)
         : await this.taskLauncher.createSession(currentForRun())
       const linkedRun = { ...run, sessionId: session.sessionId, transport: session.transport }
       current = await this.taskStore.setRunState(taskID, { status: "starting", run: linkedRun, expectedRunId: run.id })
       current = await this.taskStore.setRunState(taskID, { status: "running", run: linkedRun, expectedRunId: linkedRun.id })
       const onFailed = (error) => void this.#terminal(taskID, linkedRun, "failed", error)
       onFailed.onFailed = onFailed
-      onFailed.onCompleted = () => void this.#terminal(taskID, linkedRun, "completed")
+      onFailed.onCompleted = (result) => void this.#terminal(taskID, linkedRun, "completed", null, result)
       await this.taskLauncher.startPrompt(currentForRun(), session, onFailed)
       return current
     } catch (error) {
@@ -195,19 +219,14 @@ export class TaskRunController {
     await this.#awaitReconciliation()
     const task = await this.taskStore.get(taskID)
     if (!task) throw taskLaunchError("unknown_task", `Unknown task: ${taskID}`)
-    if (!["completed", "failed", "cancelled"].includes(task.status)) {
-      throw taskLaunchError("invalid_state", "Only a terminal task can start another run")
-    }
+    if (!["completed", "failed", "cancelled"].includes(task.status)) throw taskLaunchError("invalid_state", "Only a terminal task can start another run")
 
     const agentID = requestedAgent(task, options)
-    const previousAgent = task.run?.agentId || task.agentId
     const explicitFresh = options.mode === "fresh" || options.fresh === true
-    let reuseSession = false
-    if (!explicitFresh && agentID === previousAgent) {
-      if (!task.run?.sessionId) {
-        throw taskLaunchError("session_unavailable", "The previous native Session cannot be resumed. Start a fresh Run explicitly instead.")
-      }
-      reuseSession = true
+    const reusableRun = latestRunForAgent(task, agentID, { requireSession: true })
+    const reuseSession = !explicitFresh && Boolean(reusableRun)
+    if (!explicitFresh && agentID === runAgent(task, task.run) && !reusableRun) {
+      throw taskLaunchError("session_unavailable", "The previous native Session cannot be resumed. Start a fresh Run explicitly instead.")
     }
 
     return this.launch(taskID, { ...options, prompt: text, agentId: agentID, reuseSession })

--- a/bridge/src/task-run-controller.js
+++ b/bridge/src/task-run-controller.js
@@ -205,6 +205,7 @@ export class TaskRunController {
     const agentID = requestedAgent(task, options)
     if (!agentID) throw taskLaunchError("unknown_agent", "A target harness is required")
     const model = requestedModel(task, agentID, options)
+    await this.taskLauncher.validateModelSelection?.(agentID, model)
     const role = requestedRole(task, options)
     const reuseSession = options.reuseSession === true
     const reusableRun = reuseSession ? latestRunForAgent(task, agentID, { requireSession: true }) : null

--- a/bridge/src/task-run-store.js
+++ b/bridge/src/task-run-store.js
@@ -1,4 +1,5 @@
 import { TaskStore } from "./task-store.js"
+import { buildPersistedTaskContext } from "./task-context.js"
 
 function updateRunHistory(task, run) {
   const runs = Array.isArray(task.runs) ? task.runs.map((entry) => structuredClone(entry)) : []
@@ -32,6 +33,9 @@ export class TaskRunStore extends TaskStore {
       nextRun.finishedAt = this.clock()
     }
     const runs = updateRunHistory(task, nextRun)
+    const terminalTransition = (status === "completed" || status === "failed") && !task.run?.finishedAt
+    const currentRevision = Number(task.context?.revision) || 0
+    const nextRevision = terminalTransition ? currentRevision + 1 : currentRevision
     const updated = {
       ...task,
       status,
@@ -41,6 +45,7 @@ export class TaskRunStore extends TaskStore {
       finishedAt: status === "starting" ? null : task.finishedAt ?? null,
       updatedAt: this.clock()
     }
+    updated.context = buildPersistedTaskContext(updated, nextRevision)
     this.tasks[index] = updated
     await this.persist()
     return structuredClone(updated)

--- a/bridge/src/task-run-store.js
+++ b/bridge/src/task-run-store.js
@@ -29,6 +29,7 @@ export class TaskRunStore extends TaskStore {
     }
 
     const nextRun = structuredClone(run ?? task.run)
+    if (nextRun) nextRun.status = status
     if ((status === "completed" || status === "failed") && nextRun && !nextRun.finishedAt) {
       nextRun.finishedAt = this.clock()
     }

--- a/bridge/src/task-store.js
+++ b/bridge/src/task-store.js
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto"
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
 import path from "node:path"
+import { buildPersistedTaskContext } from "./task-context.js"
 
 function machineFileName(machineID) {
   const digest = createHash("sha256").update(machineID).digest("hex").slice(0, 16)
@@ -20,7 +21,11 @@ function normalizeTaskHistory(task) {
     : task.run
       ? [task.run]
       : []
-  return { ...task, runs, finishedAt: task.finishedAt ?? null }
+  const normalized = { ...task, runs, finishedAt: task.finishedAt ?? null }
+  const revision = Number.isFinite(Number(task.context?.revision))
+    ? Number(task.context.revision)
+    : runs.filter((run) => run?.finishedAt).length
+  return { ...normalized, context: buildPersistedTaskContext(normalized, revision) }
 }
 
 export class TaskStore {
@@ -97,6 +102,7 @@ export class TaskStore {
       createdAt: timestamp,
       updatedAt: timestamp
     }
+    task.context = buildPersistedTaskContext(task, 0)
     this.tasks.push(task)
     await this.persist()
     return structuredClone(task)
@@ -125,6 +131,7 @@ export class TaskStore {
     if (task.finishedAt) return structuredClone(task)
     const timestamp = this.clock()
     const updated = { ...task, finishedAt: timestamp, updatedAt: timestamp }
+    updated.context = buildPersistedTaskContext(updated, task.context?.revision ?? 0)
     this.tasks[index] = updated
     await this.persist()
     return structuredClone(updated)
@@ -144,6 +151,7 @@ export class TaskStore {
       workspace: { mode: "project", path: task.project.path },
       updatedAt: this.clock()
     }
+    updated.context = buildPersistedTaskContext(updated, task.context?.revision ?? 0)
     this.tasks[index] = updated
     await this.persist()
     return structuredClone(updated)

--- a/bridge/src/worktree-manager.js
+++ b/bridge/src/worktree-manager.js
@@ -38,6 +38,13 @@ async function defaultRunGit(args) {
   }
 }
 
+function changedFileFromPorcelain(line) {
+  const candidate = line.length > 3 ? line.slice(3).trim() : ""
+  if (!candidate) return ""
+  const renamed = candidate.split(" -> ")
+  return renamed.at(-1)?.trim() || candidate
+}
+
 export class WorktreeManager {
   constructor({ stateDirectory, runGit = defaultRunGit }) {
     this.stateDirectory = stateDirectory
@@ -65,7 +72,8 @@ export class WorktreeManager {
     await this.#assertManagedWorkspace(workspace)
     const result = await this.runGit(["-C", workspace.path, "status", "--porcelain=v1", "--untracked-files=all"])
     const changes = String(result?.stdout ?? "").split(/\r?\n/).filter(Boolean)
-    return { managed: true, dirty: changes.length > 0, changeCount: changes.length }
+    const changedFiles = changes.map(changedFileFromPorcelain).filter(Boolean)
+    return { managed: true, dirty: changes.length > 0, changeCount: changes.length, changedFiles }
   }
 
   async cleanup(workspace) {

--- a/bridge/src/worktree-manager.js
+++ b/bridge/src/worktree-manager.js
@@ -45,6 +45,12 @@ function changedFileFromPorcelain(line) {
   return renamed.at(-1)?.trim() || candidate
 }
 
+function statusView(result, managed) {
+  const changes = String(result?.stdout ?? "").split(/\r?\n/).filter(Boolean)
+  const changedFiles = changes.map(changedFileFromPorcelain).filter(Boolean)
+  return { managed, dirty: changes.length > 0, changeCount: changes.length, changedFiles }
+}
+
 export class WorktreeManager {
   constructor({ stateDirectory, runGit = defaultRunGit }) {
     this.stateDirectory = stateDirectory
@@ -71,9 +77,16 @@ export class WorktreeManager {
   async inspect(workspace) {
     await this.#assertManagedWorkspace(workspace)
     const result = await this.runGit(["-C", workspace.path, "status", "--porcelain=v1", "--untracked-files=all"])
-    const changes = String(result?.stdout ?? "").split(/\r?\n/).filter(Boolean)
-    const changedFiles = changes.map(changedFileFromPorcelain).filter(Boolean)
-    return { managed: true, dirty: changes.length > 0, changeCount: changes.length, changedFiles }
+    return statusView(result, true)
+  }
+
+  async inspectProject(projectPath) {
+    if (typeof projectPath !== "string" || !projectPath.trim()) {
+      throw worktreeError("invalid_project", "Task project path is unavailable")
+    }
+    await this.runGit(["-C", projectPath, "rev-parse", "--show-toplevel"])
+    const result = await this.runGit(["-C", projectPath, "status", "--porcelain=v1", "--untracked-files=all"])
+    return statusView(result, false)
   }
 
   async cleanup(workspace) {

--- a/bridge/test/task-context-bounds.test.js
+++ b/bridge/test/task-context-bounds.test.js
@@ -26,9 +26,12 @@ function largeTask(runCount = 40) {
 }
 
 test("persisted Task Context keeps only bounded recent Run summaries", () => {
-  const context = buildPersistedTaskContext(largeTask(), 40)
+  const task = largeTask()
+  const context = buildPersistedTaskContext(task, 40)
+  const runtime = buildTaskContext(task, { workspace: { dirty: false, changeCount: 0, changedFiles: [] } })
 
-  assert.equal(context.runCount, 40)
+  assert.equal(Object.hasOwn(context, "runCount"), false)
+  assert.equal(runtime.runCount, 40)
   assert.equal(context.runSummaries.length, 12)
   assert.equal(context.runSummaries[0].sequence, 29)
   assert.equal(context.runSummaries.at(-1).sequence, 40)

--- a/bridge/test/task-context-bounds.test.js
+++ b/bridge/test/task-context-bounds.test.js
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { buildPersistedTaskContext, buildTaskContext, formatTaskHandoff } from "../src/task-context.js"
+
+function largeTask(runCount = 40) {
+  const runs = Array.from({ length: runCount }, (_, index) => ({
+    id: `run-${index + 1}`,
+    sequence: index + 1,
+    agentId: index % 2 === 0 ? "codex" : "claude",
+    role: index % 2 === 0 ? "implement" : "review",
+    sessionId: `session-${index + 1}`,
+    status: "completed",
+    prompt: `prompt-${index + 1}:` + "p".repeat(5_000),
+    outcome: `outcome-${index + 1}:` + "o".repeat(10_000),
+    finishedAt: `2026-08-20T09:${String(index).padStart(2, "0")}:00.000Z`
+  }))
+  return {
+    id: "task-bounded",
+    status: "completed",
+    prompt: "objective:" + "x".repeat(20_000),
+    run: runs.at(-1),
+    runs,
+    error: null,
+    context: { version: 1, revision: runCount }
+  }
+}
+
+test("persisted Task Context keeps only bounded recent Run summaries", () => {
+  const context = buildPersistedTaskContext(largeTask(), 40)
+
+  assert.equal(context.runCount, 40)
+  assert.equal(context.runSummaries.length, 12)
+  assert.equal(context.runSummaries[0].sequence, 29)
+  assert.equal(context.runSummaries.at(-1).sequence, 40)
+  assert.equal(context.objective.length <= 12_000, true)
+  for (const run of context.runSummaries) {
+    assert.equal(run.prompt.length <= 2_000, true)
+    assert.equal(run.outcome.length <= 6_000, true)
+  }
+})
+
+test("Task Context bounds changed-file names while preserving total change count", () => {
+  const changedFiles = Array.from({ length: 120 }, (_, index) => `src/${index}-${"x".repeat(600)}.js`)
+  const context = buildTaskContext(largeTask(2), {
+    workspace: { dirty: true, changeCount: changedFiles.length, changedFiles }
+  })
+
+  assert.equal(context.changedFiles.length, 80)
+  assert.equal(context.workspace.changeCount, 120)
+  assert.equal(context.workspace.listedChangeCount, 80)
+  assert.equal(context.workspace.truncated, true)
+  assert.equal(context.changedFiles.every((file) => file.length <= 500), true)
+})
+
+test("handoff packet uses recent bounded history instead of replaying the whole Task", () => {
+  const context = buildTaskContext(largeTask(40), {
+    workspace: { dirty: false, changeCount: 0, changedFiles: [] }
+  })
+  const handoff = formatTaskHandoff(context, {
+    targetAgentId: "pi",
+    role: "test",
+    instruction: "Run the focused regression suite"
+  })
+
+  assert.match(handoff, /Run 40:/)
+  assert.doesNotMatch(handoff, /Run 1:/)
+  assert.match(handoff, /28 earlier Task step\(s\) retained in Task history but omitted from this handoff/)
+  assert.match(handoff, /USER INSTRUCTION\nRun the focused regression suite/)
+  assert.equal(handoff.length < 60_000, true)
+})

--- a/bridge/test/task-handoff-api-validation.test.js
+++ b/bridge/test/task-handoff-api-validation.test.js
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import test from "node:test"
+import { createTaskLaunchServer } from "../src/task-launch-server.js"
+import { TaskRunController } from "../src/task-run-controller.js"
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  return server.address().port
+}
+
+async function close(server) {
+  await new Promise((resolve) => server.close(resolve))
+}
+
+function completedTask() {
+  const run = {
+    id: "run-1",
+    sequence: 1,
+    agentId: "codex",
+    sessionId: "codex-1",
+    transport: "acp",
+    status: "completed",
+    prompt: "Fix it",
+    finishedAt: "2026-08-20T08:00:00.000Z"
+  }
+  return {
+    id: "task-1",
+    status: "completed",
+    agentId: "codex",
+    prompt: "Fix it",
+    project: { kind: "git", path: "/repo" },
+    workspace: { mode: "project", path: "/repo" },
+    run,
+    runs: [run],
+    context: { version: 1, revision: 1 }
+  }
+}
+
+test("Continue rejects malformed model and unsupported execution mode with stable request errors", async () => {
+  const task = completedTask()
+  const controller = new TaskRunController({
+    taskStore: { async list() { return [] }, async get() { return structuredClone(task) } },
+    taskLauncher: {}
+  })
+
+  await assert.rejects(
+    () => controller.continue("task-1", { prompt: "Continue", model: { providerID: "openai" } }),
+    (error) => error.code === "invalid_request" && /model is malformed/.test(error.message)
+  )
+  await assert.rejects(
+    () => controller.continue("task-1", { prompt: "Continue", mode: "magic" }),
+    (error) => error.code === "invalid_request" && /mode must be fresh or resume/.test(error.message)
+  )
+})
+
+test("legacy string Continue remains accepted", async () => {
+  let current = completedTask()
+  const controller = new TaskRunController({
+    taskStore: {
+      async list() { return [] },
+      async get() { return structuredClone(current) },
+      async setRunState(_id, update) {
+        current = { ...current, status: update.status, run: structuredClone(update.run) }
+        return structuredClone(current)
+      }
+    },
+    taskLauncher: {
+      async resumeSession(_task, previousRun) { return { sessionId: previousRun.sessionId, transport: "acp", directory: "/repo" } },
+      async startPrompt() {}
+    },
+    runIDFactory: () => "run-2"
+  })
+
+  const continued = await controller.continue("task-1", "Continue with the existing fix")
+  assert.equal(continued.run.id, "run-2")
+  assert.equal(continued.run.sessionId, "codex-1")
+  assert.equal(continued.run.prompt, "Continue with the existing fix")
+})
+
+test("task handoff HTTP API returns 400 for malformed JSON and non-object bodies", async () => {
+  const innerServer = new EventEmitter()
+  let calls = 0
+  const server = createTaskLaunchServer({
+    innerServer,
+    config: { username: "", password: "", corsOrigins: [] },
+    taskRunController: { async continue() { calls += 1; return {} } }
+  })
+  const port = await listen(server)
+  try {
+    const malformed = await fetch(`http://127.0.0.1:${port}/v1/tasks/task-1/continue`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{"
+    })
+    assert.equal(malformed.status, 400)
+    assert.deepEqual(await malformed.json(), { error: "Request body must be valid JSON", code: "invalid_request" })
+
+    const arrayBody = await fetch(`http://127.0.0.1:${port}/v1/tasks/task-1/continue`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "[]"
+    })
+    assert.equal(arrayBody.status, 400)
+    assert.deepEqual(await arrayBody.json(), { error: "Request body must be a JSON object", code: "invalid_request" })
+    assert.equal(calls, 0)
+  } finally {
+    await close(server)
+  }
+})

--- a/bridge/test/task-handoff-model-validation.test.js
+++ b/bridge/test/task-handoff-model-validation.test.js
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { launchStatus } from "../src/task-launch-server.js"
+import { TaskRunController } from "../src/task-run-controller.js"
+
+function completedTask() {
+  const run = {
+    id: "run-1",
+    sequence: 1,
+    agentId: "codex",
+    model: { providerID: "openai", modelID: "gpt-old" },
+    sessionId: "codex-1",
+    transport: "acp",
+    status: "completed",
+    prompt: "Implement it",
+    finishedAt: "2026-08-20T09:00:00.000Z"
+  }
+  return {
+    id: "task-1",
+    status: "completed",
+    agentId: "codex",
+    model: run.model,
+    prompt: "Implement it",
+    project: { kind: "git", path: "/repo" },
+    workspace: { mode: "project", path: "/repo" },
+    run,
+    runs: [run],
+    context: { version: 1, revision: 1 }
+  }
+}
+
+test("Continue validates the selected target model before persisting a new Run", async () => {
+  const task = completedTask()
+  let writes = 0
+  const error = new Error("Selected model is no longer available: anthropic/removed")
+  error.code = "model_unavailable"
+  const controller = new TaskRunController({
+    taskStore: {
+      async list() { return [] },
+      async get() { return structuredClone(task) },
+      async setRunState() { writes += 1; throw new Error("must not persist") }
+    },
+    taskLauncher: {
+      async validateModelSelection(agentID, model) {
+        assert.equal(agentID, "claude")
+        assert.deepEqual(model, { providerID: "anthropic", modelID: "removed" })
+        throw error
+      }
+    }
+  })
+
+  await assert.rejects(
+    () => controller.continue("task-1", {
+      prompt: "Review the implementation",
+      agentId: "claude",
+      model: { providerID: "anthropic", modelID: "removed" },
+      role: "review"
+    }),
+    (failure) => failure.code === "model_unavailable"
+  )
+  assert.equal(writes, 0)
+})
+
+test("model_unavailable is a stable handoff conflict instead of a generic server error", () => {
+  const error = new Error("model unavailable")
+  error.code = "model_unavailable"
+  assert.equal(launchStatus(error), 409)
+})

--- a/bridge/test/task-handoff-session-selection.test.js
+++ b/bridge/test/task-handoff-session-selection.test.js
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { TaskRunController } from "../src/task-run-controller.js"
+
+function taskWithRuns(runs, overrides = {}) {
+  return {
+    id: "task-1",
+    status: "completed",
+    agentId: "codex",
+    prompt: "Implement the feature",
+    project: { kind: "git", path: "/repo" },
+    workspace: { mode: "project", path: "/repo" },
+    run: runs.at(-1),
+    runs,
+    error: null,
+    context: { version: 1, revision: runs.length },
+    ...overrides
+  }
+}
+
+function completedRun(id, sequence, agentId, sessionId) {
+  return {
+    id,
+    sequence,
+    agentId,
+    sessionId,
+    transport: agentId === "opencode" ? "http" : "acp",
+    role: "continue",
+    prompt: `Run ${sequence}`,
+    status: "completed",
+    finishedAt: `2026-08-20T09:0${sequence}:00.000Z`
+  }
+}
+
+function inMemoryStore(initial) {
+  let current = structuredClone(initial)
+  return {
+    get current() { return current },
+    async list() { return [] },
+    async get() { return structuredClone(current) },
+    async setRunState(_id, update) {
+      const nextRun = structuredClone(update.run ?? current.run)
+      const runs = current.runs.map((run) => structuredClone(run))
+      if (nextRun?.id) {
+        const index = runs.findIndex((run) => run.id === nextRun.id)
+        if (index >= 0) runs[index] = nextRun
+        else runs.push(nextRun)
+      }
+      current = { ...current, status: update.status, run: nextRun, runs }
+      return structuredClone(current)
+    }
+  }
+}
+
+test("returning to a harness selects its most recent native Session", async () => {
+  const runs = [
+    completedRun("run-1", 1, "codex", "codex-old"),
+    completedRun("run-2", 2, "claude", "claude-1"),
+    completedRun("run-3", 3, "codex", "codex-new"),
+    completedRun("run-4", 4, "pi", "pi-1")
+  ]
+  const store = inMemoryStore(taskWithRuns(runs))
+  let resumedFrom
+  const controller = new TaskRunController({
+    taskStore: store,
+    taskLauncher: {
+      async resumeSession(_task, previousRun) {
+        resumedFrom = structuredClone(previousRun)
+        return { sessionId: previousRun.sessionId, transport: "acp", directory: "/repo" }
+      },
+      async startPrompt() {}
+    },
+    runIDFactory: () => "run-5"
+  })
+
+  const continued = await controller.continue("task-1", { prompt: "Fix PI findings", agentId: "codex", role: "fix" })
+  assert.equal(resumedFrom.id, "run-3")
+  assert.equal(resumedFrom.sessionId, "codex-new")
+  assert.equal(continued.run.sessionId, "codex-new")
+  assert.equal(continued.run.resumedFromRunId, "run-3")
+})
+
+test("explicit fresh mode always creates a new Session even for the same harness", async () => {
+  const runs = [completedRun("run-1", 1, "codex", "codex-old")]
+  const store = inMemoryStore(taskWithRuns(runs))
+  let creates = 0
+  let resumes = 0
+  const controller = new TaskRunController({
+    taskStore: store,
+    taskLauncher: {
+      async createSession() {
+        creates += 1
+        return { sessionId: "codex-fresh", transport: "acp", directory: "/repo" }
+      },
+      async resumeSession() { resumes += 1; throw new Error("must not resume") },
+      async startPrompt() {}
+    },
+    runIDFactory: () => "run-2"
+  })
+
+  const continued = await controller.continue("task-1", {
+    prompt: "Retry from a fresh context",
+    agentId: "codex",
+    mode: "fresh"
+  })
+  assert.equal(creates, 1)
+  assert.equal(resumes, 0)
+  assert.equal(continued.run.sessionId, "codex-fresh")
+  assert.equal(Object.hasOwn(continued.run, "resumedFromRunId"), false)
+})
+
+test("ephemeral HTTP credentials are never persisted into Task Run history", async () => {
+  const runs = [completedRun("run-1", 1, "opencode", "http-old")]
+  const store = inMemoryStore(taskWithRuns(runs, { agentId: "opencode" }))
+  let runtimeSession
+  const controller = new TaskRunController({
+    taskStore: store,
+    taskLauncher: {
+      async resumeSession() {
+        return {
+          sessionId: "http-old",
+          transport: "http",
+          directory: "/repo",
+          base: "http://127.0.0.1:4096",
+          authorization: "Basic dXNlcjpzZWNyZXQ="
+        }
+      },
+      async startPrompt(_task, session) { runtimeSession = structuredClone(session) }
+    },
+    runIDFactory: () => "run-2"
+  })
+
+  const continued = await controller.continue("task-1", { prompt: "Continue", agentId: "opencode" })
+  assert.equal(runtimeSession.authorization, "Basic dXNlcjpzZWNyZXQ=")
+  assert.equal(runtimeSession.base, "http://127.0.0.1:4096")
+  assert.equal(Object.hasOwn(continued.run, "authorization"), false)
+  assert.equal(Object.hasOwn(continued.run, "base"), false)
+  assert.equal(Object.hasOwn(store.current.run, "authorization"), false)
+  assert.equal(Object.hasOwn(store.current.runs.at(-1), "authorization"), false)
+})

--- a/bridge/test/task-launch-server.test.js
+++ b/bridge/test/task-launch-server.test.js
@@ -32,29 +32,59 @@ test("POST launch returns the persisted running task", async () => {
   }
 })
 
-test("POST continue forwards the new run prompt", async () => {
+test("POST continue forwards prompt, harness, model and role", async () => {
   const innerServer = new EventEmitter()
   const calls = []
   const server = createTaskLaunchServer({
     innerServer,
     config: { username: "", password: "", corsOrigins: [] },
     taskRunController: {
-      async continue(id, prompt) {
-        calls.push([id, prompt])
-        return { id, status: "running", run: { id: "run-2", sessionId: "session-2", prompt } }
+      async continue(id, options) {
+        calls.push([id, options])
+        return { id, status: "running", run: { id: "run-2", sessionId: "session-2", prompt: options.prompt } }
       }
     }
   })
   const port = await listen(server)
   try {
+    const body = {
+      prompt: "Review the implementation",
+      agentId: "claude",
+      model: { providerID: "anthropic", modelID: "claude-test" },
+      role: "review"
+    }
     const response = await fetch(`http://127.0.0.1:${port}/v1/tasks/task-1/continue`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ prompt: "Add tests" })
+      body: JSON.stringify(body)
     })
     assert.equal(response.status, 200)
     assert.equal((await response.json()).run.sessionId, "session-2")
-    assert.deepEqual(calls, [["task-1", "Add tests"]])
+    assert.deepEqual(calls, [["task-1", body]])
+  } finally {
+    await close(server)
+  }
+})
+
+test("GET context returns an inspectable Task Context preview", async () => {
+  const innerServer = new EventEmitter()
+  const server = createTaskLaunchServer({
+    innerServer,
+    config: { username: "", password: "", corsOrigins: [] },
+    taskRunController: {
+      async context(id) {
+        return { version: 1, revision: 2, taskId: id, objective: "Implement OAuth", changedFiles: ["src/auth.js"] }
+      }
+    }
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/tasks/task-1/context`)
+    assert.equal(response.status, 200)
+    const context = await response.json()
+    assert.equal(context.taskId, "task-1")
+    assert.equal(context.revision, 2)
+    assert.deepEqual(context.changedFiles, ["src/auth.js"])
   } finally {
     await close(server)
   }
@@ -85,6 +115,12 @@ test("launch maps coded missing tasks to 404 and delegates unrelated routes", as
   }
 })
 
+test("launch status maps unavailable native Session to a conflict", () => {
+  const error = new Error("Session unavailable")
+  error.code = "session_unavailable"
+  assert.equal(launchStatus(error), 409)
+})
+
 test("launch status ignores prose when no structured code is present", () => {
   assert.equal(launchStatus(new Error("unknown task worktree unavailable")), 500)
 })
@@ -96,7 +132,7 @@ test("worktree inspection and cleanup use explicit task lifecycle actions", asyn
     innerServer,
     config: { username: "", password: "", corsOrigins: [] },
     taskRunController: {
-      async inspectWorkspace(id) { calls.push(["inspect", id]); return { managed: true, dirty: false, changeCount: 0 } },
+      async inspectWorkspace(id) { calls.push(["inspect", id]); return { managed: true, dirty: false, changeCount: 0, changedFiles: [] } },
       async cleanupWorkspace(id) { calls.push(["cleanup", id]); return { task: { id }, cleanup: { removed: true, branchDeleted: false } } }
     }
   })

--- a/bridge/test/task-launcher-resume.test.js
+++ b/bridge/test/task-launcher-resume.test.js
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { TaskLauncher } from "../src/task-launcher.js"
+
+function task(overrides = {}) {
+  return {
+    id: "task-12345678",
+    agentId: "codex",
+    prompt: "Continue the fix",
+    model: { providerID: "openai", modelID: "gpt-x" },
+    workspace: { mode: "project", path: "/repo" },
+    run: { id: "run-2", sequence: 2, agentId: "codex", model: { providerID: "openai", modelID: "gpt-x" } },
+    ...overrides
+  }
+}
+
+test("ACP resume adopts the previous native Session instead of creating another one", async () => {
+  const calls = []
+  const service = {
+    async adoptTaskSession(sessionID, details) {
+      calls.push(["adopt", sessionID, details])
+      return true
+    },
+    async setModel(sessionID, model) {
+      calls.push(["model", sessionID, model])
+    }
+  }
+  const daemon = {
+    hostEntry: () => ({ kind: "acp", host: {} }),
+    registry: { host: () => ({ state: "available" }) }
+  }
+  const launcher = new TaskLauncher({ daemon, acpService: () => service })
+  const resumed = await launcher.resumeSession(task(), {
+    id: "run-1",
+    agentId: "codex",
+    sessionId: "native-1",
+    transport: "acp",
+    model: { providerID: "openai", modelID: "gpt-old" }
+  })
+
+  assert.equal(resumed.sessionId, "native-1")
+  assert.equal(resumed.transport, "acp")
+  assert.deepEqual(calls, [
+    ["adopt", "native-1", { title: "Task task-123 · Run 2" }],
+    ["model", "native-1", "openai/gpt-x"]
+  ])
+})
+
+test("ACP resume refuses a Session that the harness can no longer adopt", async () => {
+  const daemon = {
+    hostEntry: () => ({ kind: "acp", host: {} }),
+    registry: { host: () => ({ state: "available" }) }
+  }
+  const launcher = new TaskLauncher({
+    daemon,
+    acpService: () => ({ async adoptTaskSession() { return false } })
+  })
+
+  await assert.rejects(
+    () => launcher.resumeSession(task(), { agentId: "codex", sessionId: "missing", transport: "acp" }),
+    (error) => error.code === "session_unavailable"
+  )
+})
+
+test("managed HTTP resume reconstructs connection details for the existing Session", async () => {
+  let started = 0
+  const host = {
+    readinessHost: "127.0.0.1",
+    port: 4096,
+    username: "harness",
+    password: "secret",
+    async start() { started += 1 }
+  }
+  const daemon = {
+    hostEntry: () => ({ kind: "http", host }),
+    registry: { host: () => ({ state: "available" }) }
+  }
+  const launcher = new TaskLauncher({ daemon })
+  const selected = task({
+    agentId: "opencode",
+    run: { id: "run-2", sequence: 2, agentId: "opencode", model: { providerID: "openai", modelID: "gpt-x" } }
+  })
+
+  const resumed = await launcher.resumeSession(selected, {
+    id: "run-1",
+    agentId: "opencode",
+    sessionId: "http-existing",
+    transport: "http"
+  })
+  assert.equal(started, 1)
+  assert.equal(resumed.sessionId, "http-existing")
+  assert.equal(resumed.base, "http://127.0.0.1:4096")
+  assert.match(resumed.authorization, /^Basic /)
+})

--- a/bridge/test/task-multiharness-handoff.test.js
+++ b/bridge/test/task-multiharness-handoff.test.js
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { TaskRunController } from "../src/task-run-controller.js"
+
+function completedChain() {
+  const runs = [
+    {
+      id: "run-1",
+      sequence: 1,
+      agentId: "codex",
+      model: { providerID: "openai", modelID: "gpt-codex" },
+      role: "implement",
+      sessionId: "codex-session-a",
+      transport: "acp",
+      directory: "/repo",
+      prompt: "Implement OAuth login",
+      outcome: "Implemented the OAuth callback and token storage.",
+      status: "completed",
+      finishedAt: "2026-08-20T08:01:00.000Z"
+    },
+    {
+      id: "run-2",
+      sequence: 2,
+      agentId: "claude",
+      model: { providerID: "anthropic", modelID: "claude-test" },
+      role: "review",
+      sessionId: "claude-session-b",
+      transport: "acp",
+      directory: "/repo",
+      prompt: "Review it",
+      outcome: "Review found an unsafe refresh-token rotation path.",
+      status: "completed",
+      finishedAt: "2026-08-20T08:02:00.000Z"
+    },
+    {
+      id: "run-3",
+      sequence: 3,
+      agentId: "pi",
+      role: "test",
+      sessionId: "pi-session-c",
+      transport: "acp",
+      directory: "/repo",
+      prompt: "Verify the review findings",
+      outcome: "One refresh-token regression test is failing.",
+      status: "completed",
+      finishedAt: "2026-08-20T08:03:00.000Z"
+    }
+  ]
+  return {
+    id: "task-1",
+    machineId: "machine-1",
+    projectId: "project-1",
+    project: { id: "project-1", name: "repo", kind: "git", path: "/repo" },
+    agentId: "codex",
+    prompt: "Implement OAuth login",
+    model: { providerID: "openai", modelID: "gpt-codex" },
+    status: "completed",
+    workspace: { mode: "project", path: "/repo" },
+    run: runs[2],
+    runs,
+    error: null
+  }
+}
+
+function inMemoryStore(initial) {
+  let current = structuredClone(initial)
+  return {
+    get current() { return current },
+    async get() { return structuredClone(current) },
+    async setRunState(_taskID, update) {
+      const nextRun = structuredClone(update.run ?? current.run)
+      const runs = current.runs.map((run) => structuredClone(run))
+      if (nextRun?.id) {
+        const index = runs.findIndex((run) => run.id === nextRun.id)
+        if (index >= 0) runs[index] = nextRun
+        else runs.push(nextRun)
+      }
+      current = { ...current, status: update.status, run: nextRun, runs, error: update.error ?? null }
+      return structuredClone(current)
+    }
+  }
+}
+
+test("returning to a harness reuses its previous Session and transfers intervening findings", async () => {
+  const store = inMemoryStore(completedChain())
+  let resumeSource = null
+  let effectivePrompt = null
+  const controller = new TaskRunController({
+    taskStore: store,
+    taskLauncher: {
+      async resumeSession(task, previousRun) {
+        resumeSource = structuredClone(previousRun)
+        effectivePrompt = task.prompt
+        return { sessionId: previousRun.sessionId, transport: "acp", directory: task.workspace.path }
+      },
+      async createSession() { throw new Error("Codex already has a resumable Task Session") },
+      async startPrompt(task) { effectivePrompt = task.prompt }
+    },
+    runIDFactory: () => "run-4",
+    clock: () => "2026-08-20T08:04:00.000Z"
+  })
+
+  const continued = await controller.continue("task-1", {
+    prompt: "Fix the review and test findings",
+    agentId: "codex",
+    role: "fix"
+  })
+
+  assert.equal(resumeSource.id, "run-1")
+  assert.equal(resumeSource.sessionId, "codex-session-a")
+  assert.equal(continued.run.id, "run-4")
+  assert.equal(continued.run.sequence, 4)
+  assert.equal(continued.run.sessionId, "codex-session-a")
+  assert.equal(continued.run.resumedFromRunId, "run-1")
+  assert.equal(continued.run.handoffFromRunId, "run-3")
+  assert.deepEqual(continued.run.model, { providerID: "openai", modelID: "gpt-codex" })
+  assert.match(effectivePrompt, /Review found an unsafe refresh-token rotation path/)
+  assert.match(effectivePrompt, /One refresh-token regression test is failing/)
+  assert.match(effectivePrompt, /USER INSTRUCTION\nFix the review and test findings/)
+})
+
+test("a completed Run persists a bounded harness outcome for the next handoff", async () => {
+  const initial = {
+    ...completedChain(),
+    status: "draft",
+    run: null,
+    runs: [],
+    prompt: "Inspect the repository"
+  }
+  const store = inMemoryStore(initial)
+  const controller = new TaskRunController({
+    taskStore: store,
+    taskLauncher: {
+      async createSession() { return { sessionId: "codex-new", transport: "acp", directory: "/repo" } },
+      async startPrompt(_task, _session, callbacks) {
+        callbacks.onCompleted({ outcome: "Architecture review complete. The auth boundary needs refactoring." })
+      }
+    },
+    runIDFactory: () => "run-outcome"
+  })
+
+  const launched = await controller.launch("task-1")
+  assert.equal(launched.status, "running")
+  await new Promise((resolve) => setImmediate(resolve))
+  assert.equal(store.current.status, "completed")
+  assert.equal(store.current.run.outcome, "Architecture review complete. The auth boundary needs refactoring.")
+})

--- a/bridge/test/task-multiharness-recovery.test.js
+++ b/bridge/test/task-multiharness-recovery.test.js
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { TaskRunController } from "../src/task-run-controller.js"
+
+function chain({ status = "completed", current = "claude" } = {}) {
+  const runs = [
+    {
+      id: "run-1",
+      sequence: 1,
+      agentId: "codex",
+      role: "implement",
+      sessionId: "codex-session-a",
+      transport: "acp",
+      directory: "/repo",
+      prompt: "Implement OAuth login",
+      outcome: "OAuth implementation complete.",
+      status: "completed",
+      finishedAt: "2026-08-20T08:01:00.000Z"
+    },
+    {
+      id: "run-2",
+      sequence: 2,
+      agentId: "claude",
+      role: "review",
+      sessionId: "claude-session-b",
+      transport: "acp",
+      directory: "/repo",
+      prompt: "Review the implementation",
+      outcome: "Review found a refresh-token issue.",
+      status: current === "claude" ? status : "completed",
+      ...(current === "claude" && ["starting", "running"].includes(status) ? {} : { finishedAt: "2026-08-20T08:02:00.000Z" })
+    },
+    {
+      id: "run-3",
+      sequence: 3,
+      agentId: "pi",
+      role: "test",
+      sessionId: "pi-session-c",
+      transport: "acp",
+      directory: "/repo",
+      prompt: "Run tests",
+      outcome: "One auth regression is failing.",
+      status: current === "pi" ? status : "completed",
+      ...(current === "pi" && ["starting", "running"].includes(status) ? {} : { finishedAt: "2026-08-20T08:03:00.000Z" })
+    }
+  ]
+  const selected = current === "pi" ? runs[2] : runs[1]
+  const keptRuns = current === "pi" ? runs : runs.slice(0, 2)
+  return {
+    id: "task-1",
+    machineId: "machine-1",
+    project: { kind: "git", path: "/repo" },
+    agentId: "codex",
+    prompt: "Implement OAuth login",
+    status,
+    workspace: { mode: "project", path: "/repo" },
+    run: selected,
+    runs: keptRuns,
+    error: null,
+    context: { version: 1, revision: keptRuns.filter((run) => run.finishedAt).length }
+  }
+}
+
+function storeFor(initial) {
+  let current = structuredClone(initial)
+  const writes = []
+  return {
+    get current() { return current },
+    writes,
+    async list() { return [structuredClone(current)] },
+    async get() { return structuredClone(current) },
+    async setRunState(_taskID, update) {
+      writes.push(structuredClone({ status: update.status, run: update.run, expectedRunId: update.expectedRunId, error: update.error?.message }))
+      if (update.expectedRunId !== undefined && current.run?.id !== update.expectedRunId) return structuredClone(current)
+      const nextRun = structuredClone(update.run ?? current.run)
+      const runs = current.runs.map((run) => structuredClone(run))
+      if (nextRun?.id) {
+        const index = runs.findIndex((run) => run.id === nextRun.id)
+        if (index >= 0) runs[index] = nextRun
+        else runs.push(nextRun)
+      }
+      current = { ...current, status: update.status, run: nextRun, runs, error: update.error ? { message: update.error.message } : null }
+      return structuredClone(current)
+    }
+  }
+}
+
+test("completed multi-harness history survives restart and can return to the earlier Codex Session", async () => {
+  const store = storeFor(chain())
+  let startupAdoptions = 0
+  let resumedFrom = null
+  let prompt = null
+  const controller = new TaskRunController({
+    taskStore: store,
+    acpService: () => ({ async adoptTaskSession() { startupAdoptions += 1; return true } }),
+    taskLauncher: {
+      async resumeSession(task, previousRun) {
+        resumedFrom = structuredClone(previousRun)
+        prompt = task.prompt
+        return { sessionId: previousRun.sessionId, transport: "acp", directory: "/repo" }
+      },
+      async createSession() { throw new Error("Codex Session A should be reused after restart") },
+      async startPrompt(task) { prompt = task.prompt }
+    },
+    runIDFactory: () => "run-3-after-restart"
+  })
+
+  await controller.reconciliation
+  assert.equal(startupAdoptions, 0, "completed historical Sessions should be adopted lazily, not at daemon startup")
+
+  const continued = await controller.continue("task-1", {
+    prompt: "Fix the Claude review finding",
+    agentId: "codex",
+    role: "fix"
+  })
+
+  assert.equal(resumedFrom.id, "run-1")
+  assert.equal(resumedFrom.sessionId, "codex-session-a")
+  assert.equal(continued.run.sessionId, "codex-session-a")
+  assert.equal(continued.run.resumedFromRunId, "run-1")
+  assert.equal(continued.run.handoffFromRunId, "run-2")
+  assert.match(prompt, /Review found a refresh-token issue/)
+  assert.match(prompt, /USER INSTRUCTION\nFix the Claude review finding/)
+})
+
+test("an active PI Run keeps the same Run and Session identity across ambiguous restart recovery", async () => {
+  const store = storeFor(chain({ status: "running", current: "pi" }))
+  const adopted = []
+  const controller = new TaskRunController({
+    taskStore: store,
+    acpService: (agentID) => agentID === "pi" ? {
+      async adoptTaskSession(sessionID) { adopted.push(sessionID); return true }
+    } : undefined,
+    taskLauncher: { async inspectRun() { return "unknown" } }
+  })
+
+  await controller.reconciliation
+  assert.deepEqual(adopted, ["pi-session-c"])
+  assert.equal(store.current.status, "running")
+  assert.equal(store.current.run.id, "run-3")
+  assert.equal(store.current.run.sessionId, "pi-session-c")
+  assert.equal(store.writes.length, 0)
+})
+
+test("temporary current-harness unavailability does not fail or rewrite the active Task", async () => {
+  const store = storeFor(chain({ status: "running", current: "claude" }))
+  const controller = new TaskRunController({
+    taskStore: store,
+    acpService: () => undefined,
+    taskLauncher: { async inspectRun() { return "unknown" } }
+  })
+
+  await controller.reconciliation
+  assert.equal(store.current.status, "running")
+  assert.equal(store.current.run.id, "run-2")
+  assert.equal(store.current.run.sessionId, "claude-session-b")
+  assert.equal(store.current.runs[0].sessionId, "codex-session-a")
+  assert.equal(store.writes.length, 0)
+})
+
+test("a definitively missing current Session fails only that Run and preserves earlier harness history", async () => {
+  const store = storeFor(chain({ status: "running", current: "claude" }))
+  const controller = new TaskRunController({
+    taskStore: store,
+    acpService: (agentID) => agentID === "claude" ? {
+      async adoptTaskSession() { return false }
+    } : undefined,
+    taskLauncher: { async inspectRun() { return "unknown" } }
+  })
+
+  await controller.reconciliation
+  assert.equal(store.current.status, "failed")
+  assert.equal(store.current.run.id, "run-2")
+  assert.match(store.current.error.message, /no longer available after daemon restart/)
+  assert.equal(store.current.runs[0].id, "run-1")
+  assert.equal(store.current.runs[0].sessionId, "codex-session-a")
+})

--- a/bridge/test/task-project-context.test.js
+++ b/bridge/test/task-project-context.test.js
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { TaskRunController } from "../src/task-run-controller.js"
+import { WorktreeManager } from "../src/worktree-manager.js"
+
+test("direct Git project inspection is read-only and reports changed files", async () => {
+  const calls = []
+  const manager = new WorktreeManager({
+    stateDirectory: "/state",
+    runGit: async (args) => {
+      calls.push(args)
+      if (args.includes("rev-parse")) return { stdout: "/repo\n" }
+      return { stdout: " M src/auth.js\n?? test/auth.test.js\n" }
+    }
+  })
+
+  assert.deepEqual(await manager.inspectProject("/repo"), {
+    managed: false,
+    dirty: true,
+    changeCount: 2,
+    changedFiles: ["src/auth.js", "test/auth.test.js"]
+  })
+  assert.deepEqual(calls, [
+    ["-C", "/repo", "rev-parse", "--show-toplevel"],
+    ["-C", "/repo", "status", "--porcelain=v1", "--untracked-files=all"]
+  ])
+})
+
+test("Task Context includes changes from a direct Git project checkout", async () => {
+  const task = {
+    id: "task-project",
+    status: "completed",
+    prompt: "Fix authentication",
+    project: { kind: "git", path: "/repo" },
+    workspace: { mode: "project", path: "/repo" },
+    run: { id: "run-1", sequence: 1, agentId: "codex", status: "completed", sessionId: "codex-1", prompt: "Fix authentication" },
+    runs: [],
+    context: { version: 1, revision: 1 }
+  }
+  const controller = new TaskRunController({
+    taskStore: { async list() { return [] }, async get() { return structuredClone(task) } },
+    taskLauncher: {},
+    worktreeManager: {
+      async inspectProject(projectPath) {
+        assert.equal(projectPath, "/repo")
+        return { managed: false, dirty: true, changeCount: 1, changedFiles: ["src/auth.js"] }
+      }
+    }
+  })
+
+  const context = await controller.context("task-project")
+  assert.deepEqual(context.changedFiles, ["src/auth.js"])
+  assert.equal(context.workspace.dirty, true)
+  assert.equal(context.workspace.changeCount, 1)
+})
+
+test("non-Git project context falls back without invoking Git inspection", async () => {
+  const task = {
+    id: "task-dir",
+    status: "completed",
+    prompt: "Inspect docs",
+    project: { kind: "directory", path: "/docs" },
+    workspace: { mode: "project", path: "/docs" },
+    run: null,
+    runs: [],
+    context: { version: 1, revision: 0 }
+  }
+  let inspections = 0
+  const controller = new TaskRunController({
+    taskStore: { async list() { return [] }, async get() { return structuredClone(task) } },
+    taskLauncher: {},
+    worktreeManager: { async inspectProject() { inspections += 1; throw new Error("should not inspect") } }
+  })
+
+  const context = await controller.context("task-dir")
+  assert.equal(inspections, 0)
+  assert.deepEqual(context.changedFiles, [])
+  assert.equal(context.workspace.dirty, false)
+})

--- a/bridge/test/task-run-controller.test.js
+++ b/bridge/test/task-run-controller.test.js
@@ -40,6 +40,8 @@ test("launch persists run identity before starting the prompt and ends running",
   assert.equal(result.status, "running")
   assert.equal(result.run.id, "run-1")
   assert.equal(result.run.sessionId, "session-1")
+  assert.equal(result.run.agentId, "codex")
+  assert.equal(result.run.role, "implement")
   assert.deepEqual(calls, [
     ["state", "starting", null],
     ["session", "starting"],
@@ -98,13 +100,54 @@ test("Git tasks can intentionally launch from the project checkout", async () =>
   assert.equal(launched.run.directory, "/repo")
 })
 
-test("a terminal task can continue with a new run and prompt", async () => {
+test("same-harness Continue creates a new Run but reuses the native Session", async () => {
   let current = draft({
     status: "completed",
-    run: { id: "run-1", sessionId: "session-1", transport: "acp", directory: "/state/worktrees/task-1" },
-    runs: [{ id: "run-1", sessionId: "session-1", transport: "acp", directory: "/state/worktrees/task-1" }]
+    run: { id: "run-1", sequence: 1, agentId: "codex", sessionId: "session-1", transport: "acp", directory: "/state/worktrees/task-1", prompt: "Fix it", finishedAt: "2026-08-13T18:00:00.000Z" },
+    runs: [{ id: "run-1", sequence: 1, agentId: "codex", sessionId: "session-1", transport: "acp", directory: "/state/worktrees/task-1", prompt: "Fix it", finishedAt: "2026-08-13T18:00:00.000Z" }]
   })
-  let createdPrompt
+  let resumed
+  let sentPrompt
+  const store = {
+    async list() { return [] },
+    async get() { return structuredClone(current) },
+    async setRunState(_id, update) {
+      current = { ...current, status: update.status, run: structuredClone(update.run) }
+      return structuredClone(current)
+    }
+  }
+  const controller = new TaskRunController({
+    taskStore: store,
+    taskLauncher: {
+      async resumeSession(task, previousRun) {
+        resumed = { task: structuredClone(task), previousRun: structuredClone(previousRun) }
+        return { sessionId: previousRun.sessionId, transport: "acp", directory: task.workspace.path }
+      },
+      async createSession() { throw new Error("Continue should not create a new Session") },
+      async startPrompt(task) { sentPrompt = task.prompt }
+    },
+    runIDFactory: () => "run-2"
+  })
+
+  const continued = await controller.continue("task-1", "Now add regression tests")
+  assert.equal(continued.status, "running")
+  assert.equal(continued.run.id, "run-2")
+  assert.equal(continued.run.sessionId, "session-1")
+  assert.equal(continued.run.agentId, "codex")
+  assert.equal(continued.run.role, "continue")
+  assert.equal(continued.run.prompt, "Now add regression tests")
+  assert.equal(resumed.previousRun.sessionId, "session-1")
+  assert.equal(sentPrompt, "Now add regression tests")
+})
+
+test("cross-harness Continue creates a new Session and sends explicit Task Context", async () => {
+  let current = draft({
+    status: "completed",
+    context: { version: 1, revision: 1, taskId: "task-1", objective: "Fix it", currentState: "completed", latestOutcome: { status: "completed", agentId: "codex", role: "implement" }, runSummaries: [] },
+    run: { id: "run-1", sequence: 1, agentId: "codex", sessionId: "session-1", transport: "acp", directory: "/state/worktrees/task-1", prompt: "Fix it", status: "completed", finishedAt: "2026-08-13T18:00:00.000Z" },
+    runs: [{ id: "run-1", sequence: 1, agentId: "codex", sessionId: "session-1", transport: "acp", directory: "/state/worktrees/task-1", prompt: "Fix it", status: "completed", finishedAt: "2026-08-13T18:00:00.000Z" }]
+  })
+  let createPrompt
   let sentPrompt
   const store = {
     async list() { return [] },
@@ -118,21 +161,58 @@ test("a terminal task can continue with a new run and prompt", async () => {
     taskStore: store,
     taskLauncher: {
       async createSession(task) {
-        createdPrompt = task.prompt
-        return { sessionId: "session-2", transport: "acp", directory: task.workspace.path }
+        createPrompt = task.prompt
+        assert.equal(task.agentId, "claude")
+        return { sessionId: "claude-session", transport: "acp", directory: task.workspace.path }
       },
       async startPrompt(task) { sentPrompt = task.prompt }
     },
+    worktreeManager: { async inspect() { return { managed: true, dirty: true, changeCount: 2, changedFiles: ["src/auth.js", "test/auth.test.js"] } } },
     runIDFactory: () => "run-2"
   })
 
-  const continued = await controller.continue("task-1", "Now add regression tests")
-  assert.equal(continued.status, "running")
-  assert.equal(continued.run.id, "run-2")
-  assert.equal(continued.run.sessionId, "session-2")
-  assert.equal(continued.run.prompt, "Now add regression tests")
-  assert.equal(createdPrompt, "Now add regression tests")
-  assert.equal(sentPrompt, "Now add regression tests")
+  const continued = await controller.continue("task-1", {
+    prompt: "Review the implementation and list security issues",
+    agentId: "claude",
+    model: { providerID: "anthropic", modelID: "claude-test" },
+    role: "review"
+  })
+
+  assert.equal(continued.run.agentId, "claude")
+  assert.equal(continued.run.sessionId, "claude-session")
+  assert.equal(continued.run.role, "review")
+  assert.equal(continued.run.contextRevision, 1)
+  assert.equal(continued.run.handoffFromRunId, "run-1")
+  assert.deepEqual(continued.run.model, { providerID: "anthropic", modelID: "claude-test" })
+  assert.match(createPrompt, /transferred by TaskDesk/)
+  assert.match(createPrompt, /TASK OBJECTIVE\nFix it/)
+  assert.match(createPrompt, /CHANGED FILES\n- src\/auth\.js\n- test\/auth\.test\.js/)
+  assert.match(createPrompt, /YOUR ROLE\nreview/)
+  assert.match(createPrompt, /USER INSTRUCTION\nReview the implementation and list security issues/)
+  assert.equal(sentPrompt, createPrompt)
+})
+
+test("Task Context preview is deterministic and includes workspace changes", async () => {
+  const current = draft({
+    status: "completed",
+    context: { version: 1, revision: 2, taskId: "task-1", objective: "Fix it", currentState: "completed", latestOutcome: null, runSummaries: [] },
+    run: { id: "run-2", sequence: 2, agentId: "pi", role: "test", sessionId: "pi-1", status: "completed", prompt: "Run tests", finishedAt: "2026-08-13T19:00:00.000Z" },
+    runs: []
+  })
+  const controller = new TaskRunController({
+    taskStore: { async list() { return [] }, async get() { return structuredClone(current) } },
+    taskLauncher: {},
+    worktreeManager: { async inspect() { return { managed: true, dirty: true, changeCount: 1, changedFiles: ["src/index.js"] } } }
+  })
+
+  const context = await controller.context("task-1")
+  assert.equal(context.version, 1)
+  assert.equal(context.revision, 2)
+  assert.equal(context.objective, "Fix it")
+  assert.equal(context.latestRun.agentId, "pi")
+  assert.equal(context.latestRun.role, "test")
+  assert.deepEqual(context.changedFiles, ["src/index.js"])
+  assert.equal(context.workspace.changeCount, 1)
 })
 
 test("launch failures persist failed state", async () => {

--- a/bridge/test/task-run-history-regression.test.js
+++ b/bridge/test/task-run-history-regression.test.js
@@ -15,25 +15,31 @@ function completedTask() {
     run: {
       id: "run-1",
       sequence: 1,
+      agentId: "pi",
       sessionId: "session-1",
       transport: "acp",
       directory: "/repo",
-      prompt: "Initial task"
+      prompt: "Initial task",
+      status: "completed",
+      finishedAt: "2026-08-20T07:55:00.000Z"
     },
     runs: [{
       id: "run-1",
       sequence: 1,
+      agentId: "pi",
       sessionId: "session-1",
       transport: "acp",
       directory: "/repo",
-      prompt: "Initial task"
+      prompt: "Initial task",
+      status: "completed",
+      finishedAt: "2026-08-20T07:55:00.000Z"
     }]
   }
 }
 
-test("Continue creates a distinct numbered Run and a new Session", async () => {
+test("Continue creates a distinct numbered Run while preserving the native Session", async () => {
   let current = completedTask()
-  const created = []
+  const resumed = []
   const store = {
     async list() { return [] },
     async get() { return structuredClone(current) },
@@ -50,10 +56,11 @@ test("Continue creates a distinct numbered Run and a new Session", async () => {
   const controller = new TaskRunController({
     taskStore: store,
     taskLauncher: {
-      async createSession(task) {
-        created.push({ sequence: task.run.sequence, prompt: task.prompt })
-        return { sessionId: "session-2", transport: "acp", directory: task.workspace.path }
+      async resumeSession(task, previousRun) {
+        resumed.push({ sequence: task.run.sequence, prompt: task.prompt, previousSession: previousRun.sessionId })
+        return { sessionId: previousRun.sessionId, transport: "acp", directory: task.workspace.path }
       },
+      async createSession() { throw new Error("same-harness Continue must not create a new Session") },
       async startPrompt() {}
     },
     runIDFactory: () => "run-2",
@@ -63,12 +70,12 @@ test("Continue creates a distinct numbered Run and a new Session", async () => {
   const continued = await controller.continue("task-123456789", "Second request")
   assert.equal(continued.run.id, "run-2")
   assert.equal(continued.run.sequence, 2)
-  assert.equal(continued.run.sessionId, "session-2")
-  assert.deepEqual(created, [{ sequence: 2, prompt: "Second request" }])
-  assert.deepEqual(continued.runs.map((run) => run.sessionId), ["session-1", "session-2"])
+  assert.equal(continued.run.sessionId, "session-1")
+  assert.deepEqual(resumed, [{ sequence: 2, prompt: "Second request", previousSession: "session-1" }])
+  assert.deepEqual(continued.runs.map((run) => run.sessionId), ["session-1", "session-1"])
 })
 
-test("continuation Sessions are visibly distinguished by their Run number", async () => {
+test("a fresh Session created for a later Run is visibly distinguished by Run number", async () => {
   let receivedTitle = null
   const service = {
     async createSession(options) {

--- a/bridge/test/task-store.test.js
+++ b/bridge/test/task-store.test.js
@@ -31,7 +31,16 @@ test("persists machine-scoped draft tasks with project, agent and workspace iden
       error: null,
       finishedAt: null,
       createdAt: "2026-08-13T13:00:00.000Z",
-      updatedAt: "2026-08-13T13:00:00.000Z"
+      updatedAt: "2026-08-13T13:00:00.000Z",
+      context: {
+        version: 1,
+        revision: 0,
+        taskId: "task-1",
+        objective: "Fix issue #145",
+        currentState: "draft",
+        latestOutcome: null,
+        runSummaries: []
+      }
     })
 
     const second = new TaskStore({ machineID: "machine-1", stateDirectory })
@@ -45,7 +54,7 @@ test("persists machine-scoped draft tasks with project, agent and workspace iden
   }
 })
 
-test("legacy single-run tasks load with a compatible runs history and open lifecycle", async () => {
+test("legacy single-run tasks load with a compatible runs history and Task Context", async () => {
   const stateDirectory = await mkdtemp(path.join(os.tmpdir(), "harness-task-history-"))
   try {
     const store = new TaskStore({ machineID: "machine-1", stateDirectory })
@@ -54,12 +63,15 @@ test("legacy single-run tasks load with a compatible runs history and open lifec
     await writeFile(store.file, JSON.stringify({
       version: 1,
       machineId: "machine-1",
-      tasks: [{ id: "task-1", status: "completed", run: legacyRun }]
+      tasks: [{ id: "task-1", status: "completed", prompt: "Legacy task", agentId: "codex", run: legacyRun }]
     }), "utf8")
     const [loaded] = await store.list()
     assert.deepEqual(loaded.runs, [legacyRun])
     assert.deepEqual(loaded.run, legacyRun)
     assert.equal(loaded.finishedAt, null)
+    assert.equal(loaded.context.version, 1)
+    assert.equal(loaded.context.objective, "Legacy task")
+    assert.equal(loaded.context.revision, 0)
   } finally {
     await rm(stateDirectory, { recursive: true, force: true })
   }

--- a/bridge/test/worktree-manager.test.js
+++ b/bridge/test/worktree-manager.test.js
@@ -67,7 +67,7 @@ test("prepare uses a resettable task branch so rollback leftovers do not wedge r
   }
 })
 
-test("inspect reports dirty work without changing it", async () => {
+test("inspect reports dirty work and changed files without changing it", async () => {
   const stateDirectory = await mkdtemp(path.join(os.tmpdir(), "harness-worktree-inspect-"))
   const worktreePath = path.join(stateDirectory, "worktrees", "abc")
   try {
@@ -77,7 +77,8 @@ test("inspect reports dirty work without changing it", async () => {
     assert.deepEqual(await manager.inspect({ mode: "worktree", path: worktreePath, branch: "task/abc", source: "/repo" }), {
       managed: true,
       dirty: true,
-      changeCount: 2
+      changeCount: 2,
+      changedFiles: ["src/a.js", "new.txt"]
     })
     assert.deepEqual(calls, [["-C", worktreePath, "status", "--porcelain=v1", "--untracked-files=all"]])
   } finally {


### PR DESCRIPTION
## Purpose

Backend foundation and hardening for the TaskDesk multi-harness Task model from #263 and #267.

A Task is durable work that may move across several harness-native Sessions. A Run is one recorded execution step. Several Runs may reuse one Session, while cross-harness handoff creates a new native Session in the same Task workspace.

## Core behavior

The backend now supports the intended model:

```text
Task: Implement OAuth login
Run 1 -> Codex Session A -> implement
Run 2 -> Claude Session B -> review
Run 3 -> PI Session C -> test
Run 4 -> Codex Session A -> fix findings
```

Run 4 can reuse Codex Session A while receiving the Claude and PI findings through explicit Task Context. TaskDesk never pretends that one harness has another harness' native conversational memory.

## Implemented scope

### Multi-harness Run model

- persisted per-Run harness, model, role, status, context revision and bounded textual outcome;
- same-harness Continue reuses the most recent resumable native Session for that harness;
- returning to a harness after intervening Runs reuses that harness' most recent native Session, not an older one and never another harness' Session;
- cross-harness continuation creates a new native Session in the same Task workspace;
- explicit `fresh` mode always creates a new Session;
- explicit `resume` produces a structured resumability error when no target-harness Session exists;
- multiple Runs may legitimately reference the same Session ID;
- HTTP connection details and authorization remain runtime-only and are not persisted into Run history.

### Task Context and handoff

- persisted vendor-neutral Task Context with revisioning;
- `GET /v1/tasks/:taskId/context` returns an inspectable runtime context preview;
- deterministic handoff prompt carries the original objective, current state, changed files, previous outcomes and recent Run history;
- review/test/error outcomes can survive later handoffs even when no files changed;
- outcomes are bounded to 6,000 characters;
- persisted Task Context retains a bounded window of 12 recent Run summaries;
- generated handoff packets include at most 6 recent step summaries and bounded outcome excerpts;
- objective, errors, Run prompt summaries and changed-file names are bounded;
- changed-file previews are capped while preserving the real total change count;
- complete Run history remains in the Task itself, while the handoff packet stays bounded.

### Workspace context

- managed worktrees continue to expose changed-file state;
- Tasks running directly in a Git project checkout now get read-only changed-file inspection as well;
- non-Git or temporarily uninspectable projects gracefully fall back to Task-only context;
- inspection uses read-only Git commands and never mutates the project checkout.

### Restart and recovery hardening

Regression coverage now includes:

```text
Codex Session A -> Claude Session B -> restart -> Codex Session A
Codex Session A -> PI Session C -> restart while PI is active
active cross-harness Run -> restart with target harness temporarily unavailable
active cross-harness Run -> restart with current native Session definitively missing
```

Behavior:

- ambiguous availability does not duplicate or rewrite the active Run;
- temporary harness unavailability preserves Task state and Session identity;
- a definitively missing current ACP Session fails that Run while preserving earlier harness history;
- completed historical Sessions are not eagerly adopted merely because the daemon restarted;
- returning to an earlier harness after restart injects intervening findings explicitly through Task Context.

### API and compatibility

- legacy string-based `Continue` callers remain supported internally;
- object-form continuation supports prompt, target harness, model, role and fresh/resume mode;
- malformed handoff bodies and malformed options return stable `invalid_request` errors;
- selected handoff models are validated before a new Run is persisted;
- a disappeared model returns `model_unavailable` as a 409 conflict instead of leaving a half-started Run;
- existing persisted Tasks remain readable;
- the persisted Task Context shape remains compatible without adding runtime-only counters to stored state.

## Validation

Exact validated HEAD:

`fbd9d579b10886016e6124808252ad8e53779802`

GitHub Actions run `32354030053` is green for:

- TypeScript and production web build;
- web regression tests;
- bridge tests on Linux;
- bridge tests on macOS;
- bridge tests on Windows;
- Android debug APK build;
- Android APK signature verification.

New focused regression coverage includes bounded context growth, direct Git project context, request validation, model validation, latest target-harness Session selection, explicit fresh mode, runtime-only HTTP credentials and the multi-harness restart matrix.

## Remaining validation and limitations

This PR intentionally remains draft. Still required before merge:

- real-harness validation of Codex -> Claude -> PI -> Codex on the same machine/workspace;
- real restart validation while a Run is active;
- confirmation of model switching behavior on each harness that exposes model changes;
- frontend Continue/Handoff UX with target harness/model/role/context preview;
- automatic workflows are not implemented;
- LLM-generated Task summaries are not implemented;
- cross-machine handoff is not implemented;
- performance/SSE/transcript pagination remains isolated in #262/#266;
- UI audit/polish remains isolated in #265.

## Safety

- base remains `feature/taskdesk-unified-shell`;
- no changes to `main`;
- no direct merge to `v3/taskdesk`;
- PR remains draft and unmerged pending real-harness validation.

Refs #197
Refs #263
Refs #267
Refs #261