### PR TITLE
audit(v3): harness capability contract and project-scoped discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # Harness Remote
 
-**Run and supervise AI coding agents on the machines where your code already lives, from anywhere.**
+**Your projects. Any coding agent. One workspace.**
 
 Harness Remote is a local-first control plane for AI coding agents. Connect the machines where your repositories, CLIs, subscriptions and credentials already live, then use OpenCode, Claude Code, Codex CLI, Oh My Pi and PI from one interface on phone, web or desktop.
-
-**Your projects. Any coding agent. One workspace.**
 
 > Harness Remote is not another coding agent. It is the control plane above them.
 
@@ -12,32 +10,90 @@ Execution stays on your machines. Repositories stay on your machines. Agent cred
 
 ## Harness Remote 3.0
 
-Harness Remote 3.0 is conversation-first. It does not recreate the Session model already provided by modern coding agents.
+Harness Remote 3.0 changes the center of the product from **remote agent Sessions** to **persistent work Conversations**.
 
-The product model is:
+The idea is simple:
+
+> Start with any agent. Continue with another. Keep the same piece of work.
+
+A modern coding agent already knows how to own a Session: transcript, tools, reasoning, permissions, context, memory, model behavior and resume semantics. Harness Remote should not rebuild that layer.
+
+Instead, 3.0 adds the continuity layer that individual coding agents cannot provide on their own.
 
 ```text
 Machine
-  Projects
-    Project
-      Conversations
-        Conversation
-          Native Session: OpenCode
-          Native Session: Codex
-          Native Session: Claude
+  Project
+    Conversation
+      Native Session: OpenCode
+      Native Session: Codex
+      Native Session: Claude
 ```
 
-A **Conversation** is a thin continuity layer above real native Sessions. It keeps one piece of work easy to return to while the underlying coding agent remains responsible for its own Session history, streaming, tools, reasoning, permissions and memory.
+A **Project** is the real workspace on one of your machines.
 
-The important capability is agent independence:
+A **Conversation** is the persistent piece of work you see and return to in Harness Remote. It belongs to a Project and can continue across coding agents.
 
-1. start a Conversation with the coding agent and model you want;
-2. work in the real project directory;
-3. continue the same Conversation with another coding agent when useful;
-4. Harness Remote creates or resumes the target agent's native Session and carries the continuity context across;
-5. inspect the native Sessions and project Changes without replacing the harness transcript with a second chat protocol.
+A **Native Session** is the real harness-owned Session underneath that Conversation. OpenCode, Codex, Claude, OMP and PI keep ownership of their own history and runtime behavior.
 
-A normal Conversation does **not** create a hidden Git worktree. Isolation can be added explicitly for true parallel work, but it is not the default workspace model.
+### Conversation vs Native Session
+
+| | Conversation | Native Session |
+|---|---|---|
+| Owned by | Harness Remote | The coding agent / harness |
+| Purpose | Keep one piece of work continuous across agents | Execute work inside one specific agent |
+| Scope | Project-level, cross-agent | Harness-specific |
+| Stable identity | Yes | Depends on the harness |
+| Can switch coding agent | Yes | No, it belongs to one harness |
+| Transcript/tool semantics | Does not redefine them | Native to the harness |
+| Reasoning, tools, permissions, memory | Orchestrated, not reimplemented | Owned by the harness |
+| Model and agent-specific capabilities | Selected through the control plane | Applied by the native harness |
+
+This distinction is central to 3.0. Harness Remote is not trying to create a universal fake Session format. It keeps enough continuity to let you move between agents while preserving the native Session as the source of truth.
+
+### One Conversation, several agents
+
+For example, one Project Conversation might evolve like this:
+
+```text
+Conversation: "Refactor authentication"
+
+1. OpenCode Session
+   explore the repository and identify the current auth flow
+
+2. Codex Session
+   continue the same work and implement the refactor
+
+3. Claude Session
+   review the resulting design and find edge cases
+```
+
+From the user's point of view this is still one Conversation. Underneath, each coding agent works through its own native Session.
+
+The **Sessions** view exists precisely to make that native chain visible instead of hiding it.
+
+The **Changes** view remains grounded in the real Project workspace.
+
+### Why this matters
+
+Coding agents change quickly. The best agent, model or subscription for one step may not be the best one for the next step.
+
+Harness Remote 3.0 is designed so the workspace and the work survive that choice:
+
+- start a Conversation with the agent and model you want;
+- work directly in the real Project directory;
+- continue the same Conversation with another agent when useful;
+- create or resume the appropriate native Session for that agent;
+- preserve explicit continuity between those Sessions;
+- inspect the native Session chain instead of replacing it with a second competing protocol;
+- supervise the same work from desktop, web or Android.
+
+A normal Conversation does **not** create a hidden Git worktree. Isolation may be added explicitly for true parallel work, but it is not the default workspace model.
+
+### 3.0 status
+
+Harness Remote 3.0 is currently in pre-release audit and integration work. The conversation-first UI is usable, while the final release gate is focused on real-harness reliability, transport/reconnect behavior, capability discovery and cross-agent continuity.
+
+The stable `main` branch remains the 2.x line until the 3.0 candidate completes those gates.
 
 ## Quick start
 
@@ -116,9 +172,9 @@ Each coding agent keeps its own native Session format and behavior.
 
 When a Conversation continues with the same agent, Harness Remote resumes the most recent compatible native Session when possible. When it continues with another agent, Harness Remote creates or resumes that agent's native Session and transfers explicit continuity context.
 
-If a previously persisted native Session is no longer available, Harness Remote can create a new native Session and continue from the persisted conversation context rather than exposing an implementation-level Session ID failure to the user.
+If a previously persisted native Session is no longer available, Harness Remote can create a new native Session and continue from persisted Conversation context rather than exposing an implementation-level Session ID failure to the user.
 
-The **Sessions** tab makes this chain visible. The **Changes** tab stays grounded in the current project workspace and native Session.
+The **Sessions** tab makes this chain visible. The **Changes** tab stays grounded in the current Project workspace.
 
 ## What remains native
 
@@ -127,7 +183,7 @@ Harness Remote should orchestrate capabilities that coding agents already implem
 Harness Remote adds the layer that an individual harness cannot provide by itself:
 
 - one machine connection for multiple coding agents;
-- one project workspace across agents;
+- one Project workspace across agents;
 - one Conversation that can continue through several native Sessions;
 - agent and model switching from the same interface;
 - remote supervision from desktop, web and Android;
@@ -135,7 +191,7 @@ Harness Remote adds the layer that an individual harness cannot provide by itsel
 
 ## Legacy compatibility
 
-The repository still contains lower-level bridge and compatibility code because stable 2.x installations may depend on it. Those paths are not separate product modes in the 3.0 interface.
+The repository still contains lower-level bridge and compatibility code because stable 2.x installations may depend on it. Existing internal Task/Run naming is also retained where changing it would create unnecessary compatibility risk. Those implementation details are not the 3.0 product model.
 
 For low-level legacy setup details see [REFERENCE.md](REFERENCE.md).
 
@@ -172,6 +228,6 @@ Pull-request CI type-checks and builds the web app, runs regression and bridge t
 
 ## Project status
 
-The 3.0 release-candidate path is moving Harness Remote from a remote Session viewer to a conversation-first universal agent control plane.
+The 3.0 release path is moving Harness Remote from a remote Session viewer to a conversation-first universal agent control plane.
 
-The release gate is practical: each supported harness must route to the correct native Sessions and models, cross-agent continuation must preserve useful context, the project workspace must remain predictable, desktop/web/Android must behave consistently, and the exact candidate SHA must pass both automated checks and real-harness manual testing before promotion.
+The release gate is practical: each supported harness must route to the correct native Sessions and models, cross-agent continuation must preserve useful context, the Project workspace must remain predictable, desktop/web/Android must behave consistently, and the exact candidate SHA must pass both automated checks and real-harness manual testing before promotion.

--- a/bridge/src/agent-model-catalog.js
+++ b/bridge/src/agent-model-catalog.js
@@ -152,6 +152,12 @@ function catalogAge(refreshedAt) {
   return Number.isFinite(value) ? Math.max(0, Date.now() - value) : null
 }
 
+function laterTimestamp(values) {
+  const candidates = values.filter((value) => typeof value === "string" && Number.isFinite(Date.parse(value)))
+  if (!candidates.length) return null
+  return candidates.sort((left, right) => Date.parse(right) - Date.parse(left))[0]
+}
+
 class CachedCatalog {
   cache = []
   refreshedAt = null
@@ -206,6 +212,20 @@ class CachedCatalog {
   }
 }
 
