### PR TITLE
v3: make older chat history loading unobtrusive and stable

### DIFF
--- a/web/src/components/taskdesk-conversation.tsx
+++ b/web/src/components/taskdesk-conversation.tsx
@@ -3,6 +3,7 @@ import type { MessageEnvelope } from "../types"
 import { ChatIcon, JumpToBottomIcon, JumpToTopIcon, LoadingIcon, StopCircleIcon } from "../Icons"
 import "../taskdesk-conversation.css"
 import "../taskdesk-conversation-fixes.css"
+import "../taskdesk-history-loader.css"
 import { TaskDeskMessageContent } from "./taskdesk-message-content"
 
 const HARNESS_ICON_FILES: Record<string, string> = {
@@ -213,15 +214,27 @@ const ConversationTranscript = memo(function ConversationTranscript({
     const requestOlder = loadOlderRef.current
     if (!requestOlder || !hasMore || loadingOlder) return
     const transcript = transcriptRef.current
-    const previousHeight = transcript?.scrollHeight ?? 0
     const previousTop = transcript?.scrollTop ?? 0
+
+    // History loading is an explicit move away from the live tail. Cancel any already-scheduled
+    // follow frame before it can race the prepend and snap the transcript back to the newest turn.
+    nearBottomRef.current = false
     preservingOlderRef.current = true
+    if (followFrameRef.current !== undefined) {
+      window.cancelAnimationFrame(followFrameRef.current)
+      followFrameRef.current = undefined
+    }
+
     try {
       await requestOlder()
       window.requestAnimationFrame(() => {
         const current = transcriptRef.current
         if (current) {
-          current.scrollTop = previousTop + (current.scrollHeight - previousHeight)
+          // The history affordance is reached at the top of the transcript. Keep the same top-relative
+          // position so the newly prepended messages are actually revealed. Compensating by their
+          // added height could put a short initial page straight back at the bottom of the chat.
+          current.scrollTop = Math.max(0, Math.min(previousTop, current.scrollHeight - current.clientHeight))
+          nearBottomRef.current = false
           refreshJumpAffordances(current)
         }
         preservingOlderRef.current = false
@@ -272,9 +285,16 @@ const ConversationTranscript = memo(function ConversationTranscript({
           <>
             {hasMore ? (
               <div className="uw-history-loader">
-                <button type="button" className="uw-button uw-button-ghost" disabled={loadingOlder} onClick={() => void loadOlder()}>
-                  {loadingOlder ? <LoadingIcon size={15} /> : null}
-                  {loadingOlder ? "Loading older messages…" : "Load older messages"}
+                <button
+                  type="button"
+                  className="uw-history-load"
+                  disabled={loadingOlder}
+                  onClick={() => void loadOlder()}
+                  title={loadingOlder ? "Loading earlier messages" : "Load earlier messages"}
+                  aria-label={loadingOlder ? "Loading earlier messages" : "Load earlier messages"}
+                >
+                  {loadingOlder ? <LoadingIcon size={13} /> : <JumpToTopIcon size={13} />}
+                  <span>{loadingOlder ? "Loading…" : "Earlier messages"}</span>
                 </button>
               </div>
             ) : null}

--- a/web/src/taskdesk-history-loader.css
+++ b/web/src/taskdesk-history-loader.css
@@ -1,0 +1,76 @@
+/* Paginated chat history is a secondary transcript affordance, not a primary action. Keep it quiet,
+   in the reading flow, and visually distinct from the composer and toolbar buttons. */
+.uw-history-loader {
+  width: min(1040px, 100%);
+  margin: 0 auto 14px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 2px 0 6px;
+  overflow-anchor: none;
+}
+
+.uw-history-loader::before,
+.uw-history-loader::after {
+  content: "";
+  min-width: 20px;
+  height: 1px;
+  flex: 1;
+  background: var(--td3-border-soft);
+}
+
+.uw-history-load {
+  min-height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border: 0;
+  border-radius: 999px;
+  color: var(--td3-muted);
+  background: transparent;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 680;
+  line-height: 1;
+  letter-spacing: .01em;
+  cursor: pointer;
+  touch-action: manipulation;
+  transition: color 120ms ease, background 120ms ease;
+}
+
+.uw-history-load:hover,
+.uw-history-load:focus-visible {
+  color: var(--td3-text);
+  background: var(--td3-raise-1);
+}
+
+.uw-history-load:focus-visible {
+  outline: 2px solid var(--td3-blue-border);
+  outline-offset: 2px;
+}
+
+.uw-history-load:disabled {
+  cursor: default;
+  opacity: .7;
+}
+
+.uw-history-load svg {
+  flex: none;
+}
+
+@media (pointer: coarse) {
+  .uw-history-load {
+    min-height: 36px;
+    padding-inline: 12px;
+  }
+}
+
+@media (max-width: 780px) {
+  .uw-history-loader {
+    width: 100%;
+    margin-bottom: 10px;
+    gap: 8px;
+  }
+}

--- a/web/src/taskdesk-home.test.mjs
+++ b/web/src/taskdesk-home.test.mjs
@@ -132,7 +132,9 @@ test("Session UI preserves stable autoscroll memoized rows and mobile keyboard b
 
   assert.match(source, /const MessageBubble = memo/)
   assert.match(source, /NEAR_BOTTOM_PX = 96/)
-  assert.match(source, /previousHeight/)
+  assert.match(source, /nearBottomRef\.current = false/)
+  assert.match(source, /window\.cancelAnimationFrame\(followFrameRef\.current\)/)
+  assert.doesNotMatch(source, /previousHeight/)
   assert.match(source, /\[messages, loading, ready, sending\]/)
   assert.match(source, /window\.requestAnimationFrame/)
   assert.match(mobileCss, /env\(safe-area-inset-bottom/)

--- a/web/src/taskdesk-message-paging.test.mjs
+++ b/web/src/taskdesk-message-paging.test.mjs
@@ -71,9 +71,10 @@ test("older pages prepend without duplicating the cursor boundary", () => {
   assert.equal(merged[2], currentC)
 })
 
-test("Session conversation exposes bounded older-history loading through the shared conversation core", () => {
+test("Session conversation exposes bounded older-history loading without snapping back to the live tail", () => {
   const workspace = readFileSync(new URL("./components/universal-workspace.tsx", import.meta.url), "utf8")
   const conversation = readFileSync(new URL("./components/taskdesk-conversation.tsx", import.meta.url), "utf8")
+  const historyStyles = readFileSync(new URL("./taskdesk-history-loader.css", import.meta.url), "utf8")
 
   assert.match(workspace, /api\.loadMessagePage\(item\.config, item\.session\.id, item\.session\.directory\)/)
   assert.match(workspace, /silent \? mergeLatestMessagePage\(current\.messages, messagePage\.messages\) : messagePage\.messages/)
@@ -82,9 +83,16 @@ test("Session conversation exposes bounded older-history loading through the sha
   assert.match(workspace, /onLoadOlder=\{loadOlderMessages\}/)
   assert.match(workspace, /hasMore=\{messageHasMore\}/)
 
-  assert.match(conversation, /Load older messages/)
-  assert.match(conversation, /const previousHeight = transcript\?\.scrollHeight \?\? 0/)
-  assert.match(conversation, /const previousTop = transcript\?\.scrollTop \?\? 0/)
-  assert.match(conversation, /current\.scrollTop = previousTop \+ \(current\.scrollHeight - previousHeight\)/)
+  assert.match(conversation, /taskdesk-history-loader\.css/)
+  assert.match(conversation, /className="uw-history-load"/)
+  assert.match(conversation, /Earlier messages/)
+  assert.match(conversation, /nearBottomRef\.current = false/)
+  assert.match(conversation, /window\.cancelAnimationFrame\(followFrameRef\.current\)/)
   assert.match(conversation, /preservingOlderRef\.current = true/)
+  assert.match(conversation, /current\.scrollTop = Math\.max\(0, Math\.min\(previousTop, current\.scrollHeight - current\.clientHeight\)\)/)
+  assert.doesNotMatch(conversation, /current\.scrollTop = previousTop \+ \(current\.scrollHeight - previousHeight\)/)
+
+  assert.match(historyStyles, /\.uw-history-loader::before/)
+  assert.match(historyStyles, /\.uw-history-load/)
+  assert.match(historyStyles, /overflow-anchor: none/)
 })


### PR DESCRIPTION
## Problem

Long native Session chats paginate correctly, but the history affordance was a generic large ghost button dropped at the top of the transcript. More importantly, loading an older page compensated for the newly prepended height by adding that height to `scrollTop`. When the currently loaded page was short or only just filled the viewport, that compensation could put the user straight back at the bottom after explicitly asking for older history.

## Fix

- keep pagination explicit and available only in the transcript's top history area;
- replace the generic CTA with a compact inline `Earlier messages` affordance, visually integrated into the transcript with subtle separator lines;
- when older history is requested, leave live-tail follow mode and cancel any already scheduled follow-to-bottom frame;
- after the page is prepended, keep the same top-relative scroll position instead of compensating for the inserted height, so the newly loaded older messages are revealed rather than hidden above the viewport;
- keep the control keyboard accessible, touch friendly, and provide a compact loading state;
- add a regression guard that rejects the old height-compensation scroll formula and verifies the dedicated history styling.

## Scope

This is deliberately limited to the shared `TaskDeskConversation` paging UX. It does not change message paging, cursor semantics, Session storage, backend behavior, live refresh, model handling, or the checkpoint branch directly.

## Validation

- branch is based directly on `checkpoint/v3-session-first-working-2026-08-25`;
- diff is limited to the shared conversation component, one dedicated stylesheet, and the existing paging regression test;
- automated PR checks should validate type-check, regression suite, product smoke, and platform builds.
