### PR TITLE
perf(taskdesk): finish bounded Session history and live refresh

### DIFF
--- a/web/electron/event-transport.ts
+++ b/web/electron/event-transport.ts
@@ -17,6 +17,8 @@ const INITIAL_RECONNECT_MS = 1_000
 const MAX_RECONNECT_MS = 30_000
 const STALL_TIMEOUT_MS = 30_000
 const MAX_DIRECTORY_LENGTH = 4096
+const MAX_AGENT_ID_LENGTH = 128
+const EVENT_BACKENDS = new Set<DesktopProfile["backend"]>(["opencode", "omp", "pi", "claude", "codex"])
 
 type ChannelNames = typeof IPC_CHANNELS
 
@@ -48,6 +50,27 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Event stream failed"
 }
 
+function validateRouteOptions(options: DesktopEventSubscriptionOptions): void {
+  if (options.backend !== undefined && !EVENT_BACKENDS.has(options.backend)) {
+    throw new Error("Event subscription backend is invalid")
+  }
+  if (options.agentId !== undefined) {
+    const agentID = typeof options.agentId === "string" ? options.agentId.trim() : ""
+    if (!agentID || agentID.length > MAX_AGENT_ID_LENGTH || !/^[A-Za-z0-9._-]+$/.test(agentID)) {
+      throw new Error("Event subscription agent is invalid")
+    }
+  }
+}
+
+/** Keep the approved host and credentials while allowing TaskDesk to select another daemon agent. */
+function eventProfile(profile: DesktopProfile, options: DesktopEventSubscriptionOptions): DesktopProfile {
+  return {
+    ...profile,
+    backend: options.backend ?? profile.backend,
+    agentId: options.agentId?.trim() || profile.agentId
+  }
+}
+
 export class DesktopEventTransport {
   private readonly subscriptions = new Map<string, ActiveSubscription>()
 
@@ -61,6 +84,7 @@ export class DesktopEventTransport {
       throw new Error("Event subscription directory is invalid")
     }
     if (options.scope === "project" && !options.directory?.trim()) throw new Error("Project event directory is required")
+    validateRouteOptions(options)
     const subscription: ActiveSubscription = {
       id: randomUUID(),
       profileId,
@@ -156,14 +180,15 @@ export class DesktopEventTransport {
       this.close(subscription)
       return
     }
+    const targetProfile = eventProfile(profile, subscription.options)
     const controller = new AbortController()
     subscription.controller = controller
     let response: Response
     try {
-      const headers: Record<string, string> = { Accept: "text/event-stream", ...routingHeaders(profile, { preflight: false }) }
+      const headers: Record<string, string> = { Accept: "text/event-stream", ...routingHeaders(targetProfile, { preflight: false }) }
       const authorization = authHeader(profile)
       if (authorization) headers.Authorization = authorization
-      response = await fetch(streamURL(profile, subscription.options), { headers, redirect: "manual", signal: controller.signal })
+      response = await fetch(streamURL(targetProfile, subscription.options), { headers, redirect: "manual", signal: controller.signal })
       if (response.status >= 300 && response.status < 400) throw new Error("Server redirect was rejected")
       if (!response.ok || !response.body) throw new Error(`HTTP ${response.status}`)
       const contentType = response.headers.get("content-type") ?? ""

--- a/web/electron/ipc-contract.ts
+++ b/web/electron/ipc-contract.ts
@@ -73,6 +73,9 @@ export type DesktopRequestResult =
 export type DesktopEventSubscriptionOptions = {
   scope: "global" | "project"
   directory?: string
+  /** Optional TaskDesk route within the already approved machine profile. */
+  backend?: BackendKind
+  agentId?: string
 }
 
 export type DesktopEvent = {
@@ -126,7 +129,7 @@ export function isDesktopMenuCommand(value: unknown): value is DesktopMenuComman
 }
 
 /**
- * The renderer owns what the menu says and when each item applies — it is the side that knows the
+ * The renderer owns what the menu says and when each item applies. It is the side that knows the
  * language, the connected harness and the selected session. Main renders whatever it is handed and
  * echoes clicks back as command ids, so the platform menu and the in-app one stay one implementation
  * rather than two that drift.

--- a/web/package.json
+++ b/web/package.json
@@ -26,7 +26,7 @@
     "cap:sync": "npx cap sync",
     "cap:sync:android": "npx cap sync android && node scripts/sync-native-live-events.mjs",
     "cap:add:android": "npx cap add android",
-    "test:ui": "node src/ui-regression.test.mjs && node --experimental-strip-types src/taskdesk-home.test.mjs && node src/taskdesk-performance.test.mjs && node src/taskdesk-composer-performance.test.mjs && node --experimental-strip-types src/taskdesk-message-order.test.mjs && node src/taskdesk-appearance.test.mjs",
+    "test:ui": "node src/ui-regression.test.mjs && node --experimental-strip-types src/taskdesk-home.test.mjs && node src/taskdesk-performance.test.mjs && node --experimental-strip-types src/taskdesk-message-paging.test.mjs && node src/taskdesk-live-event-routing.test.mjs && node src/taskdesk-composer-performance.test.mjs && node --experimental-strip-types src/taskdesk-message-order.test.mjs && node src/taskdesk-appearance.test.mjs",
     "test:settings": "node src/settings-regression.test.mjs && node src/v3-ux-polish-regression.test.mjs",
     "test:model": "node src/model-regression.test.mjs",
     "test:events": "node --experimental-strip-types src/opencode-events.test.mjs",

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -57,6 +57,12 @@ type ResponseWithHeaders<T> = {
   headers: Record<string, string>
 }
 
+export type MessagePage = {
+  messages: MessageEnvelope[]
+  before?: string
+  hasMore: boolean
+}
+
 function responseDetail(body: unknown): string | null {
   if (!body) return null
   if (typeof body === "string") {
@@ -67,9 +73,6 @@ function responseDetail(body: unknown): string | null {
     }
   }
   if (typeof body === "object") {
-    // `data.message` and `message` are OpenCode's shapes; the bridge answers `{ "error": "..." }`,
-    // which fell through to the stringify below and put raw JSON on screen, so every bridge
-    // failure reached the user as `{"error":"Internal error: ..."}` instead of the sentence in it.
     const value = body as { data?: { message?: string }, message?: string, error?: string }
     const detail = value.data?.message ?? value.message ?? (typeof value.error === "string" ? value.error : undefined)
     return detail ?? JSON.stringify(body)
@@ -131,16 +134,10 @@ async function requestWithHeaders<T>(config: ServerConfig, path: string, options
   const target = `${baseUrl(config)}${path}`
   const headers: Record<string, string> = {
     Accept: "application/json",
-    // CapacitorHttp goes out through the platform's own HTTP client, which never preflights, so the
-    // routing hint the browser has to withhold is safe to send from the packaged Android app.
     ...routingHeaders(config, { preflight: !Capacitor.isNativePlatform() })
   }
-  if (hasCredentials(config)) {
-    headers.Authorization = authHeader(config)
-  }
-  if (options.body !== undefined) {
-    headers["Content-Type"] = "application/json"
-  }
+  if (hasCredentials(config)) headers.Authorization = authHeader(config)
+  if (options.body !== undefined) headers["Content-Type"] = "application/json"
 
   if (Capacitor.isNativePlatform()) {
     let response
@@ -175,8 +172,6 @@ async function requestWithHeaders<T>(config: ServerConfig, path: string, options
       body: options.body === undefined ? undefined : JSON.stringify(options.body)
     })
   } catch {
-    // Kept short: this text reaches a phone screen. The CORS note only means something in a
-    // browser, where it is the usual cause, and nothing at all inside the app.
     const corsHint = hasCredentials(config)
       ? " In a browser, Basic Auth also needs the bridge started with --cors for this origin."
       : ""
@@ -186,13 +181,9 @@ async function requestWithHeaders<T>(config: ServerConfig, path: string, options
   if (!response.ok) {
     let detail = response.status === 401 ? unauthorizedDetail(config) : `HTTP ${response.status}`
     try {
-      // A Response body is a one-shot stream. Read it once and let responseDetail
-      // parse JSON when applicable, so a plain-text server error remains useful.
       const body = await response.text()
       detail = responseDetail(body) ?? detail
-    } catch {
-      // Keep the HTTP status when an interrupted stream cannot be read.
-    }
+    } catch {}
     throw new Error(detail)
   }
 
@@ -304,10 +295,7 @@ export const api = {
           isDefault: defaultModel === modelID
         }
         const variantIDs = Object.keys(model.variants ?? {})
-        return [
-          base,
-          ...variantIDs.map((variant) => ({ ...base, variant, isDefault: false }))
-        ]
+        return [base, ...variantIDs.map((variant) => ({ ...base, variant, isDefault: false }))]
       })
     })
   },
@@ -324,9 +312,23 @@ export const api = {
     return request<boolean>(config, withDirectory(`/session/${id}`, directory), { method: "DELETE" })
   },
 
-  loadMessages(config: ServerConfig, sessionID: string, directory?: string, refreshHistory = false) {
-    const refresh = refreshHistory ? "&refresh=1" : ""
-    return request<MessageEnvelope[]>(config, withDirectory(`/session/${sessionID}/message?limit=100${refresh}`, directory))
+  async loadMessagePage(config: ServerConfig, sessionID: string, directory?: string, before?: string, limit = 100, refreshHistory = false): Promise<MessagePage> {
+    const params = new URLSearchParams({ limit: String(Math.max(1, Math.min(500, Math.trunc(limit) || 100))) })
+    if (before) params.set("before", before)
+    if (refreshHistory) params.set("refresh", "1")
+    const response = await requestWithHeaders<MessageEnvelope[]>(
+      config,
+      withDirectory(`/session/${sessionID}/message?${params.toString()}`, directory)
+    )
+    return {
+      messages: response.data,
+      before: response.headers["x-next-cursor"] || undefined,
+      hasMore: response.headers["x-has-more"] === "1"
+    }
+  },
+
+  async loadMessages(config: ServerConfig, sessionID: string, directory?: string, refreshHistory = false) {
+    return (await this.loadMessagePage(config, sessionID, directory, undefined, 100, refreshHistory)).messages
   },
 
   loadLatestMessage(config: ServerConfig, sessionID: string, directory?: string) {

--- a/web/src/components/universal-workspace.tsx
+++ b/web/src/components/universal-workspace.tsx
@@ -820,7 +820,7 @@ function QuestionPanel({
           {question.custom ? (
             <input
               value={custom[index] || ""}
-              onChange={(event) => setCustom((current) => ({ ...current, [index]: event.target.value }))
+              onChange={(event) => setCustom((current) => ({ ...current, [index]: event.target.value }))}
               placeholder="Custom answer…"
             />
           ) : null}

--- a/web/src/components/universal-workspace.tsx
+++ b/web/src/components/universal-workspace.tsx
@@ -3,9 +3,11 @@ import { api, isValidServerConfig } from "../api"
 import { backendDisplayName } from "../backendSetup"
 import { discoverMachine, selectableMachineAgents } from "../machineClient"
 import { messageText } from "../message-content"
+import { mergeLatestMessagePage, prependOlderMessagePage } from "../message-pages"
 import { taskClient, type MachineProject } from "../taskClient"
 import type { SavedServerProfile } from "../serverProfiles"
 import { createTaskDeskTranslator, type TaskDeskTranslator } from "../taskdesk-i18n"
+import { startTaskDeskSessionLiveRefresh, type SessionLiveTarget } from "../taskdesk-session-live-refresh"
 import type {
   BackendKind,
   DiffFile,
@@ -39,8 +41,8 @@ import {
 } from "../Icons"
 import { TaskDeskMessageContent } from "./taskdesk-message-content"
 
-const REFRESH_INTERVAL_MS = 10_000
-const DETAIL_REFRESH_INTERVAL_MS = 5_000
+const REFRESH_INTERVAL_MS = 60_000
+const DETAIL_REFRESH_INTERVAL_MS = 30_000
 const AGENT_SESSION_LOAD_TIMEOUT_MS = 12_000
 const PINNED_STORAGE_KEY = "harness-remote.universal-workspace.pinned"
 const HARNESS_ICON_FILES: Record<string, string> = {
@@ -684,8 +686,6 @@ function HandoffModal({
   const sameMachine = selected?.machine.key === current.machineKey
   const discoveredTargetProject = selected?.machine.projects.find((project) => project.path === current.session.directory)
     || selected?.machine.projects.find((project) => project.name === current.projectName)
-  // Another harness on the same machine can safely use the exact workspace the current
-  // native Session already owns. Project discovery is only needed when crossing machines.
   const targetDirectory = sameMachine ? current.session.directory : discoveredTargetProject?.path
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -820,7 +820,7 @@ function QuestionPanel({
           {question.custom ? (
             <input
               value={custom[index] || ""}
-              onChange={(event) => setCustom((current) => ({ ...current, [index]: event.target.value }))}
+              onChange={(event) => setCustom((current) => ({ ...current, [index]: event.target.value }))
               placeholder="Custom answer…"
             />
           ) : null}
@@ -868,6 +868,9 @@ export function UniversalWorkspace({
   const [detail, setDetail] = useState<SelectedDetail>(EMPTY_DETAIL)
   const [detailSessionKey, setDetailSessionKey] = useState<string | null>(null)
   const [detailLoading, setDetailLoading] = useState(false)
+  const [messageCursor, setMessageCursor] = useState<string | undefined>(undefined)
+  const [messageHasMore, setMessageHasMore] = useState(false)
+  const [loadingOlderMessages, setLoadingOlderMessages] = useState(false)
   const [detailTab, setDetailTab] = useState<DetailTab>("conversation")
   const [composer, setComposer] = useState("")
   const [sessionModels, setSessionModels] = useState<ModelOption[]>([])
@@ -884,12 +887,16 @@ export function UniversalWorkspace({
   const refreshGeneration = useRef(0)
   const refreshInFlight = useRef(false)
   const detailInFlight = useRef(false)
+  const messageRefreshInFlight = useRef(false)
   const selectedKeyRef = useRef<string | null>(null)
+  const selectedSessionRef = useRef<UniversalSession | null>(null)
   const appliedFocusRequest = useRef<number | null>(null)
   const transcriptRef = useRef<HTMLDivElement>(null)
+  const preserveTranscriptPosition = useRef(false)
 
   const selected = sessions.find((item) => item.key === selectedKey) || null
   selectedKeyRef.current = selectedKey
+  selectedSessionRef.current = selected
   const selectedSessionModel = sessionModels.find((model) => modelOptionKey(model) === sessionModelKey)
   const detailReady = Boolean(selected && detailSessionKey === selected.key)
   const sessionWaiting = Boolean(
@@ -1042,8 +1049,8 @@ export function UniversalWorkspace({
     detailInFlight.current = true
     if (!silent) setDetailLoading(true)
     try {
-      const [messages, diff, todos, vcs, questions, permissions] = await Promise.all([
-        api.loadMessages(item.config, item.session.id, item.session.directory),
+      const [messagePage, diff, todos, vcs, questions, permissions] = await Promise.all([
+        api.loadMessagePage(item.config, item.session.id, item.session.directory),
         api.loadDiff(item.config, item.session.id, item.session.directory).catch(() => []),
         api.loadTodo(item.config, item.session.id, item.session.directory).catch(() => []),
         api.loadVcs(item.config, item.session.directory).catch(() => null),
@@ -1051,14 +1058,18 @@ export function UniversalWorkspace({
         api.loadPermissions(item.config, item.session.directory).catch(() => [])
       ])
       if (selectedKeyRef.current !== item.key) return
-      setDetail({
-        messages,
+      if (!silent) {
+        setMessageCursor(messagePage.before)
+        setMessageHasMore(messagePage.hasMore)
+      }
+      setDetail((current) => ({
+        messages: silent ? mergeLatestMessagePage(current.messages, messagePage.messages) : messagePage.messages,
         diff,
         todos,
         vcs,
         questions: questions.filter((request) => request.sessionID === item.session.id),
         permissions: permissions.filter((request) => request.sessionID === item.session.id)
-      })
+      }))
       setDetailSessionKey(item.key)
     } catch (reason) {
       if (!silent && selectedKeyRef.current === item.key) {
@@ -1070,17 +1081,82 @@ export function UniversalWorkspace({
     }
   }, [])
 
+  const refreshMessageTail = useCallback(async (item: UniversalSession) => {
+    if (messageRefreshInFlight.current) return
+    messageRefreshInFlight.current = true
+    try {
+      const page = await api.loadMessagePage(item.config, item.session.id, item.session.directory)
+      if (selectedKeyRef.current !== item.key) return
+      setDetail((current) => ({ ...current, messages: mergeLatestMessagePage(current.messages, page.messages) }))
+      setDetailSessionKey(item.key)
+    } catch {
+      // Slow reconciliation polling remains the fallback when a live tail refresh fails.
+    } finally {
+      messageRefreshInFlight.current = false
+    }
+  }, [])
+
+  const liveTargets = useMemo<SessionLiveTarget[]>(() => machines.flatMap((machine) =>
+    machine.state === "online"
+      ? machine.agents.map((agent) => ({
+          key: `${machine.key}|${agent.id}`,
+          profile: machine.profile,
+          config: configForAgent(machine, agent)
+        }))
+      : []
+  ), [machines])
+  const liveTargetSignature = useMemo(() => liveTargets.map((target) => [
+    target.key,
+    target.config.backend,
+    target.config.agentId || "",
+    target.config.host,
+    target.config.port,
+    target.config.username
+  ].join(":" )).join("|"), [liveTargets])
+
+  useEffect(() => {
+    if (!liveTargets.length) return
+    const subscription = startTaskDeskSessionLiveRefresh({
+      targets: liveTargets,
+      getSelected: () => {
+        const item = selectedSessionRef.current
+        return item ? { targetKey: `${item.machineKey}|${item.agent.id}`, sessionID: item.session.id } : null
+      },
+      onMessage: () => {
+        if (!pageIsVisible()) return
+        const item = selectedSessionRef.current
+        if (item) void refreshMessageTail(item)
+      },
+      onIndex: () => {
+        if (pageIsVisible()) void refreshAll(true)
+      },
+      onDetail: () => {
+        if (!pageIsVisible()) return
+        const item = selectedSessionRef.current
+        if (item) void loadDetail(item, true)
+      }
+    })
+    return () => subscription.close()
+  }, [liveTargetSignature, refreshAll, loadDetail, refreshMessageTail])
+
   useEffect(() => {
     detailInFlight.current = false
+    messageRefreshInFlight.current = false
     if (!selected) {
       setDetail(EMPTY_DETAIL)
       setDetailSessionKey(null)
       setDetailLoading(false)
+      setMessageCursor(undefined)
+      setMessageHasMore(false)
+      setLoadingOlderMessages(false)
       return
     }
     setDetail(EMPTY_DETAIL)
     setDetailSessionKey(null)
     setDetailLoading(true)
+    setMessageCursor(undefined)
+    setMessageHasMore(false)
+    setLoadingOlderMessages(false)
     void loadDetail(selected, false)
     const timer = window.setInterval(() => {
       if (pageIsVisible()) void loadDetail(selected, true)
@@ -1123,6 +1199,10 @@ export function UniversalWorkspace({
 
   useEffect(() => {
     if (!transcriptRef.current || detailTab !== "conversation" || !detailReady) return
+    if (preserveTranscriptPosition.current) {
+      preserveTranscriptPosition.current = false
+      return
+    }
     transcriptRef.current.scrollTop = transcriptRef.current.scrollHeight
   }, [selected?.key, detail.messages.length, detailTab, detailReady, sessionWaiting])
 
@@ -1173,6 +1253,43 @@ export function UniversalWorkspace({
     return true
   }), [scopedSessions, filter, pinned])
 
+  async function loadOlderMessages() {
+    if (!selected || !detailReady || !messageHasMore || !messageCursor || loadingOlderMessages) return
+    const transcript = transcriptRef.current
+    const previousHeight = transcript?.scrollHeight ?? 0
+    const previousTop = transcript?.scrollTop ?? 0
+    setLoadingOlderMessages(true)
+    setGlobalError(null)
+    try {
+      const page = await api.loadMessagePage(
+        selected.config,
+        selected.session.id,
+        selected.session.directory,
+        messageCursor
+      )
+      if (selectedKeyRef.current !== selected.key) return
+      if (page.messages.length) preserveTranscriptPosition.current = true
+      setDetail((current) => ({
+        ...current,
+        messages: prependOlderMessagePage(current.messages, page.messages)
+      }))
+      setMessageCursor(page.before)
+      setMessageHasMore(page.hasMore)
+      if (page.messages.length && transcript) {
+        window.requestAnimationFrame(() => {
+          if (!transcriptRef.current || selectedKeyRef.current !== selected.key) return
+          transcriptRef.current.scrollTop = previousTop + (transcriptRef.current.scrollHeight - previousHeight)
+        })
+      }
+    } catch (reason) {
+      if (selectedKeyRef.current === selected.key) {
+        setGlobalError(reason instanceof Error ? reason.message : String(reason))
+      }
+    } finally {
+      if (selectedKeyRef.current === selected.key) setLoadingOlderMessages(false)
+    }
+  }
+
   async function sendPrompt() {
     if (!selected || !composer.trim() || sending) return
     const text = composer.trim()
@@ -1186,7 +1303,7 @@ export function UniversalWorkspace({
           ? { providerID: selected.session.model.providerID, modelID: selected.session.model.id, variant: selected.session.model.variant }
           : undefined
       await api.sendPrompt(selected.config, selected.session.id, text, selected.session.directory, model)
-      await loadDetail(selected, true)
+      await refreshMessageTail(selected)
       await refreshAll(true)
     } catch (reason) {
       setComposer((current) => current || text)
@@ -1516,16 +1633,28 @@ export function UniversalWorkspace({
                   <div className="uw-transcript" ref={transcriptRef}>
                     {detailLoading || !detailReady ? (
                       <div className="uw-empty-panel"><LoadingIcon size={22} /><strong>Loading session…</strong></div>
-                    ) : detail.messages.length === 0 && !sessionWaiting ? (
-                      <div className="uw-empty-panel"><ChatIcon size={24} /><strong>This session has no messages yet.</strong></div>
-                    ) : detail.messages.map((message) => (
-                      <MessageBubble
-                        key={message.info.id}
-                        message={message}
-                        agentLabel={selected.agent.label}
-                        agentBackend={selected.agent.backend}
-                      />
-                    ))}
+                    ) : (
+                      <>
+                        {messageHasMore ? (
+                          <div className="uw-history-loader">
+                            <BeautifulButton disabled={loadingOlderMessages} onClick={() => void loadOlderMessages()}>
+                              {loadingOlderMessages ? <LoadingIcon size={15} /> : null}
+                              {loadingOlderMessages ? "Loading older messages…" : "Load older messages"}
+                            </BeautifulButton>
+                          </div>
+                        ) : null}
+                        {detail.messages.length === 0 && !sessionWaiting ? (
+                          <div className="uw-empty-panel"><ChatIcon size={24} /><strong>This session has no messages yet.</strong></div>
+                        ) : detail.messages.map((message) => (
+                          <MessageBubble
+                            key={message.info.id}
+                            message={message}
+                            agentLabel={selected.agent.label}
+                            agentBackend={selected.agent.backend}
+                          />
+                        ))}
+                      </>
+                    )}
                     {sessionWaiting ? (
                       <div className="uw-session-typing" role="status" aria-label="Waiting for agent response">
                         <span />

--- a/web/src/desktopBridge.ts
+++ b/web/src/desktopBridge.ts
@@ -165,8 +165,8 @@ export function subscribeDesktopMenuCommands(callback: (command: DesktopMenuComm
   return bridge()?.onMenuCommand(callback) ?? (() => undefined)
 }
 
-/** True only where the platform draws the menu itself, which today means macOS. Everywhere else —
- *  the browser, Windows, Linux — the app draws its own menu bar and binds its own accelerators. */
+/** True only where the platform draws the menu itself, which today means macOS. Everywhere else,
+ *  the browser, Windows and Linux, the app draws its own menu bar and binds its own accelerators. */
 export function desktopUsesNativeMenu(): boolean {
   return desktopPlatform()?.usesNativeMenu === true
 }
@@ -198,6 +198,8 @@ export function createDesktopOpenCodeEventSubscription(options: {
   profileId: string
   scope: "global" | "project"
   directory?: string
+  backend?: ServerConfig["backend"]
+  agentId?: string
   onEvent: (event: DesktopEvent) => void
   onStatus?: (status: DesktopEventStatus) => void
 }): DesktopSubscription {
@@ -216,7 +218,12 @@ export function createDesktopOpenCodeEventSubscription(options: {
       }
       const id = await api.subscribeEvents(
         options.profileId,
-        { scope: options.scope, directory: options.directory },
+        {
+          scope: options.scope,
+          directory: options.directory,
+          backend: options.backend,
+          agentId: options.agentId
+        },
         options.onEvent,
         options.onStatus
       )

--- a/web/src/message-pages.ts
+++ b/web/src/message-pages.ts
@@ -1,0 +1,26 @@
+import type { MessageEnvelope } from "./types"
+
+/**
+ * Refresh the newest page without discarding older pages the user explicitly loaded.
+ * Reuse existing message objects when the server did not replace them so memoized
+ * transcript rows remain cheap while the composer and live status update.
+ */
+export function mergeLatestMessagePage(existing: MessageEnvelope[], latest: MessageEnvelope[]): MessageEnvelope[] {
+  if (!existing.length) return latest
+  const latestByID = new Map(latest.map((message) => [message.info.id, message]))
+  const existingIDs = new Set(existing.map((message) => message.info.id))
+  return [
+    ...existing.map((message) => latestByID.get(message.info.id) ?? message),
+    ...latest.filter((message) => !existingIDs.has(message.info.id))
+  ]
+}
+
+/** Add an older page once, keeping the current tail and its object identities intact. */
+export function prependOlderMessagePage(existing: MessageEnvelope[], older: MessageEnvelope[]): MessageEnvelope[] {
+  if (!existing.length) return older
+  const existingIDs = new Set(existing.map((message) => message.info.id))
+  return [
+    ...older.filter((message) => !existingIDs.has(message.info.id)),
+    ...existing
+  ]
+}

--- a/web/src/settings-regression.test.mjs
+++ b/web/src/settings-regression.test.mjs
@@ -93,7 +93,9 @@ assert.equal(/function routingHeaders/.test(api), false, 'api.ts should reuse th
 assert.ok(api.includes('...routingHeaders(config)'), 'ordinary API requests should carry the selected harness routing hint')
 assert.match(api, /eventStream\(config: ServerConfig\)[\s\S]*?routingHeaders\(config\)/, 'browser SSE should preserve the selected harness routing hint too')
 assert.ok(desktopRequestTransport.includes('...routingHeaders(profile, { preflight: false })'), 'desktop requests never preflight, so they always carry the routing hint')
-assert.ok(desktopEventTransport.includes('...routingHeaders(profile, { preflight: false })'), 'desktop SSE never preflights, so it always carries the routing hint')
+assert.ok(desktopEventTransport.includes('...routingHeaders(targetProfile, { preflight: false })'), 'desktop SSE should carry the selected agent routing hint')
+assert.ok(desktopEventTransport.includes('const authorization = authHeader(profile)'), 'desktop SSE authorization must still come from the approved saved profile')
+assert.ok(desktopEventTransport.includes('fetch(streamURL(targetProfile, subscription.options)'), 'desktop SSE URL should follow only the validated target routing')
 
 // The server picker used to caption itself with a visually-hidden span, but no rule ever hid it: the
 // caption rendered as stray text above the header. Every class the picker and its actions rely on has

--- a/web/src/taskdesk-live-event-routing.test.mjs
+++ b/web/src/taskdesk-live-event-routing.test.mjs
@@ -26,3 +26,16 @@ test("desktop event routing validates the renderer supplied route", () => {
   assert.match(transport, /\^\[A-Za-z0-9\._-\]\+\$/)
   assert.match(transport, /Event subscription agent is invalid/)
 })
+
+test("TaskDesk Session workspace uses live events as the primary refresh path", () => {
+  const workspace = readFileSync(new URL("./components/universal-workspace.tsx", import.meta.url), "utf8")
+
+  assert.match(workspace, /const REFRESH_INTERVAL_MS = 60_000/)
+  assert.match(workspace, /const DETAIL_REFRESH_INTERVAL_MS = 30_000/)
+  assert.match(workspace, /startTaskDeskSessionLiveRefresh\(\{/)
+  assert.match(workspace, /onMessage:[\s\S]*?refreshMessageTail\(item\)/)
+  assert.match(workspace, /onIndex:[\s\S]*?refreshAll\(true\)/)
+  assert.match(workspace, /onDetail:[\s\S]*?loadDetail\(item, true\)/)
+  assert.match(workspace, /if \(!pageIsVisible\(\)\) return/)
+  assert.match(workspace, /<TaskDeskMessageContent message=\{message\} \/>/)
+})

--- a/web/src/taskdesk-live-event-routing.test.mjs
+++ b/web/src/taskdesk-live-event-routing.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+
+test("TaskDesk desktop live events follow the selected daemon agent", () => {
+  const contract = readFileSync(new URL("../electron/ipc-contract.ts", import.meta.url), "utf8")
+  const bridge = readFileSync(new URL("./desktopBridge.ts", import.meta.url), "utf8")
+  const transport = readFileSync(new URL("../electron/event-transport.ts", import.meta.url), "utf8")
+  const liveEvents = readFileSync(new URL("./taskdesk-live-events.ts", import.meta.url), "utf8")
+
+  assert.match(contract, /backend\?: BackendKind/)
+  assert.match(contract, /agentId\?: string/)
+  assert.match(liveEvents, /backend: config\.backend/)
+  assert.match(liveEvents, /agentId: config\.agentId/)
+  assert.match(bridge, /backend: options\.backend/)
+  assert.match(bridge, /agentId: options\.agentId/)
+  assert.match(transport, /const targetProfile = eventProfile\(profile, subscription\.options\)/)
+  assert.match(transport, /routingHeaders\(targetProfile, \{ preflight: false \}\)/)
+  assert.match(transport, /streamURL\(targetProfile, subscription\.options\)/)
+})
+
+test("desktop event routing validates the renderer supplied route", () => {
+  const transport = readFileSync(new URL("../electron/event-transport.ts", import.meta.url), "utf8")
+  assert.match(transport, /EVENT_BACKENDS/)
+  assert.match(transport, /Event subscription backend is invalid/)
+  assert.match(transport, /\^\[A-Za-z0-9\._-\]\+\$/)
+  assert.match(transport, /Event subscription agent is invalid/)
+})

--- a/web/src/taskdesk-live-events.ts
+++ b/web/src/taskdesk-live-events.ts
@@ -48,8 +48,8 @@ export function taskDeskLiveEvent(name: string | undefined, data: unknown): Task
 }
 
 /**
- * Use the transport already proven by Classic on each platform. Browser/Electron fetch streams can
- * carry auth headers, Android uses the native SSE plugin, and Electron main owns desktop sockets.
+ * Use the transport already proven by Classic on each platform. Browser and Electron fetch streams
+ * can carry auth headers, Android uses the native SSE plugin, and Electron main owns desktop sockets.
  */
 export function subscribeTaskDeskLiveEvents({
   profile,
@@ -71,6 +71,8 @@ export function subscribeTaskDeskLiveEvents({
     return createDesktopOpenCodeEventSubscription({
       profileId: profile.id,
       scope: "global",
+      backend: config.backend,
+      agentId: config.agentId,
       onEvent: (event) => emit(event.name, event.data),
       onStatus
     })

--- a/web/src/taskdesk-message-paging.test.mjs
+++ b/web/src/taskdesk-message-paging.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+import { mergeLatestMessagePage, prependOlderMessagePage } from "./message-pages.ts"
+
+function message(id, text = id) {
+  return {
+    info: { id, role: "assistant", time: { created: 1, updated: 1 } },
+    parts: [{ id: `${id}-part`, type: "text", text }]
+  }
+}
+
+test("message paging client consumes bridge cursor headers", () => {
+  const api = readFileSync(new URL("./api.ts", import.meta.url), "utf8")
+  const server = readFileSync(new URL("../../bridge/src/server.js", import.meta.url), "utf8")
+
+  assert.match(api, /export type MessagePage/)
+  assert.match(api, /async loadMessagePage\(/)
+  assert.match(api, /params\.set\("before", before\)/)
+  assert.match(api, /response\.headers\["x-next-cursor"\]/)
+  assert.match(api, /response\.headers\["x-has-more"\] === "1"/)
+  assert.match(server, /service\.messagePage\(sessionID/)
+  assert.match(server, /response\.setHeader\("X-Next-Cursor", page\.before\)/)
+  assert.match(server, /response\.setHeader\("X-Has-More", page\.hasMore \? "1" : "0"\)/)
+})
+
+test("newest-page refresh preserves explicitly loaded older messages", () => {
+  const oldA = message("a")
+  const oldB = message("b")
+  const oldC = message("c")
+  const newC = message("c", "updated")
+  const newD = message("d")
+
+  const merged = mergeLatestMessagePage([oldA, oldB, oldC], [newC, newD])
+  assert.deepEqual(merged.map((entry) => entry.info.id), ["a", "b", "c", "d"])
+  assert.equal(merged[0], oldA)
+  assert.equal(merged[1], oldB)
+  assert.equal(merged[2], newC)
+  assert.equal(merged[3], newD)
+})
+
+test("older pages prepend without duplicating the cursor boundary", () => {
+  const currentB = message("b")
+  const currentC = message("c")
+  const olderA = message("a")
+  const duplicateB = message("b", "duplicate")
+
+  const merged = prependOlderMessagePage([currentB, currentC], [olderA, duplicateB])
+  assert.deepEqual(merged.map((entry) => entry.info.id), ["a", "b", "c"])
+  assert.equal(merged[1], currentB)
+  assert.equal(merged[2], currentC)
+})
+
+test("Session conversation exposes bounded older-history loading without scroll jumps", () => {
+  const workspace = readFileSync(new URL("./components/universal-workspace.tsx", import.meta.url), "utf8")
+
+  assert.match(workspace, /api\.loadMessagePage\(item\.config, item\.session\.id, item\.session\.directory\)/)
+  assert.match(workspace, /silent \? mergeLatestMessagePage\(current\.messages, messagePage\.messages\) : messagePage\.messages/)
+  assert.match(workspace, /async function loadOlderMessages\(\)/)
+  assert.match(workspace, /prependOlderMessagePage\(current\.messages, page\.messages\)/)
+  assert.match(workspace, /messageHasMore \? \(/)
+  assert.match(workspace, /Load older messages/)
+  assert.match(workspace, /previousTop \+ \(transcriptRef\.current\.scrollHeight - previousHeight\)/)
+  assert.match(workspace, /if \(preserveTranscriptPosition\.current\)/)
+})

--- a/web/src/taskdesk-performance.test.mjs
+++ b/web/src/taskdesk-performance.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict"
 import { readFileSync } from "node:fs"
 import test from "node:test"
 
-test("TaskDesk pauses hidden work and avoids duplicate Tasks and Sessions polling", () => {
+test("TaskDesk pauses hidden work and uses live events with slow Sessions reconciliation", () => {
   const taskDesk = readFileSync(new URL("./components/taskdesk-v3-unified.tsx", import.meta.url), "utf8")
   const workspace = readFileSync(new URL("./components/universal-workspace.tsx", import.meta.url), "utf8")
 
@@ -12,8 +12,9 @@ test("TaskDesk pauses hidden work and avoids duplicate Tasks and Sessions pollin
   assert.match(taskDesk, /if \(view !== "tasks" \|\| !selected \|\| !detailOpen\)/)
   assert.match(taskDesk, /if \(pageIsVisible\(\)\) void refresh\(\)/)
 
-  assert.match(workspace, /const REFRESH_INTERVAL_MS = 10_000/)
-  assert.match(workspace, /const DETAIL_REFRESH_INTERVAL_MS = 5_000/)
+  assert.match(workspace, /const REFRESH_INTERVAL_MS = 60_000/)
+  assert.match(workspace, /const DETAIL_REFRESH_INTERVAL_MS = 30_000/)
+  assert.match(workspace, /startTaskDeskSessionLiveRefresh\(\{/)
   assert.match(workspace, /const detailInFlight = useRef\(false\)/)
   assert.match(workspace, /if \(detailInFlight\.current && silent\) return/)
   assert.match(workspace, /if \(pageIsVisible\(\)\) void refreshAll\(true\)/)

--- a/web/src/taskdesk-session-live-refresh.ts
+++ b/web/src/taskdesk-session-live-refresh.ts
@@ -1,0 +1,113 @@
+import type { SavedServerProfile } from "./serverProfiles"
+import { subscribeTaskDeskLiveEvents } from "./taskdesk-live-events"
+import type { ServerConfig } from "./types"
+
+export type SessionLiveTarget = {
+  key: string
+  profile: SavedServerProfile
+  config: ServerConfig
+}
+
+export type SelectedLiveSession = {
+  targetKey: string
+  sessionID: string
+}
+
+type Timer = ReturnType<typeof setTimeout>
+
+/**
+ * Drive Session freshness from the existing per-agent event stream without turning every streamed
+ * token into a full workspace refresh. Message chunks refresh only the selected transcript tail;
+ * lifecycle events refresh the lightweight index and, for the selected Session, its detail data.
+ * Polling remains a slow reconciliation fallback in the owning React component.
+ */
+export function startTaskDeskSessionLiveRefresh({
+  targets,
+  getSelected,
+  onMessage,
+  onIndex,
+  onDetail
+}: {
+  targets: SessionLiveTarget[]
+  getSelected: () => SelectedLiveSession | null
+  onMessage: () => void
+  onIndex: () => void
+  onDetail: () => void
+}): { close(): void } {
+  let closed = false
+  let messageTimer: Timer | undefined
+  let indexTimer: Timer | undefined
+  let detailTimer: Timer | undefined
+
+  const throttle = (kind: "message" | "index" | "detail", delay: number, callback: () => void) => {
+    if (closed) return
+    const current = kind === "message" ? messageTimer : kind === "index" ? indexTimer : detailTimer
+    if (current !== undefined) return
+    const timer = setTimeout(() => {
+      if (kind === "message") messageTimer = undefined
+      else if (kind === "index") indexTimer = undefined
+      else detailTimer = undefined
+      if (!closed) callback()
+    }, delay)
+    if (kind === "message") messageTimer = timer
+    else if (kind === "index") indexTimer = timer
+    else detailTimer = timer
+  }
+
+  const subscriptions = targets.map((target) => subscribeTaskDeskLiveEvents({
+    profile: target.profile,
+    config: target.config,
+    onEvent: (event) => {
+      const selected = getSelected()
+      const selectedEvent = Boolean(
+        selected
+        && selected.targetKey === target.key
+        && event.sessionID
+        && selected.sessionID === event.sessionID
+      )
+
+      if (event.type === "message.updated") {
+        if (selectedEvent) throttle("message", 180, onMessage)
+        return
+      }
+
+      if (event.type === "todo.updated") {
+        if (selectedEvent) throttle("detail", 300, onDetail)
+        return
+      }
+
+      if (event.type === "session.updated") {
+        throttle("index", 450, onIndex)
+        if (selectedEvent) throttle("detail", 450, onDetail)
+        return
+      }
+
+      if (event.type === "session.created" || event.type === "session.deleted") {
+        throttle("index", 250, onIndex)
+        return
+      }
+
+      if (event.type === "session.error" && selectedEvent) {
+        throttle("message", 180, onMessage)
+        throttle("detail", 450, onDetail)
+      }
+    },
+    onStatus: (status) => {
+      if (status.type !== "connected") return
+      throttle("index", 100, onIndex)
+      const selected = getSelected()
+      if (selected?.targetKey === target.key) throttle("detail", 100, onDetail)
+    }
+  }))
+
+  return {
+    close() {
+      if (closed) return
+      closed = true
+      if (messageTimer !== undefined) clearTimeout(messageTimer)
+      if (indexTimer !== undefined) clearTimeout(indexTimer)
+      if (detailTimer !== undefined) clearTimeout(detailTimer)
+      for (const subscription of subscriptions) subscription.close()
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

Finish the remaining performance and memory work tracked by #266 on top of the current canonical `v3/taskdesk` branch.

This PR is intentionally focused on the Session data path and live refresh behavior. It does not target `main`.

## Included

* expose cursor based message pages in the web API client using the bridge `X-Next-Cursor` and `X-Has-More` headers
* load only the newest bounded page when a Session opens
* expose explicit `Load older messages` paging in the Session UI
* preserve scroll position while older pages are prepended
* preserve explicitly loaded older messages when the newest page refreshes
* keep stable message object identities where possible so memoized transcript rows remain cheap
* keep the ordered TaskDesk message renderer from #277 intact
* reuse the existing authenticated live event transports on browser, Android and Electron
* route Electron event subscriptions to the selected daemon agent without changing the approved host or credentials
* refresh only the selected transcript tail for `message.updated`
* refresh Session detail for targeted todo/lifecycle changes and the lightweight index for Session lifecycle events
* reconcile after event stream reconnects
* reduce index polling to 60 seconds and selected detail polling to 30 seconds so polling is a fallback rather than the primary live update loop
* add regression coverage for cursor handling, page boundaries, duplicate prevention, desktop route validation and live refresh wiring

## Remaining release validation

The code path is complete for automated review. #266 should remain open until the real daemon/Android soak records diagnostics under many Sessions and long transcripts, verifies memory plateaus, and confirms reconnect behavior after sleep/network loss.

Refs #266
Refs #197