### PR TITLE
feat(taskdesk): add intelligent Continue and handoff UX

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -26,7 +26,7 @@
     "cap:sync": "npx cap sync",
     "cap:sync:android": "npx cap sync android && node scripts/sync-native-live-events.mjs",
     "cap:add:android": "npx cap add android",
-    "test:ui": "node src/ui-regression.test.mjs && node --experimental-strip-types src/taskdesk-home.test.mjs && node src/taskdesk-performance.test.mjs && node --experimental-strip-types src/taskdesk-message-paging.test.mjs && node src/taskdesk-live-event-routing.test.mjs && node src/taskdesk-composer-performance.test.mjs && node --experimental-strip-types src/taskdesk-message-order.test.mjs && node src/taskdesk-appearance.test.mjs",
+    "test:ui": "node src/ui-regression.test.mjs && node --experimental-strip-types src/taskdesk-home.test.mjs && node src/taskdesk-performance.test.mjs && node --experimental-strip-types src/taskdesk-message-paging.test.mjs && node src/taskdesk-live-event-routing.test.mjs && node src/taskdesk-composer-performance.test.mjs && node --experimental-strip-types src/taskdesk-message-order.test.mjs && node --experimental-strip-types src/taskdesk-continue-handoff.test.mjs && node src/taskdesk-appearance.test.mjs",
     "test:settings": "node src/settings-regression.test.mjs && node src/v3-ux-polish-regression.test.mjs",
     "test:model": "node src/model-regression.test.mjs",
     "test:events": "node --experimental-strip-types src/opencode-events.test.mjs",

