### PR TITLE
fix(bridge): prevent duplicate last message on OMP refresh (#299)

### DIFF
--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -66,7 +66,32 @@ function mergeFragmentedPiSnapshot(messages) {
 }
 
 function messageSignature(message) {
-  return `${message?.info?.role ?? ""}\u0000${(message?.parts ?? []).map((part) => part?.text ?? "").join("")}`
+  // Visible text only – reasoning/tool/file are ephemeral between live stream and persisted/replayed
+  // history. Including them made live vs replayed assistant turns with same answer diverge and get
+  // appended as duplicates on every refresh (see omp-session-history.js:69 fallback).
+  const visibleText = (message?.parts ?? [])
+    .filter((part) => part?.type === "text")
+    .map((part) => part?.text ?? "")
+    .join("")
+  const error = message?.info?.error?.message ? `\u0000${message.info.error.message}` : ""
+  return `${message?.info?.role ?? ""}\u0000${visibleText}${error}`
+}
+
+function isConsecutiveAssistantDuplicate(prev, next) {
+  return prev?.info?.role === "assistant"
+    && next?.info?.role === "assistant"
+    && messageSignature(prev) === messageSignature(next)
+}
+
+function healPoisonedSnapshot(messages) {
+  if (!Array.isArray(messages) || messages.length < 2) return messages
+  const healed = []
+  for (const msg of messages) {
+    const prev = healed.at(-1)
+    if (prev && isConsecutiveAssistantDuplicate(prev, msg)) continue
+    healed.push(msg)
+  }
+  return healed.length === messages.length ? messages : healed
 }
 function stableSemanticValue(value) {
   if (Array.isArray(value)) return value.map(stableSemanticValue)
@@ -113,6 +138,10 @@ function semanticHistorySignature(messages) {
 
 /** Exported for testing only. */
 export function mergeReplay(previous, replayed) {
+  // Heal poisoned snapshots – the zero-tie bug baked a trailing assistant duplicate into
+  // persisted snapshots (acp-service.js:841). Without healing, every future merge keeps it.
+  previous = healPoisonedSnapshot(previous)
+  replayed = healPoisonedSnapshot(replayed)
   if (previous.length === 0) return replayed
   if (replayed.length === 0) return previous
   const left = previous.map(messageSignature)
@@ -125,7 +154,8 @@ export function mergeReplay(previous, replayed) {
   }
 
   if (prefix === previous.length) {
-    return [...previous, ...replayed.slice(prefix)]
+    const appended = [...previous, ...replayed.slice(prefix)]
+    return healPoisonedSnapshot(appended)
   }
 
   const midLeft = left.slice(prefix)
@@ -159,12 +189,24 @@ export function mergeReplay(previous, replayed) {
       rightIndex += 1
     }
   }
-  return [
+  const tailPrev = midPrev.slice(leftIndex)
+  const tailRep = midRep.slice(rightIndex)
+  // Tail reconciliation: when the only divergence is a trailing assistant turn with same
+  // visible text but different ephemeral parts (reasoning/tool/time), the LCS tie-break at
+  // acp-service.js:154 would emit [...prefix, live, replay]. They are the same logical turn.
+  if (tailPrev.length === 1 && tailRep.length === 1 && isConsecutiveAssistantDuplicate(tailPrev[0], tailRep[0])) {
+    return [...previous.slice(0, prefix), ...midMerged, tailPrev[0]]
+  }
+  if (tailPrev.length === tailRep.length && tailPrev.length > 0 && tailPrev.every((m, i) => m.info.role === tailRep[i].info.role && messageSignature(m) === messageSignature(tailRep[i]))) {
+    return [...previous.slice(0, prefix), ...midMerged, ...tailPrev]
+  }
+  const merged = [
     ...previous.slice(0, prefix),
     ...midMerged,
-    ...midPrev.slice(leftIndex),
-    ...midRep.slice(rightIndex)
+    ...tailPrev,
+    ...tailRep
   ]
+  return healPoisonedSnapshot(merged)
 }
 export function mergeExternalHistory(persisted, cached) {
   const persistedIDs = new Set(persisted.map((message) => message.info.id))
@@ -829,7 +871,13 @@ export class AcpService {
     try {
       const snapshot = JSON.parse(await readFile(this.#snapshotPath(sessionID), "utf8"))
       if (snapshot?.version !== 1) return
-      if (Array.isArray(snapshot.messages)) this.#messages.set(sessionID, mergeFragmentedPiSnapshot(snapshot.messages))
+      if (Array.isArray(snapshot.messages)) {
+        // Heal poisoned snapshots that already contain the trailing assistant duplicate
+        const healed = healPoisonedSnapshot(mergeFragmentedPiSnapshot(snapshot.messages))
+        this.#messages.set(sessionID, healed)
+        // Persist healed version lazily – next persist will overwrite poisoned file
+        if (healed.length !== snapshot.messages.length) this.#dirtySnapshots.add(sessionID)
+      }
       if (Array.isArray(snapshot.todos)) this.#todos.set(sessionID, snapshot.todos)
       if (!this.#preferListedTitles && typeof snapshot.title === "string" && snapshot.title) this.#titles.set(sessionID, snapshot.title)
       if (snapshot?.deleted === true) this.#deletedSessions.add(sessionID)
@@ -845,9 +893,13 @@ export class AcpService {
     const writing = (async () => {
       await mkdir(this.#snapshotDirectory, { recursive: true })
       while (this.#dirtySnapshots.delete(sessionID)) {
+        // Ensure we never persist the poisoned trailing duplicate
+        const rawMessages = this.#messages.get(sessionID) ?? []
+        const healedMessages = healPoisonedSnapshot(rawMessages)
+        if (healedMessages.length !== rawMessages.length) this.#messages.set(sessionID, healedMessages)
         const snapshot = JSON.stringify({
           version: 1,
-          messages: this.#messages.get(sessionID) ?? [],
+          messages: healedMessages,
           todos: this.#todos.get(sessionID) ?? [],
           title: this.#titleFor(sessionID),
           deleted: this.#deletedSessions.has(sessionID)

--- a/bridge/test/external-history-dedup.test.js
+++ b/bridge/test/external-history-dedup.test.js
@@ -77,7 +77,13 @@ test("differential test: mergeReplay matches full-matrix LCS on random sequences
   function referenceMergeReplay(previous, replayed) {
     if (previous.length === 0) return replayed
     if (replayed.length === 0) return previous
-    const messageSignature = (m) => `${m?.info?.role ?? ""}\u0000${(m?.parts ?? []).map((p) => p?.text ?? "").join("")}`
+    // Mirrors production messageSignature: visible text only plus the failure reason. The random
+    // generator below only produces user-role messages because mergeReplay additionally heals
+    // consecutive identical assistant envelopes, which a raw-LCS reference would not expect.
+    const messageSignature = (m) => `${m?.info?.role ?? ""}\u0000${(m?.parts ?? [])
+      .filter((p) => p?.type === "text")
+      .map((p) => p?.text ?? "")
+      .join("")}${m?.info?.error?.message ? `\u0000${m.info.error.message}` : ""}`
     const left = previous.map(messageSignature)
     const right = replayed.map(messageSignature)
     const common = Array.from({ length: left.length + 1 }, () => new Uint32Array(right.length + 1))
@@ -128,4 +134,100 @@ test("differential test: mergeReplay matches full-matrix LCS on random sequences
     const actual = mergeReplay(prev, replayed).map((m) => m.info.id)
     assert.deepEqual(actual, expected, `Trial ${trial} failed`)
   }
+})
+
+function envelope(id, role, parts, error) {
+  return {
+    info: { id, role, sessionID: "session-1", time: { created: 1_000 }, ...(error ? { error } : {}) },
+    parts
+  }
+}
+const textPart = (id, text) => ({ id, type: "text", text })
+const reasoningPart = (id, text) => ({ id, type: "reasoning", text })
+
+test("mergeReplay keeps a single copy when the live reply carried reasoning the replay omits", () => {
+  // A turn prompted from the app streams agent_thought_chunk before the answer, while the
+  // persisted history replays text only. The two representations are one logical message.
+  const previous = [
+    envelope("u2", "user", [textPart("p1", "Second question")]),
+    envelope("live-a2", "assistant", [reasoningPart("p2", "Checking the transcript."), textPart("p3", "Bridge reply")])
+  ]
+  const replayed = [
+    envelope("r-u2", "user", [textPart("p1", "Second question")]),
+    envelope("r-a2", "assistant", [textPart("p3", "Bridge reply")])
+  ]
+
+  const merged = mergeReplay(previous, replayed)
+
+  assert.deepEqual(merged.map((m) => m.info.id), ["u2", "live-a2"])
+  assert.ok(
+    merged[1].parts.some((part) => part.type === "reasoning"),
+    "the streamed thought must survive the reconciliation"
+  )
+})
+
+test("mergeReplay treats journal-split text parts and glued replay text as the same message", () => {
+  // Journal loaders map each content item to its own part while replay accumulates chunks into
+  // one; the signature must stay boundary-insensitive or reopening duplicates the reply.
+  const previous = [
+    envelope("u1", "user", [textPart("p1", "Question")]),
+    envelope("jr-a1", "assistant", [textPart("p2a", "Paragraph one."), textPart("p2b", " Paragraph two.")])
+  ]
+  const replayed = [
+    envelope("r-u1", "user", [textPart("p1", "Question")]),
+    envelope("r-a1", "assistant", [textPart("p2", "Paragraph one. Paragraph two.")])
+  ]
+
+  const merged = mergeReplay(previous, replayed)
+
+  assert.deepEqual(merged.map((m) => m.info.id), ["u1", "jr-a1"])
+  assert.equal(merged[1].parts.length, 2, "the persisted part split must be preserved as-is")
+})
+
+test("mergeReplay keeps a failed turn distinct from an otherwise identical successful reply", () => {
+  const failed = envelope("failed", "assistant", [textPart("p1", "Working on it.")], {
+    name: "HarnessTurnError",
+    message: "rate limited"
+  })
+  const plain = envelope("plain", "assistant", [textPart("p1", "Working on it.")])
+
+  const merged = mergeReplay([failed], [plain])
+
+  assert.equal(merged.length, 2)
+  assert.equal(merged[0].info.error.message, "rate limited")
+})
+
+test("mergeReplay heals a poisoned history that already contains the trailing duplicate", () => {
+  const poisoned = [
+    envelope("u1", "user", [textPart("p1", "Question")]),
+    envelope("live-a1", "assistant", [reasoningPart("p2", "thinking"), textPart("p3", "Answer")]),
+    envelope("ghost-a1", "assistant", [textPart("p4", "Answer")])
+  ]
+  const clean = [
+    envelope("r-u1", "user", [textPart("p1", "Question")]),
+    envelope("r-a1", "assistant", [textPart("p3", "Answer")])
+  ]
+
+  const merged = mergeReplay(poisoned, clean)
+
+  assert.deepEqual(merged.map((m) => m.info.id), ["u1", "live-a1"])
+})
+
+test("mergeReplay preserves legitimate repeated replies separated by prompts", () => {
+  const conversation = [
+    envelope("u1", "user", [textPart("p1", "Q1")]),
+    envelope("a1", "assistant", [textPart("p2", "Yes")]),
+    envelope("u2", "user", [textPart("p3", "Again")]),
+    envelope("a2", "assistant", [textPart("p4", "Yes")])
+  ]
+  const replayed = [
+    envelope("r-u1", "user", [textPart("p1", "Q1")]),
+    envelope("r-a1", "assistant", [textPart("p2", "Yes")]),
+    envelope("r-u2", "user", [textPart("p3", "Again")]),
+    envelope("r-a2", "assistant", [textPart("p4", "Yes")])
+  ]
+
+  const merged = mergeReplay(conversation, replayed)
+
+  assert.deepEqual(merged.map((m) => m.info.id), ["u1", "a1", "u2", "a2"])
 })

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -237,6 +237,66 @@ class RealisticOmpAcp extends EventEmitter {
   notify() {}
 }
 
+/** A live turn streams agent_thought_chunk ahead of the answer, but session/load replays text only. */
+class ThoughtfulOmpAcp extends EventEmitter {
+  agentInfo = { version: "17.2.10" }
+  #sessions = []
+  #history = new Map()
+
+  async start() {}
+
+  async listSessions() {
+    return this.#sessions.map(({ sessionId, cwd, updatedAt }) => ({ sessionId, cwd, updatedAt }))
+  }
+
+  async request(method, params) {
+    if (method === "session/new") {
+      const sessionId = `omp-${this.#sessions.length + 1}`
+      this.#sessions.push({ sessionId, cwd: params.cwd, updatedAt: "2026-08-24T00:00:00.000Z" })
+      this.#history.set(sessionId, [])
+      return { sessionId, configOptions: [] }
+    }
+    if (method === "session/prompt") {
+      const history = this.#history.get(params.sessionId) ?? []
+      const index = history.length
+      const text = params.prompt.find((part) => part.type === "text")?.text ?? ""
+      history.push({ role: "user", id: `u${index}`, text })
+      const reply = { role: "assistant", id: `a${index}`, text: "Bridge reply" }
+      history.push(reply)
+      this.#history.set(params.sessionId, history)
+      this.#chunk(params.sessionId, {
+        sessionUpdate: "agent_thought_chunk",
+        messageId: reply.id,
+        text: "Checking the transcript."
+      })
+      this.#chunk(params.sessionId, reply)
+      return { stopReason: "end_turn" }
+    }
+    if (method === "session/load") {
+      for (const message of this.#history.get(params.sessionId) ?? []) this.#chunk(params.sessionId, message)
+      return { configOptions: [] }
+    }
+    return {}
+  }
+
+  #chunk(sessionId, update) {
+    this.emit("notification", {
+      method: "session/update",
+      params: {
+        sessionId,
+        update: {
+          sessionUpdate: update.sessionUpdate
+            ?? (update.role === "assistant" ? "agent_message_chunk" : "user_message_chunk"),
+          messageId: update.messageId ?? update.id,
+          content: { type: "text", text: update.text }
+        }
+      }
+    })
+  }
+
+  notify() {}
+}
+
 /** Holds each turn open so a second prompt arrives while the first is still running. */
 class HeldTurnOmpAcp extends EventEmitter {
   agentInfo = { version: "17.1.3" }
@@ -509,6 +569,49 @@ test("keeps the submitted prompt in history when the session is reopened", async
 
     const reopenedAgain = conversation(await readJSON(bridge.baseURL, `/session/${created.id}/message?refresh=1`))
     assert.deepEqual(reopenedAgain, live)
+  } finally {
+    await bridge.close()
+  }
+})
+
+test("does not duplicate the last reply when reopening a session whose live turn carried a thought", async () => {
+  const bridge = await startServer({ acp: new ThoughtfulOmpAcp() })
+  try {
+    const created = await readJSON(bridge.baseURL, "/session", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({})
+    })
+    await readJSON(bridge.baseURL, `/session/${created.id}/prompt_async`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ parts: [{ type: "text", text: "What changed?" }] })
+    })
+    await waitForIdle(bridge.baseURL, created.id)
+
+    const visible = (messages) => messages.map((message) => ({
+      role: message.info.role,
+      text: message.parts.filter((part) => part.type === "text").map((part) => part.text).join("")
+    }))
+    const expected = [
+      { role: "user", text: "What changed?" },
+      { role: "assistant", text: "Bridge reply" }
+    ]
+
+    assert.deepEqual(visible(await readJSON(bridge.baseURL, `/session/${created.id}/message`)), expected)
+
+    // The live envelope carries the streamed thought; the replayed one does not. Reopening must
+    // reconcile them into one visible reply instead of appending a second copy of the answer.
+    const reopened = await readJSON(bridge.baseURL, `/session/${created.id}/message?refresh=1`)
+    assert.deepEqual(visible(reopened), expected, "reopening must not duplicate the reply")
+    const reply = reopened.find((message) => message.info.role === "assistant")
+    assert.ok(
+      reply.parts.some((part) => part.type === "reasoning"),
+      "the streamed thought must survive the reconciliation"
+    )
+
+    const reopenedAgain = await readJSON(bridge.baseURL, `/session/${created.id}/message?refresh=1`)
+    assert.deepEqual(visible(reopenedAgain), expected, "the transcript must stay stable across further reopens")
   } finally {
     await bridge.close()
   }


### PR DESCRIPTION
Fixes #299

**Bug:** Navigating servers view -> server on Android (and any client with ?refresh=1) duplicated the trailing assistant message on every visit. Screenshots showed Yes--we're in the pfBlockerNG repository growing from 5->6 copies, each with distinct Thought for ... duration.

**Root cause:**
- HARNESS_PROFILES.omp relies on leaf-gated omp-session-history.js:69 (activeSessionLeaf===undefined -> []) falling back to ACP session/load replay - replay is intentional, so reloadOnHistoryRefresh must stay true (unlike pi/codex).
- messageSignature (bridge/src/acp-service.js:68) role+text join included ephemeral reasoning/tool text. Live streaming (agent_thought_chunk -> reasoning{time:{start:now}} + tool_call) vs persisted/replayed history therefore diverged though visible text was identical.
- mergeReplay LCS zero-tie at acp-service.js:154 common[l+1][r] >= common[l][r+1] (0>=0) emitted [...prefix, live, replay] -> duplicate. join empty erases part boundaries, so split vs glued text must stay equal - separator must be empty (verified via repro: 3 msgs, dup=true with newline).

**Fix (bridge/src/acp-service.js):**
- messageSignature -> visible text only (filter type==text) + error, join empty preserved. Ignores reasoning/tool/time/ids - matches semanticMessagePart:81 intent but keeps mergeReplay lenient (strict semanticMessageSignature would worsen).
- Tail reconciliation after LCS: if remaining tails are single assistant with same visible sig, keep one; if tails same-length and role+visible-sig pairwise equal, keep previous (belt).
- healPoisonedSnapshot - dedup consecutive assistant visible duplicates. Wired in mergeReplay (entry/exit), #restoreSnapshot (heals mergeFragmentedPiSnapshot + marks dirty for lazy rewrite) and #persistSnapshot (never persist duplicate). Existing poisoned snapshots self-heal on next open.
- 247/247 bridge tests pass (see Tests commit); preserves user-separated legitimate repeats (healer checks role==assistant only).

**Trade-off documented:** consecutive identical assistant envelopes are assumed impossible under ACP (every turn begins with user_message_chunk), so healing is safe.

**Verification:** end-to-end repro scenarios B/D no longer duplicate; poisoned [user,live,replay] heals to one.


**Tests (3ab7937):**
- mergeReplay unit cases in external-history-dedup.test.js: live reply with streamed reasoning vs text-only replay -> one copy (thought preserved); journal-split text parts vs glued replay part -> equal (guards the empty separator); failed turn stays distinct from an identical successful reply; poisoned snapshot input heals; user-separated repeated replies never collapse.
- Differential test reference signature updated to visible-text+error so it no longer passes vacuously against the old all-parts semantics.
- End-to-end reopen test via ThoughtfulOmpAcp fake: live turn streams agent_thought_chunk, session/load replays text only -> reopening must not duplicate and must keep the thought.
- Mutation-checked: the 4 bug-dependent tests fail against 41dfe88 (pre-fix), including the end-to-end one at "reopening must not duplicate"; F-case/repeat guards pass on both by design.
