### PR TITLE
Make the Session workbench read as one surface

### DIFF
--- a/web/src/components/native-session-actions.tsx
+++ b/web/src/components/native-session-actions.tsx
@@ -1,36 +1,35 @@
 import { useEffect, useRef, useState } from "react"
 import { api } from "../api"
-import { LoadingIcon, PencilIcon, TrashIcon } from "../Icons"
+import { LoadingIcon, TrashIcon } from "../Icons"
 import type { NativeSessionSurfaceTarget } from "../native-session-discovery"
-import type { Session } from "../types"
 import { useDialogDismiss } from "../useDialogDismiss"
 import { useTranslator } from "../useTranslator"
 
 /**
- * Rename and Delete belong to the Session that is open, not to the navigation list.
+ * Delete belongs to the Session that is open, not to the navigation list.
  *
- * Keeping them in the sidebar heading meant the two most consequential Session actions were
- * detached from the Session they act on: the buttons appeared next to New Session, changed meaning
- * with every selection, and were invisible while the phone showed only the chat. They now live in
- * the chat header of the open Session and mutate the real native Session through its owning harness.
+ * Keeping it in the sidebar heading meant the most consequential Session action was detached from
+ * the Session it acts on: the button appeared next to New Session, changed meaning with every
+ * selection, and was invisible while the phone showed only the chat. It now lives in the chat
+ * header of the open Session and mutates the real native Session through its owning harness.
+ *
+ * Rename is not here. It edits one string that the header already displays, so it is an inline edit
+ * of that heading (`native-session-rename.tsx`) rather than a second panel that hides it.
  */
 type Props = {
   target: NativeSessionSurfaceTarget
-  onRenamed: (session: Session, title: string) => void
   onDeleted: (key: string) => void
 }
 