--- a/web/src/components/taskdesk-intelligent-continue.tsx
+++ b/web/src/components/taskdesk-intelligent-continue.tsx
@@ -110,6 +110,13 @@ export function IntelligentContinueTaskModal({
 
   const reusableRun = useMemo(() => latestReusableRun(record.task, agentID), [record.task, agentID])
   const reusableSessionID = runSessionID(reusableRun)
+  const selectedAgent = useMemo(
+    () => record.runtime.agents.find((agent) => agent.id === agentID) || null,
+    [record.runtime.agents, agentID]
+  )
+  const targetAgentAvailable = Boolean(
+    selectedAgent && (selectedAgent.state === "available" || selectedAgent.state === "configured")
+  )
 
   useEffect(() => {
     let cancelled = false
@@ -172,6 +179,7 @@ export function IntelligentContinueTaskModal({
   const canStart = Boolean(
     prompt.trim()
     && agentID
+    && targetAgentAvailable
     && roleValue
     && !working
     && !modelsLoading
@@ -270,6 +278,7 @@ export function IntelligentContinueTaskModal({
             </label>
           ) : null}
 
+          {!targetAgentAvailable ? <div className="td3-inline-warning td3-continue-wide">{t("detail.unavailable")}</div> : null}
           {!reusableRun ? <div className="td3-inline-warning td3-continue-wide">{copy.noReusableSession}</div> : null}
           {reusableSessionID ? <p className="td3-continue-model-note td3-continue-wide">{copy.reuseSession}: {reusableSessionID}</p> : null}
 

--- a/web/src/components/taskdesk-intelligent-continue.tsx
+++ b/web/src/components/taskdesk-intelligent-continue.tsx
@@ -1,0 +1,344 @@
+import { useEffect, useMemo, useRef, useState, type ComponentType } from "react"
+import type { LanguageCode } from "../i18n"
+import {
+  taskClient,
+  type MachineTask,
+  type MachineTaskRun,
+  type TaskContext
+} from "../taskClient"
+import { taskDeskContinueCopy } from "../taskdesk-continue-i18n"
+import type { TaskDeskTranslator } from "../taskdesk-i18n"
+import type { MachineAgentHost, ModelOption, ModelSelection } from "../types"
+import type { WorkspaceMachine } from "../workspaceMachines"
+import { LoadingIcon } from "../Icons"
+import "../taskdesk-continue.css"
+
+type ContinueRecord = {
+  runtime: {
+    machine: WorkspaceMachine
+    agents: MachineAgentHost[]
+  }
+  task: MachineTask & { finishedAt?: string | null }
+}
+
+type Props = {
+  record: ContinueRecord
+  language: LanguageCode
+  t: TaskDeskTranslator
+  onClose: () => void
+  onContinued: (task: MachineTask) => void
+  legacyFallback?: ComponentType<any>
+}
+
+const ROLE_OPTIONS = ["continue", "review", "test", "debug", "refactor", "investigate", "custom"] as const
+type RoleOption = typeof ROLE_OPTIONS[number]
+
+function runSessionID(run?: MachineTaskRun | null): string | null {
+  return run?.sessionId || run?.sessionID || null
+}
+
+function taskRuns(task: MachineTask): MachineTaskRun[] {
+  if (Array.isArray(task.runs) && task.runs.length) return task.runs
+  return task.run ? [task.run] : []
+}
+
+function runAgent(task: MachineTask, run: MachineTaskRun): string {
+  return run.agentId || task.agentId
+}
+
+function latestReusableRun(task: MachineTask, agentID: string): MachineTaskRun | null {
+  const runs = taskRuns(task)
+  for (let index = runs.length - 1; index >= 0; index -= 1) {
+    const run = runs[index]
+    if (runAgent(task, run) === agentID && runSessionID(run)) return run
+  }
+  return null
+}
+
+function latestModelForAgent(task: MachineTask, agentID: string): ModelSelection | null {
+  const runs = taskRuns(task)
+  for (let index = runs.length - 1; index >= 0; index -= 1) {
+    const run = runs[index]
+    if (runAgent(task, run) === agentID && run.model) return run.model
+  }
+  return agentID === task.agentId ? task.model || null : null
+}
+
+function modelKey(model: Pick<ModelSelection, "providerID" | "modelID" | "variant">): string {
+  return `${model.providerID}|${model.modelID}|${model.variant || ""}`
+}
+
+function selectedModel(models: ModelOption[], key: string): ModelOption | undefined {
+  return models.find((model) => modelKey(model) === key)
+}
+
+function roleLabel(role: RoleOption, copy: ReturnType<typeof taskDeskContinueCopy>): string {
+  if (role === "continue") return copy.roleContinue
+  if (role === "review") return copy.roleReview
+  if (role === "test") return copy.roleTest
+  if (role === "debug") return copy.roleDebug
+  if (role === "refactor") return copy.roleRefactor
+  if (role === "investigate") return copy.roleInvestigate
+  return copy.roleCustom
+}
+
+export function IntelligentContinueTaskModal({
+  record,
+  language,
+  t,
+  onClose,
+  onContinued,
+  legacyFallback: LegacyFallback
+}: Props) {
+  const copy = useMemo(() => taskDeskContinueCopy(language), [language])
+  const initialAgentID = record.task.run?.agentId || record.task.agentId || record.runtime.agents[0]?.id || ""
+  const [agentID, setAgentID] = useState(initialAgentID)
+  const [models, setModels] = useState<ModelOption[]>([])
+  const [modelKeyValue, setModelKeyValue] = useState("")
+  const [modelsLoading, setModelsLoading] = useState(false)
+  const [context, setContext] = useState<TaskContext | null>(null)
+  const [contextLoading, setContextLoading] = useState(true)
+  const [contextError, setContextError] = useState<string | null>(null)
+  const [legacyMode, setLegacyMode] = useState(false)
+  const [role, setRole] = useState<RoleOption>("continue")
+  const [customRole, setCustomRole] = useState("")
+  const [mode, setMode] = useState<"resume" | "fresh">(() => latestReusableRun(record.task, initialAgentID) ? "resume" : "fresh")
+  const [prompt, setPrompt] = useState("")
+  const [working, setWorking] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const modelGeneration = useRef(0)
+
+  const targetAgent = record.runtime.agents.find((agent) => agent.id === agentID)
+  const reusableRun = useMemo(() => latestReusableRun(record.task, agentID), [record.task, agentID])
+  const reusableSessionID = runSessionID(reusableRun)
+
+  useEffect(() => {
+    let cancelled = false
+    setContextLoading(true)
+    setContextError(null)
+    void taskClient.loadContext(record.runtime.machine.config, record.task.id).then((loaded) => {
+      if (!cancelled) setContext(loaded)
+    }).catch((reason) => {
+      if (cancelled) return
+      const message = reason instanceof Error ? reason.message : String(reason)
+      const compatibleFallback = /HTTP 404|incompatible response/i.test(message)
+      if (compatibleFallback && LegacyFallback) setLegacyMode(true)
+      else setContextError(message)
+    }).finally(() => {
+      if (!cancelled) setContextLoading(false)
+    })
+    return () => { cancelled = true }
+  }, [record.runtime.machine.id, record.task.id, LegacyFallback])
+
+  useEffect(() => {
+    if (!agentID) {
+      setModels([])
+      setModelKeyValue("")
+      return
+    }
+    const generation = ++modelGeneration.current
+    const preferredModel = latestModelForAgent(record.task, agentID)
+    setModelsLoading(true)
+    setError(null)
+    void taskClient.listAgentModels(record.runtime.machine.config, agentID).then((catalog) => {
+      if (generation !== modelGeneration.current) return
+      setModels(catalog.models)
+      const preferred = preferredModel
+        ? catalog.models.find((model) => model.providerID === preferredModel.providerID
+          && model.modelID === preferredModel.modelID
+          && (model.variant || "") === (preferredModel.variant || ""))
+        : undefined
+      const next = preferred || catalog.models.find((model) => model.isDefault) || catalog.models[0]
+      setModelKeyValue(next ? modelKey(next) : "")
+    }).catch((reason) => {
+      if (generation !== modelGeneration.current) return
+      setModels([])
+      setModelKeyValue("")
+      setError(reason instanceof Error ? reason.message : String(reason))
+    }).finally(() => {
+      if (generation === modelGeneration.current) setModelsLoading(false)
+    })
+  }, [record.runtime.machine.id, record.task.id, agentID])
+
+  useEffect(() => {
+    setMode(reusableRun ? "resume" : "fresh")
+  }, [agentID, reusableRun?.id, reusableSessionID])
+
+  if (legacyMode && LegacyFallback) {
+    return <LegacyFallback record={record} t={t} onClose={onClose} onContinued={onContinued} />
+  }
+
+  const model = selectedModel(models, modelKeyValue)
+  const roleValue = role === "custom" ? customRole.trim() : role
+  const canStart = Boolean(
+    prompt.trim()
+    && agentID
+    && roleValue
+    && !working
+    && !modelsLoading
+    && !contextLoading
+    && context
+    && (mode === "fresh" || reusableRun)
+  )
+
+  async function submit() {
+    if (!canStart) return
+    setWorking(true)
+    setError(null)
+    try {
+      const input = {
+        prompt: prompt.trim(),
+        agentId: agentID,
+        role: roleValue,
+        mode,
+        ...(model ? { model: { providerID: model.providerID, modelID: model.modelID, variant: model.variant } } : {})
+      } as const
+      onContinued(await taskClient.continueTask(record.runtime.machine.config, record.task.id, input))
+      onClose()
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason))
+    } finally {
+      setWorking(false)
+    }
+  }
+
+  return (
+    <div className="td3-modal-backdrop" role="presentation" onMouseDown={onClose}>
+      <section
+        className="td3-modal td3-intelligent-continue"
+        role="dialog"
+        aria-modal="true"
+        aria-label={t("continue.title")}
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <header>
+          <div>
+            <small>{t("continue.eyebrow")}</small>
+            <h2>{t("continue.title")}</h2>
+            <p>{record.task.prompt.split(/\r?\n/)[0]}</p>
+          </div>
+          <button type="button" onClick={onClose} aria-label={t("nav.close")} title={t("nav.close")}>×</button>
+        </header>
+
+        <div className="td3-modal-body td3-continue-grid">
+          <label>
+            <span>{copy.targetHarness}</span>
+            <select value={agentID} onChange={(event) => setAgentID(event.target.value)}>
+              {record.runtime.agents.map((agent) => (
+                <option
+                  key={agent.id}
+                  value={agent.id}
+                  disabled={agent.state !== "available" && agent.state !== "configured"}
+                >
+                  {agent.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label>
+            <span>{copy.targetModel}</span>
+            <select value={modelKeyValue} onChange={(event) => setModelKeyValue(event.target.value)} disabled={modelsLoading || models.length === 0}>
+              {modelsLoading ? <option value="">{t("model.loading")}</option> : null}
+              {!modelsLoading && models.length === 0 ? <option value="">{t("model.agentDefault")}</option> : null}
+              {models.map((candidate) => (
+                <option key={modelKey(candidate)} value={modelKey(candidate)}>
+                  {candidate.modelName}{candidate.variant ? ` (${candidate.variant})` : ""}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label>
+            <span>{copy.role}</span>
+            <select value={role} onChange={(event) => setRole(event.target.value as RoleOption)}>
+              {ROLE_OPTIONS.map((candidate) => <option key={candidate} value={candidate}>{roleLabel(candidate, copy)}</option>)}
+            </select>
+          </label>
+
+          <label>
+            <span>{copy.sessionStrategy}</span>
+            <select value={mode} onChange={(event) => setMode(event.target.value as "resume" | "fresh")}>
+              {reusableRun ? <option value="resume">{copy.reuseSession}</option> : null}
+              <option value="fresh">{copy.freshSession}</option>
+            </select>
+          </label>
+
+          {role === "custom" ? (
+            <label className="td3-continue-wide">
+              <span>{copy.customRole}</span>
+              <input value={customRole} onChange={(event) => setCustomRole(event.target.value.slice(0, 80))} maxLength={80} />
+            </label>
+          ) : null}
+
+          {!reusableRun ? <div className="td3-inline-warning td3-continue-wide">{copy.noReusableSession}</div> : null}
+          {reusableSessionID ? <p className="td3-continue-model-note td3-continue-wide">{copy.reuseSession}: {reusableSessionID}</p> : null}
+
+          <details className="td3-continue-context" open>
+            <summary>
+              <strong>{copy.contextTitle}</strong>
+              <span>{context ? `${copy.contextRevision} ${context.revision}` : copy.contextLoading}</span>
+            </summary>
+            <div className="td3-continue-context-body">
+              <p className="td3-continue-context-note">{copy.transferredContext}</p>
+              {contextLoading ? <div className="td3-detail-loading"><LoadingIcon size={18} /><strong>{copy.contextLoading}</strong></div> : null}
+              {contextError ? <div className="td3-inline-error" role="alert">{contextError}</div> : null}
+              {context ? (
+                <>
+                  <div className="td3-continue-context-section">
+                    <small>{copy.objective}</small>
+                    <p>{context.objective}</p>
+                  </div>
+                  <div className="td3-continue-context-section">
+                    <small>{copy.currentState}</small>
+                    <p>{context.currentState}</p>
+                  </div>
+                  {context.latestOutcome ? (
+                    <div className="td3-continue-context-section">
+                      <small>{copy.latestOutcome}</small>
+                      <p>{context.latestOutcome.text || context.latestOutcome.error || `${context.latestOutcome.agentId} / ${context.latestOutcome.status}`}</p>
+                    </div>
+                  ) : null}
+                  <div className="td3-continue-context-section">
+                    <small>{copy.changedFiles} ({context.workspace.changeCount})</small>
+                    {context.changedFiles.length ? (
+                      <div className="td3-continue-file-list">
+                        {context.changedFiles.slice(0, 12).map((file) => <code key={file}>{file}</code>)}
+                        {context.workspace.truncated ? <span>+{Math.max(0, context.workspace.changeCount - context.changedFiles.length)}</span> : null}
+                      </div>
+                    ) : <p>{copy.noChanges}</p>}
+                  </div>
+                  <div className="td3-continue-context-section">
+                    <small>{copy.recentRuns} ({context.runCount})</small>
+                    <div className="td3-continue-run-list">
+                      {context.runSummaries.slice(-6).reverse().map((run, index) => (
+                        <span key={run.id || `${run.sequence || index}-${run.agentId}`}>
+                          #{run.sequence || "?"} {run.agentId} / {run.role} / {run.status}{run.outcome ? `: ${run.outcome.slice(0, 180)}` : ""}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                </>
+              ) : null}
+            </div>
+          </details>
+
+          <label className="td3-continue-wide">
+            <span>{t("continue.prompt")}</span>
+            <textarea rows={6} value={prompt} onChange={(event) => setPrompt(event.target.value)} placeholder={t("continue.placeholder")} />
+          </label>
+
+          {error ? <div className="td3-inline-error td3-continue-wide" role="alert">{error}</div> : null}
+        </div>
+
+        <footer>
+          <button type="button" className="td3-button" onClick={onClose}>{t("action.cancel")}</button>
+          <button type="button" className="td3-button primary" disabled={!canStart} onClick={() => void submit()}>
+            {working ? <LoadingIcon size={15} /> : null}
+            {working ? t("continue.starting") : t("continue.start")}
+          </button>
+        </footer>
+      </section>
+    </div>
+  )
+}

--- a/web/src/components/taskdesk-intelligent-continue.tsx
+++ b/web/src/components/taskdesk-intelligent-continue.tsx
@@ -108,7 +108,6 @@ export function IntelligentContinueTaskModal({
   const [error, setError] = useState<string | null>(null)
   const modelGeneration = useRef(0)
 
-  const targetAgent = record.runtime.agents.find((agent) => agent.id === agentID)
   const reusableRun = useMemo(() => latestReusableRun(record.task, agentID), [record.task, agentID])
   const reusableSessionID = runSessionID(reusableRun)
 

--- a/web/src/components/taskdesk-intelligent-continue.tsx
+++ b/web/src/components/taskdesk-intelligent-continue.tsx
@@ -278,7 +278,7 @@ export function IntelligentContinueTaskModal({
             </label>
           ) : null}
 
-          {!targetAgentAvailable ? <div className="td3-inline-warning td3-continue-wide">{t("detail.unavailable")}</div> : null}
+          {!targetAgentAvailable ? <div className="td3-inline-warning td3-continue-wide">{copy.targetUnavailable}</div> : null}
           {!reusableRun ? <div className="td3-inline-warning td3-continue-wide">{copy.noReusableSession}</div> : null}
           {reusableSessionID ? <p className="td3-continue-model-note td3-continue-wide">{copy.reuseSession}: {reusableSessionID}</p> : null}
 

--- a/web/src/components/taskdesk-v3-unified.tsx
+++ b/web/src/components/taskdesk-v3-unified.tsx
@@ -63,6 +63,7 @@ import {
   SparkIcon,
   TaskListIcon
 } from "../Icons"
+import { IntelligentContinueTaskModal } from "./taskdesk-intelligent-continue"
 import { TaskDeskMessageContent } from "./taskdesk-message-content"
 import { UniversalWorkspace } from "./universal-workspace"
 
@@ -1755,9 +1756,11 @@ export function TaskDeskV3Unified({ machines, activeMachineID, onActiveMachineID
         />
       ) : null}
       {continueOpen && selected ? (
-        <ContinueTaskModal
+        <IntelligentContinueTaskModal
           record={selected}
+          language={language}
           t={t}
+          legacyFallback={ContinueTaskModal}
           onClose={() => setContinueOpen(false)}
           onContinued={(task) => { setDetailTab("review"); void refreshAndReselect(task.id, selected.runtime.machine.id) }}
         />

--- a/web/src/taskClient.ts
+++ b/web/src/taskClient.ts
@@ -26,6 +26,11 @@ export type MachineTaskRun = {
   id?: string
   sequence?: number
   agentId?: string
+  model?: ModelSelection | null
+  role?: string
+  contextRevision?: number
+  handoffFromRunId?: string | null
+  resumedFromRunId?: string | null
   sessionId?: string | null
   sessionID?: string | null
   status?: string
@@ -53,6 +58,57 @@ export type MachineTask = {
   error?: { message?: string } | null
   createdAt: string
   updatedAt: string
+}
+
+export type TaskContextRunSummary = {
+  id?: string
+  sequence?: number
+  agentId: string
+  role: string
+  model?: ModelSelection
+  sessionId?: string
+  status: string
+  prompt: string
+  outcome?: string
+  startedAt?: string
+  finishedAt?: string
+  contextRevision?: number
+}
+
+export type TaskContext = {
+  version: number
+  revision: number
+  taskId: string
+  objective: string
+  currentState: string
+  latestOutcome: null | {
+    status: string
+    agentId: string
+    role: string
+    text?: string
+    error?: string
+  }
+  runSummaries: TaskContextRunSummary[]
+  runCount: number
+  latestRun: TaskContextRunSummary | null
+  changedFiles: string[]
+  workspace: {
+    dirty: boolean
+    changeCount: number
+    listedChangeCount: number
+    truncated: boolean
+  }
+  verification: unknown
+  unresolved: string[]
+}
+
+export type ContinueTaskInput = {
+  prompt: string
+  agentId?: string
+  model?: ModelSelection | null
+  role?: string
+  mode?: "fresh" | "resume"
+  fresh?: boolean
 }
 
 export type TaskWorkspaceInspection = {
@@ -251,8 +307,13 @@ export const taskClient = {
     return machineRequest<MachineTask>(config, `/v1/tasks/${encodeURIComponent(taskId)}/launch`, { method: "POST", body: {} })
   },
 
-  continueTask(config: ServerConfig, taskId: string, prompt: string): Promise<MachineTask> {
-    return machineRequest<MachineTask>(config, `/v1/tasks/${encodeURIComponent(taskId)}/continue`, { method: "POST", body: { prompt } })
+  loadContext(config: ServerConfig, taskId: string): Promise<TaskContext> {
+    return machineRequest<TaskContext>(config, `/v1/tasks/${encodeURIComponent(taskId)}/context`)
+  },
+
+  continueTask(config: ServerConfig, taskId: string, input: string | ContinueTaskInput): Promise<MachineTask> {
+    const body = typeof input === "string" ? { prompt: input } : input
+    return machineRequest<MachineTask>(config, `/v1/tasks/${encodeURIComponent(taskId)}/continue`, { method: "POST", body })
   },
 
   inspectResult(config: ServerConfig, taskId: string): Promise<TaskWorkspaceInspection> {

--- a/web/src/taskdesk-continue-handoff.test.mjs
+++ b/web/src/taskdesk-continue-handoff.test.mjs
@@ -28,6 +28,15 @@ test("TaskDesk Continue selects harness, live model, role and native Session str
   assert.match(modal, /providerID: model\.providerID, modelID: model\.modelID, variant: model\.variant/)
 })
 
+test("TaskDesk Continue cannot launch an unavailable or stale harness target", () => {
+  const modal = readFileSync(new URL("./components/taskdesk-intelligent-continue.tsx", import.meta.url), "utf8")
+
+  assert.match(modal, /record\.runtime\.agents\.find\(\(agent\) => agent\.id === agentID\)/)
+  assert.match(modal, /selectedAgent\.state === "available" \|\| selectedAgent\.state === "configured"/)
+  assert.match(modal, /&& targetAgentAvailable[\s\S]*?&& roleValue/)
+  assert.match(modal, /!targetAgentAvailable \? <div className="td3-inline-warning td3-continue-wide">\{t\("detail\.unavailable"\)\}<\/div>/)
+})
+
 test("TaskDesk Continue previews bounded context and keeps an older-daemon compatibility path", async () => {
   const shell = readFileSync(new URL("./components/taskdesk-v3-unified.tsx", import.meta.url), "utf8")
   const modal = readFileSync(new URL("./components/taskdesk-intelligent-continue.tsx", import.meta.url), "utf8")

--- a/web/src/taskdesk-continue-handoff.test.mjs
+++ b/web/src/taskdesk-continue-handoff.test.mjs
@@ -34,7 +34,7 @@ test("TaskDesk Continue cannot launch an unavailable or stale harness target", (
   assert.match(modal, /record\.runtime\.agents\.find\(\(agent\) => agent\.id === agentID\)/)
   assert.match(modal, /selectedAgent\.state === "available" \|\| selectedAgent\.state === "configured"/)
   assert.match(modal, /&& targetAgentAvailable[\s\S]*?&& roleValue/)
-  assert.match(modal, /!targetAgentAvailable \? <div className="td3-inline-warning td3-continue-wide">\{t\("detail\.unavailable"\)\}<\/div>/)
+  assert.match(modal, /!targetAgentAvailable \? <div className="td3-inline-warning td3-continue-wide">\{copy\.targetUnavailable\}<\/div>/)
 })
 
 test("TaskDesk Continue previews bounded context and keeps an older-daemon compatibility path", async () => {
@@ -57,6 +57,7 @@ test("TaskDesk Continue previews bounded context and keeps an older-daemon compa
   for (const language of ["en", "it", "zh-TW", "zh-CN"]) {
     const copy = taskDeskContinueCopy(language)
     assert.ok(copy.targetHarness.trim(), `${language} should translate the target harness label`)
+    assert.ok(copy.targetUnavailable.trim(), `${language} should explain an unavailable target harness`)
     assert.ok(copy.transferredContext.trim(), `${language} should explain transferred Task Context`)
     assert.ok(copy.reuseSession.trim() && copy.freshSession.trim(), `${language} should translate both Session strategies`)
   }

--- a/web/src/taskdesk-continue-handoff.test.mjs
+++ b/web/src/taskdesk-continue-handoff.test.mjs
@@ -28,10 +28,11 @@ test("TaskDesk Continue selects harness, live model, role and native Session str
   assert.match(modal, /providerID: model\.providerID, modelID: model\.modelID, variant: model\.variant/)
 })
 
-test("TaskDesk Continue previews bounded context and keeps an older-daemon compatibility path", () => {
+test("TaskDesk Continue previews bounded context and keeps an older-daemon compatibility path", async () => {
   const shell = readFileSync(new URL("./components/taskdesk-v3-unified.tsx", import.meta.url), "utf8")
   const modal = readFileSync(new URL("./components/taskdesk-intelligent-continue.tsx", import.meta.url), "utf8")
-  const copy = readFileSync(new URL("./taskdesk-continue-i18n.ts", import.meta.url), "utf8")
+  const copySource = readFileSync(new URL("./taskdesk-continue-i18n.ts", import.meta.url), "utf8")
+  const { taskDeskContinueCopy } = await import("./taskdesk-continue-i18n.ts")
 
   assert.match(shell, /<IntelligentContinueTaskModal/)
   assert.match(shell, /legacyFallback=\{ContinueTaskModal\}/)
@@ -43,8 +44,11 @@ test("TaskDesk Continue previews bounded context and keeps an older-daemon compa
   assert.match(modal, /context\.changedFiles\.slice\(0, 12\)/)
   assert.match(modal, /context\.runSummaries\.slice\(-6\)\.reverse\(\)/)
   assert.match(modal, /HTTP 404\|incompatible response/)
-  assert.match(copy, /It is not native conversational memory from another harness/)
+  assert.match(copySource, /It is not native conversational memory from another harness/)
   for (const language of ["en", "it", "zh-TW", "zh-CN"]) {
-    assert.match(copy, new RegExp(`(?:^|\\n)  ${JSON.stringify(language).replace(/["']/g, "\\\"")}|(?:^|\\n)  ${language === "en" || language === "it" ? language : `"${language}"`}:`), `localized Continue copy should include ${language}`)
+    const copy = taskDeskContinueCopy(language)
+    assert.ok(copy.targetHarness.trim(), `${language} should translate the target harness label`)
+    assert.ok(copy.transferredContext.trim(), `${language} should explain transferred Task Context`)
+    assert.ok(copy.reuseSession.trim() && copy.freshSession.trim(), `${language} should translate both Session strategies`)
   }
 })

--- a/web/src/taskdesk-continue-handoff.test.mjs
+++ b/web/src/taskdesk-continue-handoff.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+
+test("TaskDesk Continue consumes durable Task Context instead of synthesizing transcript context", () => {
+  const client = readFileSync(new URL("./taskClient.ts", import.meta.url), "utf8")
+  const modal = readFileSync(new URL("./components/taskdesk-intelligent-continue.tsx", import.meta.url), "utf8")
+
+  assert.match(client, /loadContext\(config: ServerConfig, taskId: string\)/)
+  assert.match(client, /\/v1\/tasks\/\$\{encodeURIComponent\(taskId\)\}\/context/)
+  assert.match(client, /continueTask\(config: ServerConfig, taskId: string, input: string \| ContinueTaskInput\)/)
+  assert.match(client, /const body = typeof input === "string" \? \{ prompt: input \} : input/)
+  assert.match(modal, /taskClient\.loadContext\(record\.runtime\.machine\.config, record\.task\.id\)/)
+  assert.doesNotMatch(modal, /api\.loadMessages|loadMessagePage/, "Continue must use daemon Task Context, not rebuild handoff context from a transcript")
+})
+
+test("TaskDesk Continue selects harness, live model, role and native Session strategy", () => {
+  const modal = readFileSync(new URL("./components/taskdesk-intelligent-continue.tsx", import.meta.url), "utf8")
+
+  assert.match(modal, /taskClient\.listAgentModels\(record\.runtime\.machine\.config, agentID\)/)
+  assert.match(modal, /latestReusableRun\(record\.task, agentID\)/)
+  assert.match(modal, /latestModelForAgent\(record\.task, agentID\)/)
+  assert.match(modal, /setMode\(reusableRun \? "resume" : "fresh"\)/)
+  assert.match(modal, /ROLE_OPTIONS = \["continue", "review", "test", "debug", "refactor", "investigate", "custom"\]/)
+  assert.match(modal, /agentId: agentID/)
+  assert.match(modal, /role: roleValue/)
+  assert.match(modal, /mode,/)
+  assert.match(modal, /providerID: model\.providerID, modelID: model\.modelID, variant: model\.variant/)
+})
+
+test("TaskDesk Continue previews bounded context and keeps an older-daemon compatibility path", () => {
+  const shell = readFileSync(new URL("./components/taskdesk-v3-unified.tsx", import.meta.url), "utf8")
+  const modal = readFileSync(new URL("./components/taskdesk-intelligent-continue.tsx", import.meta.url), "utf8")
+  const copy = readFileSync(new URL("./taskdesk-continue-i18n.ts", import.meta.url), "utf8")
+
+  assert.match(shell, /<IntelligentContinueTaskModal/)
+  assert.match(shell, /legacyFallback=\{ContinueTaskModal\}/)
+  assert.match(shell, /language=\{language\}/)
+  assert.match(modal, /className="td3-continue-context" open/)
+  assert.match(modal, /context\.objective/)
+  assert.match(modal, /context\.currentState/)
+  assert.match(modal, /context\.latestOutcome/)
+  assert.match(modal, /context\.changedFiles\.slice\(0, 12\)/)
+  assert.match(modal, /context\.runSummaries\.slice\(-6\)\.reverse\(\)/)
+  assert.match(modal, /HTTP 404\|incompatible response/)
+  assert.match(copy, /It is not native conversational memory from another harness/)
+  for (const language of ["en", "it", "zh-TW", "zh-CN"]) {
+    assert.match(copy, new RegExp(`(?:^|\\n)  ${JSON.stringify(language).replace(/["']/g, "\\\"")}|(?:^|\\n)  ${language === "en" || language === "it" ? language : `"${language}"`}:`), `localized Continue copy should include ${language}`)
+  }
+})

--- a/web/src/taskdesk-continue-i18n.ts
+++ b/web/src/taskdesk-continue-i18n.ts
@@ -3,6 +3,7 @@ import type { LanguageCode } from "./i18n"
 type ContinueCopy = {
   targetHarness: string
   targetModel: string
+  targetUnavailable: string
   role: string
   roleContinue: string
   roleReview: string
@@ -34,6 +35,7 @@ const copy: Record<LanguageCode, ContinueCopy> = {
   en: {
     targetHarness: "Target harness",
     targetModel: "Target model",
+    targetUnavailable: "The selected harness is unavailable. Choose an available harness before starting the next Run.",
     role: "Role / purpose",
     roleContinue: "Continue implementation",
     roleReview: "Review",
@@ -63,6 +65,7 @@ const copy: Record<LanguageCode, ContinueCopy> = {
   it: {
     targetHarness: "Harness di destinazione",
     targetModel: "Modello di destinazione",
+    targetUnavailable: "L'harness selezionato non è disponibile. Scegli un harness disponibile prima di avviare il prossimo Run.",
     role: "Ruolo / scopo",
     roleContinue: "Continua implementazione",
     roleReview: "Revisione",
@@ -92,6 +95,7 @@ const copy: Record<LanguageCode, ContinueCopy> = {
   "zh-TW": {
     targetHarness: "目標 Harness",
     targetModel: "目標模型",
+    targetUnavailable: "所選 Harness 目前無法使用。請選擇可用的 Harness，再啟動下一個 Run。",
     role: "角色 / 目的",
     roleContinue: "繼續實作",
     roleReview: "審閱",
@@ -121,6 +125,7 @@ const copy: Record<LanguageCode, ContinueCopy> = {
   "zh-CN": {
     targetHarness: "目标 Harness",
     targetModel: "目标模型",
+    targetUnavailable: "所选 Harness 当前不可用。请选择可用的 Harness，再启动下一个 Run。",
     role: "角色 / 目的",
     roleContinue: "继续实现",
     roleReview: "审阅",

--- a/web/src/taskdesk-continue-i18n.ts
+++ b/web/src/taskdesk-continue-i18n.ts
@@ -1,0 +1,154 @@
+import type { LanguageCode } from "./i18n"
+
+type ContinueCopy = {
+  targetHarness: string
+  targetModel: string
+  role: string
+  roleContinue: string
+  roleReview: string
+  roleTest: string
+  roleDebug: string
+  roleRefactor: string
+  roleInvestigate: string
+  roleCustom: string
+  customRole: string
+  sessionStrategy: string
+  reuseSession: string
+  freshSession: string
+  noReusableSession: string
+  contextTitle: string
+  contextHint: string
+  contextLoading: string
+  contextRevision: string
+  objective: string
+  currentState: string
+  latestOutcome: string
+  changedFiles: string
+  recentRuns: string
+  noChanges: string
+  transferredContext: string
+  fallbackHint: string
+}
+
+const copy: Record<LanguageCode, ContinueCopy> = {
+  en: {
+    targetHarness: "Target harness",
+    targetModel: "Target model",
+    role: "Role / purpose",
+    roleContinue: "Continue implementation",
+    roleReview: "Review",
+    roleTest: "Test / verify",
+    roleDebug: "Debug",
+    roleRefactor: "Refactor",
+    roleInvestigate: "Investigate",
+    roleCustom: "Custom",
+    customRole: "Custom role",
+    sessionStrategy: "Session strategy",
+    reuseSession: "Reuse latest native Session",
+    freshSession: "Start a fresh native Session",
+    noReusableSession: "This harness has no recorded native Session to resume, so the next Run must start fresh.",
+    contextTitle: "Task Context preview",
+    contextHint: "This is the bounded context TaskDesk will use to continue the durable Task.",
+    contextLoading: "Loading Task Context…",
+    contextRevision: "Context revision",
+    objective: "Objective",
+    currentState: "Current state",
+    latestOutcome: "Latest outcome",
+    changedFiles: "Changed files",
+    recentRuns: "Recent Runs",
+    noChanges: "No changed files reported.",
+    transferredContext: "When the target is not a direct native continuation, TaskDesk transfers this context explicitly. It is not native conversational memory from another harness.",
+    fallbackHint: "This daemon does not expose Task Context yet. Continue uses the compatible prompt-only flow."
+  },
+  it: {
+    targetHarness: "Harness di destinazione",
+    targetModel: "Modello di destinazione",
+    role: "Ruolo / scopo",
+    roleContinue: "Continua implementazione",
+    roleReview: "Revisione",
+    roleTest: "Test / verifica",
+    roleDebug: "Debug",
+    roleRefactor: "Refactoring",
+    roleInvestigate: "Analisi",
+    roleCustom: "Personalizzato",
+    customRole: "Ruolo personalizzato",
+    sessionStrategy: "Strategia Sessione",
+    reuseSession: "Riusa l'ultima Sessione nativa",
+    freshSession: "Avvia una nuova Sessione nativa",
+    noReusableSession: "Questo harness non ha una Sessione nativa registrata da riprendere, quindi il prossimo Run deve partire da una nuova Sessione.",
+    contextTitle: "Anteprima Task Context",
+    contextHint: "Questo è il contesto limitato che TaskDesk userà per continuare il Task durevole.",
+    contextLoading: "Caricamento Task Context…",
+    contextRevision: "Revisione contesto",
+    objective: "Obiettivo",
+    currentState: "Stato corrente",
+    latestOutcome: "Ultimo risultato",
+    changedFiles: "File modificati",
+    recentRuns: "Run recenti",
+    noChanges: "Nessun file modificato segnalato.",
+    transferredContext: "Quando non si tratta di una continuazione nativa diretta, TaskDesk trasferisce esplicitamente questo contesto. Non è memoria conversazionale nativa di un altro harness.",
+    fallbackHint: "Questo daemon non espone ancora Task Context. Continue usa il flusso compatibile basato solo sul prompt."
+  },
+  "zh-TW": {
+    targetHarness: "目標 Harness",
+    targetModel: "目標模型",
+    role: "角色 / 目的",
+    roleContinue: "繼續實作",
+    roleReview: "審閱",
+    roleTest: "測試 / 驗證",
+    roleDebug: "除錯",
+    roleRefactor: "重構",
+    roleInvestigate: "調查",
+    roleCustom: "自訂",
+    customRole: "自訂角色",
+    sessionStrategy: "Session 策略",
+    reuseSession: "重用最近的原生 Session",
+    freshSession: "啟動新的原生 Session",
+    noReusableSession: "此 harness 沒有可恢復的原生 Session 紀錄，因此下一個 Run 必須從新的 Session 開始。",
+    contextTitle: "Task Context 預覽",
+    contextHint: "這是 TaskDesk 用來延續持久任務的有限上下文。",
+    contextLoading: "正在載入 Task Context…",
+    contextRevision: "上下文版本",
+    objective: "目標",
+    currentState: "目前狀態",
+    latestOutcome: "最新結果",
+    changedFiles: "已變更檔案",
+    recentRuns: "最近的 Run",
+    noChanges: "沒有回報已變更檔案。",
+    transferredContext: "若不是直接延續同一個原生 Session，TaskDesk 會明確轉移此上下文。這不是來自另一個 harness 的原生對話記憶。",
+    fallbackHint: "此 daemon 尚未提供 Task Context。Continue 將使用相容的純提示流程。"
+  },
+  "zh-CN": {
+    targetHarness: "目标 Harness",
+    targetModel: "目标模型",
+    role: "角色 / 目的",
+    roleContinue: "继续实现",
+    roleReview: "审阅",
+    roleTest: "测试 / 验证",
+    roleDebug: "调试",
+    roleRefactor: "重构",
+    roleInvestigate: "调查",
+    roleCustom: "自定义",
+    customRole: "自定义角色",
+    sessionStrategy: "Session 策略",
+    reuseSession: "复用最近的原生 Session",
+    freshSession: "启动新的原生 Session",
+    noReusableSession: "此 harness 没有可恢复的原生 Session 记录，因此下一个 Run 必须从新的 Session 开始。",
+    contextTitle: "Task Context 预览",
+    contextHint: "这是 TaskDesk 用来继续持久任务的有限上下文。",
+    contextLoading: "正在加载 Task Context…",
+    contextRevision: "上下文版本",
+    objective: "目标",
+    currentState: "当前状态",
+    latestOutcome: "最新结果",
+    changedFiles: "已更改文件",
+    recentRuns: "最近的 Run",
+    noChanges: "没有报告已更改文件。",
+    transferredContext: "如果不是直接延续同一个原生 Session，TaskDesk 会明确转移此上下文。这不是来自另一个 harness 的原生对话记忆。",
+    fallbackHint: "此 daemon 尚未提供 Task Context。Continue 将使用兼容的纯提示流程。"
+  }
+}
+
+export function taskDeskContinueCopy(language: LanguageCode): ContinueCopy {
+  return copy[language]
+}

--- a/web/src/taskdesk-continue.css
+++ b/web/src/taskdesk-continue.css
@@ -1,0 +1,166 @@
+.td3-intelligent-continue {
+  width: min(780px, 100%);
+}
+
+.td3-continue-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.td3-continue-grid > label {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.td3-continue-grid > label > span {
+  color: var(--td3-muted);
+  font-size: 10.5px;
+  font-weight: 650;
+}
+
+.td3-continue-grid select,
+.td3-continue-grid input,
+.td3-continue-grid textarea {
+  width: 100%;
+  border: 1px solid var(--td3-border);
+  border-radius: 9px;
+  outline: 0;
+  color: var(--td3-text);
+  background: var(--td3-control);
+  font-size: 12px;
+}
+
+.td3-continue-grid select,
+.td3-continue-grid input {
+  min-height: 38px;
+  padding: 0 9px;
+}
+
+.td3-continue-grid textarea {
+  min-height: 116px;
+  padding: 10px;
+  resize: vertical;
+  line-height: 1.55;
+}
+
+.td3-continue-wide {
+  grid-column: 1 / -1;
+}
+
+.td3-continue-context {
+  grid-column: 1 / -1;
+  border: 1px solid var(--td3-border);
+  border-radius: 10px;
+  background: var(--td3-raise-1);
+  overflow: hidden;
+}
+
+.td3-continue-context > summary {
+  min-height: 46px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 11px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.td3-continue-context > summary::-webkit-details-marker {
+  display: none;
+}
+
+.td3-continue-context > summary strong {
+  color: var(--td3-text);
+  font-size: 12px;
+}
+
+.td3-continue-context > summary span {
+  color: var(--td3-muted);
+  font-size: 10.5px;
+}
+
+.td3-continue-context-body {
+  display: grid;
+  gap: 9px;
+  max-height: 310px;
+  overflow: auto;
+  padding: 0 11px 11px;
+  border-top: 1px solid var(--td3-border-soft);
+}
+
+.td3-continue-context-note {
+  margin: 10px 0 0;
+  padding: 8px 9px;
+  border: 1px solid var(--td3-blue-border-soft);
+  border-radius: 8px;
+  color: var(--td3-text-3);
+  background: var(--td3-blue-soft);
+  font-size: 10.5px;
+  line-height: 1.45;
+}
+
+.td3-continue-context-section {
+  display: grid;
+  gap: 4px;
+}
+
+.td3-continue-context-section > small {
+  color: var(--td3-muted-2);
+  font-size: 9.5px;
+  font-weight: 750;
+  letter-spacing: .055em;
+  text-transform: uppercase;
+}
+
+.td3-continue-context-section > p {
+  margin: 0;
+  color: var(--td3-text-2);
+  font-size: 11px;
+  white-space: pre-wrap;
+}
+
+.td3-continue-file-list,
+.td3-continue-run-list {
+  display: grid;
+  gap: 4px;
+}
+
+.td3-continue-file-list code,
+.td3-continue-run-list span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--td3-text-3);
+  font-size: 10.5px;
+}
+
+.td3-continue-model-note {
+  margin: 0;
+  color: var(--td3-muted);
+  font-size: 10px;
+}
+
+@media (max-width: 680px) {
+  .td3-intelligent-continue {
+    width: 100%;
+    max-height: calc(100dvh - 20px);
+  }
+
+  .td3-continue-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .td3-continue-wide,
+  .td3-continue-context {
+    grid-column: 1;
+  }
+
+  .td3-continue-context-body {
+    max-height: 240px;
+  }
+}


### PR DESCRIPTION
## Purpose

Complete the user-facing Continue / Handoff flow tracked by #263 on top of the current canonical `v3/taskdesk` branch.

The backend multi-harness Task core and persisted Task Context already exist. This PR exposes those semantics safely and clearly in TaskDesk rather than creating another parallel backend model.

## Included

* extend the web task client to consume persisted Task Context and the object-form Continue API
* choose the target harness, defaulting to the harness from the latest Run
* block stale or unavailable harness targets from starting a Run
* load the target harness live model catalog and prefer its most recently used Task model when available
* choose a handoff role or purpose: Continue implementation, Review, Test / verify, Debug, Refactor, Investigate, or Custom
* preview the deterministic bounded Task Context before starting the next Run
* show objective, current state, latest outcome, changed files and recent Run history in the preview
* choose explicitly between reusing the latest native Session for the selected harness and starting a fresh native Session
* disable resume when the selected harness has no recorded native Session
* preserve daemon semantics for returning to a harness used before intervening Runs
* state explicitly that transferred cross-harness Task Context is not native conversational memory
* retain the existing prompt-only Continue flow only as a compatibility fallback for older daemons without the Task Context endpoint
* keep New Session independent from Task orchestration
* localize the new Continue-specific UX in English, Italian, Traditional Chinese and Simplified Chinese
* add focused regression coverage for Task Context use, live model selection, unavailable targets, roles, Session strategy, handoff semantics and compatibility fallback

## Automated validation

Exact validated head: `62ede03a34b8b6f7aacb83720fb60af26a32fda8`

Green on this exact head:

* TypeScript and production web build
* web regression suite, including intelligent Continue and unavailable-target guards
* bridge tests on Linux, macOS and Windows
* desktop application menu tests
* Android Debug APK build
* Android APK signature verification

The final diff is limited to seven frontend/client/test files. No changes target `main`.

## Remaining release gate

This PR stays draft until the real-harness matrix is exercised against the exact candidate behavior. Required manual validation includes:

* same-harness Continue reuses the exact native Session when available
* explicit fresh mode creates a new Session
* Codex -> Claude -> PI -> Codex preserves one durable Task and the intermediate findings
* returning to a previously used harness resumes its own Session while receiving intervening Task Context explicitly
* model and role selections are recorded correctly in Run history
* daemon restart preserves Run history, Task Context revisions and resumability without duplicate Runs
* Codex, OpenCode, PI, OMP and Claude are checked with real harnesses

Refs #263
Refs #197