### PR TITLE
Claude: settle the Activity sections a finished turn left on Working

### DIFF
--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -223,6 +223,43 @@ export function isHarnessInjectedText(text) {
   return HARNESS_INJECTED_BLOCK.test(text)
 }
 
+/** The two tool-call states that mean "still running" on the wire and in the transcript. */
+const UNSETTLED_TOOL_STATUSES = new Set(["pending", "running"])
+
+/**
+ * An Activity section in the conversation reads as Working purely from the parts inside it: a tool
+ * call still at `pending`/`running`, or a reasoning part with a start and no end. Both are only ever
+ * true while the turn that produced them is live, and both are left open by the adapters — Claude's
+ * in particular. It drops the closing `tool_call_update` for calls still open when a turn ends, is
+ * cancelled or fails, and for calls replayed out of a loaded session's history. So a finished Claude
+ * conversation kept individual Activity sections spinning on Working for good, in the persisted
+ * snapshot too, while the Session itself correctly read idle.
+ *
+ * A tool call with no reported outcome is closed as `incomplete`: neither success nor failure may be
+ * invented for it, since `completed` would claim a result that never arrived and `error` would
+ * accuse a tool that most likely ran. Historical parts close their reasoning at its own start
+ * instead of at `now`, because a snapshot reopened days later must not report the outage as time
+ * the agent spent thinking.
+ */
+export function settleUnfinishedActivity(messages, { now = Date.now(), historical = false } = {}) {
+  let settled = 0
+  for (const message of Array.isArray(messages) ? messages : []) {
+    for (const part of message?.parts ?? []) {
+      if (part?.type === "tool" && part.state && UNSETTLED_TOOL_STATUSES.has(part.state.status)) {
+        part.state.status = "incomplete"
+        if (part.state.time && !part.state.time.end) part.state.time.end = now
+        settled += 1
+        continue
+      }
+      if (part?.type === "reasoning" && part.time?.start && !part.time.end) {
+        part.time.end = historical ? part.time.start : now
+        settled += 1
+      }
+    }
+  }
+  return settled
+}
+
 // The app groups the picker by source and offers a skill-only filter, so the
 // `skill:` prefix OMP puts on skill commands has to survive as structured data
 // rather than staying buried in the name.