+function newAcpScope(directory) {
+  return {
+    directory,
+    cache: [],
+    refreshedAt: null,
+    lastAttemptAt: null,
+    lastError: null,
+    inFlight: null,
+    sessionID: undefined,
+    phase: "idle",
+    variantProbe: { total: 0, completed: 0, incomplete: false, lastError: null }
+  }
+}
+
 export class AcpAgentModelCatalog extends CachedCatalog {
   constructor({ agent, agentID, directory, stateDirectory, timeoutMs = ACP_MODEL_CATALOG_TIMEOUT_MS, variantConfigIDs = [] }) {
     super()
@@ -215,18 +235,64 @@ export class AcpAgentModelCatalog extends CachedCatalog {
     this.timeoutMs = timeoutMs
     this.variantConfigIDs = [...new Set(variantConfigIDs.filter((value) => typeof value === "string" && value))]
     this.stateFile = path.join(stateDirectory, `model-catalog-${agentID}.json`)
-    this.sessionID = undefined
     this.stateLoaded = false
     this.hiddenSessionIDs = new Set()
-    this.phase = "idle"
-    this.variantProbe = { total: 0, completed: 0, incomplete: false, lastError: null }
+    this.scopes = new Map()
     this.onAgentExit = (error) => {
-      this.lastError = error instanceof Error ? error.message : String(error ?? "adapter exited")
-      this.sessionID = undefined
-      this.phase = "stopped"
-      this.clear()
+      const message = error instanceof Error ? error.message : String(error ?? "adapter exited")
+      for (const scope of this.scopes.values()) {
+        scope.lastError = message
+        scope.sessionID = undefined
+        scope.phase = "stopped"
+        scope.cache = []
+        scope.refreshedAt = null
+      }
     }
     this.agent.on?.("exit", this.onAgentExit)
+  }
+
+  #scope(directory) {
+    const resolved = path.resolve(typeof directory === "string" && directory ? directory : this.directory)
+    let scope = this.scopes.get(resolved)
+    if (!scope) {
+      scope = newAcpScope(resolved)
+      this.scopes.set(resolved, scope)
+    }
+    return scope
+  }
+
+  #result(scope, models, stale = false, error) {
+    return {
+      models,
+      stale,
+      refreshedAt: scope.refreshedAt,
+      ...(error ? { error } : {})
+    }
+  }
+
+  #remember(scope, models) {
+    scope.cache = models
+    scope.refreshedAt = new Date().toISOString()
+    scope.lastError = null
+    return this.#result(scope, models, false)
+  }
+
+  #stale(scope, error) {
+    scope.lastError = error instanceof Error ? error.message : String(error)
+    if (!scope.cache.length) throw error
+    return this.#result(scope, scope.cache, true, scope.lastError)
+  }
+
+  #resolveResult(result, model) {
+    if (!model) return null
+    const candidate = result.models.find((item) => sameModel(item, model))
+    if (!candidate) {
+      const suffix = model.variant ? ` (${model.variant})` : ""
+      const error = new Error(`Selected model is no longer available: ${model.providerID}/${model.modelID}${suffix}`)
+      error.code = "model_unavailable"
+      throw error
+    }
+    return candidate
   }
 
   #remaining(deadline, phase) {
@@ -242,7 +308,7 @@ export class AcpAgentModelCatalog extends CachedCatalog {
     this.stateLoaded = true
     try {
       const state = JSON.parse(await readFile(this.stateFile, "utf8"))
-      const sessionIDs = state?.version === 2 && Array.isArray(state.sessionIDs)
+      const sessionIDs = (state?.version === 3 || state?.version === 2) && Array.isArray(state.sessionIDs)
         ? state.sessionIDs
         : state?.version === 1 && typeof state.sessionID === "string"
           ? [state.sessionID]
@@ -263,43 +329,42 @@ export class AcpAgentModelCatalog extends CachedCatalog {
   async #saveState() {
     await mkdir(path.dirname(this.stateFile), { recursive: true })
     await writeFile(this.stateFile, JSON.stringify({
-      version: 2,
+      version: 3,
       sessionIDs: [...this.hiddenSessionIDs],
-      directory: this.directory
+      directories: [...this.scopes.keys()]
     }), { mode: 0o600 })
   }
 
-  async #newCatalogSession(deadline) {
+  async #newCatalogSession(scope, deadline) {
     const created = await this.agent.request(
       "session/new",
-      { cwd: this.directory, mcpServers: [] },
+      { cwd: scope.directory, mcpServers: [] },
       this.#remaining(deadline, "technical Session creation")
     )
     if (!created?.sessionId) throw new Error(`Agent ${this.agentID} did not return a catalog session id`)
-    this.sessionID = created.sessionId
+    scope.sessionID = created.sessionId
     this.hiddenSessionIDs.add(created.sessionId)
     await this.#saveState()
     return created.configOptions
   }
 
-  async #refreshOptions(deadline) {
-    this.phase = "starting-adapter"
+  async #refreshOptions(scope, deadline) {
+    scope.phase = "starting-adapter"
     await this.agent.start(this.#remaining(deadline, "adapter startup"))
-    this.phase = "loading-state"
+    scope.phase = "loading-state"
     await this.#loadState()
-    // A historical ACP Session can legitimately retain the model options it was created with.
-    // Reusing it across daemon restarts therefore turns removed models into a permanent catalog.
-    // Old ids are loaded only so those technical Sessions stay hidden. Discovery starts from one
-    // fresh prompt-less Session for the current adapter process.
-    this.phase = "creating-session"
-    return this.#newCatalogSession(deadline)
+    // Historical technical Sessions remain hidden but are never loaded as model authority. Each
+    // authorized Project/cwd gets a fresh prompt-less technical Session for the current adapter
+    // lifetime, so one project's provider/config state cannot become another project's catalog.
+    scope.phase = "creating-session"
+    return this.#newCatalogSession(scope, deadline)
   }
 
-  async #probeVariants(configOptions, catalogDeadline) {
+  async #probeVariants(scope, configOptions, catalogDeadline) {
     const baseModels = modelsFromConfigOptions(configOptions, this.agentID)
     const modelOption = configOptions?.find((item) => item?.id === "model")
-    if (!baseModels.length || !this.variantConfigIDs.length || !this.sessionID || !modelOption || !Array.isArray(modelOption.options)) {
-      this.variantProbe = { total: 0, completed: 0, incomplete: false, lastError: null }
+    if (!baseModels.length || !this.variantConfigIDs.length || !scope.sessionID || !modelOption || !Array.isArray(modelOption.options)) {
+      scope.variantProbe = { total: 0, completed: 0, incomplete: false, lastError: null }
       return baseModels
     }
 
@@ -313,7 +378,7 @@ export class AcpAgentModelCatalog extends CachedCatalog {
     const probeDeadline = Math.min(catalogDeadline, Date.now() + ACP_VARIANT_PROBE_BUDGET_MS)
     const variants = []
     let currentModel = originalModel
-    this.variantProbe = { total: ordered.length, completed: 0, incomplete: false, lastError: null }
+    scope.variantProbe = { total: ordered.length, completed: 0, incomplete: false, lastError: null }
 
     for (const rawModel of ordered) {
       const base = modelFromConfigCandidate(rawModel, modelOption, this.agentID)
@@ -322,21 +387,21 @@ export class AcpAgentModelCatalog extends CachedCatalog {
       if (rawModel.value !== currentModel) {
         const remaining = probeDeadline - Date.now()
         if (remaining <= 0) {
-          this.variantProbe.incomplete = true
+          scope.variantProbe.incomplete = true
           break
         }
         try {
           const changed = await this.agent.request("session/set_config_option", {
-            sessionId: this.sessionID,
+            sessionId: scope.sessionID,
             configId: "model",
             value: rawModel.value
           }, Math.max(1, Math.min(ACP_VARIANT_REQUEST_TIMEOUT_MS, remaining)))
           currentModel = rawModel.value
           if (Array.isArray(changed?.configOptions)) effectiveOptions = changed.configOptions
         } catch (error) {
-          this.variantProbe.incomplete = true
-          this.variantProbe.lastError = error instanceof Error ? error.message : String(error)
-          this.variantProbe.completed += 1
+          scope.variantProbe.incomplete = true
+          scope.variantProbe.lastError = error instanceof Error ? error.message : String(error)
+          scope.variantProbe.completed += 1
           continue
         }
       }
@@ -355,69 +420,115 @@ export class AcpAgentModelCatalog extends CachedCatalog {
           })
         }
       }
-      this.variantProbe.completed += 1
+      scope.variantProbe.completed += 1
     }
 
-    if (this.variantProbe.completed < this.variantProbe.total) this.variantProbe.incomplete = true
-    // This Session exists only for catalog inspection. Restoring its original model would add more
-    // RPC latency without changing any user Session, so the probe deliberately stops here.
+    if (scope.variantProbe.completed < scope.variantProbe.total) scope.variantProbe.incomplete = true
     return dedupeModels([...baseModels, ...variants])
   }
 
-  async #refreshCatalog() {
-    this.lastAttemptAt = new Date().toISOString()
+  async #refreshCatalog(scope) {
+    scope.lastAttemptAt = new Date().toISOString()
     const deadline = Date.now() + this.timeoutMs
-    this.variantProbe = { total: 0, completed: 0, incomplete: false, lastError: null }
+    scope.variantProbe = { total: 0, completed: 0, incomplete: false, lastError: null }
     try {
-      const options = await this.#refreshOptions(deadline)
+      const options = await this.#refreshOptions(scope, deadline)
       const baseModels = modelsFromConfigOptions(options, this.agentID)
       if (!baseModels.length) throw new Error(`Agent ${this.agentID} did not advertise any models`)
-      this.phase = "probing-variants"
+      scope.phase = "probing-variants"
       // Base membership is the required result. Variant enrichment is bounded and may stop early;
       // a slow optional reasoning control must never make an otherwise valid catalog unusable.
-      const models = await this.#probeVariants(options, deadline)
-      this.phase = "ready"
-      return this.remember(models)
+      const models = await this.#probeVariants(scope, options, deadline)
+      scope.phase = "ready"
+      return this.#remember(scope, models)
     } catch (error) {
-      this.phase = "error"
+      scope.phase = "error"
       throw error
     }
   }
 
