### PR TITLE
fix(taskdesk): preserve native message order and task outcomes

### DIFF
--- a/bridge/src/task-launcher.js
+++ b/bridge/src/task-launcher.js
@@ -68,11 +68,6 @@ function boundOutcome(value) {
   return text.length <= MAX_OUTCOME_CHARS ? text : `…${text.slice(-(MAX_OUTCOME_CHARS - 1))}`
 }
 
-function messageText(message) {
-  const parts = Array.isArray(message?.parts) ? message.parts : []
-  return parts.filter((part) => part?.type === "text" && typeof part.text === "string").map((part) => part.text).join("\n").trim()
-}
-
 function terminalMessageText(message) {
   const parts = Array.isArray(message?.parts) ? message.parts : []
   const chunks = []
@@ -110,7 +105,7 @@ function outcomeFromResult(result) {
   if (!result || typeof result !== "object") return undefined
   const direct = boundOutcome(result.outcome || result.text || result.content)
   if (direct) return direct
-  if (Array.isArray(result.parts)) return boundOutcome(terminalMessageText(result) || messageText(result))
+  if (Array.isArray(result.parts)) return boundOutcome(terminalMessageText(result))
   if (result.message && typeof result.message === "object") return outcomeFromResult(result.message)
   return undefined
 }

--- a/bridge/src/task-launcher.js
+++ b/bridge/src/task-launcher.js
@@ -73,10 +73,33 @@ function messageText(message) {
   return parts.filter((part) => part?.type === "text" && typeof part.text === "string").map((part) => part.text).join("\n").trim()
 }
 
+function terminalMessageText(message) {
+  const parts = Array.isArray(message?.parts) ? message.parts : []
+  const chunks = []
+  let foundText = false
+  for (let index = parts.length - 1; index >= 0; index -= 1) {
+    const part = parts[index]
+    if (part?.type === "text") {
+      const text = typeof part.text === "string" ? part.text.trim() : ""
+      if (!text) continue
+      chunks.push(part.text)
+      foundText = true
+      continue
+    }
+    if (foundText) break
+    return ""
+  }
+  return chunks.reverse().join("\n").trim()
+}
+
 function latestAssistantOutcome(messages) {
   for (let index = (messages?.length ?? 0) - 1; index >= 0; index -= 1) {
-    if (messages[index]?.info?.role !== "assistant") continue
-    const text = boundOutcome(messageText(messages[index]))
+    const message = messages[index]
+    // A Task run owns one user turn. Never fall through to an assistant answer from a previous turn
+    // when the latest turn ended in tool/reasoning activity without a natural-language result.
+    if (message?.info?.role === "user") break
+    if (message?.info?.role !== "assistant") continue
+    const text = boundOutcome(terminalMessageText(message))
     if (text) return text
   }
   return undefined
@@ -86,7 +109,7 @@ function outcomeFromResult(result) {
   if (!result || typeof result !== "object") return undefined
   const direct = boundOutcome(result.outcome || result.text || result.content)
   if (direct) return direct
-  if (Array.isArray(result.parts)) return boundOutcome(messageText(result))
+  if (Array.isArray(result.parts)) return boundOutcome(terminalMessageText(result) || messageText(result))
   if (result.message && typeof result.message === "object") return outcomeFromResult(result.message)
   return undefined
 }

--- a/bridge/src/task-launcher.js
+++ b/bridge/src/task-launcher.js
@@ -86,6 +86,7 @@ function terminalMessageText(message) {
       foundText = true
       continue
     }
+    if (part?.type !== "reasoning" && part?.type !== "tool") continue
     if (foundText) break
     return ""
   }

--- a/bridge/src/task-run-controller.js
+++ b/bridge/src/task-run-controller.js
@@ -82,7 +82,7 @@ function requestedRole(task, options = {}) {
 
 function completedRun(run, result) {
   const outcome = boundTaskOutcome(result?.outcome)
-  return outcome ? { ...run, outcome } : run
+  return outcome ? { ...run, outcome, outcomeVersion: 2 } : run
 }
 
 export class TaskRunController {

--- a/bridge/test/task-launcher-model.test.js
+++ b/bridge/test/task-launcher-model.test.js
@@ -87,6 +87,77 @@ test("ACP task launch uses the bridge session service so the task remains visibl
   assert.equal(completed, true)
 })
 
+test("ACP task outcome keeps Claude-style final text after reasoning and tool activity", async () => {
+  const service = {
+    async promptAndWait() {},
+    async messages() {
+      return [
+        {
+          info: { id: "user-1", role: "user" },
+          parts: [{ type: "text", text: "Implement the fix" }]
+        },
+        {
+          info: { id: "assistant-1", role: "assistant" },
+          parts: [
+            { type: "text", text: "I will inspect this first." },
+            { type: "reasoning", text: "Need to find the relevant code." },
+            { type: "tool", tool: "Read", state: { status: "completed" } },
+            { type: "text", text: "Implemented the fix and opened PR #276." },
+            { type: "file", filename: "report.txt" }
+          ]
+        }
+      ]
+    }
+  }
+  const daemon = {
+    hostEntry: () => ({ kind: "acp", host: {} }),
+    registry: { host: () => ({ state: "available" }) }
+  }
+  const launcher = new TaskLauncher({ daemon, acpService: () => service })
+  let completed
+
+  await launcher.startPrompt(task({ agentId: "claude" }), { sessionId: "claude-session" }, {
+    onCompleted: (result) => { completed = result }
+  })
+  await new Promise((resolve) => setImmediate(resolve))
+
+  assert.deepEqual(completed, { outcome: "Implemented the fix and opened PR #276." })
+})
+
+test("ACP task outcome does not promote pre-tool narration when no final answer was emitted", async () => {
+  const service = {
+    async promptAndWait() {},
+    async messages() {
+      return [
+        {
+          info: { id: "user-1", role: "user" },
+          parts: [{ type: "text", text: "Implement the fix" }]
+        },
+        {
+          info: { id: "assistant-1", role: "assistant" },
+          parts: [
+            { type: "text", text: "I will inspect this first." },
+            { type: "tool", tool: "Edit", state: { status: "completed" } }
+          ]
+        }
+      ]
+    }
+  }
+  const daemon = {
+    hostEntry: () => ({ kind: "acp", host: {} }),
+    registry: { host: () => ({ state: "available" }) }
+  }
+  const launcher = new TaskLauncher({ daemon, acpService: () => service })
+  let completed
+
+  await launcher.startPrompt(task({ agentId: "claude" }), { sessionId: "claude-session" }, {
+    onCompleted: (result) => { completed = result }
+  })
+  await new Promise((resolve) => setImmediate(resolve))
+
+  assert.deepEqual(completed, { outcome: undefined })
+})
+
 test("managed HTTP task launch sends selected model and variant", async () => {
   const requests = []
   const fetchImpl = async (url, options = {}) => {

--- a/bridge/test/task-launcher-model.test.js
+++ b/bridge/test/task-launcher-model.test.js
@@ -194,6 +194,40 @@ test("managed HTTP task launch sends selected model and variant", async () => {
   assert.equal(promptBody.variant, "high")
 })
 
+test("managed HTTP task outcome also refuses pre-tool narration without a final answer", async () => {
+  const host = { readinessHost: "127.0.0.1", port: 4096, async start() {} }
+  const daemon = {
+    hostEntry: () => ({ kind: "http", host }),
+    registry: { host: () => ({ state: "available" }) }
+  }
+  const launcher = new TaskLauncher({
+    daemon,
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      async json() {
+        return {
+          info: { id: "message-1" },
+          parts: [
+            { type: "text", text: "I will inspect this first." },
+            { type: "tool", tool: "Edit", state: { status: "completed" } }
+          ]
+        }
+      }
+    })
+  })
+  let completed
+
+  await launcher.startPrompt(task({ agentId: "opencode" }), {
+    sessionId: "http-session",
+    base: "http://127.0.0.1:4096",
+    authorization: undefined
+  }, { onCompleted: (result) => { completed = result } })
+  await new Promise((resolve) => setImmediate(resolve))
+
+  assert.deepEqual(completed, { outcome: undefined })
+})
+
 test("managed HTTP task launch reports a provider failure after the prompt is accepted", async () => {
   const host = { readinessHost: "127.0.0.1", port: 4096, async start() {} }
   const daemon = {

--- a/bridge/test/task-run-controller.test.js
+++ b/bridge/test/task-run-controller.test.js
@@ -74,6 +74,28 @@ test("a synchronous prompt completion cannot race the starting to running transi
   assert.equal(current.status, "completed")
 })
 
+test("completed task outcomes are persisted with the corrected outcome version", async () => {
+  let current = draft()
+  const store = {
+    async get() { return structuredClone(current) },
+    async setRunState(_id, update) {
+      current = { ...current, status: update.status, run: structuredClone(update.run), error: update.error }
+      return structuredClone(current)
+    }
+  }
+  const launcher = {
+    async createSession(task) { return { sessionId: "session-1", transport: "acp", directory: task.workspace.path } },
+    async startPrompt(_task, _session, callbacks) { callbacks.onCompleted({ outcome: "Final answer" }) }
+  }
+  const controller = new TaskRunController({ taskStore: store, taskLauncher: launcher, runIDFactory: () => "run-1" })
+
+  await controller.launch("task-1")
+  await new Promise((resolve) => setImmediate(resolve))
+  assert.equal(current.status, "completed")
+  assert.equal(current.run.outcome, "Final answer")
+  assert.equal(current.run.outcomeVersion, 2)
+})
+
 test("Git tasks can intentionally launch from the project checkout", async () => {
   let current = draft({ workspace: { mode: "project", path: "/repo" } })
   const store = {

--- a/web/package.json
+++ b/web/package.json
@@ -26,7 +26,7 @@
     "cap:sync": "npx cap sync",
     "cap:sync:android": "npx cap sync android && node scripts/sync-native-live-events.mjs",
     "cap:add:android": "npx cap add android",
-    "test:ui": "node src/ui-regression.test.mjs && node --experimental-strip-types src/taskdesk-home.test.mjs && node src/taskdesk-performance.test.mjs && node src/taskdesk-composer-performance.test.mjs && node src/taskdesk-appearance.test.mjs",
+    "test:ui": "node src/ui-regression.test.mjs && node --experimental-strip-types src/taskdesk-home.test.mjs && node src/taskdesk-performance.test.mjs && node src/taskdesk-composer-performance.test.mjs && node --experimental-strip-types src/taskdesk-message-order.test.mjs && node src/taskdesk-appearance.test.mjs",
     "test:settings": "node src/settings-regression.test.mjs && node src/v3-ux-polish-regression.test.mjs",
     "test:model": "node src/model-regression.test.mjs",
     "test:events": "node --experimental-strip-types src/opencode-events.test.mjs",

--- a/web/src/components/taskdesk-message-content.tsx
+++ b/web/src/components/taskdesk-message-content.tsx
@@ -4,54 +4,6 @@ import type { MessageEnvelope, MessagePart } from "../types"
 
 const REMARK_PLUGINS = [remarkGfm]
 
-export function messageText(message: MessageEnvelope): string {
-  return message.parts
-    .filter((part) => part.type === "text" && typeof part.text === "string")
-    .map((part) => part.text || "")
-    .join("\n")
-    .trim()
-}
-
-/**
- * Return only the natural-language answer that occurs after the last reasoning/tool activity in a
- * message. ACP harnesses such as Claude can keep narration, reasoning, tool calls and the final
- * answer in one native message. Flattening every text part makes the final answer look as though it
- * happened before the tools and also pollutes Task outcome summaries with pre-tool narration.
- */
-export function terminalMessageText(message: MessageEnvelope): string {
-  const chunks: string[] = []
-  let foundText = false
-
-  for (let index = message.parts.length - 1; index >= 0; index -= 1) {
-    const part = message.parts[index]
-    if (part.type === "text") {
-      const text = typeof part.text === "string" ? part.text.trim() : ""
-      if (!text) continue
-      chunks.push(part.text || "")
-      foundText = true
-      continue
-    }
-    if (foundText) break
-    // The message ended in tool/reasoning activity and never emitted a final natural-language
-    // answer. Do not promote narration from before that activity to a completed Task result.
-    return ""
-  }
-
-  return chunks.reverse().join("\n").trim()
-}
-
-/** Never cross the latest user turn when looking for the result of the current turn. */
-export function latestAssistantTerminalText(messages: MessageEnvelope[]): string {
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index]
-    if (message.info.role === "user") break
-    if (message.info.role !== "assistant") continue
-    const text = terminalMessageText(message)
-    if (text) return text
-  }
-  return ""
-}
-
 function ToolPartCard({ part }: { part: MessagePart }) {
   const state = part.state
   const status = state?.status || "running"

--- a/web/src/components/taskdesk-message-content.tsx
+++ b/web/src/components/taskdesk-message-content.tsx
@@ -1,0 +1,113 @@
+import ReactMarkdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+import type { MessageEnvelope, MessagePart } from "../types"
+
+const REMARK_PLUGINS = [remarkGfm]
+
+export function messageText(message: MessageEnvelope): string {
+  return message.parts
+    .filter((part) => part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text || "")
+    .join("\n")
+    .trim()
+}
+
+/**
+ * Return only the natural-language answer that occurs after the last reasoning/tool activity in a
+ * message. ACP harnesses such as Claude can keep narration, reasoning, tool calls and the final
+ * answer in one native message. Flattening every text part makes the final answer look as though it
+ * happened before the tools and also pollutes Task outcome summaries with pre-tool narration.
+ */
+export function terminalMessageText(message: MessageEnvelope): string {
+  const chunks: string[] = []
+  let foundText = false
+
+  for (let index = message.parts.length - 1; index >= 0; index -= 1) {
+    const part = message.parts[index]
+    if (part.type === "text") {
+      const text = typeof part.text === "string" ? part.text.trim() : ""
+      if (!text) continue
+      chunks.push(part.text || "")
+      foundText = true
+      continue
+    }
+    if (foundText) break
+    // The message ended in tool/reasoning activity and never emitted a final natural-language
+    // answer. Do not promote narration from before that activity to a completed Task result.
+    return ""
+  }
+
+  return chunks.reverse().join("\n").trim()
+}
+
+/** Never cross the latest user turn when looking for the result of the current turn. */
+export function latestAssistantTerminalText(messages: MessageEnvelope[]): string {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (message.info.role === "user") break
+    if (message.info.role !== "assistant") continue
+    const text = terminalMessageText(message)
+    if (text) return text
+  }
+  return ""
+}
+
+function ToolPartCard({ part }: { part: MessagePart }) {
+  const state = part.state
+  const status = state?.status || "running"
+  const input = state?.input || {}
+  const command = typeof input.command === "string"
+    ? input.command
+    : typeof input.filePath === "string"
+      ? input.filePath
+      : typeof input.path === "string"
+        ? input.path
+        : ""
+  const output = state?.error || state?.output || ""
+
+  return (
+    <div className="uw-tool-stack">
+      <details className={`uw-tool-card uw-tool-${status}`} open={status === "error"}>
+        <summary>
+          <span className="uw-tool-icon">{status === "completed" ? "✓" : status === "error" ? "!" : "⋯"}</span>
+          <span className="uw-tool-title">{state?.title || part.tool || "Tool"}</span>
+          {command ? <code>{command.length > 90 ? `${command.slice(0, 90)}…` : command}</code> : null}
+          <span className="uw-tool-status">{status}</span>
+        </summary>
+        {output ? <pre>{output.length > 4_000 ? `${output.slice(0, 4_000)}\n…` : output}</pre> : null}
+      </details>
+    </div>
+  )
+}
+
+/** Render the harness payload in wire order instead of regrouping it by part type. */
+export function TaskDeskMessageContent({ message }: { message: MessageEnvelope }) {
+  return (
+    <div className="uw-message-parts">
+      {message.parts.map((part) => {
+        if (part.type === "text" && part.text) {
+          return (
+            <div className="uw-markdown" key={part.id}>
+              <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{part.text}</ReactMarkdown>
+            </div>
+          )
+        }
+        if (part.type === "reasoning" && part.text) {
+          return (
+            <details className="uw-tool-card uw-reasoning" key={part.id} open>
+              <summary>
+                <span className="uw-tool-icon">…</span>
+                <span className="uw-tool-title">Reasoning</span>
+              </summary>
+              <div className="uw-markdown">
+                <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{part.text}</ReactMarkdown>
+              </div>
+            </details>
+          )
+        }
+        if (part.type === "tool") return <ToolPartCard key={part.id} part={part} />
+        return null
+      })}
+    </div>
+  )
+}

--- a/web/src/components/taskdesk-message-content.tsx
+++ b/web/src/components/taskdesk-message-content.tsx
@@ -39,7 +39,7 @@ export function TaskDeskMessageContent({ message }: { message: MessageEnvelope }
       {message.parts.map((part) => {
         if (part.type === "text" && part.text) {
           return (
-            <div className="uw-markdown" key={part.id}>
+            <div className="uw-markdown td3-markdown" key={part.id}>
               <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{part.text}</ReactMarkdown>
             </div>
           )
@@ -51,7 +51,7 @@ export function TaskDeskMessageContent({ message }: { message: MessageEnvelope }
                 <span className="uw-tool-icon">…</span>
                 <span className="uw-tool-title">Reasoning</span>
               </summary>
-              <div className="uw-markdown">
+              <div className="uw-markdown td3-markdown">
                 <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{part.text}</ReactMarkdown>
               </div>
             </details>

--- a/web/src/components/taskdesk-v3-unified.tsx
+++ b/web/src/components/taskdesk-v3-unified.tsx
@@ -13,6 +13,7 @@ import {
 } from "../appPreferences"
 import { languageOptions, type LanguageCode } from "../i18n"
 import { discoverMachine, selectableMachineAgents } from "../machineClient"
+import { assistantTerminalTextForPrompt } from "../message-content"
 import {
   taskClient,
   type MachineProject,
@@ -62,6 +63,7 @@ import {
   SparkIcon,
   TaskListIcon
 } from "../Icons"
+import { TaskDeskMessageContent } from "./taskdesk-message-content"
 import { UniversalWorkspace } from "./universal-workspace"
 
 const REFRESH_MS = 10_000
@@ -178,23 +180,6 @@ function formatDate(value: string | undefined, t: TaskDeskTranslator): string {
   return Number.isFinite(timestamp)
     ? new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(timestamp)
     : value
-}
-
-function extractText(message: MessageEnvelope): string {
-  return message.parts
-    .filter((part) => part.type === "text" && part.text)
-    .map((part) => part.text || "")
-    .join("\n")
-    .trim()
-}
-
-function latestAssistantText(messages: MessageEnvelope[]): string {
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    if (messages[index].info.role === "user") continue
-    const text = extractText(messages[index])
-    if (text) return text
-  }
-  return ""
 }
 
 function taskWorkspaceLabel(task: ProductTask, t: TaskDeskTranslator): string {
@@ -594,16 +579,12 @@ function RunReviewModal({
         {loading ? <div className="td3-detail-loading"><LoadingIcon size={22} /><strong>{t("runs.archiveLoading")}</strong></div> : null}
         {!loading && error ? <div className="td3-inline-error" role="alert">{error}</div> : null}
         {!loading && !error && messages.length === 0 ? <div className="td3-empty-state"><span>{t("conversation.empty")}</span></div> : null}
-        {!loading && !error ? messages.map((message) => {
-          const text = extractText(message)
-          if (!text) return null
-          return (
-            <article key={message.info.id} className={message.info.role === "user" ? "user" : "assistant"}>
-              <header><strong>{message.info.role === "user" ? t("conversation.you") : agent?.label || t("conversation.agent")}</strong></header>
-              <div className="td3-markdown"><ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{text}</ReactMarkdown></div>
-            </article>
-          )
-        }) : null}
+        {!loading && !error ? messages.map((message) => (
+          <article key={message.info.id} className={message.info.role === "user" ? "user" : "assistant"}>
+            <header><strong>{message.info.role === "user" ? t("conversation.you") : agent?.label || t("conversation.agent")}</strong></header>
+            <TaskDeskMessageContent message={message} />
+          </article>
+        )) : null}
       </div>
       <footer>
         <button type="button" className="td3-button" onClick={onClose}>{t("nav.close")}</button>
@@ -1082,7 +1063,10 @@ export function TaskDeskV3Unified({ machines, activeMachineID, onActiveMachineID
   const selectedAgent = selected?.runtime.agents.find((agent) => agent.id === selected.task.agentId)
   const selectedSessionID = selected ? runSessionID(selected.task.run) : null
   const detailReady = Boolean(selected && detail.ownerKey === selected.key && !detail.loading)
-  const summary = detailReady ? latestAssistantText(detail.messages) : ""
+  const summary = selected?.task.run?.outcome
+    || (detailReady && selected
+      ? assistantTerminalTextForPrompt(detail.messages, selected.task.run?.prompt || selected.task.prompt)
+      : "")
   const sessionProfiles = useMemo(
     () => machineScope === "all" ? machines : machines.filter((machine) => machine.id === machineScope),
     [machines, machineScope]
@@ -1553,15 +1537,12 @@ export function TaskDeskV3Unified({ machines, activeMachineID, onActiveMachineID
                     ) : null}
                     {!detail.loading && detailTab === "conversation" ? (
                       <div className="td3-conversation">
-                        {detail.messages.length === 0 ? <div className="td3-empty-state"><span>{t("conversation.empty")}</span></div> : detail.messages.map((message) => {
-                          const text = extractText(message)
-                          return text ? (
-                            <article key={message.info.id} className={message.info.role === "user" ? "user" : "assistant"}>
-                              <header><strong>{message.info.role === "user" ? t("conversation.you") : selectedAgent?.label || t("conversation.agent")}</strong></header>
-                              <div className="td3-markdown"><ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{text}</ReactMarkdown></div>
-                            </article>
-                          ) : null
-                        })}
+                        {detail.messages.length === 0 ? <div className="td3-empty-state"><span>{t("conversation.empty")}</span></div> : detail.messages.map((message) => (
+                          <article key={message.info.id} className={message.info.role === "user" ? "user" : "assistant"}>
+                            <header><strong>{message.info.role === "user" ? t("conversation.you") : selectedAgent?.label || t("conversation.agent")}</strong></header>
+                            <TaskDeskMessageContent message={message} />
+                          </article>
+                        ))}
                       </div>
                     ) : null}
                     {!detail.loading && detailTab === "diff" ? (

--- a/web/src/components/universal-workspace.tsx
+++ b/web/src/components/universal-workspace.tsx
@@ -1,9 +1,8 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
-import ReactMarkdown from "react-markdown"
-import remarkGfm from "remark-gfm"
 import { api, isValidServerConfig } from "../api"
 import { backendDisplayName } from "../backendSetup"
 import { discoverMachine, selectableMachineAgents } from "../machineClient"
+import { messageText } from "../message-content"
 import { taskClient, type MachineProject } from "../taskClient"
 import type { SavedServerProfile } from "../serverProfiles"
 import { createTaskDeskTranslator, type TaskDeskTranslator } from "../taskdesk-i18n"
@@ -38,8 +37,8 @@ import {
   SettingsIcon,
   StopCircleIcon
 } from "../Icons"
+import { TaskDeskMessageContent } from "./taskdesk-message-content"
 
-const REMARK_PLUGINS = [remarkGfm]
 const REFRESH_INTERVAL_MS = 10_000
 const DETAIL_REFRESH_INTERVAL_MS = 5_000
 const AGENT_SESSION_LOAD_TIMEOUT_MS = 12_000
@@ -202,14 +201,6 @@ function formatClock(timestamp: number): string {
   return new Intl.DateTimeFormat(undefined, { hour: "2-digit", minute: "2-digit" }).format(timestamp)
 }
 
-function extractText(message: MessageEnvelope): string {
-  return message.parts
-    .filter((part) => part.type === "text" && part.text)
-    .map((part) => part.text || "")
-    .join("\n")
-    .trim()
-}
-
 function modelLabel(model?: Session["model"] | ModelSelection | null): string {
   if (!model) return "Default model"
   const candidate = "modelID" in model ? model.modelID : model.id
@@ -347,39 +338,6 @@ function Modal({
   )
 }
 
-function ToolCard({ message }: { message: MessageEnvelope }) {
-  const tools = message.parts.filter((part) => part.type === "tool")
-  if (!tools.length) return null
-  return (
-    <div className="uw-tool-stack">
-      {tools.map((part) => {
-        const state = part.state
-        const status = state?.status || "running"
-        const input = state?.input || {}
-        const command = typeof input.command === "string"
-          ? input.command
-          : typeof input.filePath === "string"
-            ? input.filePath
-            : typeof input.path === "string"
-              ? input.path
-              : ""
-        const output = state?.error || state?.output || ""
-        return (
-          <details key={part.id} className={`uw-tool-card uw-tool-${status}`} open={status === "error"}>
-            <summary>
-              <span className="uw-tool-icon">{status === "completed" ? "✓" : status === "error" ? "!" : "⋯"}</span>
-              <span className="uw-tool-title">{state?.title || part.tool || "Tool"}</span>
-              {command ? <code>{command.length > 90 ? `${command.slice(0, 90)}…` : command}</code> : null}
-              <span className="uw-tool-status">{status}</span>
-            </summary>
-            {output ? <pre>{output.length > 4_000 ? `${output.slice(0, 4_000)}\n…` : output}</pre> : null}
-          </details>
-        )
-      })}
-    </div>
-  )
-}
-
 function HarnessAvatar({ backend, label }: { backend: string; label: string }) {
   const [failed, setFailed] = useState(false)
   const source = harnessIconUrl(backend)
@@ -394,7 +352,6 @@ function HarnessAvatar({ backend, label }: { backend: string; label: string }) {
 
 const MessageBubble = memo(function MessageBubble({ message, agentLabel, agentBackend }: { message: MessageEnvelope; agentLabel: string; agentBackend: string }) {
   const isUser = message.info.role === "user"
-  const text = extractText(message)
   return (
     <article className={`uw-message ${isUser ? "uw-message-user" : "uw-message-agent"}`}>
       {isUser ? (
@@ -407,12 +364,7 @@ const MessageBubble = memo(function MessageBubble({ message, agentLabel, agentBa
           <strong>{isUser ? "You" : agentLabel}</strong>
           <time>{formatClock(message.info.time.created)}</time>
         </header>
-        {text ? (
-          <div className="uw-markdown">
-            <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{text}</ReactMarkdown>
-          </div>
-        ) : null}
-        <ToolCard message={message} />
+        <TaskDeskMessageContent message={message} />
       </div>
     </article>
   )
@@ -746,7 +698,7 @@ function HandoffModal({
       const config = configForAgent(selected.machine, selected.agent)
       const transcript = messages.slice(-10).map((message) => {
         const role = message.info.role === "user" ? "User" : current.agent.label
-        const text = extractText(message)
+        const text = messageText(message)
         return text ? `${role}: ${text}` : ""
       }).filter(Boolean).join("\n\n")
       const prompt = [
@@ -1033,10 +985,6 @@ export function UniversalWorkspace({
       collected.sort((left, right) => right.session.time.updated - left.session.time.updated)
       setMachines(nextMachines)
       setSessions(collected)
-      // A focus request is a one-shot instruction. Re-applying it on every refresh is what made a
-      // manual Session choice snap back to whichever Session a Task or attention item last opened,
-      // for the rest of the session. The pending check honours it during the first refresh that can
-      // see the target — which is why it is here at all — and never again after it is applied.
       const pendingFocus = focusSessionRequest && appliedFocusRequest.current !== focusSessionRequest.requestID
         ? focusSessionRequest
         : null

--- a/web/src/message-content.ts
+++ b/web/src/message-content.ts
@@ -12,6 +12,7 @@ export function messageText(message: MessageEnvelope): string {
  * Return only the natural-language answer emitted after the last reasoning/tool activity in a
  * native message. Some ACP harnesses keep narration, reasoning, tool calls and the final answer in
  * one message, so concatenating every text part puts pre-tool narration into the Task result.
+ * Non-conversational parts such as files do not erase an otherwise valid final answer.
  */
 export function terminalMessageText(message: MessageEnvelope): string {
   const chunks: string[] = []
@@ -26,6 +27,7 @@ export function terminalMessageText(message: MessageEnvelope): string {
       foundText = true
       continue
     }
+    if (part.type !== "reasoning" && part.type !== "tool") continue
     if (foundText) break
     return ""
   }

--- a/web/src/message-content.ts
+++ b/web/src/message-content.ts
@@ -44,3 +44,30 @@ export function latestAssistantTerminalText(messages: MessageEnvelope[]): string
   }
   return ""
 }
+
+/**
+ * Recover the terminal answer for a particular Task run from a Session that may have been continued
+ * manually afterwards. The matching user prompt is the turn boundary, so later Session-only work
+ * cannot become the Task's result summary.
+ */
+export function assistantTerminalTextForPrompt(messages: MessageEnvelope[], prompt: string): string {
+  const expected = prompt.trim()
+  if (!expected) return ""
+
+  for (let userIndex = messages.length - 1; userIndex >= 0; userIndex -= 1) {
+    const user = messages[userIndex]
+    if (user.info.role !== "user" || messageText(user) !== expected) continue
+
+    let latest = ""
+    for (let index = userIndex + 1; index < messages.length; index += 1) {
+      const message = messages[index]
+      if (message.info.role === "user") break
+      if (message.info.role !== "assistant") continue
+      const text = terminalMessageText(message)
+      if (text) latest = text
+    }
+    return latest
+  }
+
+  return ""
+}

--- a/web/src/message-content.ts
+++ b/web/src/message-content.ts
@@ -8,49 +8,57 @@ export function messageText(message: MessageEnvelope): string {
     .trim()
 }
 
-/**
- * Return only the natural-language answer emitted after the last reasoning/tool activity in a
- * native message. Some ACP harnesses keep narration, reasoning, tool calls and the final answer in
- * one message, so concatenating every text part puts pre-tool narration into the Task result.
- * Non-conversational parts such as files do not erase an otherwise valid final answer.
- */
-export function terminalMessageText(message: MessageEnvelope): string {
+function terminalAssistantText(messages: MessageEnvelope[], start: number, end: number): string {
   const chunks: string[] = []
   let foundText = false
 
-  for (let index = message.parts.length - 1; index >= 0; index -= 1) {
-    const part = message.parts[index]
-    if (part.type === "text") {
-      const text = typeof part.text === "string" ? part.text.trim() : ""
-      if (!text) continue
-      chunks.push(part.text || "")
-      foundText = true
-      continue
+  for (let messageIndex = end - 1; messageIndex >= start; messageIndex -= 1) {
+    const message = messages[messageIndex]
+    if (message.info.role !== "assistant") continue
+
+    for (let partIndex = message.parts.length - 1; partIndex >= 0; partIndex -= 1) {
+      const part = message.parts[partIndex]
+      if (part.type === "text") {
+        const text = typeof part.text === "string" ? part.text.trim() : ""
+        if (!text) continue
+        chunks.push(part.text || "")
+        foundText = true
+        continue
+      }
+      if (part.type !== "reasoning" && part.type !== "tool") continue
+      if (foundText) return chunks.reverse().join("\n").trim()
+      return ""
     }
-    if (part.type !== "reasoning" && part.type !== "tool") continue
-    if (foundText) break
-    return ""
   }
 
   return chunks.reverse().join("\n").trim()
 }
 
+/**
+ * Return only the natural-language answer emitted after the last reasoning/tool activity in one
+ * native message. Non-conversational parts such as files do not erase an otherwise valid answer.
+ */
+export function terminalMessageText(message: MessageEnvelope): string {
+  return terminalAssistantText([message], 0, 1)
+}
+
 /** Never cross the latest user turn when looking for the result of the current turn. */
 export function latestAssistantTerminalText(messages: MessageEnvelope[]): string {
+  let start = 0
   for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index]
-    if (message.info.role === "user") break
-    if (message.info.role !== "assistant") continue
-    const text = terminalMessageText(message)
-    if (text) return text
+    if (messages[index].info.role === "user") {
+      start = index + 1
+      break
+    }
   }
-  return ""
+  return terminalAssistantText(messages, start, messages.length)
 }
 
 /**
  * Recover the terminal answer for a particular Task run from a Session that may have been continued
  * manually afterwards. The matching user prompt is the turn boundary, so later Session-only work
- * cannot become the Task's result summary.
+ * cannot become the Task's result summary. The scan covers the whole assistant turn because some
+ * adapters split narration, tools and final text into separate native message envelopes.
  */
 export function assistantTerminalTextForPrompt(messages: MessageEnvelope[], prompt: string): string {
   const expected = prompt.trim()
@@ -60,15 +68,14 @@ export function assistantTerminalTextForPrompt(messages: MessageEnvelope[], prom
     const user = messages[userIndex]
     if (user.info.role !== "user" || messageText(user) !== expected) continue
 
-    let latest = ""
+    let end = messages.length
     for (let index = userIndex + 1; index < messages.length; index += 1) {
-      const message = messages[index]
-      if (message.info.role === "user") break
-      if (message.info.role !== "assistant") continue
-      const text = terminalMessageText(message)
-      if (text) latest = text
+      if (messages[index].info.role === "user") {
+        end = index
+        break
+      }
     }
-    return latest
+    return terminalAssistantText(messages, userIndex + 1, end)
   }
 
   return ""

--- a/web/src/message-content.ts
+++ b/web/src/message-content.ts
@@ -1,0 +1,46 @@
+import type { MessageEnvelope } from "./types"
+
+export function messageText(message: MessageEnvelope): string {
+  return message.parts
+    .filter((part) => part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text || "")
+    .join("\n")
+    .trim()
+}
+
+/**
+ * Return only the natural-language answer emitted after the last reasoning/tool activity in a
+ * native message. Some ACP harnesses keep narration, reasoning, tool calls and the final answer in
+ * one message, so concatenating every text part puts pre-tool narration into the Task result.
+ */
+export function terminalMessageText(message: MessageEnvelope): string {
+  const chunks: string[] = []
+  let foundText = false
+
+  for (let index = message.parts.length - 1; index >= 0; index -= 1) {
+    const part = message.parts[index]
+    if (part.type === "text") {
+      const text = typeof part.text === "string" ? part.text.trim() : ""
+      if (!text) continue
+      chunks.push(part.text || "")
+      foundText = true
+      continue
+    }
+    if (foundText) break
+    return ""
+  }
+
+  return chunks.reverse().join("\n").trim()
+}
+
+/** Never cross the latest user turn when looking for the result of the current turn. */
+export function latestAssistantTerminalText(messages: MessageEnvelope[]): string {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (message.info.role === "user") break
+    if (message.info.role !== "assistant") continue
+    const text = terminalMessageText(message)
+    if (text) return text
+  }
+  return ""
+}

--- a/web/src/taskClient.ts
+++ b/web/src/taskClient.ts
@@ -32,6 +32,7 @@ export type MachineTaskRun = {
   transport?: string | null
   directory?: string
   prompt?: string
+  outcome?: string
   startedAt?: string
   finishedAt?: string
 }

--- a/web/src/taskClient.ts
+++ b/web/src/taskClient.ts
@@ -33,6 +33,7 @@ export type MachineTaskRun = {
   directory?: string
   prompt?: string
   outcome?: string
+  outcomeVersion?: number
   startedAt?: string
   finishedAt?: string
 }
@@ -208,6 +209,20 @@ function requireModelCatalog(value: unknown, path: string): AgentModelCatalog {
   }
 }
 
+function trustVersionedOutcome(run: MachineTaskRun): MachineTaskRun {
+  return typeof run.outcome === "string" && run.outcomeVersion !== 2
+    ? { ...run, outcome: undefined }
+    : run
+}
+
+function normalizeTaskOutcomes(task: MachineTask): MachineTask {
+  return {
+    ...task,
+    run: task.run ? trustVersionedOutcome(task.run) : null,
+    ...(Array.isArray(task.runs) ? { runs: task.runs.map(trustVersionedOutcome) } : {})
+  }
+}
+
 export const taskClient = {
   async listProjects(config: ServerConfig): Promise<MachineProject[]> {
     const payload = await machineRequest<unknown>(config, "/v1/projects")
@@ -216,7 +231,7 @@ export const taskClient = {
 
   async listTasks(config: ServerConfig): Promise<MachineTask[]> {
     const payload = await machineRequest<unknown>(config, "/v1/tasks")
-    return requireArray<MachineTask>(payload, "tasks", "/v1/tasks")
+    return requireArray<MachineTask>(payload, "tasks", "/v1/tasks").map(normalizeTaskOutcomes)
   },
 
   async listAgentModels(config: ServerConfig, agentId: string): Promise<AgentModelCatalog> {

--- a/web/src/taskdesk-composer-performance.test.mjs
+++ b/web/src/taskdesk-composer-performance.test.mjs
@@ -2,11 +2,12 @@ import assert from "node:assert/strict"
 import { readFileSync } from "node:fs"
 import test from "node:test"
 
-test("Session composer typing does not rerender every Markdown message", () => {
+test("Session composer typing does not rerender every ordered message", () => {
   const workspace = readFileSync(new URL("./components/universal-workspace.tsx", import.meta.url), "utf8")
 
   assert.match(workspace, /import \{ memo, useCallback/)
+  assert.match(workspace, /import \{ TaskDeskMessageContent \} from "\.\/taskdesk-message-content"/)
   assert.match(workspace, /const MessageBubble = memo\(function MessageBubble/)
-  assert.match(workspace, /<ReactMarkdown remarkPlugins=\{REMARK_PLUGINS\}>\{text\}<\/ReactMarkdown>/)
+  assert.match(workspace, /<TaskDeskMessageContent message=\{message\} \/>/)
   assert.match(workspace, /value=\{composer\}[\s\S]*?onChange=\{\(event\) => setComposer\(event\.target\.value\)\}/)
 })

--- a/web/src/taskdesk-message-order.test.mjs
+++ b/web/src/taskdesk-message-order.test.mjs
@@ -78,3 +78,10 @@ test("TaskDesk renderer preserves native part order instead of regrouping text a
   assert.match(renderer, /part\.type === "reasoning"/)
   assert.match(renderer, /part\.type === "tool"/)
 })
+
+test("legacy unversioned persisted outcomes fall back to transcript reconstruction", () => {
+  const client = readFileSync(new URL("./taskClient.ts", import.meta.url), "utf8")
+  assert.match(client, /outcomeVersion\?: number/)
+  assert.match(client, /run\.outcomeVersion !== 2/)
+  assert.match(client, /\{ \.\.\.run, outcome: undefined \}/)
+})

--- a/web/src/taskdesk-message-order.test.mjs
+++ b/web/src/taskdesk-message-order.test.mjs
@@ -38,6 +38,25 @@ test("latest terminal result never crosses the latest user turn", () => {
   assert.equal(latestAssistantTerminalText(transcript), "")
 })
 
+test("tool activity in a later assistant envelope blocks earlier narration", () => {
+  const transcript = [
+    message("user-1", "user", [{ type: "text", text: "Fix it" }]),
+    message("assistant-text", "assistant", [{ type: "text", text: "I will inspect it." }]),
+    message("assistant-tool", "assistant", [{ type: "tool", tool: "Edit", state: { status: "completed" } }])
+  ]
+  assert.equal(latestAssistantTerminalText(transcript), "")
+})
+
+test("final text in a later assistant envelope wins after tool activity", () => {
+  const transcript = [
+    message("user-1", "user", [{ type: "text", text: "Fix it" }]),
+    message("assistant-text", "assistant", [{ type: "text", text: "I will inspect it." }]),
+    message("assistant-tool", "assistant", [{ type: "tool", tool: "Edit", state: { status: "completed" } }]),
+    message("assistant-final", "assistant", [{ type: "text", text: "The fix is complete." }])
+  ]
+  assert.equal(latestAssistantTerminalText(transcript), "The fix is complete.")
+})
+
 test("Task summary stays attached to its Run prompt after the Session is continued manually", () => {
   const transcript = [
     message("task-user", "user", [{ type: "text", text: "Fix the TaskDesk UI" }]),

--- a/web/src/taskdesk-message-order.test.mjs
+++ b/web/src/taskdesk-message-order.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+import {
+  assistantTerminalTextForPrompt,
+  latestAssistantTerminalText,
+  terminalMessageText
+} from "./message-content.ts"
+
+function message(id, role, parts) {
+  return {
+    info: { id, role, sessionID: "session-1", time: { created: 1 } },
+    parts: parts.map((part, index) => ({ id: `${id}:${index}`, ...part }))
+  }
+}
+
+const claudeStyleReply = message("assistant-1", "assistant", [
+  { type: "text", text: "I will inspect the UI first." },
+  { type: "reasoning", text: "Need to find the relevant component." },
+  { type: "tool", tool: "Read", state: { status: "completed" } },
+  { type: "text", text: "Fixed the UI glitch and opened PR #276." }
+])
+
+test("terminal result keeps only text after the last reasoning/tool activity", () => {
+  assert.equal(terminalMessageText(claudeStyleReply), "Fixed the UI glitch and opened PR #276.")
+})
+
+test("latest terminal result never crosses the latest user turn", () => {
+  const transcript = [
+    message("user-1", "user", [{ type: "text", text: "First task" }]),
+    claudeStyleReply,
+    message("user-2", "user", [{ type: "text", text: "Second task" }]),
+    message("assistant-2", "assistant", [
+      { type: "text", text: "Working on it." },
+      { type: "tool", tool: "Edit", state: { status: "completed" } }
+    ])
+  ]
+  assert.equal(latestAssistantTerminalText(transcript), "")
+})
+
+test("Task summary stays attached to its Run prompt after the Session is continued manually", () => {
+  const transcript = [
+    message("task-user", "user", [{ type: "text", text: "Fix the TaskDesk UI" }]),
+    claudeStyleReply,
+    message("manual-user", "user", [{ type: "text", text: "Now refactor something else" }]),
+    message("manual-assistant", "assistant", [{ type: "text", text: "The unrelated refactor is complete." }])
+  ]
+
+  assert.equal(
+    assistantTerminalTextForPrompt(transcript, "Fix the TaskDesk UI"),
+    "Fixed the UI glitch and opened PR #276."
+  )
+})
+
+test("TaskDesk renderer preserves native part order instead of regrouping text and tools", () => {
+  const renderer = readFileSync(new URL("./components/taskdesk-message-content.tsx", import.meta.url), "utf8")
+  assert.match(renderer, /message\.parts\.map\(\(part\) => \{/)
+  assert.match(renderer, /part\.type === "text"/)
+  assert.match(renderer, /part\.type === "reasoning"/)
+  assert.match(renderer, /part\.type === "tool"/)
+})


### PR DESCRIPTION
## Summary

Fix TaskDesk rendering and Task result extraction for harnesses that interleave narration, reasoning, tool activity, and a final answer inside one native assistant message.

### What changed

- render `MessageEnvelope.parts` in native wire order in the Session transcript
- use the same ordered renderer in Task Conversation and archived Run Review
- keep reasoning and tool cards in their real position relative to assistant text
- persist only the terminal natural-language answer after the last reasoning/tool activity as a Run outcome
- expose persisted `run.outcome` to the web client and prefer it for Task Result Summary
- for older Runs without a persisted outcome, recover the answer from the user turn matching that Run's prompt so later manual Session work cannot replace the Task summary
- keep message and part IDs intact
- keep Session message bubbles memoized so the composer performance fix is preserved

### Regression coverage

- Claude-style `intro -> reasoning -> tool -> final answer`
- no final answer after a tool does not promote pre-tool narration
- non-conversational file parts do not erase a valid final answer
- a Session continued manually after the Task Run does not replace that Task's summary
- ordered renderer source guard
- composer memoization guard updated for the ordered renderer

### Claude stderr seen during reproduction

The reported `vcs_state_changed` and `code_change_published` `Unexpected case` lines come from the pinned Claude ACP adapter seeing newer Claude Code system events. They do not enter the ACP transcript and are not the cause of this ordering bug. This PR intentionally does not upgrade `@agentclientprotocol/claude-agent-acp` so adapter-version changes can be validated separately.

Base is `v3/taskdesk`. No changes target `main`.