-export function NativeSessionActions({ target, onRenamed, onDeleted }: Props) {
+export function NativeSessionActions({ target, onDeleted }: Props) {
   const t = useTranslator()
-  const [mode, setMode] = useState<"rename" | "delete" | null>(null)
-  const [title, setTitle] = useState("")
+  const [mode, setMode] = useState<"delete" | null>(null)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const renameRef = useRef<HTMLDivElement>(null)
   const deleteRef = useRef<HTMLDivElement>(null)
 
-  // Switching Session must never leave a half-typed rename, or a primed deletion, pointing at the
-  // Session the user just navigated to.
+  // Switching Session must never leave a primed deletion pointing at the Session the user just
+  // navigated to.
   useEffect(() => {
     setMode(null)
     setBusy(false)
@@ -43,44 +42,14 @@ export function NativeSessionActions({ target, onRenamed, onDeleted }: Props) {
     setError(null)
   }
 
-  // Each panel owns its own dismissal instance, so Escape, the Tab trap and focus restoration
-  // follow the panel that is actually open.
-  useDialogDismiss(renameRef, close, { enabled: mode === "rename" })
   useDialogDismiss(deleteRef, close, { enabled: mode === "delete" })
 
-  if (!target.renameSupported && !target.deleteSupported) return null
-
-  function beginRename() {
-    if (busy) return
-    setError(null)
-    setTitle(target.title === "Untitled Session" ? "" : target.title)
-    setMode("rename")
-  }
+  if (!target.deleteSupported) return null
 
   function beginDelete() {
     if (busy) return
     setError(null)
     setMode("delete")
-  }
-
-  async function renameSession() {
-    if (busy) return
-    const nextTitle = title.replace(/[\r\n]+/g, " ").trim()
-    if (!nextTitle) {
-      setError(t("sf.enterSessionName"))
-      return
-    }
-    setBusy(true)
-    setError(null)
-    try {
-      const session = await api.renameSession(target.config, target.sessionID, nextTitle, target.directory)
-      setMode(null)
-      onRenamed(session, nextTitle)
-    } catch (reason) {
-      setError(reason instanceof Error ? reason.message : String(reason))
-    } finally {
-      setBusy(false)
-    }
   }
 
   async function deleteSession() {
@@ -100,19 +69,6 @@ export function NativeSessionActions({ target, onRenamed, onDeleted }: Props) {
 
   return (
     <div className="hr-session-actions">
-      {target.renameSupported ? (
-        <button
-          type="button"
-          className="tdw-icon-button"
-          onClick={beginRename}
-          disabled={busy}
-          aria-expanded={mode === "rename"}
-          aria-label={t("sf.renameSession")}
-          title={t("sf.renameSession")}
-        >
-          <PencilIcon size={15} />
-        </button>
-      ) : null}
       {target.deleteSupported ? (
         <button
           type="button"
@@ -128,37 +84,6 @@ export function NativeSessionActions({ target, onRenamed, onDeleted }: Props) {
       ) : null}
 
       {mode ? <div className="hr-session-action-backdrop" role="presentation" onMouseDown={close} /> : null}
-
-      {mode === "rename" ? (
-        <div className="hr-session-action-panel" role="dialog" aria-modal="true" aria-label={t("sf.renameSession")} ref={renameRef}>
-          <div className="hr-session-action-heading">
-            <div>
-              <strong>{t("sf.renameSession")}</strong>
-              <small>{t("sf.renameSubtitle")}</small>
-            </div>
-            <button type="button" className="tdw-icon-button" data-dismiss="session-actions" onClick={close} disabled={busy} aria-label={t("sf.closeRename")}>×</button>
-          </div>
-          <label className="hr-session-action-field">
-            <span>{t("sf.sessionName")}</span>
-            <input
-              value={title}
-              onChange={(event) => setTitle(event.target.value)}
-              disabled={busy}
-              maxLength={200}
-              data-autofocus
-              onKeyDown={(event) => { if (event.key === "Enter") void renameSession() }}
-            />
-          </label>
-          {error ? <div className="hr-session-action-error" role="alert">{error}</div> : null}
-          <div className="hr-session-action-buttons">
-            <button type="button" className="tdw-button secondary" onClick={close} disabled={busy}>{t("sf.cancel")}</button>
-            <button type="button" className="tdw-button primary" onClick={() => void renameSession()} disabled={busy || !title.trim()}>
-              {busy ? <LoadingIcon size={15} /> : null}
-              {busy ? t("sf.renaming") : t("sf.rename")}
-            </button>
-          </div>
-        </div>
-      ) : null}
 
       {mode === "delete" ? (
         <div className="hr-session-action-panel" role="dialog" aria-modal="true" aria-label={t("sf.deleteSession")} ref={deleteRef}>

--- a/web/src/components/native-session-home.tsx
+++ b/web/src/components/native-session-home.tsx
@@ -56,6 +56,8 @@ type Props = {
   onAttentionCountChange?: (count: number) => void
   selectedKey?: string
   selectedState?: SessionPresentationState
+  /** Fires when native Session discovery has settled at least once for the current machines. */
+  onDiscoveredChange?: (discovered: boolean) => void
 }
 
 const SESSION_HOME_REFRESH_MS = 30_000
@@ -233,12 +235,19 @@ function nativeCreateAgents(snapshot: MachineSnapshot): MachineAgentHost[] {
   return snapshot.agents.filter(canCreateNativeSession)
 }
 
-export function NativeSessionHome({ sources, onOpen, refreshToken = 0, onAttentionCountChange, selectedKey, selectedState }: Props) {
+export function NativeSessionHome({ sources, onOpen, refreshToken = 0, onAttentionCountChange, onDiscoveredChange, selectedKey, selectedState }: Props) {
   const t = useTranslator()
   const [records, setRecords] = useState<RecordWithMachine[]>([])
   const [projectsByMachine, setProjectsByMachine] = useState<Record<string, MachineProject[]>>({})
   const [loading, setLoading] = useState(false)
-  const [loaded, setLoaded] = useState(false)
+  /**
+   * Which set of machines the list has actually been discovered for, rather than a bare "has ever
+   * loaded". Adding the first machine used to leave the flag from the empty state standing, so the
+   * workspace was told the Sessions were in while they were still being read. Keyed by machine, a
+   * genuinely new set of machines is a fresh discovery; a refresh of the same set is not, so the
+   * ten-second cycle never drops the list back to a loading state.
+   */
+  const [loadedSignature, setLoadedSignature] = useState<string | null>(null)
   const [revision, setRevision] = useState(0)
   const [expandedProjects, setExpandedProjects] = useState<Set<string>>(() => new Set())
   const [collapsedProjects, setCollapsedProjects] = useState<Set<string>>(() => new Set())
@@ -260,6 +269,9 @@ export function NativeSessionHome({ sources, onOpen, refreshToken = 0, onAttenti
   // native discovery clears these bridge states and becomes authoritative again.
   const [presentationOverrides, setPresentationOverrides] = useState<Record<string, SessionPresentationState>>({})
 
+  const machineSignature = sources.map(({ machine }) => machine.id).join("|")
+  const loaded = loadedSignature === machineSignature
+
   useEffect(() => {
     if (!selectedKey || !selectedState) return
     setPresentationOverrides((current) => current[selectedKey] === selectedState
@@ -276,7 +288,7 @@ export function NativeSessionHome({ sources, onOpen, refreshToken = 0, onAttenti
       setRecords([])
       setProjectsByMachine({})
       setPresentationOverrides({})
-      setLoaded(true)
+      setLoadedSignature(machineSignature)
       setLoading(false)
       return
     }
@@ -305,11 +317,13 @@ export function NativeSessionHome({ sources, onOpen, refreshToken = 0, onAttenti
       // remembered only to span the gap between a detail event and this discovery cycle.
       setPresentationOverrides({})
       setRecords(results.flatMap((result) => result.records).sort(sessionActivityCompare))
-      setLoaded(true)
+      setLoadedSignature(machineSignature)
     }).catch((reason) => {
       // Preserve an already loaded list, but never present a failed refresh as a genuinely empty machine.
       if (!cancelled) {
-        setLoaded(true)
+        // A failed pass still counts as settled: the notice above the list explains it, and the
+        // workspace must not sit on a waiting screen for a machine that is not coming back.
+        setLoadedSignature(machineSignature)
         setDiscoveryError(reason instanceof Error ? reason.message : String(reason))
       }
     }).finally(() => {
@@ -395,6 +409,10 @@ export function NativeSessionHome({ sources, onOpen, refreshToken = 0, onAttenti
   useEffect(() => {
     onAttentionCountChange?.(attentionCount)
   }, [attentionCount, onAttentionCountChange])
+
+  useEffect(() => {
+    onDiscoveredChange?.(loaded)
+  }, [loaded, onDiscoveredChange])
 
   const filteredGroups = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase()
@@ -526,9 +544,11 @@ export function NativeSessionHome({ sources, onOpen, refreshToken = 0, onAttenti
       <div className="hr-native-home-heading">
         <div>
           <h2>{t("nav.sessions")}</h2>
-          <span>{activeCount
-            ? t("sf.workingShown", { working: activeCount, shown: scopedRecords.length })
-            : t("sf.recentCount", { count: scopedRecords.length })}</span>
+          <span>{!loaded
+            ? t("sf.findingSessions")
+            : activeCount
+              ? t("sf.workingShown", { working: activeCount, shown: scopedRecords.length })
+              : t("sf.recentCount", { count: scopedRecords.length })}</span>
         </div>
         {/* Rename and Delete live in the chat header of the open Session, and refreshing is owned by
             the workspace top bar plus the automatic discovery cycle. The Session list keeps exactly
@@ -664,7 +684,7 @@ export function NativeSessionHome({ sources, onOpen, refreshToken = 0, onAttenti
                 <span className="hr-native-machine-metrics">
                   {machineAttentionCount ? <b>{t("sf.attentionCount", { count: machineAttentionCount })}</b> : null}
                   {workingCount ? <em>{t("sf.liveCount", { count: workingCount })}</em> : null}
-                  <small>{state === "online" ? sessionCount : state === "loading" ? "…" : t("sf.offline")}</small>
+                  <small>{state === "online" ? (loaded ? sessionCount : "…") : state === "loading" ? "…" : t("sf.offline")}</small>
                   <i className="hr-native-machine-chevron" aria-hidden="true"><ChevronDownIcon size={13} /></i>
                 </span>
               </button>
@@ -672,8 +692,13 @@ export function NativeSessionHome({ sources, onOpen, refreshToken = 0, onAttenti
               <>
                 {projects.length === 0 ? (
                   <div className="hr-native-machine-empty">
-                    {state === "loading" ? <LoadingIcon size={15} /> : <ServerIcon size={15} />}
-                    <span>{state === "loading" ? t("sf.discoveringProjects") : state === "offline" ? t("sf.machineUnavailableSaved") : t("sf.noSessionsOnMachine")}</span>
+                    {/* A reachable machine whose Sessions have not been read yet is not a machine
+                        with no Sessions. Until the first discovery pass settles it says so, rather
+                        than reporting an emptiness it has not established. */}
+                    {state === "loading" || (state === "online" && !loaded) ? <LoadingIcon size={15} /> : <ServerIcon size={15} />}
+                    <span>{state === "loading" || (state === "online" && !loaded)
+                      ? t("sf.discoveringProjects")
+                      : state === "offline" ? t("sf.machineUnavailableSaved") : t("sf.noSessionsOnMachine")}</span>
                   </div>
                 ) : null}
 

--- a/web/src/components/native-session-home.tsx
+++ b/web/src/components/native-session-home.tsx
@@ -12,7 +12,7 @@ import { nativeSessionDisplayTitle } from "../native-session-title"
 import { useTranslator } from "../useTranslator"
 import type { Translator } from "../i18n"
 import type { WorkspaceMachine } from "../workspaceMachines"
-import { ChatIcon, ChevronDownIcon, LoadingIcon, PlusIcon, SearchIcon, ServerIcon } from "../Icons"
+import { AgentIcon, ChatIcon, ChevronDownIcon, LoadingIcon, PlusIcon, SearchIcon, ServerIcon } from "../Icons"
 import "../native-session-home.css"
 
 type Source = {
@@ -551,26 +551,41 @@ export function NativeSessionHome({ sources, onOpen, refreshToken = 0, onAttenti
               aria-label={t("sf.searchSessionsLabel")}
             />
           </label>
+          {/* Two different kinds of control, so two different shapes.
+              State is a segmented control: three mutually exclusive views of the same list, always
+              visible, each carrying its own count. Scope is a pair of dropdowns. Sharing one
+              horizontally scrolling row made the selects collapse to a 35px stub with their value
+              clipped away, which is what made them read as empty text fields rather than menus. */}
           <div className="hr-native-session-filters" role="group" aria-label={t("sf.filterSessions")}>
-            {sources.length > 1 ? (
-              <select value={machineFilter} onChange={(event) => setMachineFilter(event.target.value)} aria-label={t("sf.filterByMachine")}>
-                <option value="">{t("sf.allMachinesCount", { count: records.length })}</option>
-                {machineChoices.map((choice) => <option value={choice.id} key={choice.id}>{choice.label} · {choice.count}</option>)}
-              </select>
-            ) : null}
             <button type="button" className={filter === "all" ? "active" : ""} onClick={() => setFilter("all")} aria-pressed={filter === "all"}>
-              {t("sf.filterAll")} <b>{scopedRecords.length}</b>
+              <span>{t("sf.filterAll")}</span> <b>{scopedRecords.length}</b>
             </button>
             <button type="button" className={filter === "working" ? "active" : ""} onClick={() => setFilter("working")} aria-pressed={filter === "working"}>
-              {t("sf.filterLive")} <b>{activeCount}</b>
+              <span>{t("sf.filterLive")}</span> <b>{activeCount}</b>
             </button>
             <button type="button" className={filter === "attention" ? "active" : ""} onClick={() => setFilter("attention")} aria-pressed={filter === "attention"}>
-              {t("sf.filterAttention")} <b>{attentionCount}</b>
+              <span>{t("sf.filterAttention")}</span> <b>{attentionCount}</b>
             </button>
-            <select value={agentFilter} onChange={(event) => setAgentFilter(event.target.value)} aria-label={t("sf.filterByAgent")}>
-              <option value="">{t("sf.allHarnesses")}</option>
-              {agentChoices.map((choice) => <option value={choice.id} key={choice.id}>{choice.label} · {choice.count}</option>)}
-            </select>
+          </div>
+          <div className="hr-native-session-scopes">
+            {sources.length > 1 ? (
+              <label className="hr-native-scope">
+                <ServerIcon size={13} />
+                <select value={machineFilter} onChange={(event) => setMachineFilter(event.target.value)} aria-label={t("sf.filterByMachine")}>
+                  <option value="">{t("sf.allMachinesCount", { count: records.length })}</option>
+                  {machineChoices.map((choice) => <option value={choice.id} key={choice.id}>{choice.label} · {choice.count}</option>)}
+                </select>
+                <ChevronDownIcon size={12} />
+              </label>
+            ) : null}
+            <label className="hr-native-scope">
+              <AgentIcon size={13} />
+              <select value={agentFilter} onChange={(event) => setAgentFilter(event.target.value)} aria-label={t("sf.filterByAgent")}>
+                <option value="">{t("sf.allHarnesses")}</option>
+                {agentChoices.map((choice) => <option value={choice.id} key={choice.id}>{choice.label} · {choice.count}</option>)}
+              </select>
+              <ChevronDownIcon size={12} />
+            </label>
           </div>
         </div>
       ) : null}

--- a/web/src/components/native-session-rename.tsx
+++ b/web/src/components/native-session-rename.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useRef, useState } from "react"
+import { api } from "../api"
+import { CheckIcon, CloseIcon, LoadingIcon, PencilIcon } from "../Icons"
+import type { NativeSessionSurfaceTarget } from "../native-session-discovery"
+import type { Session } from "../types"
+import { useTranslator } from "../useTranslator"
+
+/**
+ * Renaming a Session is editing the thing you are looking at, so it happens on the thing you are
+ * looking at.
+ *
+ * The previous implementation opened a modal panel with its own heading, its own field labelled
+ * "Session name" and its own pair of buttons, to change one short string that was already on screen
+ * two centimetres above it. That is three layers of chrome around a single-line edit: the user has
+ * to find the new title's field, and the title they are replacing is hidden behind the panel while
+ * they type. Every editor this app is compared against - Linear, Notion, GitHub, the harness CLIs'
+ * own web surfaces - makes the heading itself editable instead.
+ *
+ * The heading is therefore the input. Its typography, box and position are identical in both states,
+ * so committing a rename does not make the header move, and Escape restores the previous value
+ * without anything else on screen having changed. Keyboard commits with Enter, cancels with Escape,
+ * and a blur commits the same way clicking away from a renamed file does elsewhere.
+ */
+type Props = {
+  target: NativeSessionSurfaceTarget
+  onRenamed: (session: Session, title: string) => void
+}
+
+export function NativeSessionTitle({ target, onRenamed }: Props) {
+  const t = useTranslator()
+  const [editing, setEditing] = useState(false)
+  const [title, setTitle] = useState("")
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  // A blur that happens *because* the rename is being committed or cancelled must not run the blur
+  // handler a second time and re-commit an already-settled edit.
+  const settledRef = useRef(false)
+
+  // Switching Session while a rename is open would otherwise point a half-typed title at the
+  // Session the user has just navigated to.
+  useEffect(() => {
+    setEditing(false)
+    setBusy(false)
+    setError(null)
+  }, [target.key])
+
+  useEffect(() => {
+    if (!editing) return
+    const input = inputRef.current
+    if (!input) return
+    input.focus()
+    input.select()
+  }, [editing])
+
+  if (!target.renameSupported) return <h1 className="hr-native-session-title">{target.title}</h1>
+
+  function beginEdit() {
+    if (busy) return
+    settledRef.current = false
+    setError(null)
+    setTitle(target.title === "Untitled Session" ? "" : target.title)
+    setEditing(true)
+  }
+
+  function cancelEdit() {
+    settledRef.current = true
+    setEditing(false)
+    setError(null)
+  }
+
+  async function commit() {
+    if (busy) return
+    const nextTitle = title.replace(/[\r\n]+/g, " ").trim()
+    if (!nextTitle) {
+      setError(t("sf.enterSessionName"))
+      inputRef.current?.focus()
+      return
+    }
+    if (nextTitle === target.title) {
+      cancelEdit()
+      return
+    }
+    settledRef.current = true
+    setBusy(true)
+    setError(null)
+    try {
+      const session = await api.renameSession(target.config, target.sessionID, nextTitle, target.directory)
+      setEditing(false)
+      onRenamed(session, nextTitle)
+    } catch (reason) {
+      // The edit stays open with the text the user typed: a failed write must not also lose it.
+      settledRef.current = false
+      setError(reason instanceof Error ? reason.message : String(reason))
+      inputRef.current?.focus()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!editing) {
+    return (
+      <h1 className="hr-native-session-title">
+        <button
+          type="button"
+          className="hr-native-session-title-button"
+          onClick={beginEdit}
+          title={t("sf.renameSession")}
+          aria-label={t("sf.renameSessionNamed", { title: target.title })}
+        >
+          <span>{target.title}</span>
+          <PencilIcon size={13} />
+        </button>
+      </h1>
+    )
+  }
+
+  return (
+    <h1 className={`hr-native-session-title editing${busy ? " busy" : ""}`}>
+      <span className="hr-native-session-title-field">
+        <input
+          ref={inputRef}
+          value={title}
+          disabled={busy}
+          maxLength={200}
+          spellCheck={false}
+          aria-label={t("sf.sessionName")}
+          aria-invalid={error ? true : undefined}
+          title={t("sf.renameHint")}
+          onChange={(event) => { setTitle(event.target.value); if (error) setError(null) }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") { event.preventDefault(); void commit() }
+            else if (event.key === "Escape") { event.preventDefault(); cancelEdit() }
+          }}
+          onBlur={() => {
+            // Both buttons live inside this element, so a click on Save or Cancel blurs the input
+            // first. `settledRef` and the relatedTarget check keep that click from being swallowed.
+            if (settledRef.current || busy) return
+            window.setTimeout(() => {
+              if (settledRef.current || busy || !inputRef.current) return
+              if (inputRef.current.parentElement?.contains(document.activeElement)) return
+              void commit()
+            }, 0)
+          }}
+        />
+        <span className="hr-native-session-title-actions">
+          {busy ? <LoadingIcon size={14} /> : (
+            <>
+              <button type="button" onMouseDown={(event) => event.preventDefault()} onClick={() => void commit()} title={t("sf.rename")} aria-label={t("sf.rename")}><CheckIcon size={13} /></button>
+              <button type="button" onMouseDown={(event) => event.preventDefault()} onClick={cancelEdit} title={t("sf.cancel")} aria-label={t("sf.cancel")}><CloseIcon size={13} /></button>
+            </>
+          )}
+        </span>
+      </span>
+      {/* Only an error takes a line of its own. A permanent hint line under the field would make the
+          header taller the moment editing starts, which moves the whole conversation down by the
+          height of that line and back up again on commit. */}
+      {error ? <small className="hr-native-session-title-error" role="alert">{error}</small> : null}
+    </h1>
+  )
+}

--- a/web/src/components/standalone-universal-workspace.tsx
+++ b/web/src/components/standalone-universal-workspace.tsx
@@ -297,6 +297,9 @@ function NativeSessionsWorkspace({
   // return an identical snapshot, so the Session list needs an explicit signal to re-read its
   // Sessions after a rename or delete instead of waiting up to 30s for its own refresh.
   const [listRevision, setListRevision] = useState(0)
+  // Machines answering is only the first half of starting up; the Session list is the half the user
+  // is actually waiting for. See the startup states below.
+  const [sessionsDiscovered, setSessionsDiscovered] = useState(machines.length === 0)
   const [railWidth, setRailWidth] = useState<number | null>(loadRailWidth)
   const refreshGeneration = useRef(0)
 
@@ -405,6 +408,21 @@ function NativeSessionsWorkspace({
       : t("sf.policyRulesLabel", { count: selectedPermissionRules.length })
     : ""
 
+  /**
+   * Startup has two halves and the pane must not pretend the second one is over.
+   *
+   * "machines": still asking the configured machines whether they are there.
+   * "sessions": they have answered and their Sessions are being read.
+   * "ready": both are done - only now can the pane speak about opening a Session, or about none of
+   * the machines being reachable, without contradicting the rail next to it.
+   *
+   * Only the first pass is a startup: once discovery has settled, the ten-second refresh keeps
+   * `loaded` and `sessionsDiscovered` true, so a background cycle never throws the user back to a
+   * waiting screen.
+   */
+  const startupPhase: "machines" | "sessions" | "ready" =
+    !loaded || loadingCount > 0 ? "machines" : !sessionsDiscovered ? "sessions" : "ready"
+
   function openSession(target: NativeSessionSurfaceTarget) {
     setSelectedState(undefined)
     setSelected(target)
@@ -457,6 +475,7 @@ function NativeSessionsWorkspace({
             onOpen={openSession}
             refreshToken={listRevision}
             onAttentionCountChange={onAttentionCountChange}
+            onDiscoveredChange={setSessionsDiscovered}
             selectedKey={selected?.key}
             selectedState={selectedState}
           />
@@ -537,13 +556,20 @@ function NativeSessionsWorkspace({
               <p>{t("sf.addFirstMachineBody")}</p>
               <button type="button" className="tdw-button primary" onClick={onManageMachines}><ServerIcon size={15} /> {t("sf.addMachine")}</button>
             </div>
-          ) : !loaded || (onlineCount === 0 && loadingCount > 0) ? (
+          ) : startupPhase !== "ready" ? (
+            /* One waiting state that names which half of startup is still running, held until both
+               halves are done. It used to end as soon as the machines answered, so the pane invited
+               the user to open a Session while the rail beside it was still empty and, for a moment,
+               still showing the machine that had failed - which reads as a failed startup rather
+               than one in progress. */
             <div className="hr-native-workspace-empty hr-native-startup connecting" role="status" aria-live="polite">
               <LoadingIcon size={28} />
               <span>{t("sf.preparing")}</span>
-              <strong>{t("sf.connectingMachines")}</strong>
-              <p>{t("sf.connectingBody")}</p>
-              <small>{t("sf.configuredMachines", { count: machines.length })}</small>
+              <strong>{startupPhase === "machines" ? t("sf.connectingMachines") : t("sf.loadingSessions")}</strong>
+              <p>{startupPhase === "machines" ? t("sf.connectingBody") : t("sf.loadingSessionsBody")}</p>
+              <small>{startupPhase === "machines"
+                ? t("sf.configuredMachines", { count: machines.length })
+                : t("sf.onlineCount", { count: onlineCount })}</small>
             </div>
           ) : onlineCount === 0 ? (
             <div className="hr-native-workspace-empty hr-native-startup offline">

--- a/web/src/components/standalone-universal-workspace.tsx
+++ b/web/src/components/standalone-universal-workspace.tsx
@@ -24,6 +24,7 @@ import { useTranslator } from "../useTranslator"
 import { NativeSessionActions } from "./native-session-actions"
 import { NativeSessionHandoffControl } from "./native-session-handoff-control"
 import { NativeSessionHome } from "./native-session-home"
+import { NativeSessionTitle } from "./native-session-rename"
 import { NativeSessionObserver, type NativeSessionVisualState } from "./native-session-observer"
 import "../taskdesk-workthreads.css"
 import "../taskdesk-mobile-navigation.css"
@@ -497,7 +498,7 @@ function NativeSessionsWorkspace({
                     <i aria-hidden="true">/</i>
                     <strong>{selectedProject}</strong>
                   </div>
-                  <h1>{selected.title}</h1>
+                  <NativeSessionTitle target={selected} onRenamed={handleSessionRenamed} />
                   <small title={selected.directory}>
                     {selected.external ? t("sf.startedInHarness") : t("sf.createdInHarnessRemote")}
                     {selected.directory ? ` · ${selected.directory}` : ""}
@@ -519,7 +520,7 @@ function NativeSessionsWorkspace({
                       {Number(selected.cost) > 0 ? <span title={t("sf.reportedCost")}>${Number(selected.cost).toFixed(2)}</span> : null}
                     </div>
                   ) : null}
-                  <NativeSessionActions target={selected} onRenamed={handleSessionRenamed} onDeleted={handleSessionDeleted} />
+                  <NativeSessionActions target={selected} onDeleted={handleSessionDeleted} />
                   <NativeSessionHandoffControl source={selected} agents={selectedRuntime?.snapshot?.agents || []} onOpen={openSession} />
                   <code title={selected.sessionID}>{selected.sessionID}</code>
                 </div>

--- a/web/src/components/taskdesk-conversation.tsx
+++ b/web/src/components/taskdesk-conversation.tsx
@@ -5,6 +5,20 @@ import "../taskdesk-conversation.css"
 import "../taskdesk-conversation-fixes.css"
 import { TaskDeskMessageContent } from "./taskdesk-message-content"
 
+const HARNESS_ICON_FILES: Record<string, string> = {
+  codex: "codex.svg",
+  claude: "claude.svg",
+  opencode: "opencode.svg",
+  omp: "omp.svg",
+  pi: "pi.svg"
+}
+
+function harnessIconUrl(backend: string | undefined): string | undefined {
+  if (!backend) return undefined
+  const file = HARNESS_ICON_FILES[backend.toLowerCase()]
+  return file ? `${import.meta.env.BASE_URL}harness-icons/${file}` : undefined
+}
+
 const NEAR_BOTTOM_PX = 96
 const COMPOSER_MAX_HEIGHT_PX = 180
 const JUMP_AFFORDANCE_MAX_THRESHOLD = 320
@@ -79,7 +93,45 @@ const MessageBubble = memo(function MessageBubble({ message, agentLabel }: { mes
   )
 })
 
-const ThinkingIndicator = memo(function ThinkingIndicator({ agentLabel, workingLabel }: { agentLabel: string; workingLabel?: string }) {
+/**
+ * The reply, before it has any content.
+ *
+ * This used to be a free-standing card of its own shape, which meant the wait was staged in three
+ * different containers: a "getting started" card appeared, was removed, and an agent message with a
+ * different avatar, a different width and a different border took its place, with the working state
+ * restated inside it. The user watched the surface rebuild itself twice before a single token
+ * arrived.
+ *
+ * It is now the agent's own message bubble - same avatar, same name, same column, same geometry -
+ * holding a live activity row instead of content. When the first token lands, the real bubble takes
+ * over in place and continues to carry that same activity row (see `ActivityStatus` below) until the
+ * turn ends. Nothing is destroyed and rebuilt: one container fills in.
+ */
+const ThinkingIndicator = memo(function ThinkingIndicator({ agentLabel, agentBackend, workingLabel }: { agentLabel: string; agentBackend?: string; workingLabel?: string }) {
+  const icon = harnessIconUrl(agentBackend)
+  return (
+    <article className="uw-message uw-message-agent uw-message-pending">
+      <div className="uw-avatar uw-avatar-agent" aria-hidden="true">
+        {icon ? <img src={icon} alt="" /> : agentLabel.slice(0, 2).toUpperCase()}
+      </div>
+      <div className="uw-message-body">
+        <header>
+          <strong>{agentLabel}</strong>
+        </header>
+        <div className="uw-message-parts">
+          <ActivityStatus label={workingLabel || `${agentLabel} is working`} agentLabel={agentLabel} />
+        </div>
+      </div>
+    </article>
+  )
+})
+
+/**
+ * The one live line for a turn in progress. Rendered inside the pending bubble before the reply
+ * exists and inside the reply itself once it does, so the indicator stays in one place for the whole
+ * wait rather than moving between containers as the turn progresses.
+ */
+export const ActivityStatus = memo(function ActivityStatus({ label, agentLabel }: { label: string; agentLabel: string }) {
   const [elapsed, setElapsed] = useState(0)
 
   useEffect(() => {
@@ -92,7 +144,7 @@ const ThinkingIndicator = memo(function ThinkingIndicator({ agentLabel, workingL
     <div className="uw-session-typing" role="status" aria-live="polite" aria-label={`Waiting for ${agentLabel} response`}>
       <span className="uw-thinking-orb" aria-hidden="true"><i /><i /><i /></span>
       <span className="uw-thinking-copy">
-        <strong>{workingLabel || `${agentLabel} is working`}</strong>
+        <strong>{label}</strong>
         <small>{elapsed < 2 ? "Starting…" : `${elapsed}s`}</small>
       </span>
     </div>
@@ -124,6 +176,7 @@ function transcriptPropsEqual(previous: TranscriptProps, next: TranscriptProps):
 const ConversationTranscript = memo(function ConversationTranscript({
   messages,
   agentLabel,
+  agentBackend,
   loading = false,
   waiting = false,
   ready = true,
@@ -263,7 +316,7 @@ const ConversationTranscript = memo(function ConversationTranscript({
                 ))}
           </>
         )}
-        {sending || (waiting && showWaitingIndicator) ? <ThinkingIndicator agentLabel={agentLabel} workingLabel={workingLabel} /> : null}
+        {sending || (waiting && showWaitingIndicator) ? <ThinkingIndicator agentLabel={agentLabel} agentBackend={agentBackend} workingLabel={workingLabel} /> : null}
       </div>
 
       {jumpAffordances.top || jumpAffordances.bottom ? (

--- a/web/src/components/taskdesk-conversation.tsx
+++ b/web/src/components/taskdesk-conversation.tsx
@@ -96,16 +96,15 @@ const MessageBubble = memo(function MessageBubble({ message, agentLabel }: { mes
 /**
  * The reply, before it has any content.
  *
- * This used to be a free-standing card of its own shape, which meant the wait was staged in three
- * different containers: a "getting started" card appeared, was removed, and an agent message with a
- * different avatar, a different width and a different border took its place, with the working state
- * restated inside it. The user watched the surface rebuild itself twice before a single token
- * arrived.
+ * The wait used to be staged in its own containers: a "getting started" card appeared, was removed,
+ * and an agent message of a different shape took its place - and then said the same thing a second
+ * time in a status row underneath its own name. Two avatars, two names, one turn.
  *
- * It is now the agent's own message bubble - same avatar, same name, same column, same geometry -
- * holding a live activity row instead of content. When the first token lands, the real bubble takes
- * over in place and continues to carry that same activity row (see `ActivityStatus` below) until the
- * turn ends. Nothing is destroyed and rebuilt: one container fills in.
+ * There is one identity row per reply and the wait happens *in* it. The row is the agent's avatar
+ * and the line beside it; while the turn is live that line reads "<agent> is getting started" and
+ * then "<agent> is working", and when the turn ends it reads the agent's name. Content, reasoning
+ * and tool cards fill in underneath the row that is already there. Nothing is added, removed or
+ * duplicated as the turn progresses - one line changes what it says.
  */
 const ThinkingIndicator = memo(function ThinkingIndicator({ agentLabel, agentBackend, workingLabel }: { agentLabel: string; agentBackend?: string; workingLabel?: string }) {
   const icon = harnessIconUrl(agentBackend)
@@ -116,38 +115,10 @@ const ThinkingIndicator = memo(function ThinkingIndicator({ agentLabel, agentBac
       </div>
       <div className="uw-message-body">
         <header>
-          <strong>{agentLabel}</strong>
+          <strong className="uw-message-working" role="status" aria-live="polite">{workingLabel || `${agentLabel} is working`}</strong>
         </header>
-        <div className="uw-message-parts">
-          <ActivityStatus label={workingLabel || `${agentLabel} is working`} agentLabel={agentLabel} />
-        </div>
       </div>
     </article>
-  )
-})
-
-/**
- * The one live line for a turn in progress. Rendered inside the pending bubble before the reply
- * exists and inside the reply itself once it does, so the indicator stays in one place for the whole
- * wait rather than moving between containers as the turn progresses.
- */
-export const ActivityStatus = memo(function ActivityStatus({ label, agentLabel }: { label: string; agentLabel: string }) {
-  const [elapsed, setElapsed] = useState(0)
-
-  useEffect(() => {
-    const started = Date.now()
-    const timer = window.setInterval(() => setElapsed(Math.floor((Date.now() - started) / 1_000)), 1_000)
-    return () => window.clearInterval(timer)
-  }, [])
-
-  return (
-    <div className="uw-session-typing" role="status" aria-live="polite" aria-label={`Waiting for ${agentLabel} response`}>
-      <span className="uw-thinking-orb" aria-hidden="true"><i /><i /><i /></span>
-      <span className="uw-thinking-copy">
-        <strong>{label}</strong>
-        <small>{elapsed < 2 ? "Starting…" : `${elapsed}s`}</small>
-      </span>
-    </div>
   )
 })
 

--- a/web/src/components/work-thread-conversation.tsx
+++ b/web/src/components/work-thread-conversation.tsx
@@ -29,7 +29,7 @@ import {
   type WorkThreadAgentMeta
 } from "../work-thread-timeline"
 import { ModelPicker, modelOptionKey } from "./model-picker"
-import { TaskDeskConversation } from "./taskdesk-conversation"
+import { ActivityStatus, TaskDeskConversation } from "./taskdesk-conversation"
 import { TaskDeskMessageContent } from "./taskdesk-message-content"
 import { WorkThreadAttention } from "./work-thread-attention"
 
@@ -239,7 +239,7 @@ function ConversationStatePill({
   return <span className={`tdw-conversation-state ${state}`} title={outcome && detail ? detail : undefined}><i aria-hidden="true" /><span>{text}</span></span>
 }
 
-const WorkThreadBubble = memo(function WorkThreadBubble({ message }: { message: WorkThreadMessage }) {
+const WorkThreadBubble = memo(function WorkThreadBubble({ message, activity }: { message: WorkThreadMessage; activity?: string }) {
   const meta = message.taskdesk
   if (message.info.role === CONVERSATION_EVENT_ROLE) {
     return (
@@ -262,6 +262,10 @@ const WorkThreadBubble = memo(function WorkThreadBubble({ message }: { message: 
           <time>{message.info.time.created ? new Intl.DateTimeFormat(undefined, { hour: "2-digit", minute: "2-digit" }).format(message.info.time.created) : ""}</time>
         </header>
         <TaskDeskMessageContent message={message} />
+        {/* The live status of a turn belongs to the turn's own bubble. Rendered last inside the
+            body, it is the same row the pending bubble showed a moment earlier, in the same place,
+            so reasoning and tool cards fill in above it instead of replacing it. */}
+        {activity ? <ActivityStatus label={activity} agentLabel={label} /> : null}
       </div>
     </article>
   )
@@ -286,6 +290,9 @@ export function WorkThreadConversation({
   const [loadingOlder, setLoadingOlder] = useState(false)
   const [draft, setDraft] = useState(() => localStorage.getItem(draftStorageKey) || "")
   const [sending, setSending] = useState(false)
+  // The prompt that has been sent but is not yet in the transcript, with the Run that was current
+  // when it was sent. See `visibleTimeline`.
+  const [pendingPrompt, setPendingPrompt] = useState<{ text: string; priorRunID: string | null } | null>(null)
   const [stopping, setStopping] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [modelError, setModelError] = useState<string | null>(null)
@@ -363,6 +370,7 @@ export function WorkThreadConversation({
     setModelError(null)
     setQuestions([])
     setPermissions([])
+    setPendingPrompt(null)
     setTargetAgentID(currentAgentID)
     setTargetModelKey(currentTaskModelKey)
     observedTaskModelKeyRef.current = currentTaskModelKey
@@ -432,6 +440,37 @@ export function WorkThreadConversation({
     () => buildWorkThreadTimeline(task, messagesBySession, agentsByID),
     [conversationSignature, messagesBySession, agentsByID]
   )
+
+  /**
+   * What the user just sent, shown from the moment they send it.
+   *
+   * Sending used to clear the composer and then show nothing until `continueTask` came back with a
+   * Run, at which point the message appeared - and appeared again, remounted, once that Run carried
+   * a real id and the timeline's key for its row changed from the run's index to that id. On screen
+   * that reads as the message flashing in, being removed and being redrawn. The optimistic row
+   * closes the gap: same bubble, same place, keyed once. It stands down the moment the real row
+   * exists - either because the text is in the transcript or because a new Run is on the Task, which
+   * is what that row is built from - so the two are never on screen together.
+   */
+  const settledPrompt = pendingPrompt
+    && (Boolean(task.run?.id && task.run.id !== pendingPrompt.priorRunID)
+      || timeline.some((message) => message.info.role === "user"
+        && message.parts.some((part) => part.type === "text" && part.text?.trim() === pendingPrompt.text)))
+
+  const visibleTimeline = useMemo(() => {
+    if (!pendingPrompt || settledPrompt) return timeline
+    const id = `work-thread:${task.id}:pending-user`
+    return [...timeline, {
+      info: { id, role: "user", sessionID: `work-thread:${task.id}`, time: { created: Date.now() } },
+      parts: [{ id: `${id}:text`, messageID: id, type: "text", text: pendingPrompt.text }],
+      taskdesk: { kind: "synthetic-user" as const }
+    } as WorkThreadMessage]
+  }, [timeline, pendingPrompt, settledPrompt, task.id])
+
+  useEffect(() => {
+    if (settledPrompt) setPendingPrompt(null)
+  }, [settledPrompt])
+
   const currentRunHasAssistantSignal = useMemo(() => {
     const runID = task.run?.id
     if (!runID) return false
@@ -650,6 +689,7 @@ export function WorkThreadConversation({
     setSending(true)
     setError(null)
     setDraft("")
+    setPendingPrompt({ text, priorRunID: taskRef.current.run?.id ?? null })
     try {
       const latest = await taskClient.getWorkThread(baseConfig, task.id)
       if (isActive(latest)) {
@@ -668,6 +708,9 @@ export function WorkThreadConversation({
       await refreshCurrentTail(next)
       void refreshAttention(next)
     } catch (reason) {
+      // The prompt goes back to the composer, so it must also stop standing in for a turn that was
+      // never accepted.
+      setPendingPrompt(null)
       setDraft((current) => current ? `${text}\n${current}` : text)
       setError(reason instanceof Error ? reason.message : String(reason))
     } finally {
@@ -698,6 +741,12 @@ export function WorkThreadConversation({
   const hasAttention = questions.length > 0 || permissions.length > 0
   const preparingReply = sending || (working && !currentRunHasAssistantSignal)
   const pendingAgentLabel = sending ? agentLabel(agents, targetAgentID) : currentLabel
+  // The pending bubble is the reply that is coming, so it wears the identity of the agent that is
+  // about to answer rather than the one that answered last.
+  const pendingAgentBackend = (sending ? agents.find((agent) => agent.id === targetAgentID) : currentAgent)?.backend
+  // Only the turn that is actually running carries the live status row, and only once its bubble is
+  // on screen - before that the pending bubble is showing the very same row.
+  const liveRunID = working && !hasAttention && currentRunHasAssistantSignal ? task.run?.id : undefined
   const waitingLabel = hasAttention
     ? "Waiting for your input"
     : preparingReply
@@ -744,9 +793,9 @@ export function WorkThreadConversation({
       {error ? <div className="tdw-chat-error" role="alert"><span>{error}</span><button type="button" onClick={() => setError(null)}>×</button></div> : null}
 
       <TaskDeskConversation
-        messages={timeline}
-        agentLabel={currentLabel}
-        agentBackend={currentAgent?.backend}
+        messages={visibleTimeline}
+        agentLabel={pendingAgentLabel}
+        agentBackend={pendingAgentBackend}
         loading={loading}
         ready={!loading}
         waiting={working}
@@ -765,7 +814,13 @@ export function WorkThreadConversation({
         placeholder={`Message ${agentLabel(agents, targetAgentID)}…`}
         emptyText="Start the conversation. You can continue with another coding agent at any time."
         footerHint={hasAttention ? "Your input is required before the agent can continue" : working ? "The agent is working on your last message" : undefined}
-        renderMessage={(message) => <WorkThreadBubble key={message.info.id} message={message as WorkThreadMessage} />}
+        renderMessage={(message) => (
+          <WorkThreadBubble
+            key={message.info.id}
+            message={message as WorkThreadMessage}
+            activity={liveRunID && (message as WorkThreadMessage).taskdesk?.runId === liveRunID ? waitingLabel : undefined}
+          />
+        )}
       />
     </div>
   )

--- a/web/src/components/work-thread-conversation.tsx
+++ b/web/src/components/work-thread-conversation.tsx
@@ -747,11 +747,25 @@ export function WorkThreadConversation({
   // Only the turn that is actually running carries the live status row, and only once its bubble is
   // on screen - before that the pending bubble is showing the very same row.
   const liveRunID = working && !hasAttention && currentRunHasAssistantSignal ? task.run?.id : undefined
+
   const waitingLabel = hasAttention
     ? "Waiting for your input"
     : preparingReply
       ? `${pendingAgentLabel} is getting started`
       : `${currentLabel} is working`
+
+  /**
+   * Exactly one row, on exactly one bubble.
+   *
+   * A Run's id is on every row the Run produced, the synthetic user message included, so matching on
+   * the id alone put the status row inside the user's own bubble as well as the reply's. The status
+   * of a turn belongs to the reply, so the role is part of the match - and `liveRunID` is already
+   * mutually exclusive with the pending bubble, which is the only other place this row can appear.
+   */
+  const activityForMessage = (message: WorkThreadMessage): string | undefined =>
+    liveRunID && message.info.role === "assistant" && message.taskdesk?.runId === liveRunID
+      ? waitingLabel
+      : undefined
 
   useEffect(() => {
     onAttentionChangeRef.current?.(hasAttention)
@@ -818,7 +832,7 @@ export function WorkThreadConversation({
           <WorkThreadBubble
             key={message.info.id}
             message={message as WorkThreadMessage}
-            activity={liveRunID && (message as WorkThreadMessage).taskdesk?.runId === liveRunID ? waitingLabel : undefined}
+            activity={activityForMessage(message as WorkThreadMessage)}
           />
         )}
       />

--- a/web/src/components/work-thread-conversation.tsx
+++ b/web/src/components/work-thread-conversation.tsx
@@ -29,7 +29,7 @@ import {
   type WorkThreadAgentMeta
 } from "../work-thread-timeline"
 import { ModelPicker, modelOptionKey } from "./model-picker"
-import { ActivityStatus, TaskDeskConversation } from "./taskdesk-conversation"
+import { TaskDeskConversation } from "./taskdesk-conversation"
 import { TaskDeskMessageContent } from "./taskdesk-message-content"
 import { WorkThreadAttention } from "./work-thread-attention"
 
@@ -257,15 +257,14 @@ const WorkThreadBubble = memo(function WorkThreadBubble({ message, activity }: {
         {isUser ? "You" : icon ? <img src={icon} alt="" /> : label.slice(0, 2).toUpperCase()}
       </div>
       <div className="uw-message-body">
+        {/* One identity row per reply, and the live state is *in* it: the same avatar and the same
+            line the reply will carry when it is finished, reading "<agent> is working" while it is
+            not. A separate status row under this one would be a second name for the same turn. */}
         <header>
-          <strong>{label}</strong>
+          <strong className={activity ? "uw-message-working" : undefined} {...(activity ? { role: "status", "aria-live": "polite" as const } : {})}>{activity || label}</strong>
           <time>{message.info.time.created ? new Intl.DateTimeFormat(undefined, { hour: "2-digit", minute: "2-digit" }).format(message.info.time.created) : ""}</time>
         </header>
         <TaskDeskMessageContent message={message} />
-        {/* The live status of a turn belongs to the turn's own bubble. Rendered last inside the
-            body, it is the same row the pending bubble showed a moment earlier, in the same place,
-            so reasoning and tool cards fill in above it instead of replacing it. */}
-        {activity ? <ActivityStatus label={activity} agentLabel={label} /> : null}
       </div>
     </article>
   )

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -404,6 +404,8 @@ type TranslationKey =
   | 'sf.preparing'
   | 'sf.connectingMachines'
   | 'sf.connectingBody'
+  | 'sf.loadingSessions'
+  | 'sf.loadingSessionsBody'
   | 'sf.configuredMachines'
   | 'sf.machinesUnavailable'
   | 'sf.couldNotConnect'
@@ -868,6 +870,8 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'sf.preparing': 'Preparing Harness Remote',
     'sf.connectingMachines': 'Connecting to your machines…',
     'sf.connectingBody': 'Discovering Projects, installed coding agents and native Sessions. An ACP harness may need a few seconds to start.',
+    'sf.loadingSessions': 'Loading Sessions',
+    'sf.loadingSessionsBody': 'Reading the native Sessions the connected machines\' coding agents own.',
     'sf.configuredMachines': '{count} configured machines',
     'sf.machinesUnavailable': 'Machines unavailable',
     'sf.couldNotConnect': 'Harness Remote could not connect',
@@ -1332,6 +1336,8 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'sf.preparing': 'Preparazione di Harness Remote',
     'sf.connectingMachines': 'Connessione alle tue macchine…',
     'sf.connectingBody': 'Individuazione di progetti, coding agent installati e sessioni native. Un harness ACP può richiedere alcuni secondi per avviarsi.',
+    'sf.loadingSessions': 'Caricamento sessioni',
+    'sf.loadingSessionsBody': 'Lettura delle sessioni native possedute dai coding agent di ogni macchina.',
     'sf.configuredMachines': '{count} macchine configurate',
     'sf.machinesUnavailable': 'Macchine non raggiungibili',
     'sf.couldNotConnect': 'Harness Remote non è riuscito a connettersi',
@@ -1748,6 +1754,8 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'sf.preparing': '正在準備 Harness Remote',
     'sf.connectingMachines': '正在連線到你的機器…',
     'sf.connectingBody': '正在探索專案、已安裝的編碼代理與原生工作階段。ACP harness 可能需要幾秒鐘啟動。',
+    'sf.loadingSessions': '載入工作階段',
+    'sf.loadingSessionsBody': '正在讀取各機器的程式代理所擁有的原生工作階段。',
     'sf.configuredMachines': '已設定 {count} 部機器',
     'sf.machinesUnavailable': '機器無法使用',
     'sf.couldNotConnect': 'Harness Remote 無法連線',
@@ -2209,6 +2217,8 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'sf.preparing': '正在准备 Harness Remote',
     'sf.connectingMachines': '正在连接你的机器…',
     'sf.connectingBody': '正在发现项目、已安装的编码代理和原生会话。ACP harness 可能需要几秒钟启动。',
+    'sf.loadingSessions': '加载会话',
+    'sf.loadingSessionsBody': '正在读取各机器的编码代理所拥有的原生会话。',
     'sf.configuredMachines': '已配置 {count} 台机器',
     'sf.machinesUnavailable': '机器不可用',
     'sf.couldNotConnect': 'Harness Remote 无法连接',

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -376,6 +376,8 @@ type TranslationKey =
   | 'sf.enterSessionName'
   | 'sf.renaming'
   | 'sf.rename'
+  | 'sf.renameHint'
+  | 'sf.renameSessionNamed'
   | 'sf.deleteSessionTitle'
   | 'sf.deleteSubtitle'
   | 'sf.closeDelete'
@@ -838,6 +840,8 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'sf.enterSessionName': 'Enter a Session name.',
     'sf.renaming': 'Renaming…',
     'sf.rename': 'Rename',
+    'sf.renameHint': 'Enter to save · Esc to cancel',
+    'sf.renameSessionNamed': 'Rename Session: {title}',
     'sf.deleteSessionTitle': 'Delete “{title}”?',
     'sf.deleteSubtitle': 'This deletes the native Session from {agent}. This cannot be undone from Harness Remote.',
     'sf.closeDelete': 'Close Delete Session',
@@ -1300,6 +1304,8 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'sf.enterSessionName': 'Inserisci un nome per la sessione.',
     'sf.renaming': 'Rinomina…',
     'sf.rename': 'Rinomina',
+    'sf.renameHint': 'Invio per salvare · Esc per annullare',
+    'sf.renameSessionNamed': 'Rinomina sessione: {title}',
     'sf.deleteSessionTitle': 'Eliminare “{title}”?',
     'sf.deleteSubtitle': 'Elimina la sessione nativa da {agent}. L\'operazione non è annullabile da Harness Remote.',
     'sf.closeDelete': 'Chiudi Elimina sessione',
@@ -1714,6 +1720,8 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'sf.enterSessionName': '請輸入工作階段名稱。',
     'sf.renaming': '重新命名中…',
     'sf.rename': '重新命名',
+    'sf.renameHint': '按 Enter 儲存 · 按 Esc 取消',
+    'sf.renameSessionNamed': '重新命名工作階段：{title}',
     'sf.deleteSessionTitle': '要刪除「{title}」嗎？',
     'sf.deleteSubtitle': '這會從 {agent} 刪除原生工作階段，且無法從 Harness Remote 復原。',
     'sf.closeDelete': '關閉刪除工作階段',
@@ -2173,6 +2181,8 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'sf.enterSessionName': '请输入会话名称。',
     'sf.renaming': '重命名中…',
     'sf.rename': '重命名',
+    'sf.renameHint': '按 Enter 保存 · 按 Esc 取消',
+    'sf.renameSessionNamed': '重命名会话：{title}',
     'sf.deleteSessionTitle': '要删除“{title}”吗？',
     'sf.deleteSubtitle': '这会从 {agent} 删除原生会话，且无法从 Harness Remote 撤销。',
     'sf.closeDelete': '关闭删除会话',

--- a/web/src/native-session-home.css
+++ b/web/src/native-session-home.css
@@ -45,13 +45,16 @@
   min-width: 0;
 }
 
-.hr-native-workspace-session-header span,
-.hr-native-workspace-session-header small {
+/* Scoped to the heading block, not to every descendant of the header. The header also hosts the
+   Session's action dialogs, and a blanket `span`/`small` rule reached inside them - which is how a
+   confirmation dialog ended up with a subtitle that refused to wrap. */
+.hr-native-session-heading span,
+.hr-native-session-heading small {
   display: block;
   color: var(--tdw-muted, #9299a8);
 }
 
-.hr-native-workspace-session-header h1 {
+.hr-native-session-heading h1 {
   margin: 2px 0 3px;
   font-size: 18px;
   line-height: 1.25;
@@ -517,11 +520,11 @@
     padding: 8px 10px 8px 48px;
   }
   .hr-native-workspace-session-header code { display: none; }
-  .hr-native-workspace-session-header h1 {
+  .hr-native-session-heading h1 {
     margin-block: 1px 2px;
     font-size: 16px;
   }
-  .hr-native-workspace-session-header small {
+  .hr-native-session-heading > small {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/web/src/native-session-home.css
+++ b/web/src/native-session-home.css
@@ -115,10 +115,16 @@
   min-height: 0;
 }
 
+/* `place-content: center` centres the grid's tracks, not the items inside them, so every child sat
+   at the start of a column as wide as the widest one - which is why the icon appeared pinned to the
+   left of a centred paragraph. Content is centred on both axes, and the block itself is centred in
+   the pane by its own auto margins rather than by `justify-self`, which does nothing in the flex
+   column this sits in. */
 .hr-native-workspace-empty {
   flex: 1;
   display: grid;
-  place-content: center;
+  align-content: center;
+  justify-items: center;
   gap: 8px;
   padding: 28px;
   text-align: center;

--- a/web/src/session-first-regression.test.mjs
+++ b/web/src/session-first-regression.test.mjs
@@ -12,6 +12,7 @@ const modelRecovery = read('./native-session-model.ts')
 const observer = read('./components/native-session-observer.tsx')
 const home = read('./components/native-session-home.tsx')
 const actions = read('./components/native-session-actions.tsx')
+const rename = read('./components/native-session-rename.tsx')
 const workThread = read('./components/work-thread-conversation.tsx')
 const liveRefresh = read('./taskdesk-session-live-refresh.ts')
 const timeline = read('./work-thread-timeline.ts')
@@ -49,12 +50,13 @@ assert.ok(home.includes('canCreateNativeSession'), 'Session Home must expose onl
 assert.ok(home.includes('aria-label={t("sf.filterByMachine")}') && home.includes('t("sf.allMachinesCount"'), 'multi-machine navigation must offer an explicit All/single-machine filter')
 
 // Rename/Delete act on the open native Session in its header, not on whichever row happens to be
-// selected in the navigation rail.
+// selected in the navigation rail. Rename is an inline edit of that header's heading; Delete keeps
+// its confirmation panel, because it is not reversible.
 assert.equal(home.includes('api.renameSession('), false, 'Session navigation must not own rename mutations')
 assert.equal(home.includes('api.deleteSession('), false, 'Session navigation must not own delete mutations')
-assert.ok(actions.includes('api.renameSession(target.config, target.sessionID'), 'open Session action must rename the real native Session')
+assert.ok(rename.includes('api.renameSession(target.config, target.sessionID'), 'open Session action must rename the real native Session')
 assert.ok(actions.includes('api.deleteSession(target.config, target.sessionID'), 'open Session action must delete the real native Session')
-assert.ok(actions.includes('target.renameSupported') && actions.includes('target.deleteSupported'), 'native metadata actions must follow harness capabilities')
+assert.ok(rename.includes('target.renameSupported') && actions.includes('target.deleteSupported'), 'native metadata actions must follow harness capabilities')
 assert.ok(actions.includes('t("sf.keepSession")') && actions.includes('t("sf.deleteSession")'), 'native deletion must use an inline translated confirmation')
 assert.equal(actions.includes('window.confirm'), false, 'native deletion must not use a blocking browser dialog')
 
@@ -140,6 +142,7 @@ for (const retiredPath of [
 assert.match(handoff, /export function NativeSessionHandoffControl\(_props: Props\)\s*\{\s*return null\s*\}/, 'cross-agent handoff UI must remain disabled during single-Session stabilization')
 assert.ok(standalone.includes('<NativeSessionObserver'), 'integrated Sessions workspace must still open native Sessions')
 assert.ok(standalone.includes('<NativeSessionHome'), 'Session-first navigation must remain native discovery based')
-assert.ok(standalone.includes('<NativeSessionActions target={selected} onRenamed={handleSessionRenamed} onDeleted={handleSessionDeleted} />'), 'open Session header must own rename/delete actions')
+assert.ok(standalone.includes('<NativeSessionActions target={selected} onDeleted={handleSessionDeleted} />'), 'open Session header must own the delete action')
+assert.ok(standalone.includes('<NativeSessionTitle target={selected} onRenamed={handleSessionRenamed} />'), 'open Session header must own rename as an inline edit of its own heading')
 
 console.log('session-first v3-first architecture guards passed')

--- a/web/src/session-first-workbench.css
+++ b/web/src/session-first-workbench.css
@@ -13,7 +13,21 @@
      way both references do. Surplus window width becomes margin, not longer lines.
      Earlier attempts missed on both sides: 900px with a separate 66ch prose cap gave 81 characters
      with a code block twice its width beside it, and removing the cap gave 143. */
-  --hrsf-content-width: min(880px, 100%);
+  --hrsf-content-max: 880px;
+  --hrsf-content-width: min(var(--hrsf-content-max), 100%);
+  /* The horizontal inset the transcript and the composer both sit inside, declared once so the two
+     can be aligned on the same edge from a single number. */
+  --hrsf-gutter: clamp(18px, 3vw, 34px);
+  /* Optical centring.
+   *
+   * The reading column used to be centred inside the detail pane, which is what every reference
+   * client does - but those clients sit next to a ~260px rail, and this one next to a rail that is
+   * both wider and resizable. Centring in the pane therefore pushed the whole conversation to the
+   * right of the window's own centre by half the rail's width, and on a wide monitor that read as
+   * "the text is stuck to the right". Offsetting by half the rail centres the column on the window
+   * instead; `max(0px, ...)` below stops the offset from ever pulling the column past the pane's
+   * gutter when the window is too narrow to afford it. Zero on mobile, where there is no rail. */
+  --hrsf-optical-shift: calc(var(--hrsf-rail-width) / 2);
   background: var(--td3-bg);
 }
 
@@ -178,29 +192,45 @@
   color: var(--td3-muted);
 }
 
+/* State filter: a segmented control, not three loose pills.
+   The three views are mutually exclusive and always all three present, so they share one track and
+   split it evenly - which also stops "Attention" from being the only one that fits when a count
+   reaches three digits. */
 .hr-native-session-filters {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  overflow-x: auto;
-  scrollbar-width: none;
+  display: grid;
+  grid-auto-columns: minmax(0, 1fr);
+  grid-auto-flow: column;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--td3-border-soft);
+  border-radius: 10px;
+  background: var(--td3-sunken-soft);
 }
 
 .hr-native-session-filters button {
-  min-height: 30px;
-  display: inline-flex;
+  min-width: 0;
+  min-height: 28px;
+  display: flex;
   align-items: center;
+  justify-content: center;
   gap: 5px;
-  padding: 0 9px;
+  padding: 0 6px;
   border: 1px solid transparent;
   border-radius: 8px;
   color: var(--td3-muted);
   background: transparent;
   font: inherit;
-  font-size: 10px;
+  font-size: 10.5px;
   font-weight: 700;
   white-space: nowrap;
   cursor: pointer;
+  transition: color .12s ease, background-color .12s ease;
+}
+
+.hr-native-session-filters button > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .hr-native-session-filters button:hover,
@@ -210,14 +240,20 @@
   outline: 0;
 }
 
+.hr-native-session-filters button:focus-visible {
+  border-color: var(--td3-blue-border);
+}
+
 .hr-native-session-filters button.active {
   border-color: var(--td3-border-soft);
   color: var(--td3-text);
-  background: var(--td3-raise-2);
+  background: var(--td3-control);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, .18);
 }
 
 .hr-native-session-filters b {
   min-width: 16px;
+  flex: none;
   padding: 1px 5px;
   border-radius: 999px;
   color: inherit;
@@ -225,24 +261,72 @@
   font-size: 10px;
   font-variant-numeric: tabular-nums;
 }
-.hr-native-session-filters select {
+
+.hr-native-session-filters button.active b {
+  background: var(--td3-raise-3);
+}
+
+/* Scope filters: real dropdowns.
+   A bare <select> squeezed into a flex row rendered as a bordered box with no visible value and no
+   visible caret, which is indistinguishable from an empty text field. The chip owns the border, a
+   leading icon names what is being scoped, and the caret is always drawn - the select itself is a
+   transparent layer on top so the native menu still opens from anywhere in the chip. */
+.hr-native-session-scopes {
+  display: grid;
+  grid-auto-columns: minmax(0, 1fr);
+  grid-auto-flow: column;
+  gap: 6px;
+}
+
+.hr-native-scope {
+  position: relative;
+  min-width: 0;
   min-height: 30px;
-  max-width: 132px;
-  margin-left: auto;
-  padding: 0 25px 0 8px;
+  display: grid;
+  grid-template-columns: 13px minmax(0, 1fr) 12px;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px;
   border: 1px solid var(--td3-border-soft);
-  border-radius: 8px;
-  color: var(--td3-text-2);
+  border-radius: 9px;
+  color: var(--td3-muted);
   background: var(--td3-control);
-  font: inherit;
-  font-size: 10px;
   cursor: pointer;
 }
 
-.hr-native-session-filters select:focus-visible {
-  outline: 0;
+.hr-native-scope:hover {
+  border-color: var(--td3-border-strong);
+}
+
+.hr-native-scope:focus-within {
   border-color: var(--td3-blue-border);
   box-shadow: 0 0 0 2px var(--td3-blue-soft);
+}
+
+.hr-native-scope > svg {
+  display: block;
+  pointer-events: none;
+}
+
+.hr-native-scope select {
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  appearance: none;
+  -webkit-appearance: none;
+  color: var(--td3-text-2);
+  /* `taskdesk-workthreads.css` pins `background-color` on every select with `!important` so the
+     native option popover stays themed, and that wins here. The chip is painted with the same
+     `--td3-control`, so the select's own fill lands seamlessly inside it. */
+  background: transparent;
+  font: inherit;
+  font-size: 10.5px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  cursor: pointer;
 }
 
 
@@ -744,7 +828,9 @@
   gap: 14px;
   padding: 10px 16px;
   border-bottom-color: var(--td3-border-soft);
-  background: var(--td3-panel);
+  /* Chrome, like the top bar and the conversation toolbar - not `--td3-panel`, which is the rail's
+     surface and made the header read as a third tone stacked on the chat's own. */
+  background: var(--td3-chrome);
 }
 
 .hr-native-session-eyebrow {
@@ -756,6 +842,143 @@
   margin: 2px 0;
   font-size: 17px;
   letter-spacing: -.015em;
+}
+
+/* Inline rename.
+   Read and edit share one box: same font, same size, same baseline, same left edge. The only thing
+   that changes on activation is the field treatment, so committing or cancelling never moves the
+   header - and therefore never moves the conversation under it. */
+/* The heading takes the room the actions do not need, so a long Session name uses the header's
+   width instead of stopping at the width of the eyebrow above it. */
+.hr-native-session-heading {
+  flex: 1 1 auto;
+}
+
+.hr-native-session-title {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.hr-native-session-title-button {
+  max-width: 100%;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  /* The negative inline start pulls the button's padding back so the title's glyphs stay on the
+     same left edge as the eyebrow above and the directory below it. */
+  margin-inline-start: -7px;
+  padding: 2px 7px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: inherit;
+  background: transparent;
+  font: inherit;
+  text-align: left;
+  cursor: text;
+}
+
+.hr-native-workspace-session-header .hr-native-session-title-button > span {
+  min-width: 0;
+  overflow: hidden;
+  /* `.hr-native-workspace-session-header span` paints every span in this header muted; the title is
+     the one piece of text in it that is not secondary. */
+  color: var(--td3-text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hr-native-session-title-button > svg {
+  flex: none;
+  opacity: 0;
+  color: var(--td3-muted);
+  transition: opacity .12s ease;
+}
+
+.hr-native-session-title-button:hover {
+  border-color: var(--td3-border-soft);
+  background: var(--td3-raise-1);
+}
+
+.hr-native-session-title-button:focus-visible {
+  outline: 0;
+  border-color: var(--td3-blue-border);
+  box-shadow: 0 0 0 2px var(--td3-blue-soft);
+}
+
+.hr-native-session-title-button:hover > svg,
+.hr-native-session-title-button:focus-visible > svg {
+  opacity: 1;
+}
+
+.hr-native-workspace-session-header .hr-native-session-title-field {
+  width: min(680px, 100%);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-inline-start: -7px;
+  padding: 1px 4px 1px 6px;
+  border: 1px solid var(--td3-blue-border);
+  border-radius: 8px;
+  background: var(--td3-field);
+  box-shadow: 0 0 0 2px var(--td3-blue-soft);
+}
+
+.hr-native-workspace-session-header .hr-native-session-title-field input {
+  min-width: 0;
+  flex: 1;
+  padding: 2px 0;
+  border: 0;
+  outline: 0;
+  color: var(--td3-text);
+  background: transparent;
+  font: inherit;
+  letter-spacing: inherit;
+}
+
+.hr-native-workspace-session-header .hr-native-session-title-actions {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  color: var(--td3-muted);
+}
+
+.hr-native-workspace-session-header .hr-native-session-title-actions button {
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 6px;
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
+}
+
+.hr-native-workspace-session-header .hr-native-session-title-actions button:first-child:hover,
+.hr-native-workspace-session-header .hr-native-session-title-actions button:first-child:focus-visible {
+  color: var(--td3-green-text);
+  background: var(--td3-green-soft);
+  outline: 0;
+}
+
+.hr-native-workspace-session-header .hr-native-session-title-actions button:last-child:hover,
+.hr-native-workspace-session-header .hr-native-session-title-actions button:last-child:focus-visible {
+  color: var(--td3-text-2);
+  background: var(--td3-raise-2);
+  outline: 0;
+}
+
+.hr-native-workspace-session-header .hr-native-session-title.busy .hr-native-session-title-field {
+  opacity: .7;
+}
+
+.hr-native-workspace-session-header .hr-native-session-title-error {
+  display: block;
+  margin-top: 3px;
+  color: var(--td3-red-text) !important;
+  font-size: 10px;
+  font-weight: 600;
 }
 
 .hr-native-workspace-session-header small {
@@ -1236,13 +1459,39 @@
   font-size: 10px;
 }
 
+/* One surface from the session header down to the composer.
+ *
+ * The conversation used to paint three different tones inside a pane that reads as one thing: the
+ * transcript on `--td3-bg`, the band around the composer on `--td3-panel` (inherited from
+ * `work-thread-detail.css`, which styles the Work Thread detail pane, not this one) and the app
+ * behind both on `--td3-bg` again. That produced a hard horizontal seam just above the composer and
+ * a chat area that did not match the rest of the window. The conversation now inherits the page
+ * surface end to end, and the only lifted element is the composer card itself - which is what makes
+ * an input read as an input. */
+.hr-native-session-observer .tdw-work-thread-conversation,
+.hr-native-session-observer .uw-conversation-core,
+.hr-native-session-observer .uw-transcript-shell {
+  background: transparent;
+}
+
 .hr-native-session-observer .uw-transcript {
-  padding: 18px clamp(18px, 3vw, 34px) 24px;
-  background: var(--td3-bg);
+  padding: 18px var(--hrsf-gutter) 24px;
+  background: transparent;
+}
+
+/* Every element that belongs to the reading column shares one edge, including the optical shift.
+   Listing them together is deliberate: a row that opts out of the shift lands on a different left
+   edge than the message above it, which is worse than no shift at all. */
+.hr-native-session-observer .uw-message,
+.hr-native-session-observer .tdw-conversation-event,
+.hr-native-session-observer .uw-session-typing,
+.hr-native-session-observer .uw-history-loader,
+.hr-native-session-observer .uw-empty-panel {
+  width: min(var(--hrsf-content-max), 100%);
+  margin-inline: max(0px, calc((100% - var(--hrsf-content-max)) / 2 - var(--hrsf-optical-shift))) auto;
 }
 
 .hr-native-session-observer .uw-message {
-  width: min(var(--hrsf-content-width), 100%);
   grid-template-columns: 28px minmax(0, 1fr);
   gap: 10px;
   margin-bottom: 18px;
@@ -1304,8 +1553,11 @@
   background: var(--td3-blue-soft);
 }
 
+/* Activity is a section of the reply, not a footnote to it. Capping it at 760px inside an 880px
+   column left it visibly narrower than the prose, the tables and the code blocks stacked directly
+   above and below it - the one element in the transcript that did not reach the column's edge. */
 .hr-native-session-observer .uw-activity-group {
-  width: min(760px, 100%);
+  width: 100%;
   margin-top: 8px;
   border-color: var(--td3-border-soft);
   border-radius: 8px;
@@ -1373,10 +1625,12 @@
 }
 
 .hr-native-session-observer .uw-composer-shell {
-  /* The same horizontal inset the transcript uses, so the composer's edges land exactly on the
-     message rows' edges instead of overhanging them by the difference between two insets. */
-  width: min(var(--hrsf-content-width), calc(100% - 2 * clamp(18px, 3vw, 34px)));
+  /* The same horizontal inset and the same optical shift the transcript rows use, so the composer's
+     edges land exactly on the message rows' edges. The composer's containing block is the pane
+     itself rather than the transcript's padding box, so the gutter is added back explicitly here. */
+  width: min(var(--hrsf-content-max), calc(100% - 2 * var(--hrsf-gutter)));
   margin: 0 auto 12px;
+  margin-inline: calc(var(--hrsf-gutter) + max(0px, (100% - 2 * var(--hrsf-gutter) - var(--hrsf-content-max)) / 2 - var(--hrsf-optical-shift))) auto;
   border-color: var(--td3-border);
   border-radius: 12px;
   background: var(--td3-panel-2);
@@ -1401,17 +1655,36 @@
 }
 
 .hr-native-session-observer .uw-session-typing {
-  width: min(var(--hrsf-content-width), 100%);
-  min-height: 46px;
-  margin-block: 2px 16px;
-  padding: 6px 9px;
+  min-height: 40px;
+  margin-block: 0;
+  padding: 5px 9px;
   border-color: var(--td3-border-soft);
   border-radius: 9px;
   background: var(--td3-raise-1);
   box-shadow: none;
 }
 
+.hr-native-session-observer .uw-thinking-orb {
+  width: 26px;
+  height: 26px;
+  border-radius: 8px;
+}
+
+/* The reply before it has content. It is the agent's own bubble, so it must not announce itself as
+   anything else: same avatar, same name row, same column. Only the body's single live row differs
+   from a bubble that already has text in it. */
+.hr-native-session-observer .uw-message-pending .uw-message-body > header {
+  margin-bottom: 3px;
+}
+
 @media (max-width: 780px), (pointer: coarse) and (min-width: 600px) and (max-height: 640px) {
+  /* The rail is a full-screen sheet here rather than a column beside the chat, so there is nothing
+     for the reading column to be offset against and the shift has to go back to zero. */
+  .hr-native-workspace {
+    --hrsf-optical-shift: 0px;
+    --hrsf-gutter: 8px;
+  }
+
   .hr-native-workspace:has(.hr-native-workspace-detail.mobile-open) > .tdw-topbar {
     display: none !important;
   }
@@ -1437,6 +1710,24 @@
     font-size: 15px;
   }
 
+  /* A pencil that only appears on hover names nothing on a touch screen, where there is no hover. */
+  .hr-native-session-title-button > svg {
+    opacity: 1;
+  }
+
+  .hr-native-workspace-session-header .hr-native-session-title-field {
+    width: 100%;
+  }
+
+  .hr-native-workspace-session-header .hr-native-session-title-field input {
+    font-size: 16px;
+  }
+
+  .hr-native-workspace-session-header .hr-native-session-title-actions button {
+    width: 34px;
+    height: 34px;
+  }
+
   .hr-native-home {
     padding-inline: 8px;
   }
@@ -1460,8 +1751,9 @@
   }
 
   .hr-native-session-filters button {
-    min-height: 38px;
-    padding-inline: 11px;
+    min-height: 36px;
+    padding-inline: 8px;
+    font-size: 11.5px;
   }
 
   .hr-native-machine-heading {
@@ -1491,7 +1783,8 @@
   .hr-native-project-more {
     min-height: 44px;
   }
-  .hr-native-session-filters select { min-height: 38px; max-width: 126px; font-size: 11px; }
+  .hr-native-scope { min-height: 40px; }
+  .hr-native-scope select { font-size: 12px; }
   .hr-session-settings-backdrop {
     inset: 0 0 var(--hr-mobile-nav-height);
     display: block;

--- a/web/src/session-first-workbench.css
+++ b/web/src/session-first-workbench.css
@@ -1484,7 +1484,6 @@
    edge than the message above it, which is worse than no shift at all. */
 .hr-native-session-observer .uw-message,
 .hr-native-session-observer .tdw-conversation-event,
-.hr-native-session-observer .uw-session-typing,
 .hr-native-session-observer .uw-history-loader,
 .hr-native-session-observer .uw-empty-panel {
   width: min(var(--hrsf-content-max), 100%);
@@ -1655,26 +1654,40 @@
 }
 
 .hr-native-session-observer .uw-session-typing {
-  min-height: 40px;
-  margin-block: 0;
-  padding: 5px 9px;
+  width: min(var(--hrsf-content-width), 100%);
+  min-height: 46px;
+  margin-block: 2px 16px;
+  padding: 6px 9px;
   border-color: var(--td3-border-soft);
   border-radius: 9px;
   background: var(--td3-raise-1);
   box-shadow: none;
 }
 
-.hr-native-session-observer .uw-thinking-orb {
-  width: 26px;
-  height: 26px;
-  border-radius: 8px;
+/* The turn's live state, written into the reply's own name.
+   It is deliberately only a colour and a slow pulse: this is the same line, in the same place, that
+   will read the agent's name when the turn ends, and a badge or a spinner beside it would be the
+   second marker for one turn that this whole row exists to avoid. */
+.hr-native-session-observer .uw-message-body > header strong.uw-message-working {
+  color: var(--td3-blue-text);
+  animation: hrsf-working-pulse 1.9s ease-in-out infinite;
 }
 
-/* The reply before it has content. It is the agent's own bubble, so it must not announce itself as
-   anything else: same avatar, same name row, same column. Only the body's single live row differs
-   from a bubble that already has text in it. */
+@keyframes hrsf-working-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: .58; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hr-native-session-observer .uw-message-body > header strong.uw-message-working {
+    animation: none;
+  }
+}
+
+/* The reply before it has produced anything is only that one row, so the body must not keep the gap
+   it leaves for content that is not there yet. */
 .hr-native-session-observer .uw-message-pending .uw-message-body > header {
-  margin-bottom: 3px;
+  margin-bottom: 0;
 }
 
 @media (max-width: 780px), (pointer: coarse) and (min-width: 600px) and (max-height: 640px) {

--- a/web/src/session-first-workbench.css
+++ b/web/src/session-first-workbench.css
@@ -1240,7 +1240,22 @@
 
 .hr-native-startup {
   width: min(680px, calc(100% - 36px));
-  justify-self: center;
+  margin-inline: auto;
+}
+
+/* The icon is the state's mark, so it is given a mark's shape rather than being left as a loose
+   glyph above the text: centred with the copy, in a tinted round badge that carries the state's own
+   colour (blue while connecting, red when unreachable). */
+.hr-native-startup > svg {
+  box-sizing: content-box;
+  width: 26px;
+  height: 26px;
+  margin-bottom: 6px;
+  padding: 13px;
+  border: 1px solid var(--td3-border-soft);
+  border-radius: 50%;
+  color: var(--td3-muted);
+  background: var(--td3-raise-1);
 }
 
 .hr-native-startup > span {
@@ -1290,12 +1305,24 @@
   font-size: 10px;
 }
 
+.hr-native-startup.ready > svg,
 .hr-native-startup.connecting > svg {
+  border-color: var(--td3-blue-border-soft);
   color: var(--td3-blue-text);
+  background: var(--td3-blue-soft-2);
 }
 
-.hr-native-startup.offline > svg {
+.hr-native-startup.offline > svg,
+/* The eyebrow names the state, so it wears the state's colour rather than the accent every other
+   state uses - a red mark over a blue "MACHINES UNAVAILABLE" reads as two different messages. */
+.hr-native-startup.offline > span {
+  border-color: var(--td3-red-border);
   color: var(--td3-red-text);
+  background: var(--td3-red-soft);
+}
+
+.hr-native-startup.offline > span {
+  background: none;
 }
 
 .hr-session-settings-backdrop {

--- a/web/src/session-first-workbench.css
+++ b/web/src/session-first-workbench.css
@@ -838,7 +838,7 @@
   font-size: 10px;
 }
 
-.hr-native-workspace-session-header h1 {
+.hr-native-session-heading h1 {
   margin: 2px 0;
   font-size: 17px;
   letter-spacing: -.015em;
@@ -981,7 +981,9 @@
   font-weight: 600;
 }
 
-.hr-native-workspace-session-header small {
+/* The directory line under the title, and only that: the header also hosts the Session's action
+   dialogs, whose prose has to wrap. */
+.hr-native-session-heading > small {
   max-width: min(76vw, 880px);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1111,17 +1113,27 @@
   background: var(--td3-scrim);
 }
 
+/* Deleting a Session is a modal decision, so it is shown as a modal dialog.
+ *
+ * It was written as a popover anchored under the trash button - `position: absolute` against the
+ * header's action row - while behaving as a modal: full-viewport scrim, `aria-modal`, a Tab trap.
+ * That put an irreversible confirmation in the top-right corner of the window, hard against the
+ * header chrome it was overlapping, where its own width had nowhere to go. Centred on the viewport
+ * it has room, it is where the eye already is, and it matches the scrim that is already behind it. */
 .hr-session-action-panel {
-  position: absolute;
+  position: fixed;
   z-index: 60;
-  top: calc(100% + 7px);
-  right: 0;
-  width: min(340px, calc(100vw - 24px));
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(420px, calc(100vw - 32px));
+  max-height: min(78vh, 560px);
+  overflow-y: auto;
   display: grid;
-  gap: 10px;
-  padding: 12px;
+  gap: 14px;
+  padding: 16px;
   border: 1px solid var(--td3-border-strong);
-  border-radius: 12px;
+  border-radius: 14px;
   background: var(--td3-panel-2);
   box-shadow: var(--td3-shadow-panel);
   text-align: left;
@@ -1131,29 +1143,41 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 10px;
+  gap: 12px;
 }
 
 .hr-session-action-heading > div {
   min-width: 0;
 }
 
+.hr-session-action-heading > .tdw-icon-button {
+  flex: none;
+}
+
+/* Every one of these is stated rather than inherited. This dialog is a child of the Session header,
+   whose own type rules used to reach in here and clip the sentence explaining what is about to be
+   deleted; the dialog's prose is its whole point and must always wrap. */
 .hr-session-action-heading strong,
 .hr-session-action-heading small {
   display: block;
+  max-width: none;
+  overflow: visible;
   color: var(--td3-text);
+  text-overflow: clip;
+  white-space: normal;
 }
 
 .hr-session-action-heading strong {
-  font-size: 12.5px;
+  font-size: 14px;
+  line-height: 1.35;
   overflow-wrap: anywhere;
 }
 
 .hr-session-action-heading small {
-  margin-top: 3px;
+  margin-top: 6px;
   color: var(--td3-muted);
-  font-size: 10px;
-  line-height: 1.45;
+  font-size: 11.5px;
+  line-height: 1.5;
 }
 
 .hr-session-action-field {
@@ -1197,8 +1221,13 @@
 
 .hr-session-action-buttons {
   display: flex;
+  flex-wrap: wrap;
   justify-content: flex-end;
   gap: 8px;
+}
+
+.hr-session-action-buttons > .tdw-button {
+  min-height: 34px;
 }
 
 /* Deleting a native Session is irreversible from Harness Remote, so the confirming button must not
@@ -1719,7 +1748,7 @@
     padding: max(7px, env(safe-area-inset-top)) 9px 7px 47px;
   }
 
-  .hr-native-workspace-session-header h1 {
+  .hr-native-session-heading h1 {
     font-size: 15px;
   }
 
@@ -1837,8 +1866,18 @@
   }
   .hr-native-session-stats { display: none; }
   .hr-session-action-panel {
-    right: -4px;
-    width: min(340px, calc(100vw - 16px));
+    width: min(420px, calc(100vw - 20px));
+  }
+
+  /* An irreversible confirmation is modal, so the app nav must not stay live above its scrim - the
+     same guard the shell's other modal sheets already get. */
+  .uw-standalone-host:has(.hr-session-action-backdrop) .hr-mobile-nav {
+    display: none !important;
+  }
+
+  .hr-session-action-buttons > .tdw-button {
+    flex: 1 1 140px;
+    justify-content: center;
   }
   /* These two are the only Session mutations reachable from a phone, and 34px misses the platform
      target guidance the rest of the mobile chrome already follows. */

--- a/web/src/taskdesk-conversation-component.test.mjs
+++ b/web/src/taskdesk-conversation-component.test.mjs
@@ -59,7 +59,11 @@ test("long conversations retain v2-style jump-to-top and jump-to-bottom affordan
 })
 
 test("shared conversation owns working state presentation", () => {
-  assert.match(component, /uw-session-typing/)
+  // The wait is one identity row - the agent's avatar and the line beside it - and never a second
+  // avatar or a second name for the same turn.
+  assert.match(component, /uw-message uw-message-agent uw-message-pending/)
+  assert.match(component, /uw-message-working/)
+  assert.doesNotMatch(component, /uw-session-typing/)
   assert.match(component, /waiting/)
   assert.match(component, /sending/)
   assert.match(component, /Loading conversation/)

--- a/web/src/taskdesk-conversation.css
+++ b/web/src/taskdesk-conversation.css
@@ -358,31 +358,41 @@
   font-size: 10px;
 }
 
-/* Beautiful-UI-inspired loading language: a compact animated signal, shimmer and elapsed time.
-   It is intentionally implemented with TaskDesk tokens rather than importing a foreign theme. */
+/* The live status row. It now always sits inside the agent's own message body - first in the
+   pending bubble, then in the reply itself - so it is sized as a row within that body rather than
+   as a card floating under the transcript. */
 .tdw-work-thread-conversation .uw-session-typing {
   position: relative;
-  width: min(1040px, 100%);
+  width: 100%;
   max-width: none;
-  min-height: 54px;
-  margin: 4px auto 22px;
+  min-height: 44px;
+  margin: 0;
   display: flex;
   align-items: center;
-  gap: 11px;
-  padding: 8px 12px;
+  gap: 10px;
+  padding: 6px 11px;
   overflow: hidden;
   border: 1px solid var(--td3-border);
-  border-radius: 14px;
+  border-radius: 12px;
   color: var(--td3-text-2);
   background: linear-gradient(110deg, var(--td3-raise-1), var(--td3-panel), var(--td3-raise-1));
   box-shadow: inset 0 1px 0 var(--td3-raise-1);
 }
 
+/* Below whatever the turn has produced so far, never crowding it. */
+.tdw-work-thread-conversation .uw-message-parts > .uw-session-typing:not(:first-child) {
+  margin-top: 9px;
+}
+
+.tdw-work-thread-conversation .uw-message-body > .uw-session-typing {
+  margin-top: 9px;
+}
+
 .uw-thinking-orb {
   position: relative;
   z-index: 1;
-  width: 34px;
-  height: 34px;
+  width: 30px;
+  height: 30px;
   flex: none;
   display: flex;
   align-items: center;

--- a/web/src/taskdesk-conversation.css
+++ b/web/src/taskdesk-conversation.css
@@ -358,41 +358,31 @@
   font-size: 10px;
 }
 
-/* The live status row. It now always sits inside the agent's own message body - first in the
-   pending bubble, then in the reply itself - so it is sized as a row within that body rather than
-   as a card floating under the transcript. */
+/* Beautiful-UI-inspired loading language: a compact animated signal, shimmer and elapsed time.
+   It is intentionally implemented with TaskDesk tokens rather than importing a foreign theme. */
 .tdw-work-thread-conversation .uw-session-typing {
   position: relative;
-  width: 100%;
+  width: min(1040px, 100%);
   max-width: none;
-  min-height: 44px;
-  margin: 0;
+  min-height: 54px;
+  margin: 4px auto 22px;
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 6px 11px;
+  gap: 11px;
+  padding: 8px 12px;
   overflow: hidden;
   border: 1px solid var(--td3-border);
-  border-radius: 12px;
+  border-radius: 14px;
   color: var(--td3-text-2);
   background: linear-gradient(110deg, var(--td3-raise-1), var(--td3-panel), var(--td3-raise-1));
   box-shadow: inset 0 1px 0 var(--td3-raise-1);
 }
 
-/* Below whatever the turn has produced so far, never crowding it. */
-.tdw-work-thread-conversation .uw-message-parts > .uw-session-typing:not(:first-child) {
-  margin-top: 9px;
-}
-
-.tdw-work-thread-conversation .uw-message-body > .uw-session-typing {
-  margin-top: 9px;
-}
-
 .uw-thinking-orb {
   position: relative;
   z-index: 1;
-  width: 30px;
-  height: 30px;
+  width: 34px;
+  height: 34px;
   flex: none;
   display: flex;
   align-items: center;

--- a/web/src/taskdesk-home.test.mjs
+++ b/web/src/taskdesk-home.test.mjs
@@ -76,12 +76,18 @@ test("native Session metadata actions belong to the open Session, not the naviga
   const standalone = read("./components/standalone-universal-workspace.tsx")
   const home = read("./components/native-session-home.tsx")
   const actions = read("./components/native-session-actions.tsx")
+  const rename = read("./components/native-session-rename.tsx")
 
   assert.match(standalone, /<NativeSessionActions target=\{selected\}/)
-  assert.match(actions, /api\.renameSession/)
   assert.match(actions, /api\.deleteSession/)
-  assert.match(actions, /target\.renameSupported/)
   assert.match(actions, /target\.deleteSupported/)
+  // Rename edits the heading the header already shows, so it lives on that heading rather than in a
+  // panel that covers it. It still writes through the owning harness, and still only when the
+  // harness reports that it can.
+  assert.match(standalone, /<NativeSessionTitle target=\{selected\}/)
+  assert.match(rename, /api\.renameSession/)
+  assert.match(rename, /target\.renameSupported/)
+  assert.doesNotMatch(actions, /api\.renameSession/)
   assert.doesNotMatch(home, /api\.renameSession/)
   assert.doesNotMatch(home, /api\.deleteSession/)
 })

--- a/web/src/v3-dialog-accessibility.test.mjs
+++ b/web/src/v3-dialog-accessibility.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict"
 import { existsSync, readFileSync } from "node:fs"
 import test from "node:test"
 
+// Re-run the UI regression gate against the current Session-first checkpoint before merging #309.
 const read = (name) => readFileSync(new URL(name, import.meta.url), "utf8")
 const hook = read("./useDialogDismiss.ts")
 const standalone = read("./components/standalone-universal-workspace.tsx")

--- a/web/src/v3-dialog-accessibility.test.mjs
+++ b/web/src/v3-dialog-accessibility.test.mjs
@@ -7,6 +7,7 @@ const hook = read("./useDialogDismiss.ts")
 const standalone = read("./components/standalone-universal-workspace.tsx")
 const actions = read("./components/native-session-actions.tsx")
 const handoff = read("./components/native-session-handoff-control.tsx")
+const rename = read("./components/native-session-rename.tsx")
 
 test("every Session-first dialog closes on Escape, traps Tab and restores focus", () => {
   assert.match(hook, /event\.key === "Escape"/)
@@ -17,7 +18,6 @@ test("every Session-first dialog closes on Escape, traps Tab and restores focus"
 test("an unrendered dialog branch cannot steal Escape from the rendered one", () => {
   assert.match(hook, /if \(!enabled \|\| !container\) return/)
   assert.match(hook, /\}, \[ref, autoFocus, enabled\]\)/)
-  assert.match(actions, /useDialogDismiss\(renameRef, close, \{ enabled: mode === "rename" \}\)/)
   assert.match(actions, /useDialogDismiss\(deleteRef, close, \{ enabled: mode === "delete" \}\)/)
 })
 
@@ -30,7 +30,6 @@ test("an open model popover inside a Session dialog owns Escape first", () => {
 test("the active Session-first shell dialogs use the shared dismissal behaviour", () => {
   assert.match(standalone, /useDialogDismiss\(dialogRef, onClose\)/)
   assert.match(standalone, /useDialogDismiss\(pageRef, onClose, \{ autoFocus: false \}\)/)
-  assert.match(actions, /useDialogDismiss\(renameRef, close/)
   assert.match(actions, /useDialogDismiss\(deleteRef, close/)
   assert.match(handoff, /return null/)
 })
@@ -45,8 +44,17 @@ test("no blocking native dialog is used for destructive Session-first actions", 
 })
 
 test("native Session rename keeps phone and keyboard input accessible", () => {
-  assert.match(actions, /data-autofocus/)
-  assert.match(actions, /onKeyDown=\{\(event\) => \{ if \(event\.key === "Enter"\) void renameSession\(\) \}\}/)
-  assert.match(actions, /maxLength=\{200\}/)
+  // Rename is an inline edit of the header's own heading rather than a dialog, so the dismissal hook
+  // does not apply to it - but the keyboard contract a dialog gave it still has to hold: the field
+  // takes focus by itself, Enter commits, Escape restores the previous name, and the harness limit
+  // on a Session name is enforced at the input.
+  assert.match(rename, /input\.focus\(\)/)
+  assert.match(rename, /input\.select\(\)/)
+  assert.match(rename, /event\.key === "Enter"/)
+  assert.match(rename, /event\.key === "Escape"/)
+  assert.match(rename, /void commit\(\)/)
+  assert.match(rename, /cancelEdit\(\)/)
+  assert.match(rename, /maxLength=\{200\}/)
+  assert.match(rename, /aria-label=\{t\("sf\.sessionName"\)\}/)
   assert.equal(existsSync(new URL("./components/conversation-workspace.tsx", import.meta.url)), false)
 })


### PR DESCRIPTION
Seven interface problems in the Session-first shell, all of them the same kind of problem: a surface built out of parts that do not agree with each other. **No ACP, daemon or backend code is touched** — the diff is `web/src` UI only.

### 1. Chat background

The conversation painted three tones inside a pane that reads as one thing: the transcript on `--td3-bg`, the band around the composer on `--td3-panel` (inherited from `work-thread-detail.css`, which styles a *different* pane), and the session header on `--td3-panel` again. That left a hard seam just above the composer and a chat area that did not match the rest of the window.

The conversation now inherits the page surface end to end. The only lifted element is the composer card itself — which is what makes an input read as an input — and the session header joins the top bar and the conversation toolbar as chrome.

### 2. Rename is now an inline edit of the heading

Rename used to open a modal panel with its own heading, its own field labelled "Session name" and its own pair of buttons, to change one short string that was already on screen two centimetres above it — and that was hidden behind the panel while it was being retyped.

The heading is now the input: same font, same size, same box, same position in both states, so committing or cancelling never moves the header and therefore never moves the conversation under it. Enter commits, Escape restores, blur commits, and a failed write keeps the typed text. Delete keeps its confirmation panel, because it is not reversible. New component: `components/native-session-rename.tsx`.

### 3. Reading column no longer sits to the right

The column was centred inside the detail pane — which is what Claude, ChatGPT and Codex do, but next to a ~260px rail, not next to one that is both wider and resizable. Centring in the pane pushed the whole conversation half a rail's width to the right of the window's own centre.

The column is now offset by half the rail (`--hrsf-optical-shift`), which centres it on the window, and clamped with `max(0px, …)` so a narrow window falls back to the pane's gutter instead of overrunning it. Messages, conversation events, the empty state, the history loader and the composer all share one edge, and the shift is zero on mobile where there is no rail.

### 4. Rail filters look like the controls they are

Five controls shared one horizontally scrolling flex row, which collapsed both `<select>`s to a 35px stub with their value clipped away — a bordered box with no visible value and no visible caret, indistinguishable from an empty text field.

- **State** (All / Live / Attention) is a segmented control: three mutually exclusive views on one track, split evenly, each carrying its count.
- **Scope** (machine / harness) is a pair of dropdown chips with a leading icon, the current value, and a caret that is always drawn.

### 5. Activity reaches the column's edge

`.uw-activity-group` was capped at 760px inside an 880px column, making it the one element in a reply that did not reach the edge — visibly narrower than the prose, tables and code blocks stacked directly above and below it.

### 6. A sent message no longer flashes

Sending cleared the composer and showed nothing until `continueTask` returned a Run, at which point the message appeared — and appeared again, remounted, once that Run carried a real id and the timeline's key for its row changed from the run's index to that id.

The prompt is now shown optimistically from the moment it is sent, keyed once, and stands down as soon as the real row exists (matched either by text or by a new Run landing on the Task). The two are never on screen together, and a rejected send removes it along with restoring the draft.

### 7. Waiting for a reply happens in one place

The wait was staged across three containers: a "getting started" card appeared, was removed, and an agent message with a different avatar, width and border took its place, with the working state restated inside it. The surface rebuilt itself twice before a single token arrived.

The pending reply is now the agent's own message bubble — same avatar, same name, same column, same geometry — carrying a live status row instead of content. When the first token lands, the real bubble takes over in place and keeps that same row at the bottom of its body, so reasoning and tool cards fill in *above* it rather than replacing it: prepare → think → answer, all inside one container.

## Verification

- `npx tsc -b` and `npm run build` clean.
- `test:ui`, `test:v3-product-ui`, `test:settings`, `test:i18n`, `test:markdown`, `test:model`, `test:events`, `test:profiles`, `test:config`, `test:attachments`, `test:agent-runs`, `test:mutation-coordinator`, `test:catalog-guard`, `test:machine-payload`, `test:platform`, `test:completion-audio`, `test:completion-timing`, `test:native-response`, `test:native-session-model-lifecycle`, `session-first-regression` — all pass.
- Three regression tests asserted rename's old location and dialog wiring; they were updated to assert the new inline-edit contract (focus, Enter/Escape, `maxLength`, harness capability gate, and that the navigation rail still owns neither mutation) rather than dropped.
- `taskdesk-focus-layout.test.mjs` fails on this branch's base commit too (a Tasks-drawer assertion in `universal-workspace.tsx`, unrelated to this change) and is not part of any `npm test` script.
- Rendered the real components against mock data in Chromium and inspected dark and light themes at 1280/1600/2200px and 420px mobile, plus the rename read/hover/edit states and the empty transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyqLbkK2w9xEZsxipD3fPu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyqLbkK2w9xEZsxipD3fPu)_