@@ -870,6 +907,8 @@ export class AcpService {
       if (this.#turnGenerations.get(sessionID) !== generation) return
       this.#active.delete(sessionID)
       this.#chunkMessageIDs.delete(`${sessionID}:assistant`)
+      // The turn is over, so no activity it started is still running, whatever the adapter said.
+      this.#settleActivity(sessionID)
       this.#emit("session.updated", sessionID)
       this.#persistSnapshot(sessionID)
       void this.#runNextQueued(sessionID)
@@ -936,6 +975,8 @@ export class AcpService {
     this.#cancelledSessions.add(sessionID)
     this.#active.delete(sessionID)
     this.#chunkMessageIDs.delete(`${sessionID}:assistant`)
+    // A cancelled turn gets no closing tool_call_update at all, so settle before it is published.
+    this.#settleActivity(sessionID)
     this.#acp.notify("session/cancel", { sessionId: sessionID })
     this.#emit("session.updated", sessionID)
     this.#persistSnapshot(sessionID)
@@ -962,7 +1003,14 @@ export class AcpService {
     try {
       const snapshot = JSON.parse(await readFile(this.#snapshotPath(sessionID), "utf8"))
       if (snapshot?.version !== 1) return
-      if (Array.isArray(snapshot.messages)) this.#messages.set(sessionID, mergeFragmentedPiSnapshot(snapshot.messages))
+      if (Array.isArray(snapshot.messages)) {
+        const restored = mergeFragmentedPiSnapshot(snapshot.messages)
+        // A snapshot written mid-turn keeps that turn's open tool calls at `running`. The turn did
+        // not survive the restart, so reopening the Session must not present them as live work; the
+        // rewrite is left to the next persist rather than forcing one on every restore.
+        if (settleUnfinishedActivity(restored, { historical: true })) this.#dirtySnapshots.add(sessionID)
+        this.#messages.set(sessionID, restored)
+      }
       if (Array.isArray(snapshot.todos)) this.#todos.set(sessionID, snapshot.todos)
       if (!this.#preferListedTitles && typeof snapshot.title === "string" && snapshot.title) this.#titles.set(sessionID, snapshot.title)
       if (snapshot?.deleted === true) this.#deletedSessions.add(sessionID)
@@ -1004,6 +1052,34 @@ export class AcpService {
   /** A queued prompt is still outstanding work, so the session must not read as idle between turns. */
   #isBusy(sessionID) {
     return this.#active.has(sessionID) || Boolean(this.#queues.get(sessionID)?.length)
+  }
+
+  /**
+   * Close the session's still-open activity, which is only ever correct while no turn of its own is
+   * live — see settleUnfinishedActivity. Silent while a replay is still being assembled: that path
+   * publishes the transcript itself once it is whole.
+   */
+  #settleActivity(sessionID, { emit = true, historical = false } = {}) {
+    if (this.#active.has(sessionID)) return 0
+    const settled = settleUnfinishedActivity(this.#messages.get(sessionID) ?? [], { historical })
+    if (settled && emit) this.#emit("message.updated", sessionID)
+    return settled
+  }
+
+  /**
+   * The status layer in front of this service can establish that a Session is idle while the service
+   * still holds its own busy flag — Claude's adapter leaves that flag set when it stops answering a
+   * turn it never finished. The transcript must not contradict that conclusion: a Session presented
+   * as idle cannot keep an Activity section on Working, so whoever corrects the status settles the
+   * activity the abandoned turn left open through here. A tool_call_update that does arrive later
+   * still overwrites the part, so this can only ever be as premature as the status it follows.
+   */
+  settleReportedIdleActivity(sessionID) {
+    const settled = settleUnfinishedActivity(this.#messages.get(sessionID) ?? [])
+    if (!settled) return 0
+    this.#emit("message.updated", sessionID)
+    this.#persistSnapshot(sessionID)
+    return settled
   }
 
   /**
@@ -1133,6 +1209,10 @@ export class AcpService {
       this.#rememberConfigOptions(sessionID, result.configOptions)
       const replayedMessages = mergeFragmentedPiSnapshot(this.#messages.get(sessionID) ?? [])
       this.#messages.set(sessionID, replaceHistory ? replayedMessages : mergeReplay(previousMessages, replayedMessages))
+      // Replayed history is finished work by definition, and the adapter does not always close the
+      // tool calls in it. Settling before the signature check keeps the restored (already settled)
+      // snapshot and this replay comparable, so an unchanged history still reads as unchanged.
+      this.#settleActivity(sessionID, { emit: false, historical: true })
       const replayedTodos = this.#todos.get(sessionID) ?? []
       this.#todos.set(sessionID, replaceHistory ? replayedTodos : mergeTodos(previousTodos, replayedTodos))
       if (semanticHistorySignature(this.#messages.get(sessionID) ?? []) !== previousMessageSnapshot) {
@@ -1267,6 +1347,13 @@ export class AcpService {
           parts: []
         }
         messages.push(message)
+      }
+      // A reasoning part is closed by the part that follows it, but only the message-chunk path did
+      // that: reasoning followed by a tool call — Claude's normal shape — stayed open forever, which
+      // is enough on its own to keep that Activity section reading Working after the turn ended.
+      const openReasoning = message.parts.at(-1)
+      if (openReasoning?.type === "reasoning" && openReasoning.time && !openReasoning.time.end) {
+        openReasoning.time.end = Date.now()
       }
       message.parts.push({
         id: update.toolCallId,

--- a/bridge/src/server.js
+++ b/bridge/src/server.js
@@ -201,7 +201,11 @@ export function createBridgeServer({ config, acp, serviceOptions, machineRegistr
     if (backend !== "claude") return status
     const pendingRequests = acp.diagnostics?.()?.pendingRequests ?? []
     const lastActivityAt = Math.max(liveSessionActivity.get(sessionID) ?? 0, Number(fallbackActivityAt) || 0)
-    return corroborateClaudeSessionStatus(status, sessionID, pendingRequests, lastActivityAt)
+    const corroborated = corroborateClaudeSessionStatus(status, sessionID, pendingRequests, lastActivityAt)
+    // The transcript is part of the same presentation: a Session that is reported idle must not keep
+    // its Activity sections on Working, which is what correcting the status alone left on screen.
+    if (status?.type === "busy" && corroborated.type === "idle") service.settleReportedIdleActivity(sessionID)
+    return corroborated
   }
   const listVisibleSessions = async (directory) => {
     let sessions = await service.listSessions(directory)

--- a/bridge/test/claude-v3-regression.test.js
+++ b/bridge/test/claude-v3-regression.test.js
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict"
 import { EventEmitter } from "node:events"
+import { mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
 import path from "node:path"
 import test from "node:test"
-import { AcpService } from "../src/acp-service.js"
+import { AcpService, settleUnfinishedActivity } from "../src/acp-service.js"
 import { HARNESS_PROFILES, resolveAcpLaunch } from "../src/harness-profiles.js"
 import { detectBackends, resolveLaunchPlan } from "../src/launcher.js"
 import {
@@ -189,4 +191,308 @@ test("Claude TaskDesk launch uses the same ACP service that owns visible session
     ["prompt", "claude-task-session", "Implement the Claude fix"]
   ])
   assert.equal(completed, true)
+})
+
+const ACTIVITY_SESSION = "01a02000-0000-7000-8000-000000000000"
+
+function toolParts(messages) {
+  return messages
+    .flatMap((message) => message.parts)
+    .filter((part) => part.type === "tool")
+    .map((part) => [part.state?.title ?? part.tool, part.state?.status])
+}
+
+test("activity a Claude turn left open stops reading as running", () => {
+  const now = 1_800_000_000_000
+  const messages = [{
+    info: { id: "m1", role: "assistant", sessionID: ACTIVITY_SESSION, time: { created: now } },
+    parts: [
+      { type: "reasoning", text: "still thinking", time: { start: now - 6_000 } },
+      { type: "tool", tool: "Bash", callID: "c1", state: { status: "running", time: { start: now - 5_000 } } },
+      { type: "tool", tool: "Read", callID: "c2", state: { status: "pending", time: { start: now - 4_000 } } },
+      { type: "tool", tool: "Edit", callID: "c3", state: { status: "completed", time: { start: now - 3_000, end: now - 2_000 } } },
+      { type: "tool", tool: "Grep", callID: "c4", state: { status: "error", time: { start: now - 1_000 } } },
+      { type: "reasoning", text: "thought it through", time: { start: now - 900, end: now - 800 } },
+      { type: "text", text: "done" }
+    ]
+  }]
+
+  assert.equal(settleUnfinishedActivity(messages, { now }), 3)
+  assert.deepEqual(
+    messages[0].parts.map((part) => part.state?.status ?? part.type),
+    ["reasoning", "incomplete", "incomplete", "completed", "error", "reasoning", "text"]
+  )
+  // An outcome the harness never reported may not be invented, and the timing of the parts that did
+  // report one may not be rewritten.
+  assert.equal(messages[0].parts[0].time.end, now)
+  assert.equal(messages[0].parts[1].state.time.end, now)
+  assert.equal(messages[0].parts[3].state.time.end, now - 2_000)
+  assert.equal(messages[0].parts[4].state.time.end, undefined)
+  assert.equal(messages[0].parts[5].time.end, now - 800)
+  assert.equal(settleUnfinishedActivity(messages, { now }), 0)
+})
+
+test("reopened history closes its thinking at its own start instead of claiming the outage", () => {
+  const now = 1_800_000_000_000
+  const messages = [{
+    info: { id: "m1", role: "assistant", sessionID: ACTIVITY_SESSION, time: { created: now - 86_400_000 } },
+    parts: [{ type: "reasoning", text: "thinking", time: { start: now - 86_400_000 } }]
+  }]
+
+  assert.equal(settleUnfinishedActivity(messages, { now, historical: true }), 1)
+  assert.equal(messages[0].parts[0].time.end, now - 86_400_000)
+})
+
+/** Claude's adapter is observed to open tool calls it never closes; the transcript kept spinning. */
+class ClaudeToolCallAcp extends EventEmitter {
+  constructor({ closeSecondCall = false } = {}) {
+    super()
+    this.closeSecondCall = closeSecondCall
+    this.cancelled = []
+  }
+
+  async listSessions() {
+    return [{ sessionId: ACTIVITY_SESSION, cwd: process.cwd(), title: "Claude activity", updatedAt: new Date().toISOString() }]
+  }
+
+  #toolCall(id, title) {
+    this.emit("notification", {
+      method: "session/update",
+      params: {
+        sessionId: ACTIVITY_SESSION,
+        update: { sessionUpdate: "tool_call", toolCallId: id, title, status: "in_progress", rawInput: { command: title } }
+      }
+    })
+  }
+
+  async request(method, params) {
+    if (method === "session/load") return { configOptions: [] }
+    if (method !== "session/prompt") throw new Error(`Unexpected request: ${method}`)
+    this.emit("notification", {
+      method: "session/update",
+      params: {
+        sessionId: params.sessionId,
+        update: { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "Run the suite first." } }
+      }
+    })
+    this.#toolCall("call-1", "npm test")
+    this.emit("notification", {
+      method: "session/update",
+      params: {
+        sessionId: params.sessionId,
+        update: { sessionUpdate: "tool_call_update", toolCallId: "call-1", status: "completed", rawOutput: "415 passing" }
+      }
+    })
+    this.#toolCall("call-2", "npm run build")
+    if (this.closeSecondCall) {
+      this.emit("notification", {
+        method: "session/update",
+        params: {
+          sessionId: params.sessionId,
+          update: { sessionUpdate: "tool_call_update", toolCallId: "call-2", status: "completed" }
+        }
+      })
+    }
+    this.emit("notification", {
+      method: "session/update",
+      params: {
+        sessionId: params.sessionId,
+        update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Done." } }
+      }
+    })
+    return { stopReason: "end_turn" }
+  }
+
+  notify(method, params) {
+    if (method === "session/cancel") this.cancelled.push(params.sessionId)
+  }
+}
+
+test("a finished Claude turn settles the activity its tool calls never closed", async () => {
+  const service = new AcpService(new ClaudeToolCallAcp())
+  await service.prompt(ACTIVITY_SESSION, "run the suite")
+  await new Promise((resolve) => setTimeout(resolve, 20))
+
+  assert.deepEqual(service.status(ACTIVITY_SESSION), { type: "idle" })
+  assert.deepEqual(toolParts(await service.messages(ACTIVITY_SESSION)), [
+    ["npm test", "completed"],
+    ["npm run build", "incomplete"]
+  ])
+})
+
+test("a Claude tool call still reads as running while its turn is live", async () => {
+  const acp = new ClaudeToolCallAcp()
+  let release = () => {}
+  const held = new Promise((resolve) => { release = resolve })
+  const request = acp.request.bind(acp)
+  acp.request = async (method, params) => {
+    const result = await request(method, params)
+    if (method === "session/prompt") await held
+    return result
+  }
+
+  const service = new AcpService(acp)
+  await service.prompt(ACTIVITY_SESSION, "run the suite")
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  assert.deepEqual(service.status(ACTIVITY_SESSION), { type: "busy" })
+  assert.deepEqual(toolParts(await service.messages(ACTIVITY_SESSION)), [
+    ["npm test", "completed"],
+    ["npm run build", "running"]
+  ])
+
+  release()
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  assert.deepEqual(toolParts(await service.messages(ACTIVITY_SESSION)), [
+    ["npm test", "completed"],
+    ["npm run build", "incomplete"]
+  ])
+})
+
+test("stopping a Claude turn settles the tool call it interrupted", async () => {
+  const acp = new ClaudeToolCallAcp()
+  let release = () => {}
+  const held = new Promise((resolve) => { release = resolve })
+  const request = acp.request.bind(acp)
+  acp.request = async (method, params) => {
+    const result = await request(method, params)
+    if (method === "session/prompt") await held
+    return result
+  }
+
+  const service = new AcpService(acp)
+  await service.prompt(ACTIVITY_SESSION, "run the suite")
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  service.abort(ACTIVITY_SESSION)
+
+  assert.deepEqual(acp.cancelled, [ACTIVITY_SESSION])
+  assert.deepEqual(toolParts(await service.messages(ACTIVITY_SESSION)), [
+    ["npm test", "completed"],
+    ["npm run build", "incomplete"]
+  ])
+  release()
+})
+
+test("a Claude turn that does close its tool calls is left exactly as reported", async () => {
+  const service = new AcpService(new ClaudeToolCallAcp({ closeSecondCall: true }))
+  await service.prompt(ACTIVITY_SESSION, "run the suite")
+  await new Promise((resolve) => setTimeout(resolve, 20))
+
+  assert.deepEqual(toolParts(await service.messages(ACTIVITY_SESSION)), [
+    ["npm test", "completed"],
+    ["npm run build", "completed"]
+  ])
+})
+
+test("replayed Claude history never reopens a tool call as running activity", async () => {
+  class ReplayAcp extends EventEmitter {
+    async listSessions() {
+      return [{ sessionId: ACTIVITY_SESSION, cwd: process.cwd(), title: "Claude history", updatedAt: new Date().toISOString() }]
+    }
+
+    async request(method, params) {
+      if (method !== "session/load") throw new Error(`Unexpected request: ${method}`)
+      this.emit("notification", {
+        method: "session/update",
+        params: {
+          sessionId: params.sessionId,
+          update: { sessionUpdate: "user_message_chunk", messageId: "u1", content: { type: "text", text: "run the suite" } }
+        }
+      })
+      this.emit("notification", {
+        method: "session/update",
+        params: {
+          sessionId: params.sessionId,
+          update: { sessionUpdate: "tool_call", toolCallId: "old-call", title: "npm test", status: "in_progress", rawInput: {} }
+        }
+      })
+      return { configOptions: [] }
+    }
+
+    notify() {}
+  }
+
+  const service = new AcpService(new ReplayAcp())
+  assert.deepEqual(toolParts(await service.messages(ACTIVITY_SESSION)), [["npm test", "incomplete"]])
+})
+
+test("a snapshot written mid-turn reopens with settled activity", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "harness-claude-activity-"))
+  const snapshot = {
+    version: 1,
+    messages: [{
+      info: { id: "m1", role: "assistant", sessionID: ACTIVITY_SESSION, time: { created: Date.now() } },
+      parts: [{
+        id: "call-1",
+        messageID: "m1",
+        type: "tool",
+        tool: "Bash",
+        callID: "call-1",
+        state: { status: "running", title: "npm test", input: {}, time: { start: Date.now() - 1_000 } }
+      }]
+    }],
+    todos: [],
+    title: "Claude activity"
+  }
+  await writeFile(
+    path.join(directory, `${Buffer.from(ACTIVITY_SESSION).toString("base64url")}.json`),
+    JSON.stringify(snapshot),
+    "utf8"
+  )
+
+  class SnapshotAcp extends EventEmitter {
+    async listSessions() {
+      return [{ sessionId: ACTIVITY_SESSION, cwd: process.cwd(), title: "Claude activity", updatedAt: new Date().toISOString() }]
+    }
+
+    async request(method) {
+      if (method === "session/load") return { configOptions: [] }
+      throw new Error(`Unexpected request: ${method}`)
+    }
+
+    notify() {}
+  }
+
+  const service = new AcpService(new SnapshotAcp(), { snapshotDirectory: directory })
+  assert.deepEqual(toolParts(await service.messages(ACTIVITY_SESSION)), [["npm test", "incomplete"]])
+})
+
+test("a Session reported idle by the status correction settles its stale activity too", async () => {
+  const acp = new ClaudeToolCallAcp()
+  let release = () => {}
+  const held = new Promise((resolve) => { release = resolve })
+  const request = acp.request.bind(acp)
+  acp.request = async (method, params) => {
+    const result = await request(method, params)
+    if (method === "session/prompt") await held
+    return result
+  }
+
+  const service = new AcpService(acp)
+  await service.prompt(ACTIVITY_SESSION, "run the suite")
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  // The turn is still flagged busy in the service, which is the stale state the public status
+  // correction resolves; the transcript has to follow it rather than keep spinning.
+  assert.deepEqual(service.status(ACTIVITY_SESSION), { type: "busy" })
+  assert.equal(service.settleReportedIdleActivity(ACTIVITY_SESSION), 1)
+  assert.deepEqual(toolParts(await service.messages(ACTIVITY_SESSION)), [
+    ["npm test", "completed"],
+    ["npm run build", "incomplete"]
+  ])
+  assert.equal(service.settleReportedIdleActivity(ACTIVITY_SESSION), 0)
+  release()
+})
+
+test("thinking that a Claude tool call interrupts is closed by that tool call", async () => {
+  const service = new AcpService(new ClaudeToolCallAcp({ closeSecondCall: true }))
+  await service.prompt(ACTIVITY_SESSION, "run the suite")
+  await new Promise((resolve) => setTimeout(resolve, 20))
+
+  const reasoning = (await service.messages(ACTIVITY_SESSION))
+    .flatMap((message) => message.parts)
+    .filter((part) => part.type === "reasoning")
+  assert.equal(reasoning.length, 1)
+  // Only the message-chunk path used to close reasoning, so thinking followed by a tool call — the
+  // ordinary Claude shape — kept its Activity section on Working for the rest of the transcript.
+  assert.ok(reasoning[0].time.start > 0)
+  assert.ok(reasoning[0].time.end >= reasoning[0].time.start)
 })

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -166,6 +166,12 @@ the configured browsing roots to anyone who has the bridge credentials. Treat th
 full access to the Claude Code account on that host, and use a trusted LAN, VPN or TLS-terminating
 proxy rather than exposing the bridge directly to the Internet.
 
+**Not assumed:** that every `tool_call` the adapter opens is closed by a `tool_call_update`. It is
+observed to leave calls open — those still running when a turn ends, is cancelled or fails, and those
+replayed out of a loaded session's history — so `AcpService` settles a Session's open tool calls and
+reasoning as soon as the turn behind them is no longer live (`settleUnfinishedActivity`). Without it
+an Activity section in a finished conversation reads `Working` for good, snapshot included.
+
 **Watch:** the pinned adapter version, bare model ids, ACP session update and permission-request
 shapes, and whether session visibility or image capability changes. The app intentionally does not
 expose agent selection, server slash commands or VCS/diff for this backend.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1102,6 +1102,15 @@ function ToolPartView({
               …
             </span>
           )}
+          {status === "incomplete" && (
+            <span
+              className="message-tool-status-incomplete"
+              title={t('action.toolIncomplete')}
+              aria-label={t('action.toolIncomplete')}
+            >
+              –
+            </span>
+          )}
         </span>
       </button>
 

--- a/web/src/components/taskdesk-message-content.tsx
+++ b/web/src/components/taskdesk-message-content.tsx
@@ -114,10 +114,15 @@ function ToolPartCard({ part }: { part: MessagePart }) {
         onToggle={(event) => setOpen(event.currentTarget.open)}
       >
         <summary>
-          <span className="uw-tool-icon">{status === "completed" ? "✓" : status === "error" ? "!" : "⋯"}</span>
+          {/* `incomplete` is the bridge's marker for a call whose turn ended before the harness
+              reported an outcome: it is finished work with nothing to show, so it takes neither the
+              running ellipsis nor the failure mark. */}
+          <span className="uw-tool-icon">
+            {status === "completed" ? "✓" : status === "error" ? "!" : status === "incomplete" ? "–" : "⋯"}
+          </span>
           <span className="uw-tool-title">{state?.title || part.tool || "Tool"}</span>
           {command ? <code>{command.length > 90 ? `${command.slice(0, 90)}…` : command}</code> : null}
-          <span className="uw-tool-status">{status}</span>
+          <span className="uw-tool-status">{status === "incomplete" ? "no result" : status}</span>
         </summary>
         {/* The truncated body is what is on screen, but the copy carries the whole output: a stack
             trace clipped at 4000 characters is the half you cannot paste anywhere useful. */}

--- a/web/src/conversation-parts.test.mjs
+++ b/web/src/conversation-parts.test.mjs
@@ -102,3 +102,33 @@ test("an unfinished reasoning fragment keeps Activity live", () => {
   assert.equal(groups[0].kind, "activity")
   assert.equal(groups[0].status, "running")
 })
+
+test("an abandoned tool call stops holding its Activity section on Working", () => {
+  const groups = groupConversationParts([
+    part("reasoning", "reasoning", { text: "thinking", time: { start: 1, end: 2 } }),
+    part("tool-1", "tool", { tool: "Read", state: { status: "completed" } }),
+    // The bridge settles a call its turn never closed as `incomplete`, and a historical Session that
+    // finished long ago must read as finished: only live wire states keep an Activity on Working.
+    part("tool-2", "tool", { tool: "Bash", state: { status: "incomplete" } })
+  ])
+
+  assert.equal(groups.length, 1)
+  assert.equal(groups[0].kind, "activity")
+  assert.equal(groups[0].status, "completed")
+})
+
+test("a live tool call still holds its Activity section on Working", () => {
+  for (const status of ["pending", "running", "in_progress"]) {
+    const groups = groupConversationParts([part("tool", "tool", { tool: "Bash", state: { status } })])
+    assert.equal(groups[0].status, "running", status)
+  }
+})
+
+test("a tool call that reports no status at all is not read as live work", () => {
+  const groups = groupConversationParts([
+    part("tool", "tool", { tool: "Read", state: {} }),
+    part("tool-2", "tool", { tool: "Read" })
+  ])
+
+  assert.equal(groups[0].status, "completed")
+})

--- a/web/src/conversation-parts.ts
+++ b/web/src/conversation-parts.ts
@@ -13,13 +13,21 @@ export function isConversationActivityPart(part: MessagePart): boolean {
   return part.type === "reasoning" || part.type === "tool"
 }
 
+/**
+ * The wire states that mean a tool call is still open. This is deliberately an allow-list: reading
+ * "anything that is not completed or error" as running let a single state the harness never closes —
+ * or the `incomplete` the bridge stamps on a call its turn abandoned — keep one Activity section on
+ * Working forever, in a Session that had long finished.
+ */
+const LIVE_TOOL_STATUSES = new Set(["pending", "running", "in_progress"])
+
 function activityStatus(parts: MessagePart[], forceRunning = false): "running" | "completed" | "error" {
   // A failed tool call is local technical activity, not the state of the whole assistant turn.
   // While the native Run is alive the Activity stays visibly Working; once the Run ends, the
   // individual tool card retains its error while the Activity itself can complete normally.
   // A real turn failure is rendered separately from message.info.error by TaskDeskMessageContent.
   if (forceRunning) return "running"
-  if (parts.some((part) => part.type === "tool" && part.state?.status && part.state.status !== "completed" && part.state.status !== "error")) return "running"
+  if (parts.some((part) => part.type === "tool" && LIVE_TOOL_STATUSES.has(part.state?.status ?? ""))) return "running"
   if (parts.some((part) => part.type === "reasoning" && part.time?.start && !part.time.end)) return "running"
   return "completed"
 }

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -260,6 +260,7 @@ type TranslationKey =
   | 'action.usedSkillNamed'
   | 'action.toolFailed'
   | 'action.running'
+  | 'action.toolIncomplete'
   | 'action.preparingTool'
   | 'action.showDiffFor'
   | 'action.actionsFallback'
@@ -674,6 +675,7 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'action.usedSkillNamed': 'Used skill: {name}',
     'action.toolFailed': 'Tool failed',
     'action.running': 'Running…',
+    'action.toolIncomplete': 'No result reported',
     'action.preparingTool': 'Preparing {tool}',
     'action.showDiffFor': 'Show diff for {file}',
     'action.actionsFallback': 'Actions',
@@ -1136,6 +1138,7 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'action.usedSkillNamed': 'Usata skill: {name}',
     'action.toolFailed': 'Tool fallito',
     'action.running': 'In esecuzione…',
+    'action.toolIncomplete': 'Nessun risultato riportato',
     'action.preparingTool': 'Preparazione di {tool}',
     'action.showDiffFor': 'Mostra diff per {file}',
     'action.actionsFallback': 'Azioni',
@@ -1598,6 +1601,7 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'action.usedSkillNamed': '已使用技能：{name}',
     'action.toolFailed': '工具失敗',
     'action.running': '執行中…',
+    'action.toolIncomplete': '未回報結果',
     'action.preparingTool': '正在準備 {tool}',
     'action.showDiffFor': '顯示 {file} 的差異',
     'action.actionsFallback': '動作',
@@ -2057,6 +2061,7 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'action.usedSkillNamed': '已使用技能：{name}',
     'action.toolFailed': '工具失败',
     'action.running': '运行中…',
+    'action.toolIncomplete': '未报告结果',
     'action.preparingTool': '正在准备 {tool}',
     'action.showDiffFor': '显示 {file} 的差异',
     'action.actionsFallback': '操作',

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2245,6 +2245,15 @@ a:focus-visible,
   line-height: 1;
 }
 
+/* A tool call the harness stopped reporting on: it is not running any more, and no outcome ever
+   arrived for it, so the row is marked as closed without borrowing the failure palette. */
+.message-tool-status-incomplete {
+  color: var(--muted);
+  font-size: var(--font-xs);
+  line-height: 1;
+  opacity: 0.7;
+}
+
 .message-tool-error.message-tool-output {
   color: var(--danger);
 }


### PR DESCRIPTION
Follow-up to #307, which it targets rather than replaces. Real-device feedback: the Sessions are not the ones stuck on `Working` — individual **Activity sections inside finished Claude Sessions** are, and only some of them. `corroborateClaudeSessionStatus` cannot reach that symptom at all, because an Activity section's status is never derived from the Session status.

## Root cause

`web/src/conversation-parts.ts` derives an Activity section's status purely from the parts inside it — a tool call still at `pending`/`running`, or a reasoning part with a start and no end — and `taskdesk-message-content.tsx` prints `running` as **`Working`**. So one part the bridge never closes pins that one section on `Working` for good, which is exactly why only *some* sections are affected. Two independent producers in `bridge/src/acp-service.js` leave parts open:

1. **Tool calls with no closing `tool_call_update`.** That branch is the only thing that ever moves a tool part off `running`. A call still open when the turn ends, is cancelled or fails — and a call replayed out of `session/load` history — keeps `state.status: "running"`, and it is written into the snapshot, so it survives restarts and reopens identically every time.
2. **Reasoning that a tool call interrupts.** Only the message-chunk path stamps `time.end` on a preceding reasoning part; the `tool_call` branch pushed its part without that. So *thinking → tool call*, Claude's ordinary shape, left a reasoning part open forever — on its own enough to keep the section on `Working`.

Both survive `#active` being cleared and neither is visible at Session level: hence "the Session reads idle but the section still says Working".

## Changes

**Bridge — the source of truth**
- `settleUnfinishedActivity()` closes a Session's open tool calls and reasoning once the turn behind them is no longer live: end of turn, `abort`, snapshot restore, after a history replay, and when the public status layer concludes the Session is idle while the service still holds its busy flag (`settleReportedIdleActivity`, wired into `publicSessionStatus`).
- A call with no reported outcome closes as `incomplete` — not `completed`, which would claim a result that never arrived, and not `error`, which would accuse a tool that most likely ran. A later `tool_call_update` still overwrites the part, so settling can never lose a real outcome.
- Historical reasoning closes at its own `start`, so a snapshot reopened days later does not bill the outage as thinking time.
- The `tool_call` branch now closes a preceding open reasoning part, which also fixes the duration reported for it.

**Web — presentation, robust on its own**
- `activityStatus` reads live tool states from an allow-list (`pending`, `running`, `in_progress`) instead of "anything that is not `completed` or `error`", so no unknown or settled state can hold a section on `Working` again.
- `incomplete` gets its own presentation in both conversation UIs: a closed row with no result, rather than the running ellipsis or the failure mark.

**Docs** — `docs/DEPENDENCIES.md` records that a closing `tool_call_update` is explicitly *not* assumed from the Claude adapter, and where that is handled.

## Validation

- `bridge`: 425 pass, 0 fail (10 new — a Claude adapter that opens a tool call it never closes, a live turn that must keep reading `running`, abort mid-call, a turn that does close its calls, replayed history, a snapshot written mid-turn, and the reported-idle path).
- `web`: `conversation-parts` 11 pass; `test:ui`, `test:settings`, `test:v3-product-ui`, `test:i18n` and every other runnable suite pass. `test:native-session-home` needs `vite`, which is not installed in this environment.

## On the change already in #307

Kept, not reverted: it does clear a genuinely stale `#active` flag, and reverting risks bringing back the Session-level symptom seen on device. Two pre-existing effects of it, neither introduced here: a queued prompt between turns now reads **idle** while work is still outstanding, and `#startTurn` emits `session.updated` just before the ACP request is registered, so a status read in that window reports idle too. Both are transient presentation flickers; the narrow fix is to let the corroboration see the queue, not to loosen the staleness rule again.

No behaviour change for PI, OMP, Codex or OpenCode beyond the shared `AcpService` settling, which is correct for every harness: nothing a finished turn started is still running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtzJpReZsPDXPQreDv1xXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtzJpReZsPDXPQreDv1xXQ)_