### PR TITLE
fix(session-first): make OMP continuation follow native branch truth

### DIFF
--- a/bridge/src/harness-profiles.js
+++ b/bridge/src/harness-profiles.js
@@ -122,6 +122,7 @@ export const HARNESS_PROFILES = {
     // explicitly and invoke its published binary instead of relying on npx package-spec inference.
     args: ["--yes", "--package=@agentclientprotocol/codex-acp@1.1.14", "codex-acp"],
     adapterCommand: "codex-acp",
+    permissionMode: "allow",
     // The adapter offers `api-key` before `chat-gpt`; the former demands CODEX_API_KEY or
     // OPENAI_API_KEY, while a `codex login` leaves ChatGPT credentials the `chat-gpt` method
     // reads from disk. Prefer the login, exactly like the generic default already avoids

--- a/bridge/src/harness-profiles.js
+++ b/bridge/src/harness-profiles.js
@@ -18,6 +18,12 @@ const COMMON_CAPABILITIES = {
   sessionDelete: false
 }
 
+const OMP_HISTORY_LOADER = createOmpHistoryLoader()
+// OMP's JSONL file is a tree, not a linear transcript. The newest terminal leaf can belong to an
+// abandoned sibling branch, so paging must ask the OMP extension for the authoritative active leaf
+// before choosing a branch. AcpService falls back to its full load path if that state is unavailable.
+OMP_HISTORY_LOADER.pageRequiresActiveLeaf = true
+
 export const HARNESS_PROFILES = {
   omp: {
     id: "omp",
@@ -25,7 +31,7 @@ export const HARNESS_PROFILES = {
     command: "omp",
     args: ["acp"],
     permissionMode: "allow",
-    historyLoader: createOmpHistoryLoader(),
+    historyLoader: OMP_HISTORY_LOADER,
     // OMP exposes thinking as a real ACP config option. We probe only ids the running adapter
     // actually advertises; this list is a routing hint, never a source of invented variants.
     modelVariantConfigIDs: ["thinking"],
@@ -116,7 +122,6 @@ export const HARNESS_PROFILES = {
     // explicitly and invoke its published binary instead of relying on npx package-spec inference.
     args: ["--yes", "--package=@agentclientprotocol/codex-acp@1.1.14", "codex-acp"],
     adapterCommand: "codex-acp",
-    permissionMode: "allow",
     // The adapter offers `api-key` before `chat-gpt`; the former demands CODEX_API_KEY or
     // OPENAI_API_KEY, while a `codex login` leaves ChatGPT credentials the `chat-gpt` method
     // reads from disk. Prefer the login, exactly like the generic default already avoids

--- a/bridge/src/omp-session-history.js
+++ b/bridge/src/omp-session-history.js
@@ -1,10 +1,8 @@
 import { createReadStream } from "node:fs"
-import { open, readdir } from "node:fs/promises"
+import { readdir } from "node:fs/promises"
 import { homedir } from "node:os"
 import path from "node:path"
 import { createInterface } from "node:readline"
-
-const BACKWARD_READ_BYTES = 64 * 1024
 
 function messageParts(content, messageID) {
   if (typeof content === "string") return [{ id: `${messageID}:text:0`, messageID, type: "text", text: content }]
@@ -66,14 +64,14 @@ function messageEnvelope(record, sessionID) {
   }
 }
 
-function encodePageCursor(offset, target) {
-  return Buffer.from(JSON.stringify({ offset, target }), "utf8").toString("base64url")
+function encodeVisiblePageCursor(beforeID, target) {
+  return Buffer.from(JSON.stringify({ beforeID, target }), "utf8").toString("base64url")
 }
 
-function decodePageCursor(value) {
+function decodeVisiblePageCursor(value) {
   try {
     const parsed = JSON.parse(Buffer.from(String(value), "base64url").toString("utf8"))
-    if (!Number.isSafeInteger(parsed?.offset) || parsed.offset < 0 || typeof parsed?.target !== "string" || !parsed.target) {
+    if (typeof parsed?.beforeID !== "string" || !parsed.beforeID || typeof parsed?.target !== "string" || !parsed.target) {
       return undefined
     }
     return parsed
@@ -82,97 +80,11 @@ function decodePageCursor(value) {
   }
 }
 
-function parseRecordBuffer(buffer) {
-  if (buffer.length > 0 && buffer[buffer.length - 1] === 0x0d) buffer = buffer.subarray(0, -1)
-  try {
-    const record = JSON.parse(buffer.toString("utf8"))
-    return record && typeof record === "object" ? record : undefined
-  } catch {
-    return undefined
-  }
-}
-
-async function readOmpPage(file, sessionID, { limit = 100, before, activeSessionLeaf } = {}) {
-  const boundedLimit = Math.max(1, Math.min(500, Number(limit) || 100))
-  if (activeSessionLeaf === null) return { messages: [], before: null, hasMore: false }
-
-  const handle = await open(file, "r")
-  try {
-    const { size } = await handle.stat()
-    const decoded = before ? decodePageCursor(before) : undefined
-    if (before && (!decoded || decoded.offset > size)) throw new Error("Invalid OMP history cursor")
-
-    let cursor = decoded?.offset ?? size
-    let target = decoded?.target ?? activeSessionLeaf
-    let matchedTarget = false
-    let carry = Buffer.alloc(0)
-    const messages = []
-    let resumeCursor = null
-    let hasMore = false
-    let done = false
-
-    while (cursor > 0 && !done) {
-      const start = Math.max(0, cursor - BACKWARD_READ_BYTES)
-      const chunk = Buffer.allocUnsafe(cursor - start)
-      const { bytesRead } = await handle.read(chunk, 0, chunk.length, start)
-      const data = carry.length > 0
-        ? Buffer.concat([chunk.subarray(0, bytesRead), carry])
-        : chunk.subarray(0, bytesRead)
-
-      let lineEnd = data.length
-      const visit = (line, offset) => {
-        const record = parseRecordBuffer(line)
-        if (!record || typeof record.id !== "string" || record.id !== target) return
-        matchedTarget = true
-        target = typeof record.parentId === "string" && record.parentId ? record.parentId : undefined
-        const message = messageEnvelope(record, sessionID)
-        if (message) {
-          if (messages.length < boundedLimit) {
-            messages.push(message)
-            if (messages.length === boundedLimit && target) resumeCursor = encodePageCursor(offset, target)
-          } else {
-            hasMore = true
-            done = true
-          }
-        }
-        if (!target) done = true
-      }
-
-      for (let index = data.length - 1; index >= 0 && !done; index -= 1) {
-        if (data[index] !== 0x0a) continue
-        const lineStart = index + 1
-        if (lineStart < lineEnd) visit(data.subarray(lineStart, lineEnd), start + lineStart)
-        lineEnd = index
-      }
-      if (start === 0) {
-        if (lineEnd > 0 && !done) visit(data.subarray(0, lineEnd), 0)
-        carry = Buffer.alloc(0)
-        cursor = 0
-      } else {
-        carry = lineEnd > 0 ? Buffer.from(data.subarray(0, lineEnd)) : Buffer.alloc(0)
-        cursor = start
-      }
-    }
-
-    if (!matchedTarget) {
-      if (before) throw new Error("Invalid OMP history cursor")
-      throw new Error("OMP active session leaf is missing from transcript")
-    }
-    return {
-      messages: messages.slice(0, boundedLimit).reverse(),
-      before: hasMore ? resumeCursor : null,
-      hasMore
-    }
-  } finally {
-    await handle.close()
-  }
-}
-
 /**
- * OMP's undo extension normally tells us the selected leaf.  Without it, a JSONL journal still
- * contains enough ordering information for the normal case: the last terminal record is the
- * branch the writer most recently reached.  Selecting it is observational and, unlike ACP
- * session/load, cannot claim or stall the native Session.
+ * OMP's undo extension normally tells us the selected leaf. Without it, a JSONL journal still
+ * contains enough ordering information for standalone/history-only consumers to choose the newest
+ * terminal node. Production Session-first explicitly disables that fallback: a newer sibling may be
+ * an abandoned failed/retried turn and must never replace the extension's authoritative branch.
  */
 function inferLatestTerminalLeaf(records) {
   const parents = new Set(records
@@ -199,6 +111,91 @@ async function readOmpRecords(file) {
   return records
 }
 
+function selectedBranchRecords(records, selectedLeaf) {
+  if (selectedLeaf === null) return []
+  const entries = new Map(records.map((record) => [record.id, record]))
+  if (!entries.has(selectedLeaf)) throw new Error("OMP active session leaf is missing from transcript")
+
+  const branch = []
+  const visited = new Set()
+  let entry = entries.get(selectedLeaf)
+  while (entry && !visited.has(entry.id)) {
+    visited.add(entry.id)
+    branch.push(entry)
+    entry = typeof entry.parentId === "string" ? entries.get(entry.parentId) : undefined
+  }
+  return branch.reverse()
+}
+
+/**
+ * The selected OMP branch is the conversation truth, but a failed attempt is still user-visible
+ * history: OMP can retry the same user node by creating a successful sibling, which would otherwise
+ * make the earlier red error disappear the moment the Session is reopened. Preserve only assistant
+ * failures attached to user prompts that are on the selected branch, and only failures journalled no
+ * later than the selected leaf. Normal assistant siblings remain excluded, so this cannot resurrect
+ * an abandoned answer or create the duplicate replies seen after failed turns.
+ */
+function visibleBranchRecords(records, selectedLeaf) {
+  const branch = selectedBranchRecords(records, selectedLeaf)
+  if (selectedLeaf === null) return branch
+
+  const branchIDs = new Set(branch.map((record) => record.id))
+  const visibleUserIDs = new Set(branch
+    .filter((record) => record.type === "message" && record.message?.role === "user")
+    .map((record) => record.id))
+  const selectedLeafIndex = records.findIndex((record) => record.id === selectedLeaf)
+  const visibleIDs = new Set(branchIDs)
+
+  for (let index = 0; index <= selectedLeafIndex; index += 1) {
+    const record = records[index]
+    if (
+      record?.type === "message"
+      && record.message?.role === "assistant"
+      && typeof record.parentId === "string"
+      && visibleUserIDs.has(record.parentId)
+      && messageError(record.message)
+    ) {
+      visibleIDs.add(record.id)
+    }
+  }
+
+  // Journal append order is the real chronological order across sibling attempts. Filtering the
+  // original records instead of appending the failures after the branch keeps error -> retry ->
+  // success in the same order OMP actually wrote it.
+  return records.filter((record, index) => index <= selectedLeafIndex && visibleIDs.has(record.id))
+}
+
+function visibleBranchMessages(records, sessionID, selectedLeaf) {
+  return visibleBranchRecords(records, selectedLeaf).flatMap((record) => {
+    const message = messageEnvelope(record, sessionID)
+    return message ? [message] : []
+  })
+}
+
+function pageVisibleBranch(records, sessionID, { limit = 100, before, activeSessionLeaf } = {}) {
+  const boundedLimit = Math.max(1, Math.min(500, Number(limit) || 100))
+  if (activeSessionLeaf === null) return { messages: [], before: null, hasMore: false }
+
+  const decoded = before ? decodeVisiblePageCursor(before) : undefined
+  if (before && !decoded) throw new Error("Invalid OMP history cursor")
+  const selectedLeaf = decoded?.target ?? activeSessionLeaf
+  if (typeof selectedLeaf !== "string" || !selectedLeaf) throw new Error("OMP active session leaf is missing from transcript")
+
+  const messages = visibleBranchMessages(records, sessionID, selectedLeaf)
+  const requestedEnd = decoded
+    ? messages.findIndex((message) => message.info.id === decoded.beforeID)
+    : messages.length
+  if (decoded && requestedEnd < 0) throw new Error("Invalid OMP history cursor")
+  const end = requestedEnd >= 0 ? requestedEnd : messages.length
+  const start = Math.max(0, end - boundedLimit)
+  const page = messages.slice(start, end)
+  return {
+    messages: page,
+    before: start > 0 && page.length > 0 ? encodeVisiblePageCursor(page[0].info.id, selectedLeaf) : null,
+    hasMore: start > 0
+  }
+}
+
 function modelSelection(providerID, modelID) {
   if (typeof providerID !== "string" || !providerID || typeof modelID !== "string" || !modelID) return undefined
   return { providerID, modelID }
@@ -211,20 +208,14 @@ function modelSelectionFromWireName(value) {
   return modelSelection(value.slice(0, separator), value.slice(separator + 1))
 }
 
-/** Resolve the model selected on one exact branch, including journals predating model_change. */
+/**
+ * Resolve the model selected for the visible branch. A failed assistant attempt is valid model
+ * evidence even when OMP then retries the same user node as a sibling: ignoring it can make a Session
+ * that just answered with the chosen model reopen as Harness default after an earlier red error.
+ */
 function branchModel(records, selectedLeaf) {
-  const entries = new Map(records.map((record) => [record.id, record]))
-  const branch = []
-  const visited = new Set()
-  let entry = entries.get(selectedLeaf)
-  while (entry && !visited.has(entry.id)) {
-    visited.add(entry.id)
-    branch.push(entry)
-    entry = typeof entry.parentId === "string" ? entries.get(entry.parentId) : undefined
-  }
-
   let selected
-  for (const record of branch.reverse()) {
+  for (const record of visibleBranchRecords(records, selectedLeaf)) {
     if (record.type === "model_change" && (record.role === undefined || record.role === "default")) {
       selected = modelSelectionFromWireName(record.model) ?? selected
       continue
@@ -310,48 +301,19 @@ export function createOmpHistoryLoader(sessionRoot = path.join(homedir(), ".omp"
   const loadOmpHistory = async function loadOmpHistory(sessionID, { activeSessionLeaf } = {}) {
     const file = await locateSession(sessionID)
     if (!file) return []
-    const records = []
-    const entries = new Map()
-    const lines = createInterface({ input: createReadStream(file), crlfDelay: Infinity })
-    for await (const line of lines) {
-      let record
-      try {
-        record = JSON.parse(line)
-      } catch {
-        continue
-      }
-      if (typeof record?.id === "string") {
-        records.push(record)
-        entries.set(record.id, record)
-      }
-    }
+    const records = await readOmpRecords(file)
 
-    const selected = []
     let selectedLeaf = activeSessionLeaf
     if (selectedLeaf === undefined) {
+      // The production profile sets pageRequiresActiveLeaf on this same function. In that mode a
+      // missing extension state is not permission to guess: AcpService keeps its last known snapshot
+      // and retries observationally instead of opening an arbitrary terminal sibling.
+      if (loadOmpHistory.pageRequiresActiveLeaf === true) return []
       selectedLeaf = inferLatestTerminalLeaf(records)
       if (!selectedLeaf) return []
     }
-    if (selectedLeaf === null) {
-      // The extension selected the session root.
-    } else if (entries.has(selectedLeaf)) {
-      const branch = []
-      const visited = new Set()
-      let entry = entries.get(selectedLeaf)
-      while (entry && !visited.has(entry.id)) {
-        visited.add(entry.id)
-        branch.push(entry)
-        entry = typeof entry.parentId === "string" ? entries.get(entry.parentId) : undefined
-      }
-      selected.push(...branch.reverse())
-    } else {
-      throw new Error("OMP active session leaf is missing from transcript")
-    }
 
-    return selected.flatMap((record) => {
-      const message = messageEnvelope(record, sessionID)
-      return message ? [message] : []
-    })
+    return visibleBranchMessages(records, sessionID, selectedLeaf)
   }
 
   /** How often the session tree was walked, and how many files that walk is currently serving. */
@@ -362,19 +324,21 @@ export function createOmpHistoryLoader(sessionRoot = path.join(homedir(), ".omp"
     resolvedSessions: sessionFiles.size,
     listingAgeMs: listedAt ? Date.now() - listedAt : null
   })
-  // The loader derives a latest terminal leaf when the optional undo extension is absent, so
-  // paging remains journal-only and does not wait on ACP session/load.
+  // Standalone/history-only consumers may infer a terminal leaf. The production profile overrides
+  // this flag to true, which makes both full loads and pages require extension-provided branch truth.
   loadOmpHistory.pageRequiresActiveLeaf = false
   loadOmpHistory.deferAcpReplayWithoutActiveLeaf = true
   loadOmpHistory.page = async (sessionID, options = {}) => {
     const file = await locateSession(sessionID)
     if (!file) return { messages: [], before: null, hasMore: false }
     const records = await readOmpRecords(file)
-    const activeSessionLeaf = options.activeSessionLeaf === undefined
-      ? inferLatestTerminalLeaf(records)
-      : options.activeSessionLeaf
+    let activeSessionLeaf = options.activeSessionLeaf
+    if (activeSessionLeaf === undefined) {
+      if (loadOmpHistory.pageRequiresActiveLeaf === true) return { messages: [], before: null, hasMore: false }
+      activeSessionLeaf = inferLatestTerminalLeaf(records)
+    }
     if (activeSessionLeaf === undefined) return { messages: [], before: null, hasMore: false }
-    const page = await readOmpPage(file, sessionID, { ...options, activeSessionLeaf })
+    const page = pageVisibleBranch(records, sessionID, { ...options, activeSessionLeaf })
     const model = activeSessionLeaf === null ? undefined : branchModel(records, activeSessionLeaf)
     return { ...page, ...(model ? { model } : {}) }
   }

--- a/bridge/test/omp-active-leaf-regression.test.js
+++ b/bridge/test/omp-active-leaf-regression.test.js
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { HARNESS_PROFILES } from "../src/harness-profiles.js"
+
+test("OMP paged history requires the extension's authoritative active leaf", () => {
+  const loader = HARNESS_PROFILES.omp.historyLoader
+  assert.equal(
+    loader.pageRequiresActiveLeaf,
+    true,
+    "OMP JSONL is a tree: newest terminal leaf may be an abandoned sibling and must not choose the visible branch"
+  )
+})

--- a/bridge/test/omp-session-recovery-regression.test.js
+++ b/bridge/test/omp-session-recovery-regression.test.js
@@ -5,6 +5,7 @@ import path from "node:path"
 import test from "node:test"
 import { createOmpHistoryLoader } from "../src/omp-session-history.js"
 
+// Keep this regression on the PR head so GitHub validates the exact OMP recovery implementation.
 async function withJournal(records, run) {
   const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-recovery-"))
   const sessionID = "session-recovery"

--- a/bridge/test/omp-session-recovery-regression.test.js
+++ b/bridge/test/omp-session-recovery-regression.test.js
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import test from "node:test"
+import { createOmpHistoryLoader } from "../src/omp-session-history.js"
+
+async function withJournal(records, run) {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-recovery-"))
+  const sessionID = "session-recovery"
+  await writeFile(
+    path.join(root, `2026-08-26_${sessionID}.jsonl`),
+    `${records.map((record) => JSON.stringify(record)).join("\n")}\n`
+  )
+  try {
+    await run(createOmpHistoryLoader(root), sessionID)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+const records = [
+  {
+    type: "session_init",
+    id: "init",
+    parentId: null,
+    timestamp: "2026-08-26T12:00:00.000Z",
+    resolvedModel: "openai/gpt-default"
+  },
+  {
+    type: "message",
+    id: "user-1",
+    parentId: "init",
+    timestamp: "2026-08-26T12:00:01.000Z",
+    message: { role: "user", content: "Fix it" }
+  },
+  {
+    type: "message",
+    id: "failed-1",
+    parentId: "user-1",
+    timestamp: "2026-08-26T12:00:02.000Z",
+    message: {
+      role: "assistant",
+      provider: "openai-codex",
+      model: "gpt-5.6-luna",
+      content: [],
+      stopReason: "error",
+      errorMessage: "Provider request failed"
+    }
+  },
+  {
+    type: "message",
+    id: "assistant-1",
+    parentId: "user-1",
+    timestamp: "2026-08-26T12:00:03.000Z",
+    message: { role: "assistant", content: "Final answer" }
+  },
+  // A later abandoned sibling must not leak back into the selected branch just because it is newer.
+  {
+    type: "message",
+    id: "abandoned-success",
+    parentId: "user-1",
+    timestamp: "2026-08-26T12:00:04.000Z",
+    message: { role: "assistant", content: "Wrong sibling" }
+  },
+  {
+    type: "message",
+    id: "abandoned-error",
+    parentId: "user-1",
+    timestamp: "2026-08-26T12:00:05.000Z",
+    message: { role: "assistant", content: [], errorMessage: "Later abandoned error" }
+  }
+]
+
+test("production OMP history never guesses a terminal sibling when activeSessionLeaf is unavailable", async () => {
+  await withJournal(records, async (loader, sessionID) => {
+    loader.pageRequiresActiveLeaf = true
+
+    assert.deepEqual(await loader(sessionID), [])
+    assert.deepEqual(
+      await loader.page(sessionID, { limit: 20 }),
+      { messages: [], before: null, hasMore: false }
+    )
+  })
+})
+
+test("OMP reopen keeps failed attempts on the selected prompt without resurrecting abandoned answers", async () => {
+  await withJournal(records, async (loader, sessionID) => {
+    const messages = await loader(sessionID, { activeSessionLeaf: "assistant-1" })
+
+    assert.deepEqual(
+      messages.map((message) => [message.info.id, message.info.role, message.info.error?.message, message.parts.at(-1)?.text]),
+      [
+        ["user-1", "user", undefined, "Fix it"],
+        ["failed-1", "assistant", "Provider request failed", undefined],
+        ["assistant-1", "assistant", undefined, "Final answer"]
+      ]
+    )
+    assert.equal(messages.some((message) => message.info.id === "abandoned-success"), false)
+    assert.equal(messages.some((message) => message.info.id === "abandoned-error"), false)
+  })
+})
+
+test("OMP newest-page recovery keeps the red failure and the model used by that visible attempt", async () => {
+  await withJournal(records, async (loader, sessionID) => {
+    const page = await loader.page(sessionID, { activeSessionLeaf: "assistant-1", limit: 3 })
+
+    assert.deepEqual(page.messages.map((message) => message.info.id), ["user-1", "failed-1", "assistant-1"])
+    assert.equal(page.messages[1].info.error?.message, "Provider request failed")
+    assert.deepEqual(page.model, { providerID: "openai-codex", modelID: "gpt-5.6-luna" })
+    assert.equal(page.hasMore, false)
+    assert.equal(page.before, null)
+  })
+})

--- a/web/src/message-pages.ts
+++ b/web/src/message-pages.ts
@@ -16,63 +16,6 @@ function visibleText(message: MessageEnvelope): string {
     .join("")
 }
 
-function canonicalText(value: string): string {
-  return value.replace(/\r\n/g, "\n").trim()
-}
-
-function lastUserMessage(messages: MessageEnvelope[]): MessageEnvelope | undefined {
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    if (messages[index].info.role === "user") return messages[index]
-  }
-  return undefined
-}
-
-function lastAssistantAfterUser(messages: MessageEnvelope[], user: MessageEnvelope): MessageEnvelope | undefined {
-  const userIndex = messages.lastIndexOf(user)
-  for (let index = messages.length - 1; index > userIndex; index -= 1) {
-    if (messages[index].info.role === "assistant") return messages[index]
-  }
-  return undefined
-}
-
-function stableAssistantCandidate(message?: MessageEnvelope): message is MessageEnvelope {
-  if (!message || message.info.role !== "assistant" || message.info.error || !message.parts.length) return false
-  if (message.parts.some((part) => part.type !== "text" && part.type !== "reasoning")) return false
-  return Boolean(canonicalText(visibleText(message)))
-}
-
-/**
- * ACP streaming and native journals do not always use the same id for one logical assistant reply.
- * PI is the clearest example, but OMP can cross the same live -> journal boundary. When the selected
- * tail is still on the same user turn and the journal answer is exactly the streamed text or a prefix
- * extension/regression of it, keep the browser's live message identity. This is deliberately limited
- * to the final assistant of the final user turn: repeated historical answers, tools and divergent
- * rewrites must retain their native identities.
- */
-function stabilizeTrailingAssistantIdentity(existing: MessageEnvelope[], latest: MessageEnvelope[]): MessageEnvelope[] {
-  const currentUser = lastUserMessage(existing)
-  const incomingUser = lastUserMessage(latest)
-  if (!currentUser || !incomingUser) return latest
-  const currentPrompt = canonicalText(visibleText(currentUser))
-  const incomingPrompt = canonicalText(visibleText(incomingUser))
-  if (!currentPrompt || currentPrompt !== incomingPrompt) return latest
-
-  const currentAssistant = lastAssistantAfterUser(existing, currentUser)
-  const incomingAssistant = lastAssistantAfterUser(latest, incomingUser)
-  if (!stableAssistantCandidate(currentAssistant) || !stableAssistantCandidate(incomingAssistant)) return latest
-  if (currentAssistant.info.id === incomingAssistant.info.id) return latest
-
-  const currentText = canonicalText(visibleText(currentAssistant))
-  const incomingText = canonicalText(visibleText(incomingAssistant))
-  if (!(currentText === incomingText || currentText.startsWith(incomingText) || incomingText.startsWith(currentText))) return latest
-
-  return latest.map((message) => message !== incomingAssistant ? message : {
-    ...message,
-    info: { ...message.info, id: currentAssistant.info.id },
-    parts: message.parts.map((part) => ({ ...part, messageID: currentAssistant.info.id }))
-  })
-}
-
 /**
  * A live ACP reply can be ahead of its append-only journal for a brief moment after the turn becomes
  * idle. The next newest-page reconcile must never replace that complete in-memory reply with an older
@@ -93,9 +36,7 @@ function regressesAssistantText(current: MessageEnvelope, incoming: MessageEnvel
  */
 export function mergeLatestMessagePage(existing: MessageEnvelope[], latest: MessageEnvelope[]): MessageEnvelope[] {
   if (!existing.length) return latest
-
-  const stabilizedLatest = stabilizeTrailingAssistantIdentity(existing, latest)
-  const latestByID = new Map(stabilizedLatest.map((message) => [message.info.id, message]))
+  const latestByID = new Map(latest.map((message) => [message.info.id, message]))
   const existingIDs = new Set(existing.map((message) => message.info.id))
   let changed = false
 
@@ -105,7 +46,7 @@ export function mergeLatestMessagePage(existing: MessageEnvelope[], latest: Mess
     changed = true
     return incoming
   })
-  for (const message of stabilizedLatest) {
+  for (const message of latest) {
     if (existingIDs.has(message.info.id)) continue
     merged.push(message)
     changed = true

--- a/web/src/message-pages.ts
+++ b/web/src/message-pages.ts
@@ -16,6 +16,63 @@ function visibleText(message: MessageEnvelope): string {
     .join("")
 }
 
+function canonicalText(value: string): string {
+  return value.replace(/\r\n/g, "\n").trim()
+}
+
+function lastUserMessage(messages: MessageEnvelope[]): MessageEnvelope | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index].info.role === "user") return messages[index]
+  }
+  return undefined
+}
+
+function lastAssistantAfterUser(messages: MessageEnvelope[], user: MessageEnvelope): MessageEnvelope | undefined {
+  const userIndex = messages.lastIndexOf(user)
+  for (let index = messages.length - 1; index > userIndex; index -= 1) {
+    if (messages[index].info.role === "assistant") return messages[index]
+  }
+  return undefined
+}
+
+function stableAssistantCandidate(message?: MessageEnvelope): message is MessageEnvelope {
+  if (!message || message.info.role !== "assistant" || message.info.error || !message.parts.length) return false
+  if (message.parts.some((part) => part.type !== "text" && part.type !== "reasoning")) return false
+  return Boolean(canonicalText(visibleText(message)))
+}
+
+/**
+ * ACP streaming and native journals do not always use the same id for one logical assistant reply.
+ * PI is the clearest example, but OMP can cross the same live -> journal boundary. When the selected
+ * tail is still on the same user turn and the journal answer is exactly the streamed text or a prefix
+ * extension/regression of it, keep the browser's live message identity. This is deliberately limited
+ * to the final assistant of the final user turn: repeated historical answers, tools and divergent
+ * rewrites must retain their native identities.
+ */
+function stabilizeTrailingAssistantIdentity(existing: MessageEnvelope[], latest: MessageEnvelope[]): MessageEnvelope[] {
+  const currentUser = lastUserMessage(existing)
+  const incomingUser = lastUserMessage(latest)
+  if (!currentUser || !incomingUser) return latest
+  const currentPrompt = canonicalText(visibleText(currentUser))
+  const incomingPrompt = canonicalText(visibleText(incomingUser))
+  if (!currentPrompt || currentPrompt !== incomingPrompt) return latest
+
+  const currentAssistant = lastAssistantAfterUser(existing, currentUser)
+  const incomingAssistant = lastAssistantAfterUser(latest, incomingUser)
+  if (!stableAssistantCandidate(currentAssistant) || !stableAssistantCandidate(incomingAssistant)) return latest
+  if (currentAssistant.info.id === incomingAssistant.info.id) return latest
+
+  const currentText = canonicalText(visibleText(currentAssistant))
+  const incomingText = canonicalText(visibleText(incomingAssistant))
+  if (!(currentText === incomingText || currentText.startsWith(incomingText) || incomingText.startsWith(currentText))) return latest
+
+  return latest.map((message) => message !== incomingAssistant ? message : {
+    ...message,
+    info: { ...message.info, id: currentAssistant.info.id },
+    parts: message.parts.map((part) => ({ ...part, messageID: currentAssistant.info.id }))
+  })
+}
+
 /**
  * A live ACP reply can be ahead of its append-only journal for a brief moment after the turn becomes
  * idle. The next newest-page reconcile must never replace that complete in-memory reply with an older
@@ -36,7 +93,9 @@ function regressesAssistantText(current: MessageEnvelope, incoming: MessageEnvel
  */
 export function mergeLatestMessagePage(existing: MessageEnvelope[], latest: MessageEnvelope[]): MessageEnvelope[] {
   if (!existing.length) return latest
-  const latestByID = new Map(latest.map((message) => [message.info.id, message]))
+
+  const stabilizedLatest = stabilizeTrailingAssistantIdentity(existing, latest)
+  const latestByID = new Map(stabilizedLatest.map((message) => [message.info.id, message]))
   const existingIDs = new Set(existing.map((message) => message.info.id))
   let changed = false
 
@@ -46,7 +105,7 @@ export function mergeLatestMessagePage(existing: MessageEnvelope[], latest: Mess
     changed = true
     return incoming
   })
-  for (const message of latest) {
+  for (const message of stabilizedLatest) {
     if (existingIDs.has(message.info.id)) continue
     merged.push(message)
     changed = true

--- a/web/src/native-session-model-lifecycle.test.mjs
+++ b/web/src/native-session-model-lifecycle.test.mjs
@@ -186,16 +186,20 @@ assert.deepEqual(
   'a flat OpenCode assistant envelope must inherit the matching immediately preceding user variant'
 )
 
-// --- 8. OMP continuation must establish a new logical Run before writer activity -----------------
+// --- 8. OMP projection fixes must not change other harness continuation semantics -----------------
 const adapter = readFileSync(new URL('./native-session-v3-adapter.ts', import.meta.url), 'utf8')
-assert.match(adapter, /\["opencode", "codex", "omp"\]\.includes\(entry\.target\.backend\)/, 'OMP page.model must participate in live projection reconciliation')
-assert.match(adapter, /entry\.target\.backend === "omp" && entry\.forcedStatus === "running"/, 'a lagging OMP journal must not overwrite the selected model while the new turn is live')
-assert.match(adapter, /const prepared = beginProjectionRun\(entry, prompt, model \?\? null\)/, 'continuation must create the logical user-turn boundary before network mutation')
-const preparedIndex = adapter.indexOf('const prepared = beginProjectionRun(entry, prompt, model ?? null)')
+assert.match(adapter, /if \(entry\.target\.backend === "omp"\) \{[\s\S]*?const model = page\.model \?\? null/, 'OMP page.model must participate in its own projection reconciliation branch')
+assert.match(adapter, /entry\.forcedStatus === "running" && entry\.currentModel && !sameModel\(entry\.currentModel, model\)/, 'a lagging OMP journal must not overwrite the selected model while the new turn is live')
+assert.match(adapter, /if \(entry\.target\.backend !== "omp"\) \{[\s\S]*?await ensureWriter\(entry\)[\s\S]*?sendNativeSessionPrompt\(entry\.target, prompt, model\)[\s\S]*?appendAcceptedRun\(entry, prompt, model \?\? null/, 'non-OMP harnesses must retain the validated post-accept continuation path')
+assert.match(adapter, /page = stabilizeOmpTailPage\(entry, page, before\)/, 'OMP live-to-journal identity repair must stay inside the OMP projection')
+assert.match(adapter, /if \(entry\.target\.backend !== "omp" \|\| before\) return page/, 'OMP tail stabilization must not run for another harness')
+
+const ompGateIndex = adapter.indexOf('if (entry.target.backend !== "omp")')
+const preparedIndex = adapter.indexOf('const prepared = beginProjectionRun(entry, prompt, model ?? null)', ompGateIndex)
 const writerIndex = adapter.indexOf('await ensureWriter(entry)', preparedIndex)
 const sendIndex = adapter.indexOf('await sendNativeSessionPrompt(entry.target, prompt, model)', preparedIndex)
-assert.ok(preparedIndex >= 0 && writerIndex > preparedIndex && sendIndex > writerIndex, 'the new Run boundary must exist before OMP claim or prompt can emit session.updated')
-assert.match(adapter, /const effectiveModel = model \?\? entry\.currentModel/, 'a continuation with no explicit picker change must retain the recovered native model')
+assert.ok(ompGateIndex >= 0 && preparedIndex > ompGateIndex && writerIndex > preparedIndex && sendIndex > writerIndex, 'only OMP creates the logical Run boundary before claim/prompt can emit session.updated')
+assert.match(adapter, /const effectiveModel = model \?\? entry\.currentModel/, 'an OMP continuation with no explicit picker change must retain the recovered native model')
 assert.match(adapter, /if \(run && !run\.model && entry\.currentModel\) run\.model = entry\.currentModel/, 'late OMP model enrichment must fill the current Run instead of leaving Harness default')
 
 console.log('native-session model lifecycle regressions: OK')

--- a/web/src/native-session-model-lifecycle.test.mjs
+++ b/web/src/native-session-model-lifecycle.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 
 /*
  * Regression coverage for the Session-first model-change failure class reported in #287.
@@ -184,5 +185,17 @@ assert.deepEqual(
   { providerID: 'anthropic', modelID: 'claude-sonnet-4-6', variant: 'high' },
   'a flat OpenCode assistant envelope must inherit the matching immediately preceding user variant'
 )
+
+// --- 8. OMP continuation must establish a new logical Run before writer activity -----------------
+const adapter = readFileSync(new URL('./native-session-v3-adapter.ts', import.meta.url), 'utf8')
+assert.match(adapter, /\["opencode", "codex", "omp"\]\.includes\(entry\.target\.backend\)/, 'OMP page.model must participate in live projection reconciliation')
+assert.match(adapter, /entry\.target\.backend === "omp" && entry\.forcedStatus === "running"/, 'a lagging OMP journal must not overwrite the selected model while the new turn is live')
+assert.match(adapter, /const prepared = beginProjectionRun\(entry, prompt, model \?\? null\)/, 'continuation must create the logical user-turn boundary before network mutation')
+const preparedIndex = adapter.indexOf('const prepared = beginProjectionRun(entry, prompt, model ?? null)')
+const writerIndex = adapter.indexOf('await ensureWriter(entry)', preparedIndex)
+const sendIndex = adapter.indexOf('await sendNativeSessionPrompt(entry.target, prompt, model)', preparedIndex)
+assert.ok(preparedIndex >= 0 && writerIndex > preparedIndex && sendIndex > writerIndex, 'the new Run boundary must exist before OMP claim or prompt can emit session.updated')
+assert.match(adapter, /const effectiveModel = model \?\? entry\.currentModel/, 'a continuation with no explicit picker change must retain the recovered native model')
+assert.match(adapter, /if \(run && !run\.model && entry\.currentModel\) run\.model = entry\.currentModel/, 'late OMP model enrichment must fill the current Run instead of leaving Harness default')
 
 console.log('native-session model lifecycle regressions: OK')

--- a/web/src/native-session-v3-adapter.ts
+++ b/web/src/native-session-v3-adapter.ts
@@ -30,6 +30,7 @@ type ProjectionEntry = {
   currentModel: ModelSelection | null
   initialPageCaptured: boolean
   piTailMessages: MessageEnvelope[]
+  ompTailMessages: MessageEnvelope[]
   writerReady: boolean
   writerClaimInFlight: Promise<void> | null
   runs: Map<string, ProjectionRun>
@@ -160,6 +161,105 @@ function visiblePrompt(message: MessageEnvelope): string {
   return canonicalText(value.slice(instructionStart, footerStart >= 0 ? footerStart : undefined))
 }
 
+function lastUserIndex(messages: MessageEnvelope[]): number {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index].info.role === "user") return index
+  }
+  return -1
+}
+
+function ompErrorText(message: MessageEnvelope): string {
+  return canonicalText(message.info.error?.message || "")
+}
+
+function ompStableAssistantText(message: MessageEnvelope): string | null {
+  if (message.info.role !== "assistant" || message.info.error || !message.parts.length) return null
+  if (message.parts.some((part) => part.type !== "text" && part.type !== "reasoning")) return null
+  const text = canonicalText(messageText(message))
+  return text || null
+}
+
+/**
+ * OMP can expose one logical reply with a live ACP id and then a different persisted JSONL id. Keep
+ * that identity repair inside the OMP projection instead of changing the shared message-page merge.
+ * Failed attempts are matched by their error text in order, so a red error already rendered live does
+ * not duplicate when the journal later exposes the same failed sibling. The final normal assistant is
+ * stabilized only when its text is equal or a prefix extension/regression of the live text.
+ */
+function stabilizeOmpTailMessageIDs(previous: MessageEnvelope[], next: MessageEnvelope[]): MessageEnvelope[] {
+  if (!previous.length || !next.length) return next
+  const previousUserIndex = lastUserIndex(previous)
+  const nextUserIndex = lastUserIndex(next)
+  if (previousUserIndex < 0 || nextUserIndex < 0) return next
+  const previousPrompt = visiblePrompt(previous[previousUserIndex])
+  const nextPrompt = visiblePrompt(next[nextUserIndex])
+  if (!previousPrompt || previousPrompt !== nextPrompt) return next
+
+  const previousIDs = new Set(previous.map((message) => message.info.id))
+  const nextIDs = new Set(next.map((message) => message.info.id))
+  const previousTail = previous.slice(previousUserIndex + 1).filter((message) => message.info.role === "assistant")
+  const nextTail = next.slice(nextUserIndex + 1).filter((message) => message.info.role === "assistant")
+  const usedPrevious = new Set<string>()
+  const replacementByIncomingID = new Map<string, string>()
+
+  // Preserve each failed attempt exactly once. If two attempts have the same provider error, pair
+  // them in journal/live order rather than collapsing them into one message.
+  for (const incoming of nextTail) {
+    if (previousIDs.has(incoming.info.id)) continue
+    const error = ompErrorText(incoming)
+    if (!error) continue
+    const candidate = previousTail.find((message) => (
+      !usedPrevious.has(message.info.id)
+      && !nextIDs.has(message.info.id)
+      && ompErrorText(message) === error
+    ))
+    if (!candidate) continue
+    usedPrevious.add(candidate.info.id)
+    replacementByIncomingID.set(incoming.info.id, candidate.info.id)
+  }
+
+  // The successful answer is the last non-error assistant for this user turn. OMP's live stream and
+  // journal can differ only in id and durability prefix, so preserve the browser identity in that
+  // narrow case and leave genuinely divergent sibling answers alone.
+  const incomingFinal = [...nextTail].reverse().find((message) => ompStableAssistantText(message))
+  if (incomingFinal && !previousIDs.has(incomingFinal.info.id)) {
+    const incomingText = ompStableAssistantText(incomingFinal)
+    const candidate = [...previousTail].reverse().find((message) => (
+      !usedPrevious.has(message.info.id)
+      && !nextIDs.has(message.info.id)
+      && ompStableAssistantText(message)
+    ))
+    const candidateText = candidate ? ompStableAssistantText(candidate) : null
+    if (
+      candidate
+      && candidateText
+      && incomingText
+      && (candidateText === incomingText || candidateText.startsWith(incomingText) || incomingText.startsWith(candidateText))
+    ) {
+      usedPrevious.add(candidate.info.id)
+      replacementByIncomingID.set(incomingFinal.info.id, candidate.info.id)
+    }
+  }
+
+  if (!replacementByIncomingID.size) return next
+  return next.map((message) => {
+    const stableID = replacementByIncomingID.get(message.info.id)
+    if (!stableID) return message
+    return {
+      ...message,
+      info: { ...message.info, id: stableID },
+      parts: message.parts.map((part) => ({ ...part, messageID: stableID }))
+    }
+  })
+}
+
+function stabilizeOmpTailPage(entry: ProjectionEntry, page: MessagePage, before?: string): MessagePage {
+  if (entry.target.backend !== "omp" || before) return page
+  const messages = stabilizeOmpTailMessageIDs(entry.ompTailMessages, page.messages)
+  entry.ompTailMessages = messages
+  return messages === page.messages ? page : { ...page, messages }
+}
+
 function nativeAssistantCompleted(message: MessageEnvelope): boolean {
   if (message.info.role !== "assistant") return false
   if (message.info.error || message.info.time?.completed) return true
@@ -168,10 +268,14 @@ function nativeAssistantCompleted(message: MessageEnvelope): boolean {
 }
 
 function sameModel(left: ModelSelection | null, right: ModelSelection | null): boolean {
-  if (!left || !right) return !left && !right
-  return left.providerID === right.providerID
+  return Boolean(left && right
+    && left.providerID === right.providerID
     && left.modelID === right.modelID
-    && (left.variant || "") === (right.variant || "")
+    && (left.variant || "") === (right.variant || ""))
+}
+
+function sameOptionalModel(left: ModelSelection | null, right: ModelSelection | null): boolean {
+  return (!left && !right) || sameModel(left, right)
 }
 
 /**
@@ -179,36 +283,52 @@ function sameModel(left: ModelSelection | null, right: ModelSelection | null): b
  * new native envelope is durable, then return while the reply is still streaming. Every current-tail
  * page can therefore advance the projection from stale/default metadata to the model on the newest
  * native turn.
- *
- * OMP reports the model of its selected JSONL branch as page.model. That is native truth and must be
- * allowed to fill a projection that mounted before model enrichment. While an HR-originated turn is
- * already running, however, an older journal page may still describe the previous model for a few
- * milliseconds; never let that stale page undo a concrete model the user just selected for the turn.
  */
 function reconcileNativeSessionModel(entry: ProjectionEntry, page: MessagePage, before?: string): void {
-  if (before || !["opencode", "codex", "omp"].includes(entry.target.backend)) return
-  const model = page.model ?? (entry.target.backend === "opencode" ? lastNativeMessageModel(page.messages) : null)
-  if (!model) return
-  if (entry.target.backend === "omp" && entry.forcedStatus === "running" && entry.currentModel && !sameModel(entry.currentModel, model)) {
+  if (before) return
+
+  if (entry.target.backend === "omp") {
+    const model = page.model ?? null
+    if (!model) return
+    // OMP's journal may still describe the previous branch model for a few milliseconds after Send.
+    // Never let that lag overwrite the concrete model already chosen for the live HR turn.
+    if (entry.forcedStatus === "running" && entry.currentModel && !sameModel(entry.currentModel, model)) return
+
+    let changed = !sameModel(entry.currentModel, model)
+    entry.currentModel = model
+    const orderedRuns = [...entry.runs.values()].sort((left, right) => left.created - right.created || left.id.localeCompare(right.id))
+    const latestRun = orderedRuns[orderedRuns.length - 1]
+    if (latestRun && !latestRun.model) {
+      latestRun.model = model
+      changed = true
+    } else {
+      const latestUser = [...page.messages].reverse().find((message) => message.info.role === "user" && message.info.id)
+      if (latestUser) {
+        const run = entry.runs.get(`${projectionID(entry.target)}:native-user:${latestUser.info.id}`)
+        if (run && !sameModel(run.model, model)) {
+          run.model = model
+          changed = true
+        }
+      }
+    }
+    if (changed) notify(entry)
     return
   }
 
+  // Preserve the validated #304 behavior byte-for-byte for OpenCode/Codex. The OMP recovery above
+  // must not change their model/run enrichment semantics.
+  if (entry.target.backend !== "opencode" && entry.target.backend !== "codex") return
+  const model = page.model ?? (entry.target.backend === "opencode" ? lastNativeMessageModel(page.messages) : null)
+  if (!model) return
+
   let changed = !sameModel(entry.currentModel, model)
   entry.currentModel = model
-
-  const orderedRuns = [...entry.runs.values()].sort((left, right) => left.created - right.created || left.id.localeCompare(right.id))
-  const latestRun = orderedRuns[orderedRuns.length - 1]
-  if (latestRun && !latestRun.model) {
-    latestRun.model = model
-    changed = true
-  } else {
-    const latestUser = [...page.messages].reverse().find((message) => message.info.role === "user" && message.info.id)
-    if (latestUser) {
-      const run = entry.runs.get(`${projectionID(entry.target)}:native-user:${latestUser.info.id}`)
-      if (run && !sameModel(run.model, model)) {
-        run.model = model
-        changed = true
-      }
+  const latestUser = [...page.messages].reverse().find((message) => message.info.role === "user" && message.info.id)
+  if (latestUser) {
+    const run = entry.runs.get(`${projectionID(entry.target)}:native-user:${latestUser.info.id}`)
+    if (run && !sameModel(run.model, model)) {
+      run.model = model
+      changed = true
     }
   }
   if (changed) notify(entry)
@@ -380,15 +500,29 @@ function captureUserRuns(entry: ProjectionEntry, page: MessagePage, before?: str
   if (changed) notify(entry)
 }
 
+/** Baseline continuation path for every non-OMP native Session. */
+function appendAcceptedRun(entry: ProjectionEntry, prompt: string, model: ModelSelection | null, clientRequestId: string): MachineTask {
+  const id = `${projectionID(entry.target)}:request:${clientRequestId}`
+  if (!entry.runs.has(id)) {
+    const created = Date.now()
+    entry.runs.set(id, { id, prompt: canonicalText(prompt), created, model })
+    entry.updatedAt = created
+  }
+  entry.currentModel = model
+  entry.forcedStatus = "running"
+  entry.statusType = "running"
+  return notify(entry)
+}
+
 function requestRunID(entry: ProjectionEntry, clientRequestId: string): string {
   return `${projectionID(entry.target)}:request:${clientRequestId}`
 }
 
 /**
- * Create the logical continuation boundary before writer acquisition or HTTP prompt delivery starts.
+ * OMP-only: create the logical continuation boundary before writer acquisition or prompt delivery.
  * OMP can emit session.updated while claim/model application is in progress; without a new Run in the
  * projection that event marks the preceding assistant as active and its old Activity flips back to
- * Working. A provisional Run gives the mature timeline the correct current turn immediately.
+ * Working. Other harnesses retain the validated post-accept appendAcceptedRun path above.
  */
 function beginProjectionRun(entry: ProjectionEntry, prompt: string, model: ModelSelection | null): PreparedProjectionRun {
   const normalizedPrompt = canonicalText(prompt)
@@ -397,7 +531,7 @@ function beginProjectionRun(entry: ProjectionEntry, prompt: string, model: Model
   const canReusePending = Boolean(
     unresolved
     && canonicalText(unresolved.text) === normalizedPrompt
-    && sameModel(unresolved.model ?? null, effectiveModel)
+    && sameOptionalModel(unresolved.model ?? null, effectiveModel)
   )
   const created = canReusePending && unresolved ? unresolved.createdAt : Date.now()
   const id = canReusePending && unresolved
@@ -499,6 +633,7 @@ function installAdapter(): void {
     const entry = entryForRead(config, sessionID, directory)
     if (entry) {
       page = stabilizePiTailPage(entry, page, before)
+      page = stabilizeOmpTailPage(entry, page, before)
       captureUserRuns(entry, page, before)
       reconcileOpenCodeTranscriptStatus(entry, page, before)
       reconcileNativeSessionModel(entry, page, before)
@@ -526,12 +661,22 @@ function installAdapter(): void {
     }
 
     // The shared v3 controller emits null while its model picker is still catching up with native
-    // transcript enrichment. For a native Session that is not an explicit new catalog selection,
-    // preserve the model already recovered from the authoritative Session instead of silently
-    // switching the next turn to the harness default. A concrete ModelSelection still wins.
+    // transcript enrichment. Preserve the native model already recovered for this Session unless a
+    // concrete catalog selection was supplied.
     const model = body.model ?? entry.currentModel
-    const prepared = beginProjectionRun(entry, prompt, model ?? null)
 
+    if (entry.target.backend !== "omp") {
+      // Preserve #304 lifecycle semantics for PI, Claude, Codex and OpenCode. OMP alone needs the
+      // provisional boundary because its claim/model setup can emit session.updated before Send.
+      await ensureWriter(entry)
+      const result = await sendNativeSessionPrompt(entry.target, prompt, model)
+      if (result.status !== "accepted") {
+        throw new Error(`Prompt delivery is ${result.status}. Retry the same prompt to reconcile the existing request id.`)
+      }
+      return appendAcceptedRun(entry, prompt, model ?? null, result.clientRequestId)
+    }
+
+    const prepared = beginProjectionRun(entry, prompt, model ?? null)
     try {
       await ensureWriter(entry)
       const result = await sendNativeSessionPrompt(entry.target, prompt, model)
@@ -541,15 +686,14 @@ function installAdapter(): void {
       }
       return promoteProjectionRun(entry, prepared, result.clientRequestId, true)
     } catch (reason) {
-      // A transport failure after dispatch keeps the durable pending request id. Preserve that logical
-      // user turn so retrying cannot reactivate the preceding Activity, but do not claim it is still
-      // Working until native status proves delivery. A claim/HTTP refusal clears the pending record,
-      // which proves no turn exists and allows the provisional boundary to be removed completely.
+      // OMP transport failures after dispatch keep the durable pending request id. Preserve that
+      // logical user turn so retrying cannot reactivate the preceding Activity, but do not claim it
+      // is still Working until native status proves delivery.
       const pending = loadPendingNativeSessionPrompt(entry.target)
       if (
         pending
         && canonicalText(pending.text) === prepared.prompt
-        && sameModel(pending.model ?? null, prepared.model)
+        && sameOptionalModel(pending.model ?? null, prepared.model)
       ) {
         promoteProjectionRun(entry, prepared, pending.clientRequestId, false)
       } else if (entry.runs.has(prepared.id)) {
@@ -596,6 +740,7 @@ export function registerNativeSessionV3Adapter(
       currentModel: target.model,
       initialPageCaptured: false,
       piTailMessages: [],
+      ompTailMessages: [],
       writerReady: !target.requiresExplicitClaim,
       writerClaimInFlight: null,
       runs: new Map(),

--- a/web/src/native-session-v3-adapter.ts
+++ b/web/src/native-session-v3-adapter.ts
@@ -2,7 +2,7 @@ import { api, type MessagePage } from "./api"
 import { probeNativeSessionContinuation } from "./native-session-continuation"
 import { lastNativeMessageModel } from "./native-session-model"
 import type { NativeSessionSurfaceTarget } from "./native-session-discovery"
-import { sendNativeSessionPrompt } from "./native-session-prompt"
+import { loadPendingNativeSessionPrompt, sendNativeSessionPrompt } from "./native-session-prompt"
 import { stopNativeSession } from "./native-session-stop"
 import {
   taskClient,
@@ -36,8 +36,16 @@ type ProjectionEntry = {
   listeners: Set<(task: MachineTask) => void>
 }
 
+type PreparedProjectionRun = {
+  id: string
+  created: number
+  prompt: string
+  model: ModelSelection | null
+}
+
 const projections = new Map<string, ProjectionEntry>()
 let installed = false
+let provisionalRunSequence = 0
 
 export function nativeSessionIsWorking(status?: string): boolean {
   const value = status?.trim().toLowerCase() || ""
@@ -160,10 +168,10 @@ function nativeAssistantCompleted(message: MessageEnvelope): boolean {
 }
 
 function sameModel(left: ModelSelection | null, right: ModelSelection | null): boolean {
-  return Boolean(left && right
-    && left.providerID === right.providerID
+  if (!left || !right) return !left && !right
+  return left.providerID === right.providerID
     && left.modelID === right.modelID
-    && (left.variant || "") === (right.variant || ""))
+    && (left.variant || "") === (right.variant || "")
 }
 
 /**
@@ -171,20 +179,36 @@ function sameModel(left: ModelSelection | null, right: ModelSelection | null): b
  * new native envelope is durable, then return while the reply is still streaming. Every current-tail
  * page can therefore advance the projection from stale/default metadata to the model on the newest
  * native turn.
+ *
+ * OMP reports the model of its selected JSONL branch as page.model. That is native truth and must be
+ * allowed to fill a projection that mounted before model enrichment. While an HR-originated turn is
+ * already running, however, an older journal page may still describe the previous model for a few
+ * milliseconds; never let that stale page undo a concrete model the user just selected for the turn.
  */
 function reconcileNativeSessionModel(entry: ProjectionEntry, page: MessagePage, before?: string): void {
-  if (before || (entry.target.backend !== "opencode" && entry.target.backend !== "codex")) return
+  if (before || !["opencode", "codex", "omp"].includes(entry.target.backend)) return
   const model = page.model ?? (entry.target.backend === "opencode" ? lastNativeMessageModel(page.messages) : null)
   if (!model) return
+  if (entry.target.backend === "omp" && entry.forcedStatus === "running" && entry.currentModel && !sameModel(entry.currentModel, model)) {
+    return
+  }
 
   let changed = !sameModel(entry.currentModel, model)
   entry.currentModel = model
-  const latestUser = [...page.messages].reverse().find((message) => message.info.role === "user" && message.info.id)
-  if (latestUser) {
-    const run = entry.runs.get(`${projectionID(entry.target)}:native-user:${latestUser.info.id}`)
-    if (run && !sameModel(run.model, model)) {
-      run.model = model
-      changed = true
+
+  const orderedRuns = [...entry.runs.values()].sort((left, right) => left.created - right.created || left.id.localeCompare(right.id))
+  const latestRun = orderedRuns[orderedRuns.length - 1]
+  if (latestRun && !latestRun.model) {
+    latestRun.model = model
+    changed = true
+  } else {
+    const latestUser = [...page.messages].reverse().find((message) => message.info.role === "user" && message.info.id)
+    if (latestUser) {
+      const run = entry.runs.get(`${projectionID(entry.target)}:native-user:${latestUser.info.id}`)
+      if (run && !sameModel(run.model, model)) {
+        run.model = model
+        changed = true
+      }
     }
   }
   if (changed) notify(entry)
@@ -356,16 +380,68 @@ function captureUserRuns(entry: ProjectionEntry, page: MessagePage, before?: str
   if (changed) notify(entry)
 }
 
-function appendAcceptedRun(entry: ProjectionEntry, prompt: string, model: ModelSelection | null, clientRequestId: string): MachineTask {
-  const id = `${projectionID(entry.target)}:request:${clientRequestId}`
+function requestRunID(entry: ProjectionEntry, clientRequestId: string): string {
+  return `${projectionID(entry.target)}:request:${clientRequestId}`
+}
+
+/**
+ * Create the logical continuation boundary before writer acquisition or HTTP prompt delivery starts.
+ * OMP can emit session.updated while claim/model application is in progress; without a new Run in the
+ * projection that event marks the preceding assistant as active and its old Activity flips back to
+ * Working. A provisional Run gives the mature timeline the correct current turn immediately.
+ */
+function beginProjectionRun(entry: ProjectionEntry, prompt: string, model: ModelSelection | null): PreparedProjectionRun {
+  const normalizedPrompt = canonicalText(prompt)
+  const effectiveModel = model ?? entry.currentModel
+  const unresolved = loadPendingNativeSessionPrompt(entry.target)
+  const canReusePending = Boolean(
+    unresolved
+    && canonicalText(unresolved.text) === normalizedPrompt
+    && sameModel(unresolved.model ?? null, effectiveModel)
+  )
+  const created = canReusePending && unresolved ? unresolved.createdAt : Date.now()
+  const id = canReusePending && unresolved
+    ? requestRunID(entry, unresolved.clientRequestId)
+    : `${projectionID(entry.target)}:pending:${created.toString(36)}:${++provisionalRunSequence}`
+
   if (!entry.runs.has(id)) {
-    const created = Date.now()
-    entry.runs.set(id, { id, prompt: canonicalText(prompt), created, model })
-    entry.updatedAt = created
+    entry.runs.set(id, { id, prompt: normalizedPrompt, created, model: effectiveModel })
   }
-  entry.currentModel = model
+  if (effectiveModel) entry.currentModel = effectiveModel
+  entry.updatedAt = Math.max(entry.updatedAt, created)
   entry.forcedStatus = "running"
-  entry.statusType = "running"
+  notify(entry)
+  return { id, created, prompt: normalizedPrompt, model: effectiveModel }
+}
+
+function promoteProjectionRun(
+  entry: ProjectionEntry,
+  prepared: PreparedProjectionRun,
+  clientRequestId: string,
+  running: boolean
+): MachineTask {
+  const id = requestRunID(entry, clientRequestId)
+  const existing = entry.runs.get(prepared.id)
+  if (prepared.id !== id) entry.runs.delete(prepared.id)
+  if (!entry.runs.has(id)) {
+    entry.runs.set(id, {
+      id,
+      prompt: existing?.prompt ?? prepared.prompt,
+      created: existing?.created ?? prepared.created,
+      model: existing?.model ?? prepared.model ?? entry.currentModel
+    })
+  }
+  const run = entry.runs.get(id)
+  if (run && !run.model && entry.currentModel) run.model = entry.currentModel
+  entry.updatedAt = Math.max(entry.updatedAt, run?.created ?? prepared.created)
+  entry.forcedStatus = running ? "running" : null
+  if (running) entry.statusType = "running"
+  return notify(entry)
+}
+
+function abandonProjectionRun(entry: ProjectionEntry, prepared: PreparedProjectionRun): MachineTask {
+  entry.runs.delete(prepared.id)
+  entry.forcedStatus = null
   return notify(entry)
 }
 
@@ -448,17 +524,39 @@ function installAdapter(): void {
     if (body.agentId && body.agentId !== entry.target.agentID) {
       throw new Error("Cross-agent continuation is disabled until single-Session parity is validated")
     }
-    await ensureWriter(entry)
+
     // The shared v3 controller emits null while its model picker is still catching up with native
-    // transcript enrichment. For a native Session that is not an explicit new catalog selection;
+    // transcript enrichment. For a native Session that is not an explicit new catalog selection,
     // preserve the model already recovered from the authoritative Session instead of silently
     // switching the next turn to the harness default. A concrete ModelSelection still wins.
     const model = body.model ?? entry.currentModel
-    const result = await sendNativeSessionPrompt(entry.target, prompt, model)
-    if (result.status !== "accepted") {
-      throw new Error(`Prompt delivery is ${result.status}. Retry the same prompt to reconcile the existing request id.`)
+    const prepared = beginProjectionRun(entry, prompt, model ?? null)
+
+    try {
+      await ensureWriter(entry)
+      const result = await sendNativeSessionPrompt(entry.target, prompt, model)
+      if (result.status !== "accepted") {
+        promoteProjectionRun(entry, prepared, result.clientRequestId, false)
+        throw new Error(`Prompt delivery is ${result.status}. Retry the same prompt to reconcile the existing request id.`)
+      }
+      return promoteProjectionRun(entry, prepared, result.clientRequestId, true)
+    } catch (reason) {
+      // A transport failure after dispatch keeps the durable pending request id. Preserve that logical
+      // user turn so retrying cannot reactivate the preceding Activity, but do not claim it is still
+      // Working until native status proves delivery. A claim/HTTP refusal clears the pending record,
+      // which proves no turn exists and allows the provisional boundary to be removed completely.
+      const pending = loadPendingNativeSessionPrompt(entry.target)
+      if (
+        pending
+        && canonicalText(pending.text) === prepared.prompt
+        && sameModel(pending.model ?? null, prepared.model)
+      ) {
+        promoteProjectionRun(entry, prepared, pending.clientRequestId, false)
+      } else if (entry.runs.has(prepared.id)) {
+        abandonProjectionRun(entry, prepared)
+      }
+      throw reason
     }
-    return appendAcceptedRun(entry, prompt, model ?? null, result.clientRequestId)
   }
 
   const originalCancelWorkThread = taskClient.cancelWorkThread.bind(taskClient)

--- a/web/src/taskdesk-live-event-routing.test.mjs
+++ b/web/src/taskdesk-live-event-routing.test.mjs
@@ -47,16 +47,18 @@ test("OpenCode completion lifecycle reconciles status and the selected transcrip
   assert.match(lifecycle, /event\.type === "session\.idle"/)
   assert.match(lifecycle, /throttle\("index", [^,]+, onIndex\)/)
   assert.match(lifecycle, /selectedEvent[\s\S]*?throttle\("message", [^,]+, onMessage\)/)
+  assert.doesNotMatch(lifecycle, /backend === "omp"/)
   assert.doesNotMatch(lifecycle, /send|prompt|continueWorkThread/)
 })
 
-test("ACP session.updated lifecycle also reconciles the selected transcript tail", () => {
+test("ACP session.updated keeps baseline detail behavior except for OMP tail convergence", () => {
   const refresh = readFileSync(new URL("./taskdesk-session-live-refresh.ts", import.meta.url), "utf8")
   const lifecycle = refresh.match(/if \(event\.type === "session\.updated"\) \{[\s\S]*?\n      \}/)?.[0] || ""
 
   assert.match(lifecycle, /throttle\("index", [^,]+, onIndex\)/)
-  assert.match(lifecycle, /selectedEvent[\s\S]*?throttle\("message", [^,]+, onMessage\)/)
-  assert.match(lifecycle, /settleAfterLifecycle\(\)/)
+  assert.match(lifecycle, /selectedEvent[\s\S]*?throttle\("detail", [^,]+, onDetail\)/)
+  assert.match(lifecycle, /if \(target\.config\.backend === "omp"\) \{[\s\S]*?throttle\("message", [^,]+, onMessage\)[\s\S]*?settleAfterLifecycle\(\)/)
+  assert.doesNotMatch(lifecycle, /backend === "pi"|backend === "claude"|backend === "codex"/)
   assert.doesNotMatch(lifecycle, /send|prompt|continueWorkThread/)
 })
 

--- a/web/src/taskdesk-live-event-routing.test.mjs
+++ b/web/src/taskdesk-live-event-routing.test.mjs
@@ -50,6 +50,16 @@ test("OpenCode completion lifecycle reconciles status and the selected transcrip
   assert.doesNotMatch(lifecycle, /send|prompt|continueWorkThread/)
 })
 
+test("ACP session.updated lifecycle also reconciles the selected transcript tail", () => {
+  const refresh = readFileSync(new URL("./taskdesk-session-live-refresh.ts", import.meta.url), "utf8")
+  const lifecycle = refresh.match(/if \(event\.type === "session\.updated"\) \{[\s\S]*?\n      \}/)?.[0] || ""
+
+  assert.match(lifecycle, /throttle\("index", [^,]+, onIndex\)/)
+  assert.match(lifecycle, /selectedEvent[\s\S]*?throttle\("message", [^,]+, onMessage\)/)
+  assert.match(lifecycle, /settleAfterLifecycle\(\)/)
+  assert.doesNotMatch(lifecycle, /send|prompt|continueWorkThread/)
+})
+
 test("foregrounding the app immediately reconciles durable conversation state", () => {
   const refresh = readFileSync(new URL("./taskdesk-session-live-refresh.ts", import.meta.url), "utf8")
 

--- a/web/src/taskdesk-live-event-routing.test.mjs
+++ b/web/src/taskdesk-live-event-routing.test.mjs
@@ -60,6 +60,18 @@ test("ACP session.updated lifecycle also reconciles the selected transcript tail
   assert.doesNotMatch(lifecycle, /send|prompt|continueWorkThread/)
 })
 
+test("OMP alone gets a bounded multi-read lifecycle convergence window", () => {
+  const refresh = readFileSync(new URL("./taskdesk-session-live-refresh.ts", import.meta.url), "utf8")
+
+  assert.match(refresh, /const DEFAULT_LIFECYCLE_SETTLE_DELAYS_MS = \[900\] as const/)
+  assert.match(refresh, /const OMP_LIFECYCLE_SETTLE_DELAYS_MS = \[350, 900, 1_800, 3_200\] as const/)
+  assert.match(refresh, /target\?\.config\.backend === "omp"[\s\S]*?OMP_LIFECYCLE_SETTLE_DELAYS_MS[\s\S]*?DEFAULT_LIFECYCLE_SETTLE_DELAYS_MS/)
+  assert.match(refresh, /selectedNow\.targetKey !== selectedAtSchedule\.targetKey/)
+  assert.match(refresh, /selectedNow\.sessionID !== selectedAtSchedule\.sessionID/)
+  assert.match(refresh, /if \(!finalAttempt\) scheduleAttempt\(index \+ 1\)/)
+  assert.doesNotMatch(refresh, /setInterval\([\s\S]*?OMP_LIFECYCLE_SETTLE/)
+})
+
 test("foregrounding the app immediately reconciles durable conversation state", () => {
   const refresh = readFileSync(new URL("./taskdesk-session-live-refresh.ts", import.meta.url), "utf8")
 

--- a/web/src/taskdesk-message-paging.test.mjs
+++ b/web/src/taskdesk-message-paging.test.mjs
@@ -59,34 +59,18 @@ test("newest-page reconcile never cuts a streamed assistant reply back to a stal
   assert.equal(caughtUp[0], laterJournal, "a journal that catches up and extends the answer remains authoritative")
 })
 
-test("live-to-journal id swaps cannot cut the final reply or duplicate it", () => {
+test("shared paging does not invent identity across different native message ids", () => {
   const prompt = userMessage("user-1", "Explain the final state")
-  const complete = message("live-reply", "This is the complete answer from the live ACP stream.")
+  const liveReply = message("live-reply", "This is the complete answer")
   const journalPrompt = userMessage("user-1", "Explain the final state")
-  const staleJournal = message("journal-reply", "This is the complete answer")
+  const journalReply = message("journal-reply", "This is the complete answer")
 
-  const merged = mergeLatestMessagePage([prompt, complete], [journalPrompt, staleJournal])
-  assert.deepEqual(merged.map((entry) => entry.info.id), ["user-1", "live-reply"])
-  assert.equal(merged[1], complete, "a lagging journal with a new transport id must not replace or duplicate the live answer")
-
-  const caughtUpJournal = message("journal-reply", "This is the complete answer from the live ACP stream. Persisted.")
-  const caughtUp = mergeLatestMessagePage(merged, [journalPrompt, caughtUpJournal])
-  assert.deepEqual(caughtUp.map((entry) => entry.info.id), ["user-1", "live-reply"])
-  assert.equal(caughtUp[1].parts[0].text, "This is the complete answer from the live ACP stream. Persisted.")
-})
-
-test("cross-id stabilization is limited to the same final user turn", () => {
-  const current = [
-    userMessage("user-1", "First prompt"),
-    message("live-reply", "Same looking answer")
-  ]
-  const differentTurn = [
-    userMessage("user-2", "Different prompt"),
-    message("journal-reply", "Same looking answer")
-  ]
-
-  const merged = mergeLatestMessagePage(current, differentTurn)
-  assert.deepEqual(merged.map((entry) => entry.info.id), ["user-1", "live-reply", "user-2", "journal-reply"])
+  const merged = mergeLatestMessagePage([prompt, liveReply], [journalPrompt, journalReply])
+  assert.deepEqual(
+    merged.map((entry) => entry.info.id),
+    ["user-1", "live-reply", "journal-reply"],
+    "cross-id repair belongs to the harness-specific projection, not the shared page merger"
+  )
 })
 
 test("a divergent native rewrite is not mistaken for a stale prefix", () => {

--- a/web/src/taskdesk-message-paging.test.mjs
+++ b/web/src/taskdesk-message-paging.test.mjs
@@ -10,6 +10,13 @@ function message(id, text = id) {
   }
 }
 
+function userMessage(id, text) {
+  return {
+    info: { id, role: "user", time: { created: 1, updated: 1 } },
+    parts: [{ id: `${id}-part`, type: "text", text }]
+  }
+}
+
 test("message paging client consumes bridge cursor headers", () => {
   const api = readFileSync(new URL("./api.ts", import.meta.url), "utf8")
   const server = readFileSync(new URL("../../bridge/src/server.js", import.meta.url), "utf8")
@@ -50,6 +57,36 @@ test("newest-page reconcile never cuts a streamed assistant reply back to a stal
   const laterJournal = message("reply", "This is the complete answer from the live ACP stream. Persisted.")
   const caughtUp = mergeLatestMessagePage(merged, [laterJournal])
   assert.equal(caughtUp[0], laterJournal, "a journal that catches up and extends the answer remains authoritative")
+})
+
+test("live-to-journal id swaps cannot cut the final reply or duplicate it", () => {
+  const prompt = userMessage("user-1", "Explain the final state")
+  const complete = message("live-reply", "This is the complete answer from the live ACP stream.")
+  const journalPrompt = userMessage("user-1", "Explain the final state")
+  const staleJournal = message("journal-reply", "This is the complete answer")
+
+  const merged = mergeLatestMessagePage([prompt, complete], [journalPrompt, staleJournal])
+  assert.deepEqual(merged.map((entry) => entry.info.id), ["user-1", "live-reply"])
+  assert.equal(merged[1], complete, "a lagging journal with a new transport id must not replace or duplicate the live answer")
+
+  const caughtUpJournal = message("journal-reply", "This is the complete answer from the live ACP stream. Persisted.")
+  const caughtUp = mergeLatestMessagePage(merged, [journalPrompt, caughtUpJournal])
+  assert.deepEqual(caughtUp.map((entry) => entry.info.id), ["user-1", "live-reply"])
+  assert.equal(caughtUp[1].parts[0].text, "This is the complete answer from the live ACP stream. Persisted.")
+})
+
+test("cross-id stabilization is limited to the same final user turn", () => {
+  const current = [
+    userMessage("user-1", "First prompt"),
+    message("live-reply", "Same looking answer")
+  ]
+  const differentTurn = [
+    userMessage("user-2", "Different prompt"),
+    message("journal-reply", "Same looking answer")
+  ]
+
+  const merged = mergeLatestMessagePage(current, differentTurn)
+  assert.deepEqual(merged.map((entry) => entry.info.id), ["user-1", "live-reply", "user-2", "journal-reply"])
 })
 
 test("a divergent native rewrite is not mistaken for a stale prefix", () => {

--- a/web/src/taskdesk-session-live-refresh.ts
+++ b/web/src/taskdesk-session-live-refresh.ts
@@ -73,10 +73,10 @@ export function startTaskDeskSessionLiveRefresh({
   }
 
   /**
-   * OpenCode may publish the lifecycle edge before the final assistant envelope is readable through
-   * `/session/:id/message`. Keep one bounded, coalesced settle read after the latest status edge so
+   * A harness may publish its lifecycle edge before the final assistant envelope is durable through
+   * `/session/:id/message`. Keep one bounded, coalesced settle read after the latest lifecycle edge so
    * the already-mounted Session gets a second authoritative chance without permanent fast polling.
-   * A later busy/idle status simply moves this one timer; it never creates an unbounded retry loop.
+   * A later lifecycle event simply moves this one timer; it never creates an unbounded retry loop.
    */
   const settleAfterLifecycle = () => {
     if (closed || !getSelected()) return
@@ -169,9 +169,16 @@ export function startTaskDeskSessionLiveRefresh({
         return
       }
 
+      // ACP-backed harnesses use session.updated for both the busy edge and the final idle edge. The
+      // final edge may be the only signal after the last streamed chunk, so treating it as index-only
+      // can leave the mounted transcript on a stale prefix until navigation forces a fresh read.
       if (event.type === "session.updated") {
         throttle("index", 450, onIndex)
-        if (selectedEvent) throttle("detail", 450, onDetail)
+        if (selectedEvent) {
+          throttle("message", 80, onMessage)
+          throttle("detail", 450, onDetail)
+          settleAfterLifecycle()
+        }
         return
       }
 

--- a/web/src/taskdesk-session-live-refresh.ts
+++ b/web/src/taskdesk-session-live-refresh.ts
@@ -18,7 +18,12 @@ export type SelectedLiveSession = {
 type Timer = ReturnType<typeof setTimeout>
 
 const FOREGROUND_DEDUP_MS = 500
-const LIFECYCLE_SETTLE_MS = 900
+const DEFAULT_LIFECYCLE_SETTLE_DELAYS_MS = [900] as const
+// OMP can emit its final session.updated before the JSONL writer has made the last assistant words
+// durable. One follow-up read was therefore occasionally still too early, leaving the mounted reply
+// truncated until navigation forced a fresh load. Keep a short, finite convergence window for OMP
+// only; all other harnesses retain the single existing settle read.
+const OMP_LIFECYCLE_SETTLE_DELAYS_MS = [350, 900, 1_800, 3_200] as const
 
 function isAttentionEvent(type: string): boolean {
   return type.startsWith("permission.") || type.startsWith("question.")
@@ -54,6 +59,7 @@ export function startTaskDeskSessionLiveRefresh({
   let detailTimer: Timer | undefined
   let foregroundTimer: Timer | undefined
   let lifecycleSettleTimer: Timer | undefined
+  let lifecycleSettleGeneration = 0
   let lastForegroundRefreshAt = 0
   let appStateHandle: PluginListenerHandle | undefined
 
@@ -74,19 +80,42 @@ export function startTaskDeskSessionLiveRefresh({
 
   /**
    * A harness may publish its lifecycle edge before the final assistant envelope is durable through
-   * `/session/:id/message`. Keep one bounded, coalesced settle read after the latest lifecycle edge so
-   * the already-mounted Session gets a second authoritative chance without permanent fast polling.
-   * A later lifecycle event simply moves this one timer; it never creates an unbounded retry loop.
+   * `/session/:id/message`. Keep bounded, coalesced settle reads after the latest lifecycle edge so
+   * the already-mounted Session gets another authoritative chance without permanent fast polling.
+   *
+   * OMP gets a few additional reads because its JSONL durability can lag the ACP lifecycle edge by
+   * more than the original 900ms. The selected Session identity is captured so leaving that Session
+   * cancels the old convergence chain instead of refreshing whichever Session was opened next.
    */
   const settleAfterLifecycle = () => {
-    if (closed || !getSelected()) return
+    const selectedAtSchedule = getSelected()
+    if (closed || !selectedAtSchedule) return
     if (lifecycleSettleTimer !== undefined) clearTimeout(lifecycleSettleTimer)
-    lifecycleSettleTimer = setTimeout(() => {
-      lifecycleSettleTimer = undefined
-      if (closed || !getSelected()) return
-      onMessage()
-      onIndex()
-    }, LIFECYCLE_SETTLE_MS)
+    const generation = ++lifecycleSettleGeneration
+    const target = targets.find((candidate) => candidate.key === selectedAtSchedule.targetKey)
+    const delays = target?.config.backend === "omp"
+      ? OMP_LIFECYCLE_SETTLE_DELAYS_MS
+      : DEFAULT_LIFECYCLE_SETTLE_DELAYS_MS
+
+    const scheduleAttempt = (index: number) => {
+      lifecycleSettleTimer = setTimeout(() => {
+        lifecycleSettleTimer = undefined
+        if (closed || lifecycleSettleGeneration !== generation) return
+        const selectedNow = getSelected()
+        if (
+          !selectedNow
+          || selectedNow.targetKey !== selectedAtSchedule.targetKey
+          || selectedNow.sessionID !== selectedAtSchedule.sessionID
+        ) return
+
+        onMessage()
+        const finalAttempt = index === delays.length - 1
+        if (finalAttempt) onIndex()
+        if (!finalAttempt) scheduleAttempt(index + 1)
+      }, delays[index])
+    }
+
+    scheduleAttempt(0)
   }
 
   const reconcileAfterForeground = () => {
@@ -146,8 +175,8 @@ export function startTaskDeskSessionLiveRefresh({
 
       // OpenCode's authoritative turn lifecycle is session.status. The deprecated session.idle event
       // is still accepted because older OpenCode releases emit it. The immediate tail read covers the
-      // normal case; the one bounded settle read covers real servers where transcript durability lags
-      // the lifecycle edge and no convenient final message.updated is emitted.
+      // normal case; the bounded settle read covers real servers where transcript durability lags the
+      // lifecycle edge and no convenient final message.updated is emitted.
       if (event.type === "session.status" || event.type === "session.idle") {
         throttle("index", 120, onIndex)
         if (selectedEvent) {
@@ -209,6 +238,7 @@ export function startTaskDeskSessionLiveRefresh({
     close() {
       if (closed) return
       closed = true
+      lifecycleSettleGeneration += 1
       if (messageTimer !== undefined) clearTimeout(messageTimer)
       if (indexTimer !== undefined) clearTimeout(indexTimer)
       if (detailTimer !== undefined) clearTimeout(detailTimer)

--- a/web/src/taskdesk-session-live-refresh.ts
+++ b/web/src/taskdesk-session-live-refresh.ts
@@ -22,7 +22,7 @@ const DEFAULT_LIFECYCLE_SETTLE_DELAYS_MS = [900] as const
 // OMP can emit its final session.updated before the JSONL writer has made the last assistant words
 // durable. One follow-up read was therefore occasionally still too early, leaving the mounted reply
 // truncated until navigation forced a fresh load. Keep a short, finite convergence window for OMP
-// only; all other harnesses retain the single existing settle read.
+// only; all other harnesses retain their existing lifecycle behavior.
 const OMP_LIFECYCLE_SETTLE_DELAYS_MS = [350, 900, 1_800, 3_200] as const
 
 function isAttentionEvent(type: string): boolean {
@@ -79,13 +79,10 @@ export function startTaskDeskSessionLiveRefresh({
   }
 
   /**
-   * A harness may publish its lifecycle edge before the final assistant envelope is durable through
-   * `/session/:id/message`. Keep bounded, coalesced settle reads after the latest lifecycle edge so
-   * the already-mounted Session gets another authoritative chance without permanent fast polling.
-   *
-   * OMP gets a few additional reads because its JSONL durability can lag the ACP lifecycle edge by
-   * more than the original 900ms. The selected Session identity is captured so leaving that Session
-   * cancels the old convergence chain instead of refreshing whichever Session was opened next.
+   * OpenCode already used one bounded settle read after its lifecycle edge. OMP needs a few bounded
+   * reads because its JSONL durability can lag session.updated longer than 900ms. Capture the selected
+   * Session identity so leaving it cancels the old convergence chain rather than refreshing the next
+   * Session the user opens.
    */
   const settleAfterLifecycle = () => {
     const selectedAtSchedule = getSelected()
@@ -174,9 +171,8 @@ export function startTaskDeskSessionLiveRefresh({
       }
 
       // OpenCode's authoritative turn lifecycle is session.status. The deprecated session.idle event
-      // is still accepted because older OpenCode releases emit it. The immediate tail read covers the
-      // normal case; the bounded settle read covers real servers where transcript durability lags the
-      // lifecycle edge and no convenient final message.updated is emitted.
+      // is still accepted because older OpenCode releases emit it. Preserve its existing immediate
+      // read + one 900ms settle behavior exactly.
       if (event.type === "session.status" || event.type === "session.idle") {
         throttle("index", 120, onIndex)
         if (selectedEvent) {
@@ -198,15 +194,16 @@ export function startTaskDeskSessionLiveRefresh({
         return
       }
 
-      // ACP-backed harnesses use session.updated for both the busy edge and the final idle edge. The
-      // final edge may be the only signal after the last streamed chunk, so treating it as index-only
-      // can leave the mounted transcript on a stale prefix until navigation forces a fresh read.
       if (event.type === "session.updated") {
         throttle("index", 450, onIndex)
         if (selectedEvent) {
-          throttle("message", 80, onMessage)
+          // Baseline ACP behavior is detail-only. OMP alone needs transcript convergence because its
+          // journal may trail the final ACP lifecycle edge; do not widen that behavior to PI/Claude.
+          if (target.config.backend === "omp") {
+            throttle("message", 80, onMessage)
+            settleAfterLifecycle()
+          }
           throttle("detail", 450, onDetail)
-          settleAfterLifecycle()
         }
         return
       }


### PR DESCRIPTION
## Scope

OMP-only Session-first reliability follow-up on the **final merged head of #304** (`7dddd1c9edc6fdba1fb32bce8c4fc43c00febb71`).

This PR does **not** target `main`, does not modify `v3/taskdesk`, and does not add a second chat renderer or a parallel Session model. It remains **DRAFT / UNMERGED** until real OMP validation passes.

## Failures reproduced during real validation

The first pass fixed the normal continuation path, but real-device testing isolated additional failures specifically after OMP errors/interruption:

1. normal continuation keeps the actual model instead of regressing to `Harness default`;
2. every continuation gets a fresh Activity boundary instead of marking the previous completed Activity `Working` again;
3. normal leave/reopen follows the same active JSONL branch;
4. **after one or more red failed turns**, leave/reopen can lose those errors, recover the wrong model, or show strange/duplicate replies;
5. the mounted OMP reply can occasionally stop a few words early, while leave/reopen immediately reveals the complete final text;
6. changing Session while `Oh My Pi is getting started` can restart that presentation timer. This is recorded but intentionally not changed here until it is proven OMP-specific rather than a shared mount/presentation issue.

## Root causes and fixes

### 1. Production OMP must never guess the active branch

OMP history is a tree. `inferLatestTerminalLeaf()` is useful only for standalone/history-only fallback and can choose a newer abandoned sibling after a failed/retried turn.

The original #308 made **paged** production reads require extension-provided `activeSessionLeaf`, but its full-history fallback still called `inferLatestTerminalLeaf()` when the extension state was temporarily unavailable. That contradicted the intended architecture and explains why error/interruption cases could reopen on a different terminal sibling.

The same OMP loader object now treats `pageRequiresActiveLeaf = true` as a strict contract for **both full loads and pages**. If authoritative extension state is unavailable, it returns no guessed branch and lets `AcpService` retain/retry its already-known observational state instead of replacing it with an arbitrary sibling.

Standalone loader consumers keep the previous inference fallback.

### 2. Failed attempts remain visible without resurrecting abandoned answers

A retry can create a successful assistant sibling of an earlier failed assistant for the same user node. Following only the selected ancestry made the red failure disappear on reopen; merging every sibling would instead recreate duplicate answers.

OMP history now linearizes exactly:

- the authoritative selected branch; plus
- assistant records with a real `errorMessage` whose parent user prompt belongs to that branch and whose journal record existed no later than the selected leaf.

Normal assistant siblings are never added. Later abandoned error/success siblings beyond the selected leaf are also excluded. Journal append order is retained, so visible history remains `prompt -> failed attempt -> retry/success`.

### 3. Model continuity survives a failed visible attempt

OMP `MessagePage.model` remains native truth for the projection. Model reconstruction now also accepts provider/model metadata from a visible failed assistant attempt tied to the selected prompt. This covers the real case where a failure used the selected model but the later successful journal envelope omitted provider/model metadata; reopen must not fall back to an older/default model just because the first attempt failed.

While an HR-originated OMP turn is live, a lagging journal page still cannot overwrite a concrete current selection with the previous branch model. Late model enrichment still fills a current Run whose model was unknown.

### 4. Continuation / Activity boundary remains established before ACP mutation

A logical projection Run is created **before** writer acquisition and prompt delivery. OMP can emit `session.updated` during claim/model/prompt setup; without the provisional Run that event can reactivate the preceding completed Activity.

The provisional Run is promoted to the durable daemon `clientRequestId` after acceptance. A definite refusal removes it; an ambiguous delivery preserves the durable pending identity without claiming the turn is still Working.

### 5. OMP final-tail convergence is bounded but longer than one read

The previous #308 did an immediate transcript read plus one settle read at 900 ms after `session.updated`. Real validation proved that OMP's JSONL can still lag that second read, producing a reply whose final words appear only after navigation forces a fresh read.

Other harnesses are unchanged: they keep the existing single 900 ms settle.

Only OMP now gets a finite convergence sequence after the latest lifecycle edge: **350 ms, 900 ms, 1.8 s, 3.2 s**, in addition to the immediate selected-tail read. A newer lifecycle event coalesces/restarts the sequence; leaving the selected Session cancels the old chain by Session identity. There is no permanent fast polling.

## Regression coverage added

- production OMP full history and paging do not infer a terminal sibling when `activeSessionLeaf` is unavailable;
- a failed sibling attached to the selected user prompt remains visible after reopen;
- abandoned successful siblings are not resurrected;
- abandoned errors journalled after the selected leaf are not resurrected;
- the OMP newest page keeps `prompt -> red failure -> selected final answer`;
- model recovery can use the visible failed attempt when the selected final envelope lacks model metadata;
- existing authoritative-branch pagination still keeps opaque cursors and exact limits;
- OMP alone receives the bounded multi-read lifecycle convergence window;
- a settle sequence captured for Session A cannot refresh Session B after navigation.

Existing #308 coverage remains for model reconciliation, provisional Run ordering, live -> journal assistant identity, native prompt idempotency and OMP active-leaf paging.

## CI status for the latest follow-up

The previous #308 head passed the full PR workflow. The new recovery commits are on head `1bf5b530819e578ce67e4030bac8b651f29b5ee4`.

GitHub did not dispatch a new Actions run for these connector-authored synchronize/reopen events, even after temporarily toggling the PR Ready and pushing a test-only comment. Do **not** treat the old green run as validation of this new head. Real OMP validation remains mandatory before merge.

## Real validation gate

Keep this PR **DRAFT / UNMERGED** until all of these pass on a real OMP Session:

- continue an existing clean OMP Session without changing model: picker remains on the actual model, never `Harness default`;
- continue repeatedly: every user turn creates its own Activity boundary and an older completed Activity never flips back to Working;
- deliberately produce a red failed turn, then retry successfully: the red error and the one selected successful answer both remain visible;
- after that failure + success, leave/reopen 3-4 times: no additional replies appear, no error disappears, model remains the actual last model;
- repeat with two failures before a successful retry;
- change model explicitly, fail once, retry successfully, leave/reopen: the selected model remains correct;
- wait for a long answer to finish without leaving the Session: its final words must appear by themselves and must match what is shown after reopen;
- Stop once, leave/reopen, then continue once;
- only after OMP passes, smoke PI, OpenCode, Codex and Claude for non-regression.
