### PR TITLE
fix(taskdesk): keep Session composer responsive in long chats

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -26,7 +26,7 @@
     "cap:sync": "npx cap sync",
     "cap:sync:android": "npx cap sync android && node scripts/sync-native-live-events.mjs",
     "cap:add:android": "npx cap add android",
-    "test:ui": "node src/ui-regression.test.mjs && node --experimental-strip-types src/taskdesk-home.test.mjs && node src/taskdesk-performance.test.mjs && node src/taskdesk-appearance.test.mjs",
+    "test:ui": "node src/ui-regression.test.mjs && node --experimental-strip-types src/taskdesk-home.test.mjs && node src/taskdesk-performance.test.mjs && node src/taskdesk-composer-performance.test.mjs && node src/taskdesk-appearance.test.mjs",
     "test:settings": "node src/settings-regression.test.mjs && node src/v3-ux-polish-regression.test.mjs",
     "test:model": "node src/model-regression.test.mjs",
     "test:events": "node --experimental-strip-types src/opencode-events.test.mjs",

--- a/web/src/components/universal-workspace.tsx
+++ b/web/src/components/universal-workspace.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { api, isValidServerConfig } from "../api"
@@ -392,7 +392,7 @@ function HarnessAvatar({ backend, label }: { backend: string; label: string }) {
   )
 }
 
-function MessageBubble({ message, agentLabel, agentBackend }: { message: MessageEnvelope; agentLabel: string; agentBackend: string }) {
+const MessageBubble = memo(function MessageBubble({ message, agentLabel, agentBackend }: { message: MessageEnvelope; agentLabel: string; agentBackend: string }) {
   const isUser = message.info.role === "user"
   const text = extractText(message)
   return (
@@ -416,7 +416,7 @@ function MessageBubble({ message, agentLabel, agentBackend }: { message: Message
       </div>
     </article>
   )
-}
+})
 
 function SessionCard({
   item,

--- a/web/src/taskdesk-composer-performance.test.mjs
+++ b/web/src/taskdesk-composer-performance.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+
+test("Session composer typing does not rerender every Markdown message", () => {
+  const workspace = readFileSync(new URL("./components/universal-workspace.tsx", import.meta.url), "utf8")
+
+  assert.match(workspace, /import \{ memo, useCallback/)
+  assert.match(workspace, /const MessageBubble = memo\(function MessageBubble/)
+  assert.match(workspace, /<ReactMarkdown remarkPlugins=\{REMARK_PLUGINS\}>\{text\}<\/ReactMarkdown>/)
+  assert.match(workspace, /value=\{composer\}[\s\S]*?onChange=\{\(event\) => setComposer\(event\.target\.value\)\}/)
+})


### PR DESCRIPTION
## Problem

After the integrated TaskDesk candidate was promoted to `v3/taskdesk`, typing in the Session conversation composer could visibly lag: characters appeared after the corresponding keypress instead of immediately.

## Root cause

The Session composer is controlled by `UniversalWorkspace` state. Every `setComposer(...)` therefore rerenders the whole workspace. `MessageBubble` was not memoized, so every keypress also reparsed and rerendered every existing message through `ReactMarkdown`. The cost grows with transcript length.

Classic already protects this hot path with message-level memoization; the TaskDesk Session workspace had reintroduced the unprotected pattern.

## Fix

- memoize `MessageBubble`, so unchanged transcript messages do not rerender when only composer state changes;
- add a focused regression test guarding the memoized Markdown message path;
- include the guard in `test:ui`.

The fix is intentionally narrow: no backend, API, polling, session semantics, or styling changes.

## Scope safety

Targets `v3/taskdesk` only. `main` is untouched.