### PR TITLE
chore(taskdesk): sync stable security fix from main

### DIFF
--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -20,16 +20,22 @@ name: Build desktop apps
 permissions:
   contents: read
 
-# Cutting a release pushes the same commit to main and then tags it: without a group, the two push
-# events each start the full 3-OS matrix and the duplicate run doubles the simultaneous runner
-# demand. Same commit, same build — keep the newer run (the tag one, which is what attaches the
-# artifacts to the release) and cancel the redundant main-push build.
+# Release commits are pushed to main and then tagged. The tag build is the one that owns release
+# artifacts, so the main-push copy is skipped below instead of being started and then cancelled.
+# That keeps the commit status neutral/green rather than leaving main with a cancelled red check.
 concurrency:
   group: desktop-apps-${{ github.sha }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   package:
+    # A release commit is immediately followed by a v* tag on the same SHA. Build it only for the
+    # tag: starting the main copy and cancelling it later leaves the main commit looking failed even
+    # though the release build itself is healthy. Manual runs are always allowed.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.ref, 'refs/tags/v') ||
+      !startsWith(github.event.head_commit.message, 'Release Harness Remote ')
     name: Package ${{ matrix.platform }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "harness-remote-web",
-  "version": "2.9.0",
+  "version": "2.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "harness-remote-web",
-      "version": "2.9.0",
+      "version": "2.11.1",
       "dependencies": {
         "@capacitor/android": "^8.3.4",
         "@capacitor/app": "^8.1.1",
@@ -5972,9 +5972,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.21",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
+      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -63,7 +63,9 @@
       "target": [
         {
           "target": "nsis",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         }
       ],
       "icon": "public/app-icon.png",
@@ -73,11 +75,17 @@
       "target": [
         {
           "target": "dmg",
-          "arch": ["arm64", "x64"]
+          "arch": [
+            "arm64",
+            "x64"
+          ]
         },
         {
           "target": "zip",
-          "arch": ["arm64", "x64"]
+          "arch": [
+            "arm64",
+            "x64"
+          ]
         }
       ],
       "icon": "public/app-icon.png",
@@ -89,11 +97,15 @@
       "target": [
         {
           "target": "AppImage",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         },
         {
           "target": "deb",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         }
       ],
       "icon": "public/app-icon.png",
@@ -129,5 +141,8 @@
     "electron-builder": "^26.15.3",
     "typescript": "5.6.3",
     "vite": "^8.0.14"
+  },
+  "overrides": {
+    "tar": "7.5.21"
   }
 }


### PR DESCRIPTION
Sync the latest stable-line fixes from `main` into `v3/taskdesk`.

This brings:
- the reviewed `tar` security update from PR #272 (`7.5.15` -> `7.5.21`, fixing CVE-2026-59873 and the later stack-exhaustion DoS fixed in 7.5.21);
- the already-stable desktop workflow fix from `main` that `v3/taskdesk` had not yet absorbed.

No TaskDesk product code is replaced or removed. This PR exists to keep the 3.0 integration branch on top of the current stable security/CI baseline.