-  async list({ allowStale = true, refresh = false } = {}) {
-    // One fresh technical Session per adapter lifetime avoids stale cross-restart configOptions and
-    // unbounded Session creation on ordinary picker opens. Explicit diagnostics may request refresh.
-    if (!refresh && this.cache.length) return this.result(this.cache, false)
-    if (!this.inFlight) {
-      const operation = this.#refreshCatalog()
+  async list({ allowStale = true, refresh = false, directory } = {}) {
+    const scope = this.#scope(directory)
+    if (!refresh && scope.cache.length) return this.#result(scope, scope.cache, false)
+    if (!scope.inFlight) {
+      const operation = this.#refreshCatalog(scope)
       let wrapped
       wrapped = operation.finally(() => {
-        if (this.inFlight === wrapped) this.inFlight = null
+        if (scope.inFlight === wrapped) scope.inFlight = null
       })
-      this.inFlight = wrapped
+      scope.inFlight = wrapped
     }
     try {
-      return await this.inFlight
+      return await scope.inFlight
     } catch (error) {
-      if (allowStale) return this.stale(error)
-      this.lastError = error instanceof Error ? error.message : String(error)
+      if (allowStale) return this.#stale(scope, error)
+      scope.lastError = error instanceof Error ? error.message : String(error)
       throw error
     }
   }
 
-  async resolve(model) { return this.resolveResult(await this.list({ allowStale: false }), model) }
-  async validate(model) { await this.resolve(model) }
-  diagnostics() {
+  async resolve(model, options = {}) {
+    return this.#resolveResult(await this.list({ ...options, allowStale: false }), model)
+  }
+
+  async validate(model, options = {}) {
+    await this.resolve(model, options)
+  }
+
+  #scopeDiagnostics(scope) {
     return {
-      ...this.diagnosticsBase("acp-fresh-session-config-options"),
-      phase: this.phase,
-      timeoutMs: this.timeoutMs,
-      variantProbe: { ...this.variantProbe },
-      adapterProcess: this.agent.diagnostics?.() ?? { processID: this.agent.processID },
-      technicalSessionPersisted: Boolean(this.sessionID),
-      variantConfigIDs: this.variantConfigIDs
+      directory: scope.directory,
+      cachedModels: scope.cache.length,
+      refreshedAt: scope.refreshedAt,
+      ageMs: catalogAge(scope.refreshedAt),
+      inFlight: Boolean(scope.inFlight),
+      lastAttemptAt: scope.lastAttemptAt,
+      lastError: scope.lastError,
+      phase: scope.phase,
+      technicalSessionPersisted: Boolean(scope.sessionID),
+      variantProbe: { ...scope.variantProbe }
     }
   }
+
+  diagnostics({ directory } = {}) {
+    if (directory) {
+      const scope = this.#scope(directory)
+      return {
+        source: "acp-fresh-session-config-options",
+        cacheScope: "project-cwd",
+        ...this.#scopeDiagnostics(scope),
+        timeoutMs: this.timeoutMs,
+        adapterProcess: this.agent.diagnostics?.() ?? { processID: this.agent.processID },
+        variantConfigIDs: this.variantConfigIDs
+      }
+    }
+
+    const scopes = [...this.scopes.values()]
+    const defaultScope = this.#scope(this.directory)
+    const all = scopes.length ? scopes : [defaultScope]
+    const refreshedAt = laterTimestamp(all.map((scope) => scope.refreshedAt))
+    const lastAttemptAt = laterTimestamp(all.map((scope) => scope.lastAttemptAt))
+    const errorScope = [...all].sort((left, right) => Date.parse(right.lastAttemptAt || 0) - Date.parse(left.lastAttemptAt || 0)).find((scope) => scope.lastError)
+    return {
+      source: "acp-fresh-session-config-options",
+      cacheScope: "project-cwd",
+      scopeCount: all.length,
+      cachedModels: all.reduce((total, scope) => total + scope.cache.length, 0),
+      refreshedAt,
+      ageMs: catalogAge(refreshedAt),
+      inFlight: all.some((scope) => Boolean(scope.inFlight)),
+      lastAttemptAt,
+      lastError: errorScope?.lastError ?? null,
+      phase: defaultScope.phase,
+      timeoutMs: this.timeoutMs,
+      variantProbe: { ...defaultScope.variantProbe },
+      adapterProcess: this.agent.diagnostics?.() ?? { processID: this.agent.processID },
+      technicalSessionPersisted: all.some((scope) => Boolean(scope.sessionID)),
+      variantConfigIDs: this.variantConfigIDs,
+      scopes: all.map((scope) => this.#scopeDiagnostics(scope))
+    }
+  }
+
   close() {
     this.agent.off?.("exit", this.onAgentExit)
     this.agent.close?.()
@@ -499,6 +610,7 @@ export class HttpAgentModelCatalog extends CachedCatalog {
   diagnostics() {
     return {
       ...this.diagnosticsBase(this.source),
+      cacheScope: "machine",
       timeoutMs: this.timeoutMs,
       ttlMs: this.ttlMs,
       hostProcessID: this.host.processID

--- a/bridge/src/agent-model-catalog.js
+++ b/bridge/src/agent-model-catalog.js
@@ -252,7 +252,11 @@ export class AcpAgentModelCatalog extends CachedCatalog {
   }
 
   #scope(directory) {
-    const resolved = path.resolve(typeof directory === "string" && directory ? directory : this.directory)
+    // Project paths and persisted Conversation workspaces are resolved and authorized by the
+    // daemon before reaching the catalog. Keep that native path verbatim so a Windows daemon does
+    // not reinterpret a trusted POSIX-style test/path string and so the cache key matches the
+    // exact cwd sent to the harness.
+    const resolved = typeof directory === "string" && directory ? directory : this.directory
     let scope = this.scopes.get(resolved)
     if (!scope) {
       scope = newAcpScope(resolved)

--- a/bridge/src/agent-model-server.js
+++ b/bridge/src/agent-model-server.js
@@ -46,7 +46,38 @@ async function settleWithin(promise, waitMs) {
   }
 }
 
-export function createAgentModelServer({ innerServer, config, daemon, taskStore, createServer = http.createServer }) {
+function requestError(status, message) {
+  const error = new Error(message)
+  error.status = status
+  return error
+}
+
+async function modelDirectory(url, { taskStore, projectCatalog }) {
+  const projectID = url.searchParams.get("projectId")?.trim() || ""
+  const workThreadID = url.searchParams.get("workThreadId")?.trim() || ""
+  if (projectID && workThreadID) throw requestError(400, "Model discovery accepts either projectId or workThreadId, not both")
+
+  if (workThreadID) {
+    if (typeof taskStore?.get !== "function") throw requestError(503, "Conversation model scope is unavailable")
+    const task = await taskStore.get(workThreadID)
+    if (!task) throw requestError(404, `Unknown conversation: ${workThreadID}`)
+    const directory = task.workspace?.path || task.project?.path
+    if (!directory) throw requestError(409, "Conversation workspace is not prepared")
+    return directory
+  }
+
+  if (projectID) {
+    if (typeof projectCatalog !== "function") throw requestError(503, "Project model scope is unavailable")
+    const projects = await projectCatalog()
+    const project = Array.isArray(projects) ? projects.find((candidate) => candidate?.id === projectID) : undefined
+    if (!project?.path) throw requestError(404, `Unknown project: ${projectID}`)
+    return project.path
+  }
+
+  return undefined
+}
+
+export function createAgentModelServer({ innerServer, config, daemon, taskStore, projectCatalog, createServer = http.createServer }) {
   return createServer(async (request, response) => {
     const url = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`)
     const modelMatch = MODEL_ROUTE.exec(url.pathname)
@@ -59,14 +90,22 @@ export function createAgentModelServer({ innerServer, config, daemon, taskStore,
       }
       const agentID = decodeURIComponent(modelMatch[1])
       const refresh = url.searchParams.get("refresh") === "1"
-      const discovery = daemon.listModels(agentID, { allowStale: true, refresh })
+      let directory
+      try {
+        directory = await modelDirectory(url, { taskStore, projectCatalog })
+      } catch (error) {
+        writeJSON(response, Number(error?.status) || 400, { error: error instanceof Error ? error.message : String(error), models: [], stale: true })
+        return
+      }
+      const options = { allowStale: true, refresh, ...(directory ? { directory } : {}) }
+      const discovery = daemon.listModels(agentID, options)
       const settled = await settleWithin(discovery, modelWaitMs(url))
       if (!settled.settled) {
         // The discovery remains owned by the daemon/catalog and continues after this response. A
         // mobile/browser request is therefore never required to survive a cold `npx` adapter start.
-        // Subsequent polls join the same single-flight operation instead of starting another ACP
-        // process/session and the picker can survive background/foreground network transitions.
-        const diagnostics = daemon.modelDiagnostics?.(agentID) ?? {}
+        // Subsequent polls join the same single-flight operation for the same Project scope instead
+        // of starting another technical Session.
+        const diagnostics = daemon.modelDiagnostics?.(agentID, directory ? { directory } : undefined) ?? {}
         response.setHeader("Retry-After", "1")
         writeJSON(response, 202, {
           models: [],
@@ -96,7 +135,10 @@ export function createAgentModelServer({ innerServer, config, daemon, taskStore,
           writeJSON(response, 404, { error: `Unknown task: ${taskID}` })
           return
         }
-        if (task.model) await daemon.validateModel(task.agentId, task.model)
+        if (task.model) {
+          const options = task.workspace?.path ? { directory: task.workspace.path } : undefined
+          await daemon.validateModel(task.agentId, task.model, options)
+        }
       } catch (error) {
         const status = error?.code === "model_unavailable" ? 409 : 503
         writeJSON(response, status, { error: error instanceof Error ? error.message : String(error) })

--- a/bridge/src/daemon-cli.js
+++ b/bridge/src/daemon-cli.js
@@ -3,6 +3,7 @@ import path from "node:path"
 import { AcpClient } from "./acp-client.js"
 import { AcpAgentModelCatalog, HttpAgentModelCatalog } from "./agent-model-catalog.js"
 import { parseConfig, usage as bridgeUsage } from "./config.js"
+import { acpHarnessCapabilityContract, openCodeCapabilityContract } from "./harness-capability-contract.js"
 import { harnessProfile, resolveAcpLaunch } from "./harness-profiles.js"
 import { canListen, resolveLaunchPlan } from "./launcher.js"
 import { loadMachineIdentity } from "./machine-registry.js"
@@ -143,6 +144,7 @@ async function main() {
       label: profile.label,
       backend: profile.id,
       capabilities: profile.capabilities,
+      contract: acpHarnessCapabilityContract(profile),
       agent: acp,
       modelCatalog,
       bridgeConfig: agentConfig,
@@ -182,6 +184,7 @@ async function main() {
       label: "OpenCode",
       backend: "opencode",
       capabilities: { sessions: true },
+      contract: openCodeCapabilityContract(),
       host: managedOpenCode,
       modelCatalog: openCodeModels,
       eager: false

--- a/bridge/src/harness-capability-contract.js
+++ b/bridge/src/harness-capability-contract.js
@@ -1,0 +1,58 @@
+function uniqueStrings(values = []) {
+  return [...new Set(values.filter((value) => typeof value === "string" && value))]
+}
+
+export function acpHarnessCapabilityContract(profile) {
+  const variantConfigIDs = uniqueStrings(profile?.modelVariantConfigIDs)
+  return {
+    version: 1,
+    protocol: "acp",
+    transport: {
+      control: "stdio-json-rpc",
+      events: "acp-session-update"
+    },
+    toolCalls: {
+      representation: "acp-session-update"
+    },
+    models: {
+      source: "acp-config-options",
+      cacheScope: "project-cwd",
+      variants: variantConfigIDs.length ? "runtime-advertised-config-options" : "runtime-advertised-only",
+      variantConfigIDs
+    },
+    lifecycle: {
+      sessionAuthority: "native-harness",
+      create: "native-session",
+      resume: "native-session-when-supported",
+      stop: "native-abort",
+      reconnect: "daemon-reconciliation"
+    }
+  }
+}
+
+export function openCodeCapabilityContract() {
+  return {
+    version: 1,
+    protocol: "opencode-http",
+    transport: {
+      control: "http-json",
+      events: "sse-daemon-fanout"
+    },
+    toolCalls: {
+      representation: "opencode-message-parts"
+    },
+    models: {
+      source: "runtime-provider-api",
+      cacheScope: "machine",
+      variants: "provider-advertised",
+      variantConfigIDs: []
+    },
+    lifecycle: {
+      sessionAuthority: "native-harness",
+      create: "native-session",
+      resume: "native-session-id",
+      stop: "native-abort",
+      reconnect: "daemon-sse-fanout-and-reconciliation"
+    }
+  }
+}

--- a/bridge/src/machine-daemon.js
+++ b/bridge/src/machine-daemon.js
@@ -19,15 +19,15 @@ export class MachineDaemon {
     this.hosts = new Map()
   }
 
-  registerAcpHost({ id, label, backend = id, capabilities = {}, agent, modelCatalog, bridgeConfig, serviceOptions, managed = true }) {
-    this.registry.registerHost({ id, label, backend, transport: "acp", managed, state: "configured", capabilities })
+  registerAcpHost({ id, label, backend = id, capabilities = {}, contract = {}, agent, modelCatalog, bridgeConfig, serviceOptions, managed = true }) {
+    this.registry.registerHost({ id, label, backend, transport: "acp", managed, state: "configured", capabilities, contract })
     const tracked = trackAgentHostLifecycle(agent, this.registry, id)
     this.hosts.set(id, { id, kind: "acp", host: tracked, modelCatalog, bridgeConfig, serviceOptions, eager: false })
     return tracked
   }
 
-  registerManagedHttpHost({ id, label, backend = id, capabilities = {}, host, modelCatalog, managed = true, eager = true }) {
-    this.registry.registerHost({ id, label, backend, transport: "http", managed, state: "configured", capabilities })
+  registerManagedHttpHost({ id, label, backend = id, capabilities = {}, contract = {}, host, modelCatalog, managed = true, eager = true }) {
+    this.registry.registerHost({ id, label, backend, transport: "http", managed, state: "configured", capabilities, contract })
     const tracked = trackManagedHostLifecycle(host, this.registry, id)
     this.hosts.set(id, { id, kind: "http", host: tracked, modelCatalog, eager })
     return tracked
@@ -42,10 +42,10 @@ export class MachineDaemon {
     return entry.modelCatalog.list(options)
   }
 
-  modelDiagnostics(id) {
+  modelDiagnostics(id, options) {
     const entry = this.hostEntry(id)
     if (!entry) return undefined
-    return entry.modelCatalog?.diagnostics?.() ?? {
+    return entry.modelCatalog?.diagnostics?.(options) ?? {
       source: "unavailable",
       cachedModels: 0,
       refreshedAt: null,
@@ -56,19 +56,19 @@ export class MachineDaemon {
     }
   }
 
-  async resolveModel(id, model) {
+  async resolveModel(id, model, options) {
     if (!model) return null
     const entry = this.hostEntry(id)
     if (!entry) throw new Error(`Unknown agent: ${id}`)
     if (!entry.modelCatalog) throw new Error(`Agent ${id} does not expose model discovery`)
-    if (typeof entry.modelCatalog.resolve === "function") return entry.modelCatalog.resolve(model)
-    await entry.modelCatalog.validate(model)
+    if (typeof entry.modelCatalog.resolve === "function") return entry.modelCatalog.resolve(model, options)
+    await entry.modelCatalog.validate(model, options)
     return model
   }
 
-  async validateModel(id, model) {
+  async validateModel(id, model, options) {
     if (!model) return
-    await this.resolveModel(id, model)
+    await this.resolveModel(id, model, options)
   }
 
   async startManagedHosts() {
@@ -172,7 +172,7 @@ export function createMachineDaemonServer({
     })
   })
   const launchServer = createLaunchServer({ innerServer, config, taskRunController: runs })
-  const modelServer = createModelServer({ innerServer: launchServer, config, daemon, taskStore: tasks })
+  const modelServer = createModelServer({ innerServer: launchServer, config, daemon, taskStore: tasks, projectCatalog: projects })
   const finishServer = createFinishServer({ innerServer: modelServer, config, taskStore: tasks, worktreeManager: worktrees, taskRunController: runs })
   return createWorkThreadServerFactory({ innerServer: finishServer, config, controller: threads })
 }

--- a/bridge/src/machine-registry.js
+++ b/bridge/src/machine-registry.js
@@ -13,6 +13,10 @@ function cloneRecord(value) {
   return value && typeof value === "object" ? structuredClone(value) : {}
 }
 
+function cloneOptionalRecord(value) {
+  return value && typeof value === "object" ? structuredClone(value) : undefined
+}
+
 async function readIdentity(machineFile) {
   const parsed = JSON.parse(await readFile(machineFile, "utf8"))
   return validIdentity(parsed) ? parsed : undefined
@@ -71,6 +75,14 @@ export async function loadMachineIdentity(stateDirectory, options = {}) {
   return installIdentity(machineFile, identity)
 }
 
+function publicHost(host) {
+  return {
+    ...host,
+    capabilities: cloneRecord(host.capabilities),
+    ...(host.contract ? { contract: cloneOptionalRecord(host.contract) } : {})
+  }
+}
+
 export class MachineRegistry {
   constructor(identity) {
     if (!validIdentity(identity)) throw new Error("MachineRegistry requires a stable machine identity")
@@ -89,14 +101,10 @@ export class MachineRegistry {
       managed: host.managed !== false,
       state: host.state ?? "configured",
       capabilities: cloneRecord(host.capabilities),
-      contract: cloneRecord(host.contract)
+      ...(host.contract && typeof host.contract === "object" ? { contract: cloneOptionalRecord(host.contract) } : {})
     }
     this.hosts.set(normalized.id, normalized)
-    return {
-      ...normalized,
-      capabilities: cloneRecord(normalized.capabilities),
-      contract: cloneRecord(normalized.contract)
-    }
+    return publicHost(normalized)
   }
 
   updateHost(id, patch) {
@@ -107,33 +115,21 @@ export class MachineRegistry {
       ...patch,
       id: current.id,
       capabilities: patch.capabilities ? cloneRecord(patch.capabilities) : current.capabilities,
-      contract: patch.contract ? cloneRecord(patch.contract) : current.contract
+      ...(patch.contract && typeof patch.contract === "object" ? { contract: cloneOptionalRecord(patch.contract) } : {})
     }
     this.hosts.set(id, next)
-    return {
-      ...next,
-      capabilities: cloneRecord(next.capabilities),
-      contract: cloneRecord(next.contract)
-    }
+    return publicHost(next)
   }
 
   host(id) {
     const value = this.hosts.get(id)
-    return value ? {
-      ...value,
-      capabilities: cloneRecord(value.capabilities),
-      contract: cloneRecord(value.contract)
-    } : undefined
+    return value ? publicHost(value) : undefined
   }
 
   snapshot() {
     return {
       machine: { ...this.identity },
-      agents: [...this.hosts.values()].map((host) => ({
-        ...host,
-        capabilities: cloneRecord(host.capabilities),
-        contract: cloneRecord(host.contract)
-      }))
+      agents: [...this.hosts.values()].map(publicHost)
     }
   }
 }

--- a/bridge/src/machine-registry.js
+++ b/bridge/src/machine-registry.js
@@ -9,6 +9,10 @@ function validIdentity(value) {
   return value && typeof value.id === "string" && value.id.length > 0 && typeof value.name === "string" && value.name.length > 0
 }
 
+function cloneRecord(value) {
+  return value && typeof value === "object" ? structuredClone(value) : {}
+}
+
 async function readIdentity(machineFile) {
   const parsed = JSON.parse(await readFile(machineFile, "utf8"))
   return validIdentity(parsed) ? parsed : undefined
@@ -84,10 +88,15 @@ export class MachineRegistry {
       transport: host.transport ?? "acp",
       managed: host.managed !== false,
       state: host.state ?? "configured",
-      capabilities: host.capabilities ? { ...host.capabilities } : {}
+      capabilities: cloneRecord(host.capabilities),
+      contract: cloneRecord(host.contract)
     }
     this.hosts.set(normalized.id, normalized)
-    return { ...normalized, capabilities: { ...normalized.capabilities } }
+    return {
+      ...normalized,
+      capabilities: cloneRecord(normalized.capabilities),
+      contract: cloneRecord(normalized.contract)
+    }
   }
 
   updateHost(id, patch) {
@@ -97,15 +106,24 @@ export class MachineRegistry {
       ...current,
       ...patch,
       id: current.id,
-      capabilities: patch.capabilities ? { ...patch.capabilities } : current.capabilities
+      capabilities: patch.capabilities ? cloneRecord(patch.capabilities) : current.capabilities,
+      contract: patch.contract ? cloneRecord(patch.contract) : current.contract
     }
     this.hosts.set(id, next)
-    return { ...next, capabilities: { ...next.capabilities } }
+    return {
+      ...next,
+      capabilities: cloneRecord(next.capabilities),
+      contract: cloneRecord(next.contract)
+    }
   }
 
   host(id) {
     const value = this.hosts.get(id)
-    return value ? { ...value, capabilities: { ...value.capabilities } } : undefined
+    return value ? {
+      ...value,
+      capabilities: cloneRecord(value.capabilities),
+      contract: cloneRecord(value.contract)
+    } : undefined
   }
 
   snapshot() {
@@ -113,7 +131,8 @@ export class MachineRegistry {
       machine: { ...this.identity },
       agents: [...this.hosts.values()].map((host) => ({
         ...host,
-        capabilities: { ...host.capabilities }
+        capabilities: cloneRecord(host.capabilities),
+        contract: cloneRecord(host.contract)
       }))
     }
   }

--- a/bridge/src/task-launcher.js
+++ b/bridge/src/task-launcher.js
@@ -206,9 +206,9 @@ export class TaskLauncher {
     return entry
   }
 
-  async #resolvedModel(agentID, model) {
+  async #resolvedModel(agentID, model, directory) {
     if (!model || typeof this.daemon.resolveModel !== "function") return model
-    return this.daemon.resolveModel(agentID, model)
+    return this.daemon.resolveModel(agentID, model, directory ? { directory } : undefined)
   }
 
   async #applyAcpVariant(entry, sessionID, resolvedModel) {
@@ -220,11 +220,11 @@ export class TaskLauncher {
     })
   }
 
-  async validateModelSelection(agentID, model) {
+  async validateModelSelection(agentID, model, directory) {
     if (!model) return
     await this.#entry(agentID)
     if (typeof this.daemon.validateModel !== "function") return
-    await this.daemon.validateModel(agentID, model)
+    await this.daemon.validateModel(agentID, model, directory ? { directory } : undefined)
   }
 
   async #httpSessionMessages(task, run, agentID) {
@@ -290,8 +290,8 @@ export class TaskLauncher {
     const agentID = runAgentID(task)
     const model = runModel(task)
     const entry = await this.#entry(agentID)
-    const resolvedModel = entry.kind === "acp" ? await this.#resolvedModel(agentID, model) : model
     if (!task.workspace?.path) throw taskLaunchError("workspace_required", "Task workspace is not prepared")
+    const resolvedModel = entry.kind === "acp" ? await this.#resolvedModel(agentID, model, task.workspace.path) : model
     const title = taskSessionTitle(task)
 
     if (entry.kind === "acp") {
@@ -335,8 +335,8 @@ export class TaskLauncher {
     if (!previousRun?.sessionId) throw taskLaunchError("session_unavailable", "The previous Task session is unavailable")
     if (previousRun.agentId && previousRun.agentId !== agentID) throw taskLaunchError("session_unavailable", "A native Session can only be resumed by the harness that owns it")
     const entry = await this.#entry(agentID)
-    const resolvedModel = entry.kind === "acp" ? await this.#resolvedModel(agentID, model) : model
     if (!task.workspace?.path) throw taskLaunchError("workspace_required", "Task workspace is not prepared")
+    const resolvedModel = entry.kind === "acp" ? await this.#resolvedModel(agentID, model, task.workspace.path) : model
     const modelChanged = !sameModel(previousRun.model ?? null, model)
 
     if (entry.kind === "acp") {

--- a/bridge/src/task-run-controller.js
+++ b/bridge/src/task-run-controller.js
@@ -279,7 +279,7 @@ export class TaskRunController {
     })
 
     try {
-      await this.taskLauncher.validateModelSelection?.(agentID, model)
+      await this.taskLauncher.validateModelSelection?.(agentID, model, task.workspace.path)
       const context = await this.#contextForTask(task)
       effectivePrompt = needsHandoffContext
         ? formatTaskHandoff(context, { targetAgentId: agentID, role, instruction: userPrompt })

--- a/bridge/test/agent-model-scope-server.test.js
+++ b/bridge/test/agent-model-scope-server.test.js
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict"
+import http from "node:http"
+import test from "node:test"
+import { createAgentModelServer } from "../src/agent-model-server.js"
+
+async function listen(server) {
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
+  const address = server.address()
+  return `http://127.0.0.1:${address.port}`
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+}
+
+const config = { username: "harness", password: "secret", corsOrigins: [] }
+const headers = { Authorization: `Basic ${Buffer.from("harness:secret").toString("base64")}` }
+
+function modelResult() {
+  return { models: [{ providerID: "provider", providerName: "Provider", modelID: "model", modelName: "Model" }], stale: false, refreshedAt: null }
+}
+
+test("model endpoint resolves projectId to a server-owned project cwd", async () => {
+  const calls = []
+  const daemon = { async listModels(agentID, options) { calls.push({ agentID, options }); return modelResult() } }
+  const projectCatalog = async () => [{ id: "project-1", path: "/safe/project-one" }]
+  const innerServer = http.createServer((_request, response) => { response.writeHead(500); response.end() })
+  const server = createAgentModelServer({ innerServer, config, daemon, taskStore: {}, projectCatalog })
+  const base = await listen(server)
+  try {
+    const response = await fetch(`${base}/v1/agents/pi/models?projectId=project-1`, { headers })
+    assert.equal(response.status, 200)
+    assert.deepEqual(calls, [{ agentID: "pi", options: { allowStale: true, refresh: false, directory: "/safe/project-one" } }])
+  } finally { await close(server) }
+})
+
+test("model endpoint resolves workThreadId to its persisted workspace cwd", async () => {
+  const calls = []
+  const daemon = { async listModels(agentID, options) { calls.push({ agentID, options }); return modelResult() } }
+  const taskStore = { async get(id) { return id === "conversation-1" ? { id, workspace: { path: "/safe/conversation-workspace" } } : null } }
+  const innerServer = http.createServer((_request, response) => { response.writeHead(500); response.end() })
+  const server = createAgentModelServer({ innerServer, config, daemon, taskStore, projectCatalog: async () => [] })
+  const base = await listen(server)
+  try {
+    const response = await fetch(`${base}/v1/agents/omp/models?workThreadId=conversation-1`, { headers })
+    assert.equal(response.status, 200)
+    assert.deepEqual(calls, [{ agentID: "omp", options: { allowStale: true, refresh: false, directory: "/safe/conversation-workspace" } }])
+  } finally { await close(server) }
+})
+
+test("model endpoint never accepts a client supplied cwd as model authority", async () => {
+  const calls = []
+  const daemon = { async listModels(agentID, options) { calls.push({ agentID, options }); return modelResult() } }
+  const innerServer = http.createServer((_request, response) => { response.writeHead(500); response.end() })
+  const server = createAgentModelServer({ innerServer, config, daemon, taskStore: {}, projectCatalog: async () => [] })
+  const base = await listen(server)
+  try {
+    const response = await fetch(`${base}/v1/agents/pi/models?cwd=%2Fetc`, { headers })
+    assert.equal(response.status, 200)
+    assert.deepEqual(calls, [{ agentID: "pi", options: { allowStale: true, refresh: false } }])
+  } finally { await close(server) }
+})
+
+test("model endpoint rejects ambiguous project and conversation scope", async () => {
+  let calls = 0
+  const daemon = { async listModels() { calls += 1; return modelResult() } }
+  const innerServer = http.createServer((_request, response) => { response.writeHead(500); response.end() })
+  const server = createAgentModelServer({ innerServer, config, daemon, taskStore: {}, projectCatalog: async () => [] })
+  const base = await listen(server)
+  try {
+    const response = await fetch(`${base}/v1/agents/pi/models?projectId=p&workThreadId=w`, { headers })
+    assert.equal(response.status, 400)
+    assert.equal(calls, 0)
+  } finally { await close(server) }
+})

--- a/bridge/test/agent-model-scope.test.js
+++ b/bridge/test/agent-model-scope.test.js
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import test from "node:test"
+import { AcpAgentModelCatalog } from "../src/agent-model-catalog.js"
+
+class ScopedAcp extends EventEmitter {
+  starts = 0
+  newCalls = []
+  async start() { this.starts += 1 }
+  close() {}
+  async request(method, params) {
+    if (method !== "session/new") throw new Error(`unexpected method ${method}`)
+    this.newCalls.push(params.cwd)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    const slug = params.cwd.endsWith("project-a") ? "alpha" : params.cwd.endsWith("project-b") ? "beta" : "default"
+    return {
+      sessionId: `catalog-${slug}`,
+      configOptions: [{
+        id: "model",
+        currentValue: `provider/${slug}`,
+        options: [{ value: `provider/${slug}`, name: slug }]
+      }]
+    }
+  }
+}
+
+test("ACP model catalogs isolate cache and single-flight by authorized project cwd while sharing one adapter", async () => {
+  const stateDirectory = await mkdtemp(path.join(tmpdir(), "harness-model-scope-"))
+  try {
+    const agent = new ScopedAcp()
+    const catalog = new AcpAgentModelCatalog({
+      agent,
+      agentID: "pi",
+      directory: "/projects/default",
+      stateDirectory
+    })
+
+    const [a1, a2, b] = await Promise.all([
+      catalog.list({ allowStale: false, directory: "/projects/project-a" }),
+      catalog.list({ allowStale: false, directory: "/projects/project-a" }),
+      catalog.list({ allowStale: false, directory: "/projects/project-b" })
+    ])
+
+    assert.deepEqual(a1.models.map((model) => model.modelID), ["alpha"])
+    assert.deepEqual(a2.models.map((model) => model.modelID), ["alpha"])
+    assert.deepEqual(b.models.map((model) => model.modelID), ["beta"])
+    assert.equal(agent.newCalls.filter((cwd) => cwd === "/projects/project-a").length, 1)
+    assert.equal(agent.newCalls.filter((cwd) => cwd === "/projects/project-b").length, 1)
+
+    const cachedA = await catalog.list({ allowStale: false, directory: "/projects/project-a" })
+    assert.deepEqual(cachedA.models.map((model) => model.modelID), ["alpha"])
+    assert.equal(agent.newCalls.length, 2)
+
+    const diagnostics = catalog.diagnostics()
+    assert.equal(diagnostics.cacheScope, "project-cwd")
+    assert.equal(diagnostics.scopeCount, 2)
+    assert.deepEqual(new Set(diagnostics.scopes.map((scope) => scope.directory)), new Set(["/projects/project-a", "/projects/project-b"]))
+  } finally {
+    await rm(stateDirectory, { recursive: true, force: true })
+  }
+})

--- a/bridge/test/harness-capability-contract.test.js
+++ b/bridge/test/harness-capability-contract.test.js
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { acpHarnessCapabilityContract, openCodeCapabilityContract } from "../src/harness-capability-contract.js"
+import { harnessProfile } from "../src/harness-profiles.js"
+
+test("ACP capability contract preserves runtime-specific model controls without inventing them", () => {
+  const omp = acpHarnessCapabilityContract(harnessProfile("omp"))
+  const pi = acpHarnessCapabilityContract(harnessProfile("pi"))
+  const claude = acpHarnessCapabilityContract(harnessProfile("claude"))
+
+  assert.equal(omp.protocol, "acp")
+  assert.equal(omp.transport.control, "stdio-json-rpc")
+  assert.equal(omp.models.cacheScope, "project-cwd")
+  assert.ok(omp.models.variantConfigIDs.includes("thinking"))
+  assert.ok(pi.models.variantConfigIDs.some((id) => ["thinkingLevel", "thinking_level", "thinking"].includes(id)))
+  assert.deepEqual(claude.models.variantConfigIDs, [])
+  assert.equal(claude.models.variants, "runtime-advertised-only")
+})
+
+test("OpenCode capability contract describes daemon-owned SSE fanout and runtime provider models", () => {
+  const contract = openCodeCapabilityContract()
+  assert.equal(contract.protocol, "opencode-http")
+  assert.equal(contract.transport.control, "http-json")
+  assert.equal(contract.transport.events, "sse-daemon-fanout")
+  assert.equal(contract.toolCalls.representation, "opencode-message-parts")
+  assert.equal(contract.models.source, "runtime-provider-api")
+  assert.equal(contract.models.cacheScope, "machine")
+  assert.equal(contract.models.variants, "provider-advertised")
+  assert.equal(contract.lifecycle.sessionAuthority, "native-harness")
+})

--- a/docs/V3_CAPABILITY_CONTRACT_AUDIT.md
+++ b/docs/V3_CAPABILITY_CONTRACT_AUDIT.md
@@ -1,0 +1,82 @@
+# Harness Remote 3.0 capability contract audit
+
+This branch is the backend/capability workstream for the final Harness Remote 3.0 pre-merge audit.
+
+Frozen shared baseline:
+
+`56c5c9d925045fbef542650c6d564ce502c72758`
+
+## Goal
+
+Make the per-harness capability contract explicit and make discovery/cache identity correctly project-aware without disturbing the already-validated reliability fixes.
+
+The normalized model list is only one part of the contract.
+
+## Required capability contract
+
+For OpenCode, Codex, Claude, PI and OMP, expose/document where observable:
+
+- transport/protocol;
+- native Session create/resume/load/stop behavior;
+- stream/event mechanism;
+- tool-call representation;
+- model catalog source;
+- default/current model behavior;
+- model variant/reasoning metadata;
+- attachments/tool capability metadata where truly advertised;
+- reconnect/retry behavior;
+- lifecycle guarantees and known limitations;
+- diagnostic observability.
+
+Do not invent capabilities a harness does not advertise or support.
+
+## Project/cwd-aware discovery
+
+Where model/provider configuration can be project-scoped, model/capability discovery and single-flight/cache identity must include validated project/cwd in addition to machine + harness.
+
+Carry the selected project/workspace directory end to end from the UI to the daemon.
+
+Do not accept arbitrary filesystem paths supplied by a client. Resolve/validate the requested directory against configured/discovered project roots and reject paths outside allowed roots.
+
+New Conversation should use its selected Project path. Existing Conversation should use the authoritative Work Thread workspace path.
+
+## Reliability constraints
+
+Preserve the fixes in #287/#288:
+
+- daemon-owned model discovery;
+- bounded discovery requests and polling;
+- no duplicate native PI/OMP model-filter processes;
+- no model-name blacklists;
+- accepted-prompt idempotency;
+- Stop reconciliation;
+- OpenCode single upstream event fanout;
+- Android reconnect behavior;
+- bounded diagnostics and listener/subscriber ownership.
+
+## Validation
+
+Add regressions for at least:
+
+- cache isolation between two project/cwd values for the same machine+harness;
+- concurrent same-scope requests joining one operation;
+- different-scope requests not sharing the wrong catalog;
+- invalid/out-of-root directory rejection;
+- capability snapshot/contract shape per harness profile;
+- first-selection loading/errors surfacing as capability/discovery state rather than generic disconnect where possible.
+
+Then run the existing bridge/web suites and real-harness validation from one exact final SHA.
+
+## Safety
+
+- NEVER touch `main`.
+- NEVER modify `v3/taskdesk` directly.
+- NEVER delete or rewrite `archive/harness-3-2026-08-15`.
+- Do not modify the frozen `fix/v3-backend-reliability-audit` baseline.
+- Do not modify `audit/claude-v3-product-ui`.
+- Do not merge #286 or #288.
+
+Refs #197
+Refs #287
+Refs #289
+Refs #288

--- a/docs/V3_HARNESS_CAPABILITY_MATRIX.md
+++ b/docs/V3_HARNESS_CAPABILITY_MATRIX.md
@@ -1,0 +1,144 @@
+# Harness Remote 3.0 harness capability matrix
+
+This document records the runtime contract Harness Remote 3.0 expects from each supported coding harness.
+
+The model list is only one part of that contract. Harness Remote also needs to know how a harness communicates, how tool activity is represented, which model controls are actually advertised, which component owns Session truth, and which lifecycle guarantees can be relied on.
+
+The machine snapshot exposes the same structured information as `agent.contract`. Boolean capability flags remain for compatibility, while the structured contract is the 3.0 direction.
+
+## Product rule
+
+Harness Remote owns the **Conversation** continuity layer. The coding harness owns its **Native Session**.
+
+Harness Remote must not flatten harness-specific capabilities into a fake universal Session protocol. If a harness does not advertise a control, Harness Remote does not invent it.
+
+## Matrix
+
+| Harness | Protocol / control | Live events | Tool representation | Model source | Catalog scope | Model controls | Session authority |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| OpenCode | HTTP JSON | daemon-owned SSE fanout | OpenCode message parts | runtime `/provider` or `/api/provider`; `/config/providers` compatibility fallback | machine | provider-advertised variants | OpenCode |
+| OMP | ACP over stdio JSON-RPC | ACP Session updates | ACP Session updates | fresh prompt-less technical ACP Session `configOptions` | Project / cwd | `thinking` only when advertised | OMP |
+| PI | ACP over stdio JSON-RPC | ACP Session updates | ACP Session updates | fresh prompt-less technical `pi-acp` Session `configOptions` | Project / cwd | `thinkingLevel`, compatible runtime aliases only when advertised | PI |
+| Codex | ACP over stdio JSON-RPC | ACP Session updates | ACP Session updates | fresh prompt-less technical ACP Session `configOptions` | Project / cwd | `reasoning_effort` only when advertised | Codex |
+| Claude | ACP over stdio JSON-RPC | ACP Session updates | ACP Session updates | fresh prompt-less technical ACP Session `configOptions` | Project / cwd | runtime-advertised controls only; no fabricated reasoning levels | Claude |
+
+## Model discovery scope
+
+ACP harness configuration can depend on the Project directory. Harness Remote therefore treats ACP model discovery as scoped by:
+
+```text
+machine + harness + Project/cwd
+```
+
+The browser or Android client does not send an arbitrary filesystem path to the model endpoint. It sends either:
+
+- `projectId` for New Conversation; or
+- `workThreadId` for an existing Conversation.
+
+The daemon resolves that identifier to an already-authorized Project or persisted Conversation workspace and only then passes the directory to the catalog.
+
+Each authorized ACP directory has its own:
+
+- cached model catalog;
+- single-flight discovery operation;
+- prompt-less technical Session;
+- refresh/error state;
+- variant-probe state.
+
+Those scopes share the same model-discovery ACP adapter process. Harness Remote does not spawn a second PI or OMP CLI as a competing model authority.
+
+OpenCode remains machine-scoped because its runtime provider inventory is obtained from the managed OpenCode host rather than from a Project-scoped ACP Session.
+
+## Lifecycle contract
+
+### Conversation
+
+Harness Remote owns:
+
+- stable Conversation identity;
+- Project association;
+- ordered Native Session references;
+- current harness/model selection;
+- explicit handoff context between Native Sessions;
+- retry/reconciliation metadata needed above the harness layer.
+
+### Native Session
+
+The selected harness owns:
+
+- native transcript and message semantics;
+- reasoning/activity representation;
+- tool execution and tool state;
+- questions and permissions when supported;
+- native context/memory/compaction;
+- model behavior;
+- abort/Stop behavior;
+- native resume semantics.
+
+### Create, resume and Stop
+
+The structured runtime contract currently describes the intended routing semantics as:
+
+- create: native harness Session;
+- resume: native Session when the harness supports it;
+- Stop: native abort/cancel path;
+- reconnect: daemon transport reconciliation rather than blindly replaying a prompt.
+
+Exact real-machine behavior is still part of the 3.0 release gate. This matrix documents the contract and implementation path; it does not replace validation against installed OpenCode, OMP, PI, Codex and Claude builds.
+
+## Transport notes
+
+### OpenCode
+
+OpenCode uses HTTP for control. Harness Remote owns one upstream OpenCode global SSE connection and fans events out to downstream web, desktop and Android clients. Reconnecting clients must not create an unbounded number of OpenCode upstream subscriptions.
+
+### ACP harnesses
+
+OMP, PI, Codex and Claude are controlled through ACP adapters over stdio JSON-RPC. Session updates carry the harness-native activity through the ACP representation. Model discovery uses a separate prompt-less technical ACP connection from user-facing Session ownership so discovery cannot take over a Conversation Session.
+
+## Variant and reasoning metadata
+
+Harness Remote preserves controls that the running harness actually advertises:
+
+- OMP: `thinking` when advertised;
+- PI: `thinkingLevel` or compatible runtime aliases when advertised;
+- Codex: `reasoning_effort` when advertised;
+- Claude: no fabricated low/medium/high levels;
+- OpenCode: provider-advertised variants.
+
+A base model remains usable if optional variant enrichment is slow or incomplete.
+
+## Diagnostics
+
+The 3.0 backend exposes diagnostics for model discovery and lifecycle investigation, including:
+
+- catalog source and cache scope;
+- cached model count and age;
+- in-flight discovery state;
+- ACP discovery phase;
+- variant-probe completeness;
+- scoped Project/cwd catalog state;
+- active/queued Sessions;
+- pending ACP requests;
+- event stream and reconnect counters;
+- OpenCode upstream/downstream fanout state.
+
+Diagnostics must not expose prompt bodies, credentials or generated authentication material.
+
+## Release validation still required
+
+Before 3.0 promotion, validate the contract with real installed harnesses on one exact candidate SHA:
+
+1. discover/start each harness;
+2. load models in at least two Projects where practical;
+3. create a Conversation;
+4. continue across multiple turns;
+5. run a long reasoning/tool turn;
+6. Stop a real turn;
+7. switch harness and model;
+8. switch away and back;
+9. restart daemon and reconcile/resume;
+10. background/foreground Android or interrupt the local network;
+11. prove listener, request, cache and subscription counts plateau.
+
+The final release matrix must distinguish what was **implemented**, what was **advertised by the harness**, and what was **verified on a real machine**.

--- a/web/src/components/conversation-workspace.tsx
+++ b/web/src/components/conversation-workspace.tsx
@@ -237,7 +237,7 @@ function NewConversationModal({
   }, [runtime?.machine.id])
 
   useEffect(() => {
-    if (!runtime || !agentID) {
+    if (!runtime || !agentID || !projectID) {
       setModels([])
       setModelKey("")
       return
@@ -249,7 +249,7 @@ function NewConversationModal({
     setModelKey("")
     setModelsLoading(true)
     setError(null)
-    void taskClient.listAgentModels(runtime.machine.config, agentID).then((catalog) => {
+    void taskClient.listAgentModels(runtime.machine.config, agentID, { projectId: projectID }).then((catalog) => {
       if (generation.current !== current) return
       setModels(catalog.models)
       const selected = catalog.models.find((model) => model.isDefault) || catalog.models[0]
@@ -263,7 +263,7 @@ function NewConversationModal({
     }).finally(() => {
       if (generation.current === current) setModelsLoading(false)
     })
-  }, [runtime?.machine.id, agentID])
+  }, [runtime?.machine.id, agentID, projectID])
 
   const project = runtime?.projects.find((candidate) => candidate.id === projectID)
   const agent = runtime?.agents.find((candidate) => candidate.id === agentID)

--- a/web/src/components/work-thread-conversation.tsx
+++ b/web/src/components/work-thread-conversation.tsx
@@ -503,7 +503,7 @@ export function WorkThreadConversation({
     setModels([])
     setModelsLoading(true)
     setModelError(null)
-    void taskClient.listAgentModels(baseConfig, targetAgentID).then((catalog) => {
+    void taskClient.listAgentModels(baseConfig, targetAgentID, { workThreadId: task.id }).then((catalog) => {
       if (modelGeneration.current !== current) return
       setModels(catalog.models)
       const prior = lastModelForAgent(taskRef.current, targetAgentID)
@@ -521,7 +521,7 @@ export function WorkThreadConversation({
     }).finally(() => {
       if (modelGeneration.current === current) setModelsLoading(false)
     })
-  }, [targetAgentID, task.id, baseConfig])
+  }, [targetAgentID, task.id, task.workspace.path, baseConfig])
 
   // Only a model verified by the current live catalog is sent explicitly. A null selection is
   // intentional: the controller distinguishes it from an omitted field, which means reuse the

--- a/web/src/settings-regression.test.mjs
+++ b/web/src/settings-regression.test.mjs
@@ -46,8 +46,10 @@ assert.match(preferences, /export function installAppPreferences/)
 assert.match(main, /installAppPreferences\(\)/, 'preferences must be installed before the product shell renders')
 
 // One machine connection discovers the available coding agents instead of asking for one profile per harness.
+// New Conversation discovery must remain scoped to the selected Project so project-specific providers
+// and model availability cannot leak across two workspaces on the same machine + harness.
 assert.match(workspace, /selectableMachineAgents\(snapshot\)/)
-assert.match(workspace, /taskClient\.listAgentModels\(runtime\.machine\.config, agentID\)/)
+assert.match(workspace, /taskClient\.listAgentModels\(runtime\.machine\.config, agentID, \{ projectId: projectID \}\)/)
 assert.match(workspace, /<span className="tdw-workspace-label">Coding agents<\/span>/)
 assert.match(machineClient, /export async function discoverMachine/)
 

--- a/web/src/taskClient.ts
+++ b/web/src/taskClient.ts
@@ -135,6 +135,11 @@ export type AgentModelCatalog = {
   source?: string
 }
 
+export type AgentModelScope = {
+  projectId?: string
+  workThreadId?: string
+}
+
 export type TaskContinueInput = {
   prompt: string
   agentId?: string
@@ -163,6 +168,19 @@ const pendingContinueRequests = new Map<string, PendingContinue>()
 
 function cacheKey(config: ServerConfig): string {
   return `${machineBaseUrl(config)}|${config.username || ""}`
+}
+
+function modelScopeKey(scope: AgentModelScope): string {
+  if (scope.workThreadId) return `conversation:${scope.workThreadId}`
+  if (scope.projectId) return `project:${scope.projectId}`
+  return "default"
+}
+
+function modelCatalogPath(agentId: string, scope: AgentModelScope): string {
+  const params = new URLSearchParams({ waitMs: "4000" })
+  if (scope.workThreadId) params.set("workThreadId", scope.workThreadId)
+  else if (scope.projectId) params.set("projectId", scope.projectId)
+  return `/v1/agents/${encodeURIComponent(agentId)}/models?${params.toString()}`
 }
 
 function pendingContinueKey(config: ServerConfig, taskId: string): string {
@@ -357,8 +375,8 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => globalThis.setTimeout(resolve, ms))
 }
 
-async function loadAgentModelCatalog(config: ServerConfig, agentId: string): Promise<AgentModelCatalog> {
-  const path = `/v1/agents/${encodeURIComponent(agentId)}/models?waitMs=4000`
+async function loadAgentModelCatalog(config: ServerConfig, agentId: string, scope: AgentModelScope): Promise<AgentModelCatalog> {
+  const path = modelCatalogPath(agentId, scope)
   const started = Date.now()
   while (true) {
     const catalog = requireModelCatalog(await machineRequest<unknown>(config, path), path)
@@ -428,11 +446,11 @@ export const taskClient = {
     return machineRequest<MachineTask>(config, `/v1/work-threads/${encodeURIComponent(taskId)}`, { method: "PATCH", body: { title } })
   },
 
-  async listAgentModels(config: ServerConfig, agentId: string): Promise<AgentModelCatalog> {
-    const key = `${cacheKey(config)}|${agentId}`
+  async listAgentModels(config: ServerConfig, agentId: string, scope: AgentModelScope = {}): Promise<AgentModelCatalog> {
+    const key = `${cacheKey(config)}|${agentId}|${modelScopeKey(scope)}`
     const existing = modelCatalogRequests.get(key)
     if (existing) return existing
-    const operation = loadAgentModelCatalog(config, agentId)
+    const operation = loadAgentModelCatalog(config, agentId, scope)
     let wrapped: Promise<AgentModelCatalog>
     wrapped = operation.finally(() => {
       if (modelCatalogRequests.get(key) === wrapped) modelCatalogRequests.delete(key)

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -29,6 +29,31 @@ export type HarnessCapabilities = {
   attachments: boolean
 }
 
+export type HarnessCapabilityContract = {
+  version: number
+  protocol: string
+  transport: {
+    control: string
+    events: string
+  }
+  toolCalls: {
+    representation: string
+  }
+  models: {
+    source: string
+    cacheScope: string
+    variants: string
+    variantConfigIDs: string[]
+  }
+  lifecycle: {
+    sessionAuthority: string
+    create: string
+    resume: string
+    stop: string
+    reconnect: string
+  }
+}
+
 export type MachineAgentHost = {
   id: string
   label: string
@@ -37,6 +62,7 @@ export type MachineAgentHost = {
   managed: boolean
   state: "configured" | "available" | "unavailable" | string
   capabilities: Partial<HarnessCapabilities> & Record<string, unknown>
+  contract?: HarnessCapabilityContract
   processID?: number
 }
 
@@ -81,8 +107,8 @@ export type ModelOption = ModelSelection & {
   attachments?: boolean
   isDefault?: boolean
   /** Pricing metadata is optional because not every harness advertises it. Costs follow the
-   *  provider catalog's token-pricing units. `isFree` is set only when the catalog explicitly says
-   *  so or all advertised token costs are exactly zero; TaskDesk never guesses from a model name. */
+   * provider catalog's token-pricing units. `isFree` is set only when the catalog explicitly says
+   * so or all advertised token costs are exactly zero; Harness Remote never guesses from a model name. */
   isFree?: boolean
   inputCost?: number
   outputCost?: number
@@ -161,7 +187,7 @@ export type MessageEnvelope = {
       completed?: number
     }
     /** Present when the turn ended in a provider or harness failure instead of a reply. OpenCode
-     *  nests the readable sentence under `data.message`, often as a JSON string of its own. */
+     * nests the readable sentence under `data.message`, often as a JSON string of its own. */
     error?: { name?: string; message?: string; data?: { message?: string } }
   }
   parts: MessagePart[]

--- a/web/src/v3-ux-polish-regression.test.mjs
+++ b/web/src/v3-ux-polish-regression.test.mjs
@@ -64,7 +64,7 @@ assert.match(overrides, /prefers-reduced-motion/)
 assert.match(readme, /normal public port is \*\*4097\*\*/)
 assert.match(readme, /normally on loopback port \*\*4096\*\*/)
 assert.match(readme, /one launcher per machine/)
-assert.match(readme, /Project[\s\S]*Conversations[\s\S]*Native Session: OpenCode/)
+assert.match(readme, /Project[\s\S]*Conversations?[\s\S]*Native Session: OpenCode/)
 assert.match(readme, /does \*\*not\*\* create a hidden Git worktree/)
 assert.match(readme, /one Conversation that can continue through several native Sessions/)
 


### PR DESCRIPTION
## Purpose

Parallel backend capability audit for Harness Remote 3.0.

Coordination: #289  
Backend reliability baseline: #288 / #287  
Handoff: `docs/V3_CAPABILITY_CONTRACT_AUDIT.md`  
Capability matrix: `docs/V3_HARNESS_CAPABILITY_MATRIX.md`

Base is the frozen backend-audit baseline:

`56c5c9d925045fbef542650c6d564ce502c72758`

This PR stays **DRAFT** until its automated and real-harness gates are reviewed.

## Product contract

Harness Remote owns the cross-agent **Conversation** continuity layer. OpenCode, OMP, PI, Codex and Claude remain owners of their **Native Sessions**.

The normalized model list is not the complete harness contract. Machine snapshots now expose an optional structured `agent.contract` alongside the existing compatibility capability flags.

The structured contract records:
- protocol and control transport;
- live-event mechanism;
- tool-call representation;
- model discovery source;
- model cache scope;
- runtime-advertised variant controls;
- Session ownership and create/resume/Stop/reconnect semantics.

Existing clients that only understand the old boolean flags remain compatible because `contract` is additive and omitted for hosts that do not provide one.

## Project/cwd-aware model discovery

ACP model configuration can be Project-specific. The previous model catalog had one cache, one in-flight discovery and one prompt-less technical Session per harness adapter, regardless of Project.

The ACP catalog is now partitioned by authorized Project/cwd. Each scope has its own:
- cache;
- single-flight operation;
- technical Session;
- refresh/error state;
- variant-probe state.

All scopes still share the same model-discovery ACP adapter process. This does **not** restore the removed PI/OMP native CLI filtering experiment and does not spawn a second harness as model authority.

OpenCode remains machine-scoped and uses its runtime provider API.

## Safe scope resolution

The client does not submit an arbitrary filesystem path to model discovery.

For New Conversation it sends:

`projectId`

For an existing Conversation it sends:

`workThreadId`

The daemon resolves these identifiers against its own Project catalog or persisted Conversation workspace and only then passes the trusted directory to the model catalog. A raw client `cwd` query is not accepted as model authority.

The same workspace path is also carried through Run model validation and ACP model resolution, so a model verified for one Project is not later validated against a different default scope.

## UI request isolation

`taskClient.listAgentModels()` request deduplication is now keyed by:

`machine + harness + project/conversation scope`

Two Projects using the same PI/OMP harness no longer share one browser Promise simply because machine and harness match.

New Conversation discovery is scoped by `projectId`. Existing Conversation / `Continue with` discovery is scoped by `workThreadId`.

## Runtime capability matrix

Current contract direction:

| Harness | Protocol | Events | Model source | Cache scope | Variant metadata |
| --- | --- | --- | --- | --- | --- |
| OpenCode | HTTP JSON | daemon-owned SSE fanout | runtime `/provider` or `/api/provider`; legacy config fallback | machine | provider-advertised |
| OMP | ACP / stdio JSON-RPC | ACP Session updates | fresh technical Session `configOptions` | Project/cwd | `thinking` when advertised |
| PI | ACP / stdio JSON-RPC | ACP Session updates | fresh `pi-acp` Session `configOptions` | Project/cwd | `thinkingLevel` / compatible advertised aliases |
| Codex | ACP / stdio JSON-RPC | ACP Session updates | fresh technical Session `configOptions` | Project/cwd | `reasoning_effort` when advertised |
| Claude | ACP / stdio JSON-RPC | ACP Session updates | fresh technical Session `configOptions` | Project/cwd | runtime-advertised only; no fabricated levels |

This is documented in `docs/V3_HARNESS_CAPABILITY_MATRIX.md`. Real-machine verification remains separate from declaring the contract.

## README / product documentation

README now introduces Harness Remote 3.0 as conversation-first rather than TaskDesk/task-manager oriented.

It explicitly explains:
- `Project -> Conversation -> Native Sessions`;
- Conversation versus Native Session ownership;
- one Conversation spanning OpenCode, Codex, Claude or other harnesses;
- Sessions as the visible native continuity chain;
- Changes as the real Project workspace;
- why Harness Remote orchestrates native harnesses instead of replacing their Session protocols.

Stable `main` is still documented as the 2.x line while 3.0 remains pre-release.

## Regression coverage added

New tests cover:
- same-scope ACP discovery joining one single-flight operation;
- two Project/cwd scopes having independent catalogs and technical Sessions while sharing one adapter;
- server-side `projectId` resolution;
- server-side `workThreadId` resolution;
- raw client `cwd` not becoming model authority;
- ambiguous project + conversation scope rejection;
- structured ACP capability contracts;
- OpenCode SSE/runtime-provider capability contract.

The pre-existing README UX regression was adjusted to accept the canonical singular `Conversation` wording.

## CI status

Current head:

`221afcd24d3ff6da8774bf18873aad380f7a59bf`

The first intermediate CI run exposed two implementation regressions and was useful:
- Windows reinterpreted a trusted `/repo` cwd through `path.resolve`; the catalog now preserves the daemon-resolved native workspace path verbatim;
- old registry shape tests saw `contract: {}` for hosts without a contract; optional contract output is now backward compatible.

A fresh PR-check run for the current head is in progress. Do not treat this PR as green until that exact run completes successfully.

## Safety / non-goals

- never touch `main`;
- never modify `v3/taskdesk` directly;
- never delete or rewrite `archive/harness-3-2026-08-15`;
- do not modify the frozen #288 baseline;
- do not reintroduce PI/OMP CLI model filtering;
- do not add model-name blacklists;
- do not flatten harness-specific capabilities into invented equivalence;
- do not merge this PR while the parallel audit is active.

## Remaining gate

1. obtain green CI on the exact final head;
2. review Claude's independent #291 diff separately;
3. integrate only accepted changes into a fresh candidate;
4. validate OpenCode, PI, OMP, Codex and Claude on real machines;
5. test two Project scopes where practical;
6. exercise long turns, Stop, harness switching and daemon restart;
7. verify listener/request/cache/subscriber counts plateau;
8. Android smoke test from the exact integrated candidate SHA.

Refs #197
Refs #287
Refs #288
Refs #289
Refs #291