### PR TITLE
fix(v3): rebuild the OMP ACP path from the baseline

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -69,6 +69,7 @@ jobs:
           node src/v3-mobile-regression-fixes.test.mjs
           node src/session-first-regression.test.mjs
           node scripts/run-vite-test.mjs src/native-session-discovery.test.mjs src/native-session-continuation.test.mjs
+          node scripts/run-vite-test.mjs src/omp-session-multi-turn.test.mjs src/omp-session-model-projection.test.mjs
           node src/native-session-observer.test.mjs
           npm run test:native-session-model-lifecycle
         working-directory: web

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -11,6 +11,7 @@
     "start": "node src/cli.js",
     "daemon": "node src/daemon-cli.js",
     "audit:probe": "node scripts/backend-audit-probe.mjs",
+    "smoke:omp": "node scripts/omp-real-smoke.mjs",
     "test": "node --test"
   },
   "engines": {

--- a/bridge/scripts/omp-real-smoke.mjs
+++ b/bridge/scripts/omp-real-smoke.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/*
+ * Drive a real `omp acp` installation through the multi-turn Session lifecycle.
+ *
+ * A fake, however carefully it is written against the upstream source, can only prove that the
+ * bridge is consistent with what we read. This runs the same code against the OMP the user actually
+ * has, and reports the five facts the fake asserts:
+ *
+ *   1. the adapter advertises `session/resume`, so the writer can be taken without a replay;
+ *   2. a new Session answers its first prompt;
+ *   3. it answers the ones after it, in the same Session, without a `session/load`;
+ *   4. every read hands back the same identity for a message it already returned;
+ *   5. every answer converges on its complete text.
+ *
+ * It writes real Sessions into the OMP session directory of whoever runs it, and spends real
+ * tokens, so it is deliberately opt-in and never part of CI:
+ *
+ *   node bridge/scripts/omp-real-smoke.mjs [--cwd <absolute path>] [--turns 3]
+ */
+import { AcpClient } from "../src/acp-client.js"
+import { AcpPromptEchoFilter } from "../src/acp-prompt-echo-filter.js"
+import { AcpService } from "../src/acp-service.js"
+import { HARNESS_PROFILES, resolveAcpLaunch } from "../src/harness-profiles.js"
+import { findExecutable } from "../src/launcher.js"
+
+function argument(name, fallback) {
+  const index = process.argv.indexOf(`--${name}`)
+  return index >= 0 && process.argv[index + 1] ? process.argv[index + 1] : fallback
+}
+
+const directory = argument("cwd", process.cwd())
+const turns = Math.max(1, Number(argument("turns", "3")) || 3)
+const profile = HARNESS_PROFILES.omp
+
+if (!findExecutable(profile.command)) {
+  console.error("`omp` is not on PATH. Install Oh My Pi first; this smoke deliberately does not fake it.")
+  process.exit(2)
+}
+
+const launch = resolveAcpLaunch(profile)
+const acp = new AcpClient({ command: launch.command, args: launch.args, permissionMode: profile.permissionMode })
+const service = new AcpService(new AcpPromptEchoFilter(acp), {
+  historyLoader: profile.historyLoader,
+  reloadOnHistoryRefresh: profile.reloadOnHistoryRefresh,
+  journalPageWhileOwned: profile.journalPageWhileOwned !== false,
+  modelVariantConfigIDs: profile.modelVariantConfigIDs
+})
+
+const loads = []
+const originalRequest = acp.request.bind(acp)
+acp.request = (method, params, timeout) => {
+  if (method === "session/load" || method === "session/resume") loads.push(method)
+  return originalRequest(method, params, timeout)
+}
+
+const failures = []
+function check(condition, description) {
+  console.log(`${condition ? "ok  " : "FAIL"} ${description}`)
+  if (!condition) failures.push(description)
+}
+
+function text(messages) {
+  return messages.map((message) => [
+    message.info.role,
+    message.parts.filter((part) => part.type === "text").map((part) => part.text).join("")
+  ])
+}
+
+try {
+  await acp.start()
+  console.log(`OMP ${acp.agentInfo?.version ?? "?"} via ${launch.command} (${launch.source})`)
+  check(Boolean(acp.sessionCapabilities?.resume), "advertises session/resume")
+
+  const created = await service.createSession({ directory, title: "Harness Remote smoke" })
+  console.log(`session ${created.id} in ${directory}`)
+
+  let previous = []
+  for (let turn = 1; turn <= turns; turn += 1) {
+    const prompt = `Reply with exactly this and nothing else: SMOKE-${turn}`
+    await service.promptAndWait(created.id, prompt)
+    const messages = (await service.messagePage(created.id, { limit: 200 })).messages
+    const ids = messages.map((message) => message.info.id)
+
+    check(
+      messages.some((message) => message.info.role === "user" && message.parts.some((part) => part.text === prompt)),
+      `turn ${turn}: the prompt is in the transcript`
+    )
+    const answer = text(messages).filter(([role]) => role === "assistant").at(-1)?.[1] ?? ""
+    check(answer.includes(`SMOKE-${turn}`), `turn ${turn}: the complete answer is present (${JSON.stringify(answer.slice(0, 80))})`)
+    check(new Set(ids).size === ids.length, `turn ${turn}: no message appears twice`)
+    check(
+      previous.every((id, index) => ids[index] === id),
+      `turn ${turn}: earlier messages keep the identity the previous read gave them`
+    )
+    previous = ids
+    check(service.status(created.id).type === "idle", `turn ${turn}: the Session is Ready again`)
+  }
+
+  check(!loads.includes("session/load"), `no session/load was needed (calls: ${loads.join(", ") || "none"})`)
+} catch (error) {
+  failures.push(error instanceof Error ? error.message : String(error))
+  console.error(error)
+} finally {
+  acp.close()
+}
+
+if (failures.length) {
+  console.error(`\n${failures.length} check(s) failed`)
+  process.exit(1)
+}
+console.log("\nall checks passed")

--- a/bridge/src/acp-client.js
+++ b/bridge/src/acp-client.js
@@ -33,6 +33,7 @@ export class AcpClient extends EventEmitter {
   #starting
   #agentInfo
   #promptCapabilities = {}
+  #sessionCapabilities = {}
   #stderr = ""
   #stderrPartial = ""
 
@@ -55,6 +56,18 @@ export class AcpClient extends EventEmitter {
    */
   get promptCapabilities() {
     return this.#promptCapabilities
+  }
+
+  /**
+   * Which session operations the agent advertised in `initialize`.
+   *
+   * ACP lets an agent offer `session/resume` next to `session/load`, and the two are not
+   * interchangeable: an agent that advertises `resume` opens a stored Session without replaying it.
+   * The bridge only ever sends a method the running adapter said it has, so an older build of the
+   * same harness keeps working on the method it does advertise.
+   */
+  get sessionCapabilities() {
+    return this.#sessionCapabilities
   }
 
   /** PID identifies extension runtime state published by this exact ACP process. */
@@ -151,6 +164,7 @@ export class AcpClient extends EventEmitter {
       }, remaining("initialize"))
       this.#agentInfo = initialized.agentInfo
       this.#promptCapabilities = initialized.agentCapabilities?.promptCapabilities ?? {}
+      this.#sessionCapabilities = initialized.agentCapabilities?.sessionCapabilities ?? {}
       // The bridge always runs beside a harness the user already configured, so prefer a method
       // that uses those credentials. PI's adapter offers `anthropic-api-key` first and
       // `pi-stored-credentials` last: picking the first would claim an API key from an

--- a/bridge/src/acp-prompt-echo-filter.js
+++ b/bridge/src/acp-prompt-echo-filter.js
@@ -37,6 +37,7 @@ export class AcpPromptEchoFilter extends EventEmitter {
   }
 
   get promptCapabilities() { return this.#acp.promptCapabilities }
+  get sessionCapabilities() { return this.#acp.sessionCapabilities }
   get agentInfo() { return this.#acp.agentInfo }
   get processID() { return this.#acp.processID }
 

--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -321,6 +321,8 @@ export class AcpService {
   #replaySettleMs
   #preferListedTitles
   #nativeRenameCommand
+  #journalPageWhileOwned
+  #modelVariantConfigIDs
   constructor(acp, {
     snapshotDirectory,
     historyLoader,
@@ -329,6 +331,24 @@ export class AcpService {
     replaySettleMs = 0,
     preferListedTitles = false,
     nativeRenameCommand,
+    /**
+     * Whether a paged read of a Session this bridge owns may still be answered from the harness's
+     * journal instead of from the stream this bridge is holding.
+     *
+     * It may for every harness whose journal and whose ACP stream describe a message with the same
+     * identity. OMP is the one that does not: its journal keys a message by the entry id it wrote,
+     * while its ACP stream mints a fresh `messageId` per live message and a fresh one again on
+     * every replay. Answering one read from each source therefore hands the app two different ids
+     * for one reply, and an app that reconciles pages by id has no way to tell that apart from two
+     * replies - which is what made a second turn look blank until the conversation was reopened.
+     */
+    journalPageWhileOwned = true,
+    /**
+     * Config-option ids this harness uses for the reasoning variant that belongs to a model.
+     * Only used to report the Session's current selection; a variant is still applied against an
+     * id the running adapter actually advertised.
+     */
+    modelVariantConfigIDs = [],
     actionProviders = []
   } = {}) {
     this.#acp = acp
@@ -339,6 +359,8 @@ export class AcpService {
     this.#replaySettleMs = replaySettleMs
     this.#preferListedTitles = preferListedTitles
     this.#nativeRenameCommand = nativeRenameCommand
+    this.#journalPageWhileOwned = journalPageWhileOwned
+    this.#modelVariantConfigIDs = modelVariantConfigIDs
     this.#actionProviders = actionProviders
     acp.on("notification", (notification) => this.#handleNotification(notification))
   }
@@ -576,7 +598,7 @@ export class AcpService {
 
   async messagePage(sessionID, { limit = 100, before, refresh = false } = {}) {
     const boundedLimit = Math.max(1, Math.min(500, Number(limit) || 100))
-    if (typeof this.#historyLoader?.page === "function" && !refresh && !this.#isBusy(sessionID)) {
+    if (this.#journalPageAvailable(sessionID) && !refresh && !this.#isBusy(sessionID)) {
       try {
         let pageOptions = { limit: boundedLimit, before }
         if (this.#historyLoader.pageRequiresActiveLeaf) {
@@ -599,10 +621,54 @@ export class AcpService {
       : messages.length
     const end = requestedEnd >= 0 ? requestedEnd : messages.length
     const start = Math.max(0, end - boundedLimit)
+    const model = this.#configuredModelSelection(sessionID)
     return {
       messages: messages.slice(start, end),
       before: start > 0 ? messages[start]?.info?.id ?? null : null,
-      hasMore: start > 0
+      hasMore: start > 0,
+      ...(model ? { model } : {})
+    }
+  }
+
+  /**
+   * Whether this exact Session's paged read may be served from the harness's own journal.
+   *
+   * A loader that declares itself authoritative answers every read from the journal, so paging from
+   * it is the same source. Otherwise the journal is the authority only while this bridge is not the
+   * writer - and a harness may opt out of journal paging even then, see `journalPageWhileOwned`.
+   */
+  #journalPageAvailable(sessionID) {
+    if (typeof this.#historyLoader?.page !== "function") return false
+    if (this.#historyLoader.authoritativeHistory === true) return true
+    if (this.#journalBacked(sessionID)) return true
+    return this.#journalPageWhileOwned
+  }
+
+  /**
+   * The model this Session is configured with, for the harnesses whose owned pages no longer come
+   * from the journal that used to report it.
+   *
+   * The value is the one the adapter itself last returned for the `model` config option, so it
+   * costs no I/O and cannot disagree with what the next prompt would run on. It is addressed the
+   * way the app addresses models everywhere, `provider/model`; a harness whose ids carry no
+   * provider reports nothing here rather than inventing one.
+   */
+  #configuredModelSelection(sessionID) {
+    if (this.#journalPageWhileOwned) return undefined
+    const options = this.#configOptions.get(sessionID)
+    const current = options?.find((item) => item.id === "model")?.currentValue
+    if (typeof current !== "string") return undefined
+    const separator = current.indexOf("/")
+    if (separator <= 0 || separator === current.length - 1) return undefined
+    // The reasoning variant belongs to the selection: reporting the model without it would let the
+    // app carry the next turn on with the variant silently dropped.
+    const variant = this.#modelVariantConfigIDs
+      .map((configId) => options?.find((item) => item.id === configId)?.currentValue)
+      .find((value) => typeof value === "string" && value)
+    return {
+      providerID: current.slice(0, separator),
+      modelID: current.slice(separator + 1),
+      ...(variant ? { variant } : {})
     }
   }
 
@@ -782,6 +848,13 @@ export class AcpService {
       ? model
       : option?.options?.find((candidate) => candidate.value === model.slice(model.indexOf("/") + 1))?.value
     if (!value) throw new Error(`Harness model is not available: ${model}`)
+    // Continuing on the model the Session already holds is not a model change. Sending it anyway
+    // made every prompt mutate the Session's configuration, which a harness is entitled to journal
+    // and to announce - so simply carrying on read as though the user had switched models.
+    if (option?.currentValue === value) {
+      await this.#setModelVariant(sessionID, variant)
+      return
+    }
     const changed = await this.#acp.request("session/set_config_option", { sessionId: sessionID, configId: "model", value })
     // Adopt the options the adapter reports for the model it now holds. A harness whose dependent
     // controls differ per model - PI advertises a different thinkingLevel range for each one, from a
@@ -1026,8 +1099,13 @@ export class AcpService {
     const writing = (async () => {
       await mkdir(this.#snapshotDirectory, { recursive: true })
       while (this.#dirtySnapshots.delete(sessionID)) {
+        // A transcript the journal can rebuild is not written into the snapshot: the snapshot would
+        // only be able to restore it under this process's own ids, and the next read replaces it
+        // from the journal anyway. That covers a harness whose journal is authoritative, a Session
+        // this bridge does not write, and a harness whose stream only ever seeds from the journal.
         const journalOwnsTranscript = Boolean(
-          this.#historyLoader && (this.#historyLoader.authoritativeHistory || this.#journalBacked(sessionID))
+          this.#historyLoader
+          && (this.#historyLoader.authoritativeHistory || this.#journalBacked(sessionID) || this.#journalSeedsOwnedTranscript())
         )
         const snapshot = JSON.stringify({
           version: 1,
@@ -1155,7 +1233,31 @@ export class AcpService {
         const persistedMessages = await this.#historyLoader(sessionID, {
           activeSessionLeaf: authoritativeState?.activeSessionLeaf
         })
-        if (persistedMessages.length > 0 || authoritativeState) {
+        if (this.#journalSeedsOwnedTranscript()) {
+          // The journal is the whole conversation while nothing here is writing it, and the seed
+          // for the stream once something is. Merging the two would union two id spaces for the
+          // same messages, which is exactly what the single-source page rule above avoids, so the
+          // journal is taken whole or not at all:
+          //  - while it is the authority, on every read;
+          //  - once more as this bridge takes the writer, so the last thing the harness wrote on
+          //    its own is not missed;
+          //  - when the caller says the branch itself changed, which is what an undo or redo is;
+          //  - and to refill a transcript the cache dropped, which would otherwise read as empty.
+          const seedFromJournal = this.#journalBacked(sessionID)
+            || replaceHistory
+            || !this.#acpOpenSessions.has(sessionID)
+            || previousMessages.length === 0
+          if (seedFromJournal) {
+            previousMessages = mergeFragmentedPiSnapshot(persistedMessages)
+            this.#messages.set(sessionID, previousMessages)
+          }
+          if (this.#journalBacked(sessionID) && !requireConfigOptions) {
+            this.#todos.set(sessionID, [])
+            this.#loaded.add(sessionID)
+            this.#persistSnapshot(sessionID)
+            return
+          }
+        } else if (persistedMessages.length > 0 || authoritativeState) {
           previousMessages = authoritativeState
             ? persistedMessages
             : mergeExternalHistory(persistedMessages, previousMessages)
@@ -1168,28 +1270,19 @@ export class AcpService {
             return
           }
         }
-        // OMP's journal deliberately refuses to guess a branch when its optional
-        // extension did not publish an active leaf.  Replaying through ACP is not
-        // a safe fallback for an externally-owned Session: it can take minutes
-        // (or acquire the Session) merely to render an empty attachment-only
-        // transcript.  Such a Session stays observational until the user takes
-        // ownership by sending a prompt or explicitly asks for its config.
-        if (
-          this.#journalBacked(sessionID) &&
-          !requireConfigOptions &&
-          this.#historyLoader.deferAcpReplayWithoutActiveLeaf === true &&
-          authoritativeState?.activeSessionLeaf === undefined
-        ) {
-          this.#messages.set(sessionID, previousMessages)
-          this.#todos.set(sessionID, [])
-          this.#loaded.add(sessionID)
-          this.#persistSnapshot(sessionID)
-          return
-        }
-      } catch {
+      } catch (error) {
         this.#emit("session.error", sessionID, { message: "Harness session history could not be read" })
+        // A harness whose ACP load is a replay has no second source to fall back on, so an
+        // unreadable journal has to be reported as a failed read. Answering with an empty
+        // transcript instead is how a Session that is merely unreadable came to look deleted.
+        if (this.#historyLoader.journalOnly === true) {
+          this.#messages.set(sessionID, previousMessages)
+          this.#todos.set(sessionID, previousTodos)
+          throw error
+        }
       }
     }
+    if (await this.#openWithoutReplay(sessionID, session)) return
     this.#replaying.add(sessionID)
     this.#messages.set(sessionID, [])
     this.#todos.set(sessionID, [])
@@ -1227,6 +1320,47 @@ export class AcpService {
     } finally {
       this.#replaying.delete(sessionID)
     }
+  }
+
+  /**
+   * Whether the journal seeds this harness's owned transcript instead of being merged into it.
+   *
+   * True for exactly the harnesses that opted out of journal paging while owned: those are the ones
+   * whose journal ids and stream ids are different identities for the same message, so the two are
+   * used one after the other - journal until this bridge starts writing, its own stream from then
+   * on - rather than reconciled against each other on every read.
+   */
+  #journalSeedsOwnedTranscript() {
+    return this.#historyLoader?.authoritativeHistory !== true && !this.#journalPageWhileOwned
+  }
+
+  /**
+   * Open one stored Session on the ACP connection without asking for its transcript back.
+   *
+   * `session/load` is defined to replay: OMP answers it by re-emitting every stored message as a
+   * notification under a freshly minted id, including the developer, hook and tool-output records
+   * it flattens into `user_message_chunk`s. For a Session whose transcript already came from the
+   * journal that replay is pure cost - minutes of notifications on a long conversation - and pure
+   * harm, because the ids it invents do not match the ones the app was just given, and the
+   * pseudo-user messages in it are not turns anyone typed.
+   *
+   * ACP's own answer to this is `session/resume`, which opens the same stored Session and returns
+   * the same `configOptions` with no replay at all. It is used only when the running adapter
+   * advertised it, so an older build of the same harness still opens through `session/load`.
+   */
+  async #openWithoutReplay(sessionID, session) {
+    if (!this.#journalSeedsOwnedTranscript()) return false
+    if (!this.#acp.sessionCapabilities?.resume) return false
+    const result = await this.#acp.request(
+      "session/resume",
+      { sessionId: sessionID, cwd: session.cwd, mcpServers: [] },
+      300_000
+    )
+    this.#acpOpenSessions.add(sessionID)
+    this.#rememberConfigOptions(sessionID, result?.configOptions)
+    this.#loaded.add(sessionID)
+    this.#persistSnapshot(sessionID)
+    return true
   }
 
   async #refreshSessions() {

--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -406,7 +406,9 @@ export class AcpService {
     const session = {
       sessionId: result.sessionId,
       cwd: directory,
-      title: title || "Remote session",
+      // No invented placeholder: an unnamed Session is named by the harness itself from its first
+      // message, and until then the caller's own fallback is the honest label.
+      ...(title ? { title } : {}),
       updatedAt: new Date().toISOString(),
       _meta: { messageCount: 0 }
     }

--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -415,7 +415,10 @@ export class AcpService {
     this.#todos.set(session.sessionId, [])
     this.#loaded.add(session.sessionId)
     this.#ownedSessions.add(session.sessionId)
-    if (title) this.#titles.set(session.sessionId, title)
+    if (title) {
+      this.#titles.set(session.sessionId, title)
+      await this.#applyNativeSessionName(session.sessionId, title)
+    }
     if (model) await this.setModel(session.sessionId, model)
     this.#emit("session.created", session.sessionId)
     this.#persistSnapshot(session.sessionId)
@@ -504,24 +507,8 @@ export class AcpService {
       )
     }
 
-    if (this.#nativeRenameCommand) {
-      await this.#load(sessionID, true)
-      const messagesBefore = structuredClone(this.#messages.get(sessionID) ?? [])
-      const todosBefore = structuredClone(this.#todos.get(sessionID) ?? [])
-      const wasActive = this.#active.has(sessionID)
-      if (!wasActive) this.#active.add(sessionID)
-      try {
-        await this.#acp.request("session/prompt", {
-          sessionId: sessionID,
-          prompt: [{ type: "text", text: `/${this.#nativeRenameCommand} ${normalized}` }]
-        }, 300_000)
-      } finally {
-        if (!wasActive) this.#active.delete(sessionID)
-        this.#messages.set(sessionID, messagesBefore)
-        this.#todos.set(sessionID, todosBefore)
-        this.#chunkMessageIDs.delete(`${sessionID}:user`)
-        this.#chunkMessageIDs.delete(`${sessionID}:assistant`)
-      }
+    if (await this.#nativeRenameAvailable(sessionID)) {
+      await this.#sendNativeSessionName(sessionID, normalized)
       this.#titles.delete(sessionID)
       await this.#refreshSessions()
       const session = this.#sessions.get(sessionID)
@@ -545,6 +532,69 @@ export class AcpService {
       normalized,
       Boolean(this.#historyLoader && !this.#ownedSessions.has(sessionID))
     )
+  }
+
+  /**
+   * Whether this exact Session can be named through the harness's own rename command.
+   *
+   * A name Harness Remote only keeps for itself is invisible everywhere else: the Session index the
+   * app reads is the harness's own lightweight listing, and a Session reopened from the harness has
+   * never heard of it. Asking the harness to store the name is what makes it survive - but only a
+   * command the running build actually advertises may be sent, because an unrecognised slash
+   * command is not an error, it is a prompt the model would try to answer.
+   */
+  async #nativeRenameAvailable(sessionID) {
+    if (!this.#nativeRenameCommand) return false
+    // The command is delivered into this exact Session, so the Session has to be open on this
+    // connection before it can be asked for - and its command catalog only arrives with that open.
+    await this.#loadForConfigOptions(sessionID)
+    if (!this.#commandCatalogs.has(sessionID)) await this.#waitForCommandCatalog(sessionID)
+    return (this.#commandCatalogs.get(sessionID) ?? []).some((command) => command.name === this.#nativeRenameCommand)
+  }
+
+  /**
+   * Run the harness's rename command without letting it show up as a turn.
+   *
+   * The command is delivered the only way a slash command can be, as a prompt, and the harness
+   * answers it with a confirmation line. That line is not conversation, so the transcript and todos
+   * are captured before and restored after; the session is marked active meanwhile so the harness's
+   * own output is not mistaken for unsolicited streaming.
+   */
+  async #sendNativeSessionName(sessionID, title) {
+    const messagesBefore = structuredClone(this.#messages.get(sessionID) ?? [])
+    const todosBefore = structuredClone(this.#todos.get(sessionID) ?? [])
+    const wasActive = this.#active.has(sessionID)
+    if (!wasActive) this.#active.add(sessionID)
+    try {
+      await this.#acp.request("session/prompt", {
+        sessionId: sessionID,
+        prompt: [{ type: "text", text: `/${this.#nativeRenameCommand} ${title}` }]
+      }, 300_000)
+    } finally {
+      if (!wasActive) this.#active.delete(sessionID)
+      this.#messages.set(sessionID, messagesBefore)
+      this.#todos.set(sessionID, todosBefore)
+      this.#chunkMessageIDs.delete(`${sessionID}:user`)
+      this.#chunkMessageIDs.delete(`${sessionID}:assistant`)
+    }
+  }
+
+  /**
+   * Give a Session the name it was created with, for a harness whose create call has no title.
+   *
+   * `session/new` carries no title in ACP, so a name chosen in the New Session panel would only
+   * ever have lived in this bridge. Creating the Session must not fail because naming it did, so a
+   * harness that cannot store the name keeps it here instead - which is exactly what it did before.
+   */
+  async #applyNativeSessionName(sessionID, title) {
+    try {
+      if (!await this.#nativeRenameAvailable(sessionID)) return
+      await this.#sendNativeSessionName(sessionID, title)
+      this.#titles.delete(sessionID)
+      await this.#refreshSessions()
+    } catch {
+      this.#titles.set(sessionID, title)
+    }
   }
 
   async deleteSession(sessionID) {
@@ -1415,18 +1465,24 @@ export class AcpService {
     return messageID
   }
 
-  /** ACP session listings may carry no title, so keep the creation title or derive one from the first prompt. */
+  /**
+   * ACP session listings may carry no title, so keep the creation title or derive one from the
+   * first prompt.
+   *
+   * A title held here is one someone set and the harness could not be asked to store - every path
+   * that does hand the name to the harness drops it again, so the listing stays the authority in
+   * the normal case. Until then it outranks the listing, otherwise renaming a Session on a harness
+   * that cannot store names would appear to do nothing at all.
+   */
   #titleFor(sessionID) {
-    const listed = this.#sessions.get(sessionID)?.title?.trim()
-    if (this.#preferListedTitles && listed) return listed
     const known = this.#titles.get(sessionID)
     if (known) return known
+    const listed = this.#sessions.get(sessionID)?.title?.trim()
+    if (this.#preferListedTitles && listed) return listed
     const firstPrompt = this.#messages.get(sessionID)?.find((message) => message.info.role === "user")
     const text = firstPrompt?.parts?.[0]?.text?.trim()
     if (!text) return undefined
-    const derived = text.split("\n")[0].slice(0, 60)
-    this.#titles.set(sessionID, derived)
-    return derived
+    return text.split("\n")[0].slice(0, 60)
   }
 
   #isAcknowledgedPromptChunk(sessionID, text) {

--- a/bridge/src/harness-profiles.js
+++ b/bridge/src/harness-profiles.js
@@ -32,6 +32,12 @@ export const HARNESS_PROFILES = {
     // is therefore the transcript until this bridge takes the writer, and this bridge's own stream
     // is the transcript from then on - never both at once. See AcpService#journalPageWhileOwned.
     journalPageWhileOwned: false,
+    // OMP stores a Session's name itself - `/rename` calls `setSessionName(title, "user")`, which
+    // writes the title slot and marks it user-set so OMP's own auto-titling leaves it alone. A name
+    // kept only in this bridge's snapshot was invisible in the Session index, which reads the
+    // harness's lightweight listing, and gone entirely for a Session reopened from OMP.
+    nativeRenameCommand: "rename",
+    preferListedTitles: true,
     // A transcript that already came from the journal must not be asked for again over ACP, so an
     // owned OMP Session is opened with `session/resume` rather than the replaying `session/load`.
     // Reloading on refresh would reintroduce exactly that replay.

--- a/bridge/src/harness-profiles.js
+++ b/bridge/src/harness-profiles.js
@@ -26,6 +26,16 @@ export const HARNESS_PROFILES = {
     args: ["acp"],
     permissionMode: "allow",
     historyLoader: createOmpHistoryLoader(),
+    // OMP's journal is the only place a message has a stable identity. Its ACP stream mints a new
+    // `messageId` for every live message and mints new ones again on every `session/load` replay,
+    // so a Session read once from each source is one conversation with two sets of ids. The journal
+    // is therefore the transcript until this bridge takes the writer, and this bridge's own stream
+    // is the transcript from then on - never both at once. See AcpService#journalPageWhileOwned.
+    journalPageWhileOwned: false,
+    // A transcript that already came from the journal must not be asked for again over ACP, so an
+    // owned OMP Session is opened with `session/resume` rather than the replaying `session/load`.
+    // Reloading on refresh would reintroduce exactly that replay.
+    reloadOnHistoryRefresh: false,
     // OMP exposes thinking as a real ACP config option. We probe only ids the running adapter
     // actually advertises; this list is a routing hint, never a source of invented variants.
     modelVariantConfigIDs: ["thinking"],

--- a/bridge/src/omp-session-history.js
+++ b/bridge/src/omp-session-history.js
@@ -1,202 +1,187 @@
 import { createReadStream } from "node:fs"
-import { open, readdir } from "node:fs/promises"
+import { access, readdir } from "node:fs/promises"
 import { homedir } from "node:os"
 import path from "node:path"
 import { createInterface } from "node:readline"
 
-const BACKWARD_READ_BYTES = 64 * 1024
+/*
+ * Read one OMP Session straight out of the journal OMP itself writes.
+ *
+ * Every rule below is taken from oh-my-pi 18.x rather than inferred from observed output, because
+ * the previous readers guessed at the parts of the format that only appear in old or branched
+ * Sessions - which is exactly where they produced empty transcripts:
+ *
+ * - `packages/coding-agent/src/session/session-entries.ts` defines the file's three record kinds:
+ *   a fixed-width `type:"title"` slot on line 1, a `type:"session"` header on line 2, then the
+ *   append-only `SessionEntry` list. Only entries carry `parentId`; the header carries an `id` but
+ *   is not part of the branch graph.
+ * - `SessionEntryIndex` in `session-manager.ts` selects the persisted branch: `insert()` assigns
+ *   `#leaf = entry.id` for every entry it reads, so after `rebuild()` the leaf is simply the last
+ *   entry in file order, and `pathTo()` walks `parentId` back from it.
+ * - `session-migrations.ts` shows that v1 journals have no `id`/`parentId` at all. OMP adds them in
+ *   memory (and rewrites the file) the first time it opens such a Session, so a reader that
+ *   requires ids reports a v1 Session as empty until something else makes OMP migrate it.
+ * - `session/messages.ts` marks a user turn `synthetic`/`steering` when it was injected rather than
+ *   typed, and `shouldRenderAbortReason()` suppresses the two abort reasons OMP stores on an
+ *   assistant message but never shows.
+ */
 
-function messageParts(content, messageID) {
-  if (typeof content === "string") return [{ id: `${messageID}:text:0`, messageID, type: "text", text: content }]
-  if (!Array.isArray(content)) return []
-  return content.flatMap((item, index) => {
-    if (item?.type === "text" && typeof item.text === "string" && item.text) {
-      return [{ id: `${messageID}:text:${index}`, messageID, type: "text", text: item.text }]
-    }
-    if (item?.type === "thinking" && typeof item.thinking === "string" && item.thinking) {
-      return [{ id: `${messageID}:reasoning:${index}`, messageID, type: "reasoning", text: item.thinking }]
-    }
-    // OMP stores what it re-encoded and keeps no filename, so the mime comes from the record
-    // and the app renders the thumbnail without a label.
-    if (item?.type === "image" && typeof item.data === "string" && item.data) {
-      const mime = typeof item.mimeType === "string" && item.mimeType ? item.mimeType : "image/png"
-      return [{
-        id: `${messageID}:file:${index}`,
-        messageID,
-        type: "file",
-        mime,
-        url: `data:${mime};base64,${item.data}`
-      }]
-    }
-    return []
-  })
+/** `SILENT_ABORT_MARKER` / `USER_INTERRUPT_LABEL` from OMP's session/messages.ts. */
+const SILENT_ABORT_MARKER = "__omp.silent_abort__"
+const USER_INTERRUPT_LABEL = "Interrupted by user"
+/** `AIError.Flag.SilentAbort` / `AIError.Flag.UserInterrupt` from OMP's ai/error/flags.ts. */
+const ERROR_FLAG_SILENT_ABORT = 0x0200_0000
+const ERROR_FLAG_USER_INTERRUPT = 0x0400_0000
+
+/** `blob:sha256:<hash>` externalised image payloads from OMP's blob-store.ts. */
+const BLOB_REF_PREFIX = "blob:sha256:"
+
+function isSuppressedAbort(message) {
+  const errorId = Number.isInteger(message?.errorId) ? message.errorId : 0
+  if ((errorId & ERROR_FLAG_SILENT_ABORT) !== 0 || (errorId & ERROR_FLAG_USER_INTERRUPT) !== 0) return true
+  return message?.errorMessage === SILENT_ABORT_MARKER || message?.errorMessage === USER_INTERRUPT_LABEL
 }
 
 /**
- * A turn that failed is journalled as an assistant message with no content and the provider's own
- * sentence in `errorMessage`. Skipping those for having no parts made a rate-limited or unpaid
- * session look like it had simply lost its replies: the transcript showed the prompts and nothing
- * back, with no way to tell a failure from a missing message.
+ * A turn that failed is journalled as an assistant message with the provider's own sentence in
+ * `errorMessage`. Skipping those made a rate-limited or unpaid Session look like it had simply lost
+ * its replies. The two abort reasons OMP's own renderers suppress are suppressed here too: showing
+ * them turned every Stop into a red "Interrupted by user" banner in the reopened transcript.
  */
 function messageError(message) {
+  if (isSuppressedAbort(message)) return undefined
   const detail = typeof message?.errorMessage === "string" ? message.errorMessage.trim() : ""
   if (!detail) return undefined
   return { name: "HarnessTurnError", message: detail }
 }
 
-function messageEnvelope(record, sessionID) {
-  if (record?.type !== "message") return undefined
-  const role = record.message?.role
-  if (role !== "user" && role !== "assistant") return undefined
-  const messageID = record.id
-  if (typeof messageID !== "string") return undefined
-  const parts = messageParts(record.message?.content, messageID)
-  const error = messageError(record.message)
-  if (parts.length === 0 && !error) return undefined
-  const created = Date.parse(record.timestamp ?? "")
-  return {
-    info: {
-      id: messageID,
-      role,
-      sessionID,
-      time: { created: Number.isFinite(created) ? created : Date.now() },
-      ...(error ? { error } : {})
-    },
-    parts
+function imagePart(item, messageID, index) {
+  if (typeof item?.data !== "string" || !item.data) return undefined
+  // An externalised payload is a reference into OMP's blob store, not base64. Rendering it as a
+  // data URL produced a permanently broken thumbnail, so the part is dropped instead.
+  if (item.data.startsWith(BLOB_REF_PREFIX)) return undefined
+  const mime = typeof item.mimeType === "string" && item.mimeType ? item.mimeType : "image/png"
+  return { id: `${messageID}:file:${index}`, messageID, type: "file", mime, url: `data:${mime};base64,${item.data}` }
+}
+
+/** Content blocks shared by user and assistant messages (`TextContent` / `ImageContent`). */
+function contentParts(content, messageID) {
+  if (typeof content === "string") {
+    return content ? [{ id: `${messageID}:text:0`, messageID, type: "text", text: content }] : []
   }
-}
-
-function encodePageCursor(offset, target) {
-  return Buffer.from(JSON.stringify({ offset, target }), "utf8").toString("base64url")
-}
-
-function decodePageCursor(value) {
-  try {
-    const parsed = JSON.parse(Buffer.from(String(value), "base64url").toString("utf8"))
-    if (!Number.isSafeInteger(parsed?.offset) || parsed.offset < 0 || typeof parsed?.target !== "string" || !parsed.target) {
-      return undefined
+  if (!Array.isArray(content)) return []
+  const parts = []
+  content.forEach((item, index) => {
+    if (item?.type === "text" && typeof item.text === "string" && item.text) {
+      parts.push({ id: `${messageID}:text:${index}`, messageID, type: "text", text: item.text })
+      return
     }
-    return parsed
-  } catch {
-    return undefined
-  }
-}
-
-function parseRecordBuffer(buffer) {
-  if (buffer.length > 0 && buffer[buffer.length - 1] === 0x0d) buffer = buffer.subarray(0, -1)
-  try {
-    const record = JSON.parse(buffer.toString("utf8"))
-    return record && typeof record === "object" ? record : undefined
-  } catch {
-    return undefined
-  }
-}
-
-async function readOmpPage(file, sessionID, { limit = 100, before, activeSessionLeaf } = {}) {
-  const boundedLimit = Math.max(1, Math.min(500, Number(limit) || 100))
-  if (activeSessionLeaf === null) return { messages: [], before: null, hasMore: false }
-
-  const handle = await open(file, "r")
-  try {
-    const { size } = await handle.stat()
-    const decoded = before ? decodePageCursor(before) : undefined
-    if (before && (!decoded || decoded.offset > size)) throw new Error("Invalid OMP history cursor")
-
-    let cursor = decoded?.offset ?? size
-    let target = decoded?.target ?? activeSessionLeaf
-    let matchedTarget = false
-    let carry = Buffer.alloc(0)
-    const messages = []
-    let resumeCursor = null
-    let hasMore = false
-    let done = false
-
-    while (cursor > 0 && !done) {
-      const start = Math.max(0, cursor - BACKWARD_READ_BYTES)
-      const chunk = Buffer.allocUnsafe(cursor - start)
-      const { bytesRead } = await handle.read(chunk, 0, chunk.length, start)
-      const data = carry.length > 0
-        ? Buffer.concat([chunk.subarray(0, bytesRead), carry])
-        : chunk.subarray(0, bytesRead)
-
-      let lineEnd = data.length
-      const visit = (line, offset) => {
-        const record = parseRecordBuffer(line)
-        if (!record || typeof record.id !== "string" || record.id !== target) return
-        matchedTarget = true
-        target = typeof record.parentId === "string" && record.parentId ? record.parentId : undefined
-        const message = messageEnvelope(record, sessionID)
-        if (message) {
-          if (messages.length < boundedLimit) {
-            messages.push(message)
-            if (messages.length === boundedLimit && target) resumeCursor = encodePageCursor(offset, target)
-          } else {
-            hasMore = true
-            done = true
-          }
+    if (item?.type === "thinking" && typeof item.thinking === "string" && item.thinking) {
+      parts.push({ id: `${messageID}:reasoning:${index}`, messageID, type: "reasoning", text: item.thinking })
+      return
+    }
+    if (item?.type === "toolCall" && typeof item.id === "string" && item.id) {
+      parts.push({
+        id: `${messageID}:tool:${index}`,
+        messageID,
+        type: "tool",
+        tool: typeof item.name === "string" ? item.name : "tool",
+        callID: item.id,
+        state: {
+          // Every tool call in the journal belongs to a turn OMP already finished writing. A call
+          // whose `toolResult` never landed is reported as `incomplete` rather than invented as a
+          // success or a failure, which is the same rule the live path settles turns with.
+          status: "incomplete",
+          input: item.arguments,
+          title: typeof item.name === "string" ? item.name : undefined,
+          time: {}
         }
-        if (!target) done = true
-      }
+      })
+      return
+    }
+    if (item?.type === "image") {
+      const part = imagePart(item, messageID, index)
+      if (part) parts.push(part)
+    }
+  })
+  return parts
+}
 
-      for (let index = data.length - 1; index >= 0 && !done; index -= 1) {
-        if (data[index] !== 0x0a) continue
-        const lineStart = index + 1
-        if (lineStart < lineEnd) visit(data.subarray(lineStart, lineEnd), start + lineStart)
-        lineEnd = index
-      }
-      if (start === 0) {
-        if (lineEnd > 0 && !done) visit(data.subarray(0, lineEnd), 0)
-        carry = Buffer.alloc(0)
-        cursor = 0
-      } else {
-        carry = lineEnd > 0 ? Buffer.from(data.subarray(0, lineEnd)) : Buffer.alloc(0)
-        cursor = start
-      }
-    }
+function toolResultText(content) {
+  if (typeof content === "string") return content
+  if (!Array.isArray(content)) return ""
+  return content
+    .filter((item) => item?.type === "text" && typeof item.text === "string")
+    .map((item) => item.text)
+    .join("\n")
+}
 
-    if (!matchedTarget) {
-      if (before) throw new Error("Invalid OMP history cursor")
-      throw new Error("OMP active session leaf is missing from transcript")
-    }
-    return {
-      messages: messages.slice(0, boundedLimit).reverse(),
-      before: hasMore ? resumeCursor : null,
-      hasMore
-    }
-  } finally {
-    await handle.close()
-  }
+function entryTimestamp(record) {
+  const created = Date.parse(record?.timestamp ?? "")
+  return Number.isFinite(created) ? created : undefined
 }
 
 /**
- * OMP's undo extension normally tells us the selected leaf.  Without it, a JSONL journal still
- * contains enough ordering information for the normal case: the last terminal record is the
- * branch the writer most recently reached.  Selecting it is observational and, unlike ACP
- * session/load, cannot claim or stall the native Session.
+ * Build the visible transcript for one already-selected branch.
+ *
+ * Tool activity is reconstructed here rather than left to ACP replay: an assistant message carries
+ * its `toolCall` blocks and the matching `toolResult` arrives as its own entry further down the
+ * branch, so the two are joined back into one Activity part. Without this a reopened OMP Session
+ * showed the answers with none of the work that produced them.
  */
-function inferLatestTerminalLeaf(records) {
-  const parents = new Set(records
-    .map((record) => record.parentId)
-    .filter((parentID) => typeof parentID === "string" && parentID))
-  for (let index = records.length - 1; index >= 0; index -= 1) {
-    const id = records[index].id
-    if (!parents.has(id)) return id
-  }
-  return undefined
-}
+function branchMessages(branch, sessionID) {
+  const messages = []
+  const toolParts = new Map()
+  let fallbackTime = 0
 
-async function readOmpRecords(file) {
-  const records = []
-  const lines = createInterface({ input: createReadStream(file), crlfDelay: Infinity })
-  for await (const line of lines) {
-    try {
-      const record = JSON.parse(line)
-      if (typeof record?.id === "string") records.push(record)
-    } catch {
-      // One malformed journal line must not make a valid preceding transcript unavailable.
+  for (const record of branch) {
+    if (record.type !== "message") continue
+    const message = record.message
+    const role = message?.role
+    const messageID = record.id
+    const created = entryTimestamp(record) ?? (fallbackTime += 1)
+    fallbackTime = Math.max(fallbackTime, created)
+
+    if (role === "toolResult") {
+      const part = toolParts.get(message.toolCallId)
+      if (!part) continue
+      const output = toolResultText(message.content)
+      part.state.status = message.isError === true ? "error" : "completed"
+      if (output) part.state.output = output
+      part.state.time = { ...part.state.time, end: created }
+      continue
     }
+
+    // `developer`, `custom` and the pre-v3 `hookMessage` are harness/extension injections rather
+    // than conversation. ACP replay flattens all of them into `user_message_chunk`s, which is one
+    // more reason replay cannot serve as a transcript: each would open a turn nobody wrote.
+    if (role !== "user" && role !== "assistant") continue
+    // `synthetic` marks a turn the harness injected (auto-continue) and `steering` a mid-turn
+    // nudge OMP documents as "never rendered". Either one would open a conversation turn the user
+    // did not write, which is what makes turn boundaries unusable for the app above.
+    if (role === "user" && (message.synthetic === true || message.steering === true)) continue
+
+    const parts = contentParts(message.content, messageID)
+    const error = role === "assistant" ? messageError(message) : undefined
+    if (parts.length === 0 && !error) continue
+    for (const part of parts) {
+      if (part.type === "tool") {
+        part.state.time = { start: created }
+        toolParts.set(part.callID, part)
+      }
+    }
+    messages.push({
+      info: {
+        id: messageID,
+        role,
+        sessionID,
+        time: { created },
+        ...(error ? { error } : {})
+      },
+      parts
+    })
   }
-  return records
+  return messages
 }
 
 function modelSelection(providerID, modelID) {
@@ -211,20 +196,15 @@ function modelSelectionFromWireName(value) {
   return modelSelection(value.slice(0, separator), value.slice(separator + 1))
 }
 
-/** Resolve the model selected on one exact branch, including journals predating model_change. */
-function branchModel(records, selectedLeaf) {
-  const entries = new Map(records.map((record) => [record.id, record]))
-  const branch = []
-  const visited = new Set()
-  let entry = entries.get(selectedLeaf)
-  while (entry && !visited.has(entry.id)) {
-    visited.add(entry.id)
-    branch.push(entry)
-    entry = typeof entry.parentId === "string" ? entries.get(entry.parentId) : undefined
-  }
-
+/**
+ * Resolve the model selected on one exact branch, including journals predating `model_change`.
+ *
+ * `EPHEMERAL_MODEL_CHANGE_ROLE` ("fallback") and the role-scoped entries OMP writes for its smol
+ * and slow models describe a different slot, so only the default role moves the picker.
+ */
+function branchModel(branch) {
   let selected
-  for (const record of branch.reverse()) {
+  for (const record of branch) {
     if (record.type === "model_change" && (record.role === undefined || record.role === "default")) {
       selected = modelSelectionFromWireName(record.model) ?? selected
       continue
@@ -240,11 +220,92 @@ function branchModel(records, selectedLeaf) {
   return selected
 }
 
+/**
+ * Read one journal into the branch graph OMP itself keeps in memory.
+ *
+ * The two records that are not `SessionEntry`s are dropped here: the fixed-width title slot carries
+ * no `id` at all, and the `type:"session"` header carries one but no `parentId`. Treating the
+ * header as a graph node is what made a Session whose entries were unreadable (a v1 journal) select
+ * the header as its leaf and render an empty conversation.
+ */
+async function readJournal(file) {
+  const entries = []
+  const lines = createInterface({ input: createReadStream(file), crlfDelay: Infinity })
+  for await (const line of lines) {
+    let record
+    try {
+      record = JSON.parse(line)
+    } catch {
+      // One malformed journal line must not make a valid preceding transcript unavailable.
+      continue
+    }
+    if (!record || typeof record !== "object") continue
+    if (record.type === "title") continue
+    if (record.type === "session") continue
+    entries.push(record)
+  }
+
+  // v1 journals predate the entry tree entirely. OMP reconstructs it linearly on load
+  // (migrateV1ToV2) and rewrites the file; until that happens this is the only way to read one.
+  // The ids are derived from file position so two reads of the same unmigrated file agree, and so
+  // do a read before and a read after a Session that has not been touched since.
+  //
+  // The absence of ids is the signature, not the header's version field: OMP writes the version
+  // onto the header only as it migrates, and a journal that already carries an entry tree must
+  // keep the ids it was written with whatever its header says.
+  if (entries.length > 0 && entries.every((entry) => typeof entry.id !== "string")) {
+    let previous = null
+    entries.forEach((entry, index) => {
+      entry.id = `omp-v1:${index}`
+      entry.parentId = previous
+      previous = entry.id
+    })
+  }
+
+  const byId = new Map()
+  for (const entry of entries) {
+    if (typeof entry.id === "string") byId.set(entry.id, entry)
+  }
+  return { entries, byId }
+}
+
+/** `SessionEntryIndex.pathTo()`: walk `parentId` back from the leaf and return it root-first. */
+function branchTo(byId, leaf) {
+  const branch = []
+  const visited = new Set()
+  let entry = byId.get(leaf)
+  while (entry && !visited.has(entry.id)) {
+    visited.add(entry.id)
+    branch.push(entry)
+    entry = typeof entry.parentId === "string" ? byId.get(entry.parentId) : undefined
+  }
+  return branch.reverse()
+}
+
+/**
+ * `SessionEntryIndex.rebuild()` assigns the leaf on every insert, so OMP's own persisted branch is
+ * the last entry in file order. The optional undo/redo extension publishes the live leaf while OMP
+ * is running, which is the only case where the two can differ; `null` means it selected the root.
+ */
+function resolveBranch(journal, activeSessionLeaf) {
+  if (activeSessionLeaf === null) return []
+  // A leaf the extension published for a journal that has since been rewritten - compaction and
+  // `/clear` both drop entries - is stale, not a reason to refuse the Session. Falling back to the
+  // entry order lands on exactly the branch OMP itself would resume, so a stale extension can no
+  // longer make a real conversation unreadable.
+  if (typeof activeSessionLeaf === "string" && journal.byId.has(activeSessionLeaf)) {
+    return branchTo(journal.byId, activeSessionLeaf)
+  }
+  const leaf = journal.entries.at(-1)?.id
+  return leaf ? branchTo(journal.byId, leaf) : []
+}
+
 /*
  * How long a directory listing may be reused before another lookup miss rescans.
  *
- * Short enough that a Session created moments ago is still found, long enough that opening many
- * Sessions in a row does not walk the tree once per Session.
+ * Short enough that a Session created moments ago is still found - OMP creates the journal lazily,
+ * so the file for a Session this bridge just started can legitimately appear after the first
+ * miss - and long enough that opening many Sessions in a row does not walk the tree once each.
  */
 const OMP_SESSION_LISTING_TTL_MS = 1_000
 
@@ -292,7 +353,17 @@ export function createOmpHistoryLoader(sessionRoot = path.join(homedir(), ".omp"
 
   async function locateSession(sessionID) {
     const known = sessionFiles.get(sessionID)
-    if (known) return known
+    // A remembered path is re-checked rather than trusted forever: OMP moves a Session's journal
+    // when its workspace moves, and a cached path that no longer exists otherwise reports a real
+    // Session as permanently empty.
+    if (known) {
+      try {
+        await access(known)
+        return known
+      } catch {
+        sessionFiles.delete(sessionID)
+      }
+    }
     if (!/^[A-Za-z0-9_-]+$/.test(sessionID)) return undefined
     const suffix = `_${sessionID}.jsonl`
     const find = () => listing.find((candidate) => candidate.name.endsWith(suffix))?.file
@@ -307,51 +378,17 @@ export function createOmpHistoryLoader(sessionRoot = path.join(homedir(), ".omp"
     return file
   }
 
-  const loadOmpHistory = async function loadOmpHistory(sessionID, { activeSessionLeaf } = {}) {
+  async function readBranch(sessionID, activeSessionLeaf) {
     const file = await locateSession(sessionID)
-    if (!file) return []
-    const records = []
-    const entries = new Map()
-    const lines = createInterface({ input: createReadStream(file), crlfDelay: Infinity })
-    for await (const line of lines) {
-      let record
-      try {
-        record = JSON.parse(line)
-      } catch {
-        continue
-      }
-      if (typeof record?.id === "string") {
-        records.push(record)
-        entries.set(record.id, record)
-      }
-    }
+    if (!file) return undefined
+    const journal = await readJournal(file)
+    return resolveBranch(journal, activeSessionLeaf)
+  }
 
-    const selected = []
-    let selectedLeaf = activeSessionLeaf
-    if (selectedLeaf === undefined) {
-      selectedLeaf = inferLatestTerminalLeaf(records)
-      if (!selectedLeaf) return []
-    }
-    if (selectedLeaf === null) {
-      // The extension selected the session root.
-    } else if (entries.has(selectedLeaf)) {
-      const branch = []
-      const visited = new Set()
-      let entry = entries.get(selectedLeaf)
-      while (entry && !visited.has(entry.id)) {
-        visited.add(entry.id)
-        branch.push(entry)
-        entry = typeof entry.parentId === "string" ? entries.get(entry.parentId) : undefined
-      }
-      selected.push(...branch.reverse())
-    } else {
-      throw new Error("OMP active session leaf is missing from transcript")
-    }
-
-    return selected.flatMap((record) => {
-      const message = messageEnvelope(record, sessionID)
-      return message ? [message] : []
-    })
+  const loadOmpHistory = async function loadOmpHistory(sessionID, { activeSessionLeaf } = {}) {
+    const branch = await readBranch(sessionID, activeSessionLeaf)
+    if (!branch) return []
+    return branchMessages(branch, sessionID)
   }
 
   /** How often the session tree was walked, and how many files that walk is currently serving. */
@@ -362,21 +399,51 @@ export function createOmpHistoryLoader(sessionRoot = path.join(homedir(), ".omp"
     resolvedSessions: sessionFiles.size,
     listingAgeMs: listedAt ? Date.now() - listedAt : null
   })
-  // The loader derives a latest terminal leaf when the optional undo extension is absent, so
-  // paging remains journal-only and does not wait on ACP session/load.
+
+  // The branch is resolved from the journal's own entry order, so paging never has to wait for the
+  // optional extension - or for an ACP session/load, which OMP answers by replaying the whole
+  // transcript back over the wire under freshly minted message ids.
   loadOmpHistory.pageRequiresActiveLeaf = false
-  loadOmpHistory.deferAcpReplayWithoutActiveLeaf = true
+
+  /**
+   * OMP's ACP `session/load` is a replay, not a read: `AcpAgent.loadSession` calls
+   * `#replaySessionHistory`, which re-emits every stored message under a new `crypto.randomUUID()`.
+   * There is therefore no ACP fallback that could stand in for an unreadable journal, and a failed
+   * read must surface as a failure rather than as an empty conversation.
+   */
+  loadOmpHistory.journalOnly = true
+
   loadOmpHistory.page = async (sessionID, options = {}) => {
-    const file = await locateSession(sessionID)
-    if (!file) return { messages: [], before: null, hasMore: false }
-    const records = await readOmpRecords(file)
-    const activeSessionLeaf = options.activeSessionLeaf === undefined
-      ? inferLatestTerminalLeaf(records)
-      : options.activeSessionLeaf
-    if (activeSessionLeaf === undefined) return { messages: [], before: null, hasMore: false }
-    const page = await readOmpPage(file, sessionID, { ...options, activeSessionLeaf })
-    const model = activeSessionLeaf === null ? undefined : branchModel(records, activeSessionLeaf)
-    return { ...page, ...(model ? { model } : {}) }
+    const messages = await loadOmpHistory(sessionID, options)
+    const limit = Math.max(1, Math.min(500, Number(options.limit) || 100))
+    const requestedEnd = options.before
+      ? messages.findIndex((message) => message.info.id === options.before)
+      : messages.length
+    const end = requestedEnd >= 0 ? requestedEnd : messages.length
+    const start = Math.max(0, end - limit)
+    const model = await loadOmpHistory.sessionModel(sessionID, options)
+    return {
+      messages: messages.slice(start, end),
+      before: start > 0 ? messages[start]?.info?.id ?? null : null,
+      hasMore: start > 0,
+      ...(model ? { model } : {})
+    }
+  }
+
+  /**
+   * The model selected on the Session's own branch.
+   *
+   * The picker needs this for a Session this bridge has never opened, and OMP will not report a
+   * `model` config option without opening one. Reading it from the branch keeps opening a Session
+   * free of side effects, and keeps the answer identical to the one OMP would resume with.
+   */
+  loadOmpHistory.sessionModel = async (sessionID, { activeSessionLeaf } = {}) => {
+    try {
+      const branch = await readBranch(sessionID, activeSessionLeaf)
+      return branch?.length ? branchModel(branch) : undefined
+    } catch {
+      return undefined
+    }
   }
 
   return loadOmpHistory

--- a/bridge/src/server.js
+++ b/bridge/src/server.js
@@ -181,7 +181,9 @@ export function createBridgeServer({ config, acp, serviceOptions, machineRegistr
     ...serviceOptions,
     actionProviders: profile.actionProviders,
     preferListedTitles: profile.preferListedTitles,
-    nativeRenameCommand: profile.nativeRenameCommand
+    nativeRenameCommand: profile.nativeRenameCommand,
+    journalPageWhileOwned: profile.journalPageWhileOwned !== false,
+    modelVariantConfigIDs: profile.modelVariantConfigIDs ?? []
   })
   const hiddenSessionIDs = serviceOptions?.hiddenSessionIDs
   const liveSessionActivity = new Map()

--- a/bridge/test/helpers/fake-omp-acp.js
+++ b/bridge/test/helpers/fake-omp-acp.js
@@ -24,6 +24,9 @@ import path from "node:path"
  *   chunk is always delivered before the response.
  * - `SessionManager#recordEntry` appends each entry to the JSONL as it is created; an assistant
  *   message is written once, when it ends.
+ * - `#emitBootstrapUpdates` advertises the slash commands after every new/load/resume, and
+ *   `/rename` is one of them: it calls `setSessionName(title, "user")`, which rewrites the title
+ *   slot, appends a `title_change` entry and marks the name user-set.
  */
 export class FakeOmpAcp extends EventEmitter {
   constructor({ sessionRoot, cwd = "/repo", models = ["anthropic/claude-sonnet-4", "openai/gpt-5.6"] } = {}) {
@@ -39,16 +42,21 @@ export class FakeOmpAcp extends EventEmitter {
     this.promptCapabilities = { image: true, embeddedContext: true }
     this.sessionCapabilities = { list: {}, fork: {}, resume: {}, close: {} }
     this.agentInfo = { name: "oh-my-pi", title: "Oh My Pi", version: "18.0.7" }
+    this.availableCommands = [
+      { name: "rename", description: "Rename the current session", input: { hint: "<title>" } },
+      { name: "model", description: "Show current model selection" }
+    ]
     this.turns = []
   }
 
   /** Register a stored Session whose journal already exists, as if OMP had written it elsewhere. */
   async seedSession(sessionId, { entries = [], title = "Stored session", version = 3, withTitleSlot = true } = {}) {
+    // OMP writes the fixed-width slot even when the Session has no name yet.
     const file = path.join(this.sessionRoot, `2026-08-26_${sessionId}.jsonl`)
     await mkdir(this.sessionRoot, { recursive: true })
     const lines = []
     if (withTitleSlot) {
-      const slot = { type: "title", v: 1, title, updatedAt: "2026-08-26T10:00:00.000Z", pad: "" }
+      const slot = { type: "title", v: 1, title: title ?? "", updatedAt: "2026-08-26T10:00:00.000Z", pad: "" }
       const encoded = JSON.stringify(slot)
       lines.push(`${encoded}${" ".repeat(Math.max(0, 256 - encoded.length - 1))}`)
     }
@@ -56,13 +64,13 @@ export class FakeOmpAcp extends EventEmitter {
       type: "session",
       ...(version >= 2 ? { version } : {}),
       id: sessionId,
-      title,
+      ...(title ? { title } : {}),
       timestamp: "2026-08-26T10:00:00.000Z",
       cwd: this.cwd
     }))
     for (const entry of entries) lines.push(JSON.stringify(entry))
     await writeFile(file, `${lines.join("\n")}\n`)
-    this.sessions.set(sessionId, { file, entries: [...entries], model: this.models[0], thinking: "off" })
+    this.sessions.set(sessionId, { file, title, entries: [...entries], model: this.models[0], thinking: "off" })
     return file
   }
 
@@ -97,6 +105,14 @@ export class FakeOmpAcp extends EventEmitter {
         options: [{ value: "off", name: "Off" }, { value: "high", name: "High" }]
       }
     ]
+  }
+
+  /** `#emitBootstrapUpdates`: the command catalog every open advertises. */
+  #bootstrap(sessionId) {
+    this.#notify(sessionId, {
+      sessionUpdate: "available_commands_update",
+      availableCommands: this.availableCommands
+    })
   }
 
   #notify(sessionId, update) {
@@ -134,8 +150,9 @@ export class FakeOmpAcp extends EventEmitter {
     switch (method) {
       case "session/new": {
         const sessionId = `omp-${this.sessions.size + 1}`
-        await this.seedSession(sessionId, { title: "New session" })
+        await this.seedSession(sessionId, { title: undefined })
         this.openSessions.add(sessionId)
+        this.#bootstrap(sessionId)
         return { sessionId, configOptions: this.#configOptions(sessionId) }
       }
       case "session/load": {
@@ -166,11 +183,13 @@ export class FakeOmpAcp extends EventEmitter {
               .join("")
           if (text) this.#notify(params.sessionId, { sessionUpdate: "user_message_chunk", content: { type: "text", text }, messageId })
         }
+        this.#bootstrap(params.sessionId)
         return { configOptions: this.#configOptions(params.sessionId) }
       }
       case "session/resume": {
         this.#record(params.sessionId)
         this.openSessions.add(params.sessionId)
+        this.#bootstrap(params.sessionId)
         return { configOptions: this.#configOptions(params.sessionId) }
       }
       case "session/set_config_option": {
@@ -212,6 +231,21 @@ export class FakeOmpAcp extends EventEmitter {
       .filter((part) => part.type === "text")
       .map((part) => part.text)
       .join("")
+    // A slash command is consumed before the model sees it: `/rename` renames the Session, answers
+    // with a confirmation line, and journals a `title_change` entry rather than a conversation turn.
+    if (promptText.startsWith("/rename ")) {
+      const title = promptText.slice("/rename ".length).trim()
+      if (title) {
+        session.title = title
+        await this.#append(sessionId, { type: "title_change", timestamp: new Date().toISOString(), title, source: "user" })
+      }
+      this.#notify(sessionId, {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: `Session renamed to ${title}.` },
+        messageId: randomUUID()
+      })
+      return { stopReason: "end_turn" }
+    }
     await this.#append(sessionId, {
       type: "message",
       timestamp: new Date().toISOString(),

--- a/bridge/test/helpers/fake-omp-acp.js
+++ b/bridge/test/helpers/fake-omp-acp.js
@@ -1,0 +1,292 @@
+import { EventEmitter } from "node:events"
+import { randomUUID } from "node:crypto"
+import { appendFile, mkdir, writeFile } from "node:fs/promises"
+import path from "node:path"
+
+/**
+ * An `omp acp` stand-in that follows oh-my-pi 18.x rather than Harness Remote's reading of it.
+ *
+ * Every behaviour below is taken from a specific place in the OMP source, because a fake that
+ * merely reproduces what the bridge already expects can only ever confirm the bridge's own
+ * assumptions:
+ *
+ * - `AcpAgent.initialize` advertises `sessionCapabilities.resume`, which is what makes
+ *   `session/resume` usable at all.
+ * - `AcpAgent.loadSession` calls `#replaySessionHistory`; `AcpAgent.resumeSession` does not. Both
+ *   open the same stored Session (`#openStoredSession`) and both answer with `configOptions`.
+ * - `#replaySessionHistory` mints `crypto.randomUUID()` per replayed message, and flattens tool
+ *   results and every non-dialogue role into `user_message_chunk`s.
+ * - The live path never emits `user_message_chunk` at all: `acp-event-mapper.ts` only produces
+ *   `agent_message_chunk`, `agent_thought_chunk`, `tool_call`, `tool_call_update` and `plan`.
+ * - `record.liveMessageId ??= crypto.randomUUID()` gives one id per live assistant message, unrelated
+ *   to anything on disk.
+ * - `prompt()` resolves only after `#emitEndOfTurnUpdates` and `#waitForAcpPromptIdle`, so the last
+ *   chunk is always delivered before the response.
+ * - `SessionManager#recordEntry` appends each entry to the JSONL as it is created; an assistant
+ *   message is written once, when it ends.
+ */
+export class FakeOmpAcp extends EventEmitter {
+  constructor({ sessionRoot, cwd = "/repo", models = ["anthropic/claude-sonnet-4", "openai/gpt-5.6"] } = {}) {
+    super()
+    this.sessionRoot = sessionRoot
+    this.cwd = cwd
+    this.models = models
+    this.requests = []
+    this.notifications = []
+    this.sessions = new Map()
+    this.openSessions = new Set()
+    this.processID = 4242
+    this.promptCapabilities = { image: true, embeddedContext: true }
+    this.sessionCapabilities = { list: {}, fork: {}, resume: {}, close: {} }
+    this.agentInfo = { name: "oh-my-pi", title: "Oh My Pi", version: "18.0.7" }
+    this.turns = []
+  }
+
+  /** Register a stored Session whose journal already exists, as if OMP had written it elsewhere. */
+  async seedSession(sessionId, { entries = [], title = "Stored session", version = 3, withTitleSlot = true } = {}) {
+    const file = path.join(this.sessionRoot, `2026-08-26_${sessionId}.jsonl`)
+    await mkdir(this.sessionRoot, { recursive: true })
+    const lines = []
+    if (withTitleSlot) {
+      const slot = { type: "title", v: 1, title, updatedAt: "2026-08-26T10:00:00.000Z", pad: "" }
+      const encoded = JSON.stringify(slot)
+      lines.push(`${encoded}${" ".repeat(Math.max(0, 256 - encoded.length - 1))}`)
+    }
+    lines.push(JSON.stringify({
+      type: "session",
+      ...(version >= 2 ? { version } : {}),
+      id: sessionId,
+      title,
+      timestamp: "2026-08-26T10:00:00.000Z",
+      cwd: this.cwd
+    }))
+    for (const entry of entries) lines.push(JSON.stringify(entry))
+    await writeFile(file, `${lines.join("\n")}\n`)
+    this.sessions.set(sessionId, { file, entries: [...entries], model: this.models[0], thinking: "off" })
+    return file
+  }
+
+  #record(sessionId) {
+    const session = this.sessions.get(sessionId)
+    if (!session) throw new Error(`ACP session not found: ${sessionId}`)
+    return session
+  }
+
+  async #append(sessionId, entry) {
+    const session = this.#record(sessionId)
+    const parentId = session.entries.at(-1)?.id ?? null
+    const stored = { ...entry, id: entry.id ?? randomUUID().slice(-8), parentId }
+    session.entries.push(stored)
+    await appendFile(session.file, `${JSON.stringify(stored)}\n`)
+    return stored
+  }
+
+  #configOptions(sessionId) {
+    const session = this.#record(sessionId)
+    return [
+      {
+        id: "model",
+        name: "Model",
+        currentValue: session.model,
+        options: this.models.map((value) => ({ value, name: value }))
+      },
+      {
+        id: "thinking",
+        name: "Thinking",
+        currentValue: session.thinking,
+        options: [{ value: "off", name: "Off" }, { value: "high", name: "High" }]
+      }
+    ]
+  }
+
+  #notify(sessionId, update) {
+    const notification = { method: "session/update", params: { sessionId, update } }
+    this.notifications.push(notification)
+    this.emit("notification", notification)
+  }
+
+  async start() {}
+
+  async listSessions() {
+    return [...this.sessions.entries()].map(([sessionId, session]) => ({
+      sessionId,
+      cwd: this.cwd,
+      title: session.title,
+      updatedAt: "2026-08-26T10:00:00.000Z",
+      _meta: { messageCount: session.entries.length }
+    }))
+  }
+
+  notify(method, params) {
+    this.requests.push([method, params])
+    if (method === "session/cancel") {
+      const session = this.sessions.get(params.sessionId)
+      if (session) session.cancelled = true
+    }
+  }
+
+  calls(method) {
+    return this.requests.filter(([name]) => name === method)
+  }
+
+  async request(method, params) {
+    this.requests.push([method, params])
+    switch (method) {
+      case "session/new": {
+        const sessionId = `omp-${this.sessions.size + 1}`
+        await this.seedSession(sessionId, { title: "New session" })
+        this.openSessions.add(sessionId)
+        return { sessionId, configOptions: this.#configOptions(sessionId) }
+      }
+      case "session/load": {
+        this.#record(params.sessionId)
+        this.openSessions.add(params.sessionId)
+        // `#replaySessionHistory`: one fresh uuid per message, tool results flattened into
+        // `user_message_chunk`s, and no relationship to the ids the journal stores.
+        for (const entry of this.#record(params.sessionId).entries) {
+          if (entry.type !== "message") continue
+          const messageId = randomUUID()
+          const message = entry.message
+          if (message.role === "assistant") {
+            for (const block of Array.isArray(message.content) ? message.content : []) {
+              if (block.type === "text") {
+                this.#notify(params.sessionId, { sessionUpdate: "agent_message_chunk", content: { type: "text", text: block.text }, messageId })
+              }
+              if (block.type === "thinking") {
+                this.#notify(params.sessionId, { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: block.thinking }, messageId })
+              }
+            }
+            continue
+          }
+          const text = typeof message.content === "string"
+            ? message.content
+            : (Array.isArray(message.content) ? message.content : [])
+              .filter((block) => block.type === "text")
+              .map((block) => block.text)
+              .join("")
+          if (text) this.#notify(params.sessionId, { sessionUpdate: "user_message_chunk", content: { type: "text", text }, messageId })
+        }
+        return { configOptions: this.#configOptions(params.sessionId) }
+      }
+      case "session/resume": {
+        this.#record(params.sessionId)
+        this.openSessions.add(params.sessionId)
+        return { configOptions: this.#configOptions(params.sessionId) }
+      }
+      case "session/set_config_option": {
+        const session = this.#record(params.sessionId)
+        if (params.configId === "model") {
+          session.model = params.value
+          await this.#append(params.sessionId, {
+            type: "model_change",
+            timestamp: new Date().toISOString(),
+            model: params.value
+          })
+        }
+        if (params.configId === "thinking") session.thinking = params.value
+        return { configOptions: this.#configOptions(params.sessionId) }
+      }
+      case "session/prompt":
+        return await this.#prompt(params)
+      default:
+        return {}
+    }
+  }
+
+  /**
+   * The scripted answer for the next `session/prompt` on any Session.
+   *
+   * `reasoning`, `tool` and `text` map onto the three notification kinds the live mapper produces;
+   * `text` accepts several chunks because a real answer streams that way and the last one has to be
+   * the one the client ends up showing.
+   */
+  queueTurn(turn) {
+    this.turns.push(turn)
+  }
+
+  async #prompt(params) {
+    const sessionId = params.sessionId
+    const session = this.#record(sessionId)
+    session.cancelled = false
+    const promptText = (params.prompt ?? [])
+      .filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("")
+    await this.#append(sessionId, {
+      type: "message",
+      timestamp: new Date().toISOString(),
+      message: { role: "user", content: promptText, timestamp: Date.now() }
+    })
+
+    const turn = this.turns.shift() ?? { text: ["Answer"] }
+    const provider = session.model.split("/")[0]
+    const model = session.model.split("/")[1]
+    const assistantEntry = (content, extra = {}) => this.#append(sessionId, {
+      type: "message",
+      timestamp: new Date().toISOString(),
+      message: { role: "assistant", provider, model, content, timestamp: Date.now(), ...extra }
+    })
+
+    // `#getLiveMessageId` mints one id per live assistant message and
+    // `#clearLiveAssistantMessageAfterEvent` drops it when that message ends, so a turn that calls a
+    // tool streams under two ids - and journals two assistant entries, the tool-calling one first.
+    const thinkingId = randomUUID()
+    const reasoningContent = []
+    for (const thought of turn.reasoning ?? []) {
+      this.#notify(sessionId, { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: thought }, messageId: thinkingId })
+      reasoningContent.push({ type: "thinking", thinking: thought })
+    }
+    const tools = turn.tools ?? []
+    for (const tool of tools) {
+      this.#notify(sessionId, {
+        sessionUpdate: "tool_call",
+        toolCallId: tool.id,
+        title: tool.name,
+        status: "in_progress",
+        rawInput: tool.input,
+        _meta: { toolName: tool.name }
+      })
+    }
+    if (session.cancelled) {
+      // `#resolveStopReason` reports `cancelled`, and the aborted assistant message keeps
+      // `USER_INTERRUPT_LABEL` on `errorMessage` - which OMP's own renderers suppress.
+      await assistantEntry(reasoningContent, { stopReason: "aborted", errorMessage: "Interrupted by user" })
+      return { stopReason: "cancelled" }
+    }
+    if (reasoningContent.length || tools.length) {
+      await assistantEntry(
+        [...reasoningContent, ...tools.map((tool) => ({ type: "toolCall", id: tool.id, name: tool.name, arguments: tool.input ?? {} }))],
+        { stopReason: tools.length ? "toolUse" : "endTurn" }
+      )
+    }
+    for (const tool of tools) {
+      this.#notify(sessionId, {
+        sessionUpdate: "tool_call_update",
+        toolCallId: tool.id,
+        status: "completed",
+        rawOutput: tool.output ?? "done"
+      })
+      await this.#append(sessionId, {
+        type: "message",
+        timestamp: new Date().toISOString(),
+        message: {
+          role: "toolResult",
+          toolCallId: tool.id,
+          toolName: tool.name,
+          content: [{ type: "text", text: tool.output ?? "done" }],
+          isError: false,
+          timestamp: Date.now()
+        }
+      })
+    }
+
+    const answerId = randomUUID()
+    for (const chunk of turn.text ?? []) {
+      this.#notify(sessionId, { sessionUpdate: "agent_message_chunk", content: { type: "text", text: chunk }, messageId: answerId })
+    }
+    if ((turn.text ?? []).length) {
+      await assistantEntry([{ type: "text", text: (turn.text ?? []).join("") }], { stopReason: "endTurn" })
+    }
+    return { stopReason: "end_turn" }
+  }
+}

--- a/bridge/test/omp-acp-lifecycle.test.js
+++ b/bridge/test/omp-acp-lifecycle.test.js
@@ -29,6 +29,7 @@ async function harness({ sessionRoot } = {}) {
     replaySettleMs: profile.replaySettleMs,
     preferListedTitles: profile.preferListedTitles,
     journalPageWhileOwned: profile.journalPageWhileOwned !== false,
+    nativeRenameCommand: profile.nativeRenameCommand,
     modelVariantConfigIDs: profile.modelVariantConfigIDs ?? []
   })
   return { root, acp, service, cleanup: () => rm(root, { recursive: true, force: true }) }
@@ -427,5 +428,73 @@ test("an unreadable journal is reported rather than answered with an empty conve
     assert.equal(acp.calls("session/resume").length, 0, "and neither is acquiring the writer")
   } finally {
     await rm(root, { recursive: true, force: true })
+  }
+})
+
+test("the name a Session is created with is stored by OMP, not only here", async () => {
+  const { root, acp, service, cleanup } = await harness()
+  try {
+    const created = await service.createSession({ directory: "/repo", title: "Rebuild the ACP path" })
+    assert.equal(created.title, "Rebuild the ACP path")
+
+    const renames = acp.calls("session/prompt").filter(([, params]) => params.prompt?.[0]?.text?.startsWith("/rename "))
+    assert.equal(renames.length, 1, "session/new carries no title, so the name is handed over as the harness's own command")
+    assert.equal((await acp.listSessions())[0].title, "Rebuild the ACP path", "OMP itself must know the name")
+    assert.deepEqual(await tail(service, created.id), [], "naming a Session is not a turn in it")
+
+    acp.queueTurn({ text: ["Answer"] })
+    await service.promptAndWait(created.id, "Prompt 1")
+    assert.equal((await service.listSessions())[0].title, "Rebuild the ACP path", "and it survives the first turn")
+
+    // A second bridge over the same OMP sees the name because OMP is where it lives, not because
+    // this process remembered it.
+    const second = new AcpService(new AcpPromptEchoFilter(acp), {
+      historyLoader: createOmpHistoryLoader(root),
+      reloadOnHistoryRefresh: profile.reloadOnHistoryRefresh,
+      preferListedTitles: profile.preferListedTitles,
+      journalPageWhileOwned: false,
+      nativeRenameCommand: profile.nativeRenameCommand
+    })
+    assert.equal((await second.listSessions())[0].title, "Rebuild the ACP path")
+  } finally {
+    await cleanup()
+  }
+})
+
+test("renaming a Session later persists the same way and leaves no trace in the conversation", async () => {
+  const { acp, service, cleanup } = await harness()
+  try {
+    const sessionID = (await service.createSession({ directory: "/repo" })).id
+    acp.queueTurn({ text: ["Answer"] })
+    await service.promptAndWait(sessionID, "Prompt 1")
+    const before = await tail(service, sessionID)
+
+    const renamed = await service.renameSession(sessionID, "Named after the fact")
+    assert.equal(renamed.title, "Named after the fact")
+    assert.equal((await acp.listSessions())[0].title, "Named after the fact")
+    assert.equal((await service.listSessions())[0].title, "Named after the fact")
+    assert.deepEqual(await tail(service, sessionID), before, "the harness's confirmation line is not conversation")
+    assert.equal(service.status(sessionID).type, "idle", "renaming must not leave the Session reading as Working")
+
+    acp.queueTurn({ text: ["Second answer"] })
+    await service.promptAndWait(sessionID, "Prompt 2")
+    assert.equal((await service.listSessions())[0].title, "Named after the fact", "and later turns keep it")
+  } finally {
+    await cleanup()
+  }
+})
+
+test("a Session named in OMP itself keeps that name here", async () => {
+  const { acp, service, cleanup } = await harness()
+  try {
+    await acp.seedSession("stored-named", {
+      title: "Written in the OMP TUI",
+      entries: [
+        { type: "message", id: "e1", parentId: null, timestamp: "2026-08-26T10:00:00.000Z", message: { role: "user", content: "Question" } }
+      ]
+    })
+    assert.equal((await service.listSessions()).find((session) => session.id === "stored-named").title, "Written in the OMP TUI")
+  } finally {
+    await cleanup()
   }
 })

--- a/bridge/test/omp-acp-lifecycle.test.js
+++ b/bridge/test/omp-acp-lifecycle.test.js
@@ -1,0 +1,431 @@
+import assert from "node:assert/strict"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import test from "node:test"
+import { AcpPromptEchoFilter } from "../src/acp-prompt-echo-filter.js"
+import { AcpService } from "../src/acp-service.js"
+import { HARNESS_PROFILES } from "../src/harness-profiles.js"
+import { createOmpHistoryLoader } from "../src/omp-session-history.js"
+import { FakeOmpAcp } from "./helpers/fake-omp-acp.js"
+
+/**
+ * The OMP Session lifecycle, driven end to end through the same objects the daemon builds.
+ *
+ * These cases are written against the multi-turn behaviour a person actually exercises - send,
+ * read the answer, send again, leave and come back - because a suite that only proves the first
+ * prompt cannot see the failure that made the second one appear blank.
+ */
+
+const profile = HARNESS_PROFILES.omp
+
+async function harness({ sessionRoot } = {}) {
+  const root = sessionRoot ?? await mkdtemp(path.join(tmpdir(), "harness-remote-omp-lifecycle-"))
+  const acp = new FakeOmpAcp({ sessionRoot: root })
+  const service = new AcpService(new AcpPromptEchoFilter(acp), {
+    historyLoader: createOmpHistoryLoader(root),
+    preserveListedTimestamps: profile.preserveListedTimestamps,
+    reloadOnHistoryRefresh: profile.reloadOnHistoryRefresh,
+    replaySettleMs: profile.replaySettleMs,
+    preferListedTitles: profile.preferListedTitles,
+    journalPageWhileOwned: profile.journalPageWhileOwned !== false,
+    modelVariantConfigIDs: profile.modelVariantConfigIDs ?? []
+  })
+  return { root, acp, service, cleanup: () => rm(root, { recursive: true, force: true }) }
+}
+
+/** What the app reads: the newest page of the transcript. */
+async function tail(service, sessionID) {
+  return (await service.messagePage(sessionID, { limit: 200 })).messages
+}
+
+function shape(messages) {
+  return messages.map((message) => [
+    message.info.role,
+    message.parts.map((part) => part.type === "tool" ? `tool:${part.tool}:${part.state.status}` : `${part.type}:${part.text ?? ""}`)
+  ])
+}
+
+function ids(messages) {
+  return messages.map((message) => message.info.id)
+}
+
+test("a new OMP Session answers its first prompt and every prompt after it", async () => {
+  const { acp, service, cleanup } = await harness()
+  try {
+    const created = await service.createSession({ directory: "/repo", title: "Rebuild" })
+    const sessionID = created.id
+
+    const seen = []
+    for (let turn = 1; turn <= 5; turn += 1) {
+      acp.queueTurn({
+        reasoning: [`Thinking about ${turn}`],
+        tools: [{ id: `call-${turn}`, name: "read", input: { path: `file-${turn}.ts` }, output: `contents ${turn}` }],
+        text: [`Answer ${turn} `, "part two"]
+      })
+      await service.promptAndWait(sessionID, `Prompt ${turn}`)
+      seen.push(shape(await tail(service, sessionID)))
+    }
+
+    const final = await tail(service, sessionID)
+    assert.deepEqual(
+      final.filter((message) => message.info.role === "user").map((message) => message.parts[0].text),
+      ["Prompt 1", "Prompt 2", "Prompt 3", "Prompt 4", "Prompt 5"],
+      "five prompts must produce five turns in one Session"
+    )
+    const answers = final
+      .filter((message) => message.info.role === "assistant")
+      .flatMap((message) => message.parts.filter((part) => part.type === "text").map((part) => part.text))
+    assert.deepEqual(
+      answers,
+      [1, 2, 3, 4, 5].map((turn) => `Answer ${turn} part two`),
+      "every answer must converge on its complete text, last chunk included"
+    )
+    assert.equal(new Set(ids(final)).size, final.length, "no message may appear twice")
+    assert.equal(acp.calls("session/load").length, 0, "a Session this bridge created is never replayed back to it")
+    assert.equal(service.status(sessionID).type, "idle")
+
+    // Every intermediate read is a prefix of the next: nothing is re-identified between turns, which
+    // is what lets the app reconcile pages by id without inventing a second copy of a turn.
+    for (let index = 1; index < seen.length; index += 1) {
+      assert.deepEqual(seen[index].slice(0, seen[index - 1].length), seen[index - 1], `turn ${index + 1} must extend turn ${index}`)
+    }
+  } finally {
+    await cleanup()
+  }
+})
+
+test("reasoning, tool activity and text are readable while the turn is still running", async () => {
+  const { acp, service, cleanup } = await harness()
+  try {
+    const sessionID = (await service.createSession({ directory: "/repo" })).id
+    acp.queueTurn({ reasoning: ["First I look"], tools: [{ id: "call-a", name: "grep" }], text: ["Done"] })
+    await service.promptAndWait(sessionID, "Prompt 1")
+
+    const during = []
+    acp.queueTurn({ reasoning: ["Second I look"], tools: [{ id: "call-b", name: "edit" }], text: ["Fixed"] })
+    const unsubscribe = service.subscribe(async (event) => {
+      if (event.sessionId !== sessionID || event.type !== "message.updated") return
+      during.push(shape(await tail(service, sessionID)))
+    })
+    await service.promptAndWait(sessionID, "Prompt 2")
+    unsubscribe()
+
+    const streamed = during.flat().flatMap(([, parts]) => parts)
+    assert.ok(streamed.includes("reasoning:Second I look"), "reasoning must be visible while the second turn runs")
+    assert.ok(streamed.some((part) => part.startsWith("tool:edit")), "tool activity must be visible while the second turn runs")
+    assert.ok(streamed.includes("text:Fixed"), "the answer must be visible while the second turn runs")
+
+    const settled = await tail(service, sessionID)
+    assert.ok(
+      settled.every((message) => message.parts.every((part) => part.type !== "tool" || part.state.status !== "running")),
+      "no Activity may still read as Working once the turn ended"
+    )
+  } finally {
+    await cleanup()
+  }
+})
+
+test("leaving and returning during a turn does not re-identify or duplicate the conversation", async () => {
+  const { acp, service, cleanup } = await harness()
+  try {
+    const sessionID = (await service.createSession({ directory: "/repo" })).id
+    acp.queueTurn({ text: ["First answer"] })
+    await service.promptAndWait(sessionID, "Prompt 1")
+    const afterFirst = ids(await tail(service, sessionID))
+
+    // Navigating away and back is a fresh read of the same Session, both while it is working and
+    // once it is Ready. Neither may hand the app a different identity for a message it already has.
+    const mid = []
+    acp.queueTurn({ reasoning: ["Working"], text: ["Second answer"] })
+    const unsubscribe = service.subscribe(async (event) => {
+      if (event.sessionId === sessionID && event.type === "message.updated") mid.push(ids(await tail(service, sessionID)))
+    })
+    await service.promptAndWait(sessionID, "Prompt 2")
+    unsubscribe()
+
+    const afterSecond = ids(await tail(service, sessionID))
+    assert.deepEqual(afterSecond.slice(0, afterFirst.length), afterFirst, "the first turn keeps its identity across the second")
+    for (const snapshot of mid) {
+      assert.deepEqual(snapshot.slice(0, afterFirst.length), afterFirst, "a read taken mid-turn agrees with the settled one")
+    }
+    assert.deepEqual(await tail(service, sessionID), await tail(service, sessionID), "repeated reads are stable")
+  } finally {
+    await cleanup()
+  }
+})
+
+test("two prompts with identical text stay two turns", async () => {
+  const { acp, service, cleanup } = await harness()
+  try {
+    const sessionID = (await service.createSession({ directory: "/repo" })).id
+    acp.queueTurn({ text: ["One"] })
+    await service.promptAndWait(sessionID, "Same question")
+    acp.queueTurn({ text: ["Two"] })
+    await service.promptAndWait(sessionID, "Same question")
+
+    const messages = await tail(service, sessionID)
+    assert.deepEqual(shape(messages), [
+      ["user", ["text:Same question"]],
+      ["assistant", ["text:One"]],
+      ["user", ["text:Same question"]],
+      ["assistant", ["text:Two"]]
+    ], "repeated prompts must not be collapsed into one turn")
+    assert.equal(new Set(ids(messages)).size, 4)
+  } finally {
+    await cleanup()
+  }
+})
+
+test("an existing OMP Session is resumed rather than replayed, and continues without duplicating itself", async () => {
+  const { acp, service, cleanup } = await harness()
+  try {
+    await acp.seedSession("stored-1", {
+      title: "Written by OMP itself",
+      entries: [
+        { type: "message", id: "e1", parentId: null, timestamp: "2026-08-26T10:00:00.000Z", message: { role: "user", content: "Earlier question" } },
+        { type: "message", id: "e2", parentId: "e1", timestamp: "2026-08-26T10:00:01.000Z", message: { role: "assistant", provider: "anthropic", model: "claude-sonnet-4", content: [{ type: "text", text: "Earlier answer" }] } }
+      ]
+    })
+
+    const observed = await tail(service, "stored-1")
+    assert.deepEqual(shape(observed), [
+      ["user", ["text:Earlier question"]],
+      ["assistant", ["text:Earlier answer"]]
+    ], "an OMP Session opened elsewhere is readable without opening it here")
+    assert.equal(acp.calls("session/load").length + acp.calls("session/resume").length, 0, "reading must not acquire the writer")
+
+    assert.equal(await service.claimSession("stored-1"), true)
+    assert.equal(acp.calls("session/resume").length, 1, "taking the writer uses the non-replaying open")
+    assert.equal(acp.calls("session/load").length, 0, "session/load would replay the whole transcript under new ids")
+
+    acp.queueTurn({ text: ["Later answer"] })
+    await service.promptAndWait("stored-1", "Later question")
+
+    const continued = await tail(service, "stored-1")
+    assert.deepEqual(shape(continued), [
+      ["user", ["text:Earlier question"]],
+      ["assistant", ["text:Earlier answer"]],
+      ["user", ["text:Later question"]],
+      ["assistant", ["text:Later answer"]]
+    ], "continuing a stored Session must neither replay nor duplicate its history")
+    assert.deepEqual(ids(continued).slice(0, 2), ["e1", "e2"], "the stored turns keep the identity the journal gave them")
+    assert.equal(acp.calls("session/load").length, 0)
+  } finally {
+    await cleanup()
+  }
+})
+
+test("continuing on the same model sends no model mutation, and a real change sends exactly one", async () => {
+  const { acp, service, cleanup } = await harness()
+  try {
+    const sessionID = (await service.createSession({ directory: "/repo" })).id
+    const mutations = () => acp.calls("session/set_config_option").filter(([, params]) => params.configId === "model")
+
+    acp.queueTurn({ text: ["One"] })
+    await service.promptAndWait(sessionID, "Prompt 1", "anthropic/claude-sonnet-4")
+    assert.equal(mutations().length, 0, "the Session already holds this model")
+
+    acp.queueTurn({ text: ["Two"] })
+    await service.promptAndWait(sessionID, "Prompt 2", "anthropic/claude-sonnet-4")
+    assert.equal(mutations().length, 0, "continuing on the same model is not a model change")
+
+    acp.queueTurn({ text: ["Three"] })
+    await service.promptAndWait(sessionID, "Prompt 3", "openai/gpt-5.6")
+    assert.equal(mutations().length, 1, "a real switch is applied once")
+
+    const page = await service.messagePage(sessionID, { limit: 200 })
+    assert.deepEqual(
+      page.model,
+      { providerID: "openai", modelID: "gpt-5.6", variant: "off" },
+      "the page reports the model the Session now holds, with the reasoning level it is set to"
+    )
+  } finally {
+    await cleanup()
+  }
+})
+
+test("the reported model carries the reasoning variant the Session holds", async () => {
+  const { acp, service, cleanup } = await harness()
+  try {
+    const sessionID = (await service.createSession({ directory: "/repo" })).id
+    await service.setModel(sessionID, "openai/gpt-5.6", { configId: "thinking", value: "high" })
+    const page = await service.messagePage(sessionID, { limit: 10 })
+    assert.deepEqual(page.model, { providerID: "openai", modelID: "gpt-5.6", variant: "high" })
+  } finally {
+    await cleanup()
+  }
+})
+
+test("cancelling a turn leaves no invented interruption in the transcript", async () => {
+  const { acp, service, cleanup } = await harness()
+  try {
+    const sessionID = (await service.createSession({ directory: "/repo" })).id
+    acp.queueTurn({ reasoning: ["Half a thought"], text: ["Never sent"] })
+    const running = service.promptAndWait(sessionID, "Prompt 1").catch(() => undefined)
+    service.abort(sessionID)
+    await running
+
+    assert.equal(service.status(sessionID).type, "idle", "a cancelled Session must read Ready")
+    const messages = await tail(service, sessionID)
+    assert.ok(
+      messages.every((message) => !message.info.error),
+      "OMP's own abort reason is one its renderers suppress, so it must not become a red banner here"
+    )
+
+    acp.queueTurn({ text: ["Answer after stop"] })
+    await service.promptAndWait(sessionID, "Prompt 2")
+    const continued = await tail(service, sessionID)
+    assert.ok(
+      continued.some((message) => message.parts.some((part) => part.text === "Answer after stop")),
+      "a Session must keep working after a Stop"
+    )
+  } finally {
+    await cleanup()
+  }
+})
+
+test("an OMP build without session/resume still opens through session/load", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-legacy-"))
+  try {
+    const acp = new FakeOmpAcp({ sessionRoot: root })
+    // OMP advertised `sessionCapabilities` only from the release that added resume; an installation
+    // that predates it must keep working on the method it does offer.
+    acp.sessionCapabilities = {}
+    const service = new AcpService(new AcpPromptEchoFilter(acp), {
+      historyLoader: createOmpHistoryLoader(root),
+      reloadOnHistoryRefresh: profile.reloadOnHistoryRefresh,
+      journalPageWhileOwned: false,
+      modelVariantConfigIDs: profile.modelVariantConfigIDs
+    })
+    await acp.seedSession("stored-legacy", {
+      entries: [
+        { type: "message", id: "e1", parentId: null, timestamp: "2026-08-26T10:00:00.000Z", message: { role: "user", content: "Earlier question" } },
+        { type: "message", id: "e2", parentId: "e1", timestamp: "2026-08-26T10:00:01.000Z", message: { role: "assistant", provider: "anthropic", model: "claude-sonnet-4", content: [{ type: "text", text: "Earlier answer" }] } }
+      ]
+    })
+
+    assert.equal(await service.claimSession("stored-legacy"), true)
+    assert.equal(acp.calls("session/load").length, 1)
+    acp.queueTurn({ text: ["Later answer"] })
+    await service.promptAndWait("stored-legacy", "Later question")
+    const messages = await tail(service, "stored-legacy")
+    assert.deepEqual(
+      messages.filter((message) => message.info.role === "user").map((message) => message.parts[0].text),
+      ["Earlier question", "Later question"],
+      "the replay a legacy open produces must not double the history the journal already supplied"
+    )
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test("an OMP Session whose journal predates the entry tree is readable before OMP migrates it", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-v1-"))
+  try {
+    const acp = new FakeOmpAcp({ sessionRoot: root })
+    const service = new AcpService(new AcpPromptEchoFilter(acp), {
+      historyLoader: createOmpHistoryLoader(root),
+      reloadOnHistoryRefresh: false,
+      journalPageWhileOwned: false
+    })
+    // A v1 journal: no title slot, no version on the header, and no `id`/`parentId` anywhere.
+    const lines = [
+      { type: "session", id: "v1-session", timestamp: "2026-01-02T10:00:00.000Z", cwd: "/repo" },
+      { type: "message", timestamp: "2026-01-02T10:00:01.000Z", message: { role: "user", content: "Old question" } },
+      { type: "message", timestamp: "2026-01-02T10:00:02.000Z", message: { role: "assistant", provider: "anthropic", model: "claude-sonnet-4", content: [{ type: "text", text: "Old answer" }] } }
+    ]
+    await writeFile(path.join(root, "2026-01-02_v1-session.jsonl"), `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`)
+
+    const messages = await tail(service, "v1-session")
+    assert.deepEqual(shape(messages), [
+      ["user", ["text:Old question"]],
+      ["assistant", ["text:Old answer"]]
+    ], "an unmigrated Session must not read as empty")
+    assert.deepEqual(ids(await tail(service, "v1-session")), ids(messages), "its ids must be stable across reads")
+    assert.equal(acp.calls("session/load").length, 0)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test("a Session whose journal has not been created yet still answers its first prompt", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-lazy-"))
+  try {
+    const acp = new FakeOmpAcp({ sessionRoot: root })
+    const service = new AcpService(new AcpPromptEchoFilter(acp), {
+      historyLoader: createOmpHistoryLoader(root),
+      reloadOnHistoryRefresh: false,
+      journalPageWhileOwned: false
+    })
+    // The lookup misses before OMP writes anything, which used to be remembered as "no such
+    // Session" for as long as the bridge ran.
+    assert.deepEqual(await tail(service, "omp-1"), [])
+    const sessionID = (await service.createSession({ directory: "/repo" })).id
+    acp.queueTurn({ text: ["First answer"] })
+    await service.promptAndWait(sessionID, "First question")
+    assert.deepEqual(shape(await tail(service, sessionID)), [
+      ["user", ["text:First question"]],
+      ["assistant", ["text:First answer"]]
+    ])
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test("taking the writer picks up what OMP wrote on its own in the meantime", async () => {
+  const { acp, service, cleanup } = await harness()
+  try {
+    await acp.seedSession("stored-2", {
+      entries: [
+        { type: "message", id: "e1", parentId: null, timestamp: "2026-08-26T10:00:00.000Z", message: { role: "user", content: "First question" } },
+        { type: "message", id: "e2", parentId: "e1", timestamp: "2026-08-26T10:00:01.000Z", message: { role: "assistant", provider: "anthropic", model: "claude-sonnet-4", content: [{ type: "text", text: "First answer" }] } }
+      ]
+    })
+    assert.equal((await tail(service, "stored-2")).length, 2)
+
+    // The user keeps talking to OMP directly while the Session is only being observed here.
+    await acp.seedSession("stored-2", {
+      entries: [
+        { type: "message", id: "e1", parentId: null, timestamp: "2026-08-26T10:00:00.000Z", message: { role: "user", content: "First question" } },
+        { type: "message", id: "e2", parentId: "e1", timestamp: "2026-08-26T10:00:01.000Z", message: { role: "assistant", provider: "anthropic", model: "claude-sonnet-4", content: [{ type: "text", text: "First answer" }] } },
+        { type: "message", id: "e3", parentId: "e2", timestamp: "2026-08-26T10:00:02.000Z", message: { role: "user", content: "Second question" } },
+        { type: "message", id: "e4", parentId: "e3", timestamp: "2026-08-26T10:00:03.000Z", message: { role: "assistant", provider: "anthropic", model: "claude-sonnet-4", content: [{ type: "text", text: "Second answer" }] } }
+      ]
+    })
+    assert.equal((await tail(service, "stored-2")).length, 4, "an observed Session keeps following its journal")
+
+    await service.claimSession("stored-2")
+    acp.queueTurn({ text: ["Third answer"] })
+    await service.promptAndWait("stored-2", "Third question")
+    assert.deepEqual(
+      (await tail(service, "stored-2")).map((message) => message.parts[0].text),
+      ["First question", "First answer", "Second question", "Second answer", "Third question", "Third answer"],
+      "continuing must build on everything OMP had written, and repeat none of it"
+    )
+  } finally {
+    await cleanup()
+  }
+})
+
+test("an unreadable journal is reported rather than answered with an empty conversation", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-unreadable-"))
+  try {
+    const acp = new FakeOmpAcp({ sessionRoot: root })
+    const loader = async () => { throw new Error("EIO") }
+    loader.journalOnly = true
+    loader.page = async () => { throw new Error("EIO") }
+    const service = new AcpService(new AcpPromptEchoFilter(acp), {
+      historyLoader: loader,
+      reloadOnHistoryRefresh: false,
+      journalPageWhileOwned: false
+    })
+    await acp.seedSession("stored-broken", { entries: [] })
+
+    await assert.rejects(() => service.messagePage("stored-broken", { limit: 100 }), /EIO/)
+    assert.equal(acp.calls("session/load").length, 0, "a replay is not a fallback for a read that failed")
+    assert.equal(acp.calls("session/resume").length, 0, "and neither is acquiring the writer")
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/bridge/test/omp-session-history.test.js
+++ b/bridge/test/omp-session-history.test.js
@@ -34,9 +34,10 @@ test("reads only the authoritative branch from an OMP session transcript", async
 
     const undone = await loadHistory(sessionID, { activeSessionLeaf: "user-1" })
     assert.deepEqual(undone.map((message) => message.parts[0].text), ["Question"])
-    await assert.rejects(
-      loadHistory(sessionID, { activeSessionLeaf: "missing-leaf" }),
-      /active session leaf is missing/
+    assert.deepEqual(
+      (await loadHistory(sessionID, { activeSessionLeaf: "missing-leaf" })).map((message) => message.parts.at(-1)?.text),
+      ["Question", "Answer"],
+      "a leaf the extension published for a journal that has since been rewritten is stale, not a reason to refuse the Session"
     )
   } finally {
     await rm(root, { recursive: true, force: true })
@@ -120,9 +121,11 @@ test("pages only the authoritative OMP branch and ignores later abandoned record
     const inferred = await loadHistory.page(sessionID, { limit: 2 })
     assert.deepEqual(inferred.messages.map((message) => message.parts[0].text), ["abandoned-u", "abandoned-a"])
     assert.equal(inferred.hasMore, true)
-    await assert.rejects(
-      loadHistory.page(sessionID, { activeSessionLeaf: "missing-leaf", limit: 2 }),
-      /active session leaf is missing/
+    const stale = await loadHistory.page(sessionID, { activeSessionLeaf: "missing-leaf", limit: 2 })
+    assert.deepEqual(
+      stale.messages.map((message) => message.parts[0].text),
+      ["abandoned-u", "abandoned-a"],
+      "a stale extension leaf falls back to the branch OMP itself would resume rather than failing the read"
     )
   } finally {
     await rm(root, { recursive: true, force: true })
@@ -189,6 +192,242 @@ test("ignores an image record carrying no payload", async () => {
     const loadHistory = createOmpHistoryLoader(root)
     const messages = await loadHistory(sessionID, { activeSessionLeaf: "user-1" })
     assert.deepEqual(messages[0].parts.map((part) => part.type), ["text"], "an empty image must not become a broken thumbnail")
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+/*
+ * The parts of the journal that only appear in old or real Sessions.
+ *
+ * Each of these was read out of oh-my-pi 18.x rather than inferred, because guessing at them is
+ * what made the previous readers report a real conversation as empty.
+ */
+
+async function writeJournal(root, sessionID, { titleSlot = true, header = { version: 3 }, entries = [] } = {}) {
+  const lines = []
+  if (titleSlot) {
+    const slot = JSON.stringify({ type: "title", v: 1, title: "Stored", updatedAt: "2026-08-26T10:00:00.000Z", pad: "" })
+    lines.push(`${slot}${" ".repeat(Math.max(0, 256 - slot.length - 1))}`)
+  }
+  if (header) lines.push(JSON.stringify({ type: "session", id: sessionID, timestamp: "2026-08-26T10:00:00.000Z", cwd: "/repo", ...header }))
+  for (const entry of entries) lines.push(JSON.stringify(entry))
+  await writeFile(path.join(root, `2026-08-26_${sessionID}.jsonl`), `${lines.join("\n")}\n`)
+}
+
+test("the fixed title slot and the session header are not branch nodes", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-header-"))
+  try {
+    await writeJournal(root, "session-header", {
+      entries: [
+        { type: "message", id: "e1", parentId: null, timestamp: "2026-08-26T10:00:01.000Z", message: { role: "user", content: "Question" } },
+        { type: "message", id: "e2", parentId: "e1", timestamp: "2026-08-26T10:00:02.000Z", message: { role: "assistant", content: [{ type: "text", text: "Answer" }] } }
+      ]
+    })
+    const loadHistory = createOmpHistoryLoader(root)
+    assert.deepEqual(
+      (await loadHistory("session-header")).map((message) => [message.info.role, message.parts[0].text]),
+      [["user", "Question"], ["assistant", "Answer"]],
+      "a Session carrying OMP 18's title slot and header must read normally"
+    )
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test("a journal written before the entry tree existed is read linearly with stable ids", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-v1-journal-"))
+  try {
+    await writeJournal(root, "session-v1", {
+      titleSlot: false,
+      header: {},
+      entries: [
+        { type: "message", timestamp: "2026-01-02T10:00:01.000Z", message: { role: "user", content: "Old question" } },
+        { type: "message", timestamp: "2026-01-02T10:00:02.000Z", message: { role: "assistant", content: [{ type: "text", text: "Old answer" }] } }
+      ]
+    })
+    const loadHistory = createOmpHistoryLoader(root)
+    const first = await loadHistory("session-v1")
+    assert.deepEqual(first.map((message) => message.parts[0].text), ["Old question", "Old answer"])
+    assert.deepEqual(
+      (await loadHistory("session-v1")).map((message) => message.info.id),
+      first.map((message) => message.info.id),
+      "position-derived ids must be identical across reads of an unmigrated journal"
+    )
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test("tool calls and their results are rejoined into Activity", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-tools-"))
+  try {
+    await writeJournal(root, "session-tools", {
+      entries: [
+        { type: "message", id: "e1", parentId: null, timestamp: "2026-08-26T10:00:01.000Z", message: { role: "user", content: "Read it" } },
+        {
+          type: "message",
+          id: "e2",
+          parentId: "e1",
+          timestamp: "2026-08-26T10:00:02.000Z",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "thinking", thinking: "I should read the file" },
+              { type: "toolCall", id: "call-1", name: "read", arguments: { path: "a.ts" } },
+              { type: "toolCall", id: "call-2", name: "grep", arguments: { pattern: "x" } }
+            ]
+          }
+        },
+        {
+          type: "message",
+          id: "e3",
+          parentId: "e2",
+          timestamp: "2026-08-26T10:00:03.000Z",
+          message: { role: "toolResult", toolCallId: "call-1", toolName: "read", content: [{ type: "text", text: "file body" }], isError: false }
+        },
+        {
+          type: "message",
+          id: "e4",
+          parentId: "e3",
+          timestamp: "2026-08-26T10:00:04.000Z",
+          message: { role: "toolResult", toolCallId: "call-2", toolName: "grep", content: [{ type: "text", text: "no match" }], isError: true }
+        },
+        { type: "message", id: "e5", parentId: "e4", timestamp: "2026-08-26T10:00:05.000Z", message: { role: "assistant", content: [{ type: "text", text: "Done" }] } }
+      ]
+    })
+    const loadHistory = createOmpHistoryLoader(root)
+    const messages = await loadHistory("session-tools")
+    assert.deepEqual(messages.map((message) => message.info.role), ["user", "assistant", "assistant"], "a tool result is not a message of its own")
+    const activity = messages[1].parts
+    assert.deepEqual(activity.map((part) => part.type), ["reasoning", "tool", "tool"])
+    assert.deepEqual(activity.slice(1).map((part) => [part.tool, part.state.status, part.state.output]), [
+      ["read", "completed", "file body"],
+      ["grep", "error", "no match"]
+    ])
+    assert.ok(activity[1].state.time.start && activity[1].state.time.end, "a finished call reports when it ran")
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test("a tool call whose result never arrived is neither a success nor a failure", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-tool-open-"))
+  try {
+    await writeJournal(root, "session-open-tool", {
+      entries: [
+        { type: "message", id: "e1", parentId: null, timestamp: "2026-08-26T10:00:01.000Z", message: { role: "user", content: "Read it" } },
+        {
+          type: "message",
+          id: "e2",
+          parentId: "e1",
+          timestamp: "2026-08-26T10:00:02.000Z",
+          message: { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "read", arguments: {} }] }
+        }
+      ]
+    })
+    const loadHistory = createOmpHistoryLoader(root)
+    const messages = await loadHistory("session-open-tool")
+    assert.equal(messages[1].parts[0].state.status, "incomplete", "history must never read as still Working")
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test("the abort reasons OMP suppresses are not shown as errors, and real failures still are", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-abort-"))
+  try {
+    await writeJournal(root, "session-abort", {
+      entries: [
+        { type: "message", id: "e1", parentId: null, timestamp: "2026-08-26T10:00:01.000Z", message: { role: "user", content: "One" } },
+        { type: "message", id: "e2", parentId: "e1", timestamp: "2026-08-26T10:00:02.000Z", message: { role: "assistant", content: [{ type: "text", text: "Partial" }], stopReason: "aborted", errorMessage: "Interrupted by user" } },
+        { type: "message", id: "e3", parentId: "e2", timestamp: "2026-08-26T10:00:03.000Z", message: { role: "user", content: "Two" } },
+        { type: "message", id: "e4", parentId: "e3", timestamp: "2026-08-26T10:00:04.000Z", message: { role: "assistant", content: [], stopReason: "aborted", errorMessage: "__omp.silent_abort__" } },
+        { type: "message", id: "e5", parentId: "e4", timestamp: "2026-08-26T10:00:05.000Z", message: { role: "user", content: "Three" } },
+        { type: "message", id: "e6", parentId: "e5", timestamp: "2026-08-26T10:00:06.000Z", message: { role: "assistant", content: [], errorMessage: "You have exceeded your quota" } },
+        { type: "message", id: "e7", parentId: "e6", timestamp: "2026-08-26T10:00:07.000Z", message: { role: "assistant", content: [{ type: "text", text: "Later" }], errorId: 0x0400_0000, errorMessage: "aborted by the user" } }
+      ]
+    })
+    const loadHistory = createOmpHistoryLoader(root)
+    const messages = await loadHistory("session-abort")
+    assert.deepEqual(
+      messages.map((message) => [message.info.role, message.info.error?.message ?? null]),
+      [
+        ["user", null],
+        ["assistant", null],
+        ["user", null],
+        ["user", null],
+        ["assistant", "You have exceeded your quota"],
+        ["assistant", null]
+      ],
+      "a Stop leaves the partial answer without a banner, while a provider refusal keeps its reason"
+    )
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test("injected and steering user turns are not conversation", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-synthetic-"))
+  try {
+    await writeJournal(root, "session-synthetic", {
+      entries: [
+        { type: "message", id: "e1", parentId: null, timestamp: "2026-08-26T10:00:01.000Z", message: { role: "user", content: "Real question" } },
+        { type: "message", id: "e2", parentId: "e1", timestamp: "2026-08-26T10:00:02.000Z", message: { role: "user", content: "Continue.", synthetic: true } },
+        { type: "message", id: "e3", parentId: "e2", timestamp: "2026-08-26T10:00:03.000Z", message: { role: "user", content: "Be quicker", steering: true } },
+        { type: "message", id: "e4", parentId: "e3", timestamp: "2026-08-26T10:00:04.000Z", message: { role: "developer", content: "Repository context" } },
+        { type: "message", id: "e5", parentId: "e4", timestamp: "2026-08-26T10:00:05.000Z", message: { role: "assistant", content: [{ type: "text", text: "Answer" }] } }
+      ]
+    })
+    const loadHistory = createOmpHistoryLoader(root)
+    assert.deepEqual(
+      (await loadHistory("session-synthetic")).map((message) => [message.info.role, message.parts[0].text]),
+      [["user", "Real question"], ["assistant", "Answer"]],
+      "only a turn the user typed may open a turn"
+    )
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test("an externalised image payload is skipped rather than rendered as a broken thumbnail", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-blob-"))
+  try {
+    await writeJournal(root, "session-blob", {
+      entries: [
+        {
+          type: "message",
+          id: "e1",
+          parentId: null,
+          timestamp: "2026-08-26T10:00:01.000Z",
+          message: { role: "user", content: [{ type: "text", text: "look" }, { type: "image", mimeType: "image/webp", data: `blob:sha256:${"a".repeat(64)}` }] }
+        }
+      ]
+    })
+    const loadHistory = createOmpHistoryLoader(root)
+    assert.deepEqual((await loadHistory("session-blob"))[0].parts.map((part) => part.type), ["text"])
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test("the model on the branch is reported without paging the transcript", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-remote-omp-branch-model-"))
+  try {
+    await writeJournal(root, "session-branch-model", {
+      entries: [
+        { type: "session_init", id: "e0", parentId: null, timestamp: "2026-08-26T10:00:00.000Z", resolvedModel: "anthropic/claude-sonnet-4" },
+        { type: "message", id: "e1", parentId: "e0", timestamp: "2026-08-26T10:00:01.000Z", message: { role: "user", content: "Question" } },
+        { type: "model_change", id: "e2", parentId: "e1", timestamp: "2026-08-26T10:00:02.000Z", model: "openai/gpt-5.6" },
+        { type: "model_change", id: "e3", parentId: "e2", timestamp: "2026-08-26T10:00:03.000Z", role: "smol", model: "openai/gpt-5-mini" }
+      ]
+    })
+    const loadHistory = createOmpHistoryLoader(root)
+    assert.deepEqual(
+      await loadHistory.sessionModel("session-branch-model"),
+      { providerID: "openai", modelID: "gpt-5.6" },
+      "a role-scoped model change describes a different slot and must not move the picker"
+    )
   } finally {
     await rm(root, { recursive: true, force: true })
   }

--- a/bridge/test/pi-native-history-metadata.test.js
+++ b/bridge/test/pi-native-history-metadata.test.js
@@ -18,6 +18,12 @@ class PiHistoryAcp extends EventEmitter {
   async request(method, params) {
     if (method === "session/load") {
       this.loadCount += 1
+      // A harness advertises what it can be asked to do. The bridge only ever sends a slash command
+      // the running adapter listed, because an unknown one is not refused - it is answered.
+      this.emit("notification", {
+        method: "session/update",
+        params: { sessionId: params.sessionId, update: { sessionUpdate: "available_commands_update", availableCommands: [{ name: "name", description: "Rename" }] } }
+      })
       this.emit("notification", {
         method: "session/update",
         params: {
@@ -76,4 +82,17 @@ test("PI list and rename use PI's native display name", async () => {
   assert.equal(acp.prompts.at(-1), "/name Renamed from Harness Remote")
   assert.equal(renamed.title, "Renamed from Harness Remote")
   assert.equal((await service.listSessions())[0].title, "Renamed from Harness Remote")
+})
+
+test("a harness that does not advertise its rename command keeps the title here instead", async () => {
+  const acp = new PiHistoryAcp()
+  acp.request = async function request(method, params) {
+    if (method === "session/load") return { configOptions: [] }
+    return PiHistoryAcp.prototype.request.call(this, method, params)
+  }
+  const service = new AcpService(acp, { preferListedTitles: true, nativeRenameCommand: "name" })
+
+  const renamed = await service.renameSession("pi-session", "Local only")
+  assert.equal(acp.prompts.length, 0, "an unlisted slash command must never be sent as a prompt")
+  assert.equal(renamed.title, "Local only")
 })

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -839,14 +839,14 @@ test("replays ACP history when extension state is unavailable", async () => {
   assert.deepEqual(await service.actions("session-1"), [])
 })
 
-test("keeps an external OMP session observational when its journal has no active leaf", async () => {
+test("keeps an external OMP session observational when its journal is empty", async () => {
   const acp = new ExtensionActionAcp()
   const historyLoader = async () => []
-  historyLoader.deferAcpReplayWithoutActiveLeaf = true
-  const service = new AcpService(acp, { historyLoader })
+  historyLoader.page = async () => ({ messages: [], before: null, hasMore: false })
+  const service = new AcpService(acp, { historyLoader, journalPageWhileOwned: false })
 
   // The Session-first UI uses the paged endpoint, not `messages()` directly.
-  // Keep this on that path so a missing active leaf cannot turn opening a row
+  // Keep this on that path so an empty journal cannot turn opening a row
   // into a minutes-long `session/load` that serializes all OMP requests.
   assert.deepEqual((await service.messagePage("session-1", { limit: 100 })).messages, [])
   assert.equal(acp.loads, 0, "a read-only OMP open must not fall back to a blocking ACP replay")

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -855,11 +855,16 @@ test("keeps an external OMP session observational when its journal is empty", as
 test("renames and hides ACP sessions through OpenCode-compatible endpoints", async () => {
   const bridge = await startServer()
   try {
-    const renamed = await fetch(`${bridge.baseURL}/session/session-1`, {
+    // Naming a Session is a command sent into it, so the rename opens it first. This adapter holds
+    // its first open until it is released, exactly as a slow harness would.
+    const renaming = fetch(`${bridge.baseURL}/session/session-1`, {
       method: "PATCH",
       headers: jsonHeaders(),
       body: JSON.stringify({ title: "Renamed from mobile" })
     })
+    await bridge.acp.loadStarted
+    bridge.acp.releaseLoad()
+    const renamed = await renaming
     assert.equal(renamed.status, 200)
     assert.equal((await renamed.json()).title, "Renamed from mobile")
     assert.equal((await readJSON(bridge.baseURL, "/session"))[0].title, "Renamed from mobile")

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -37,7 +37,8 @@ advertise `session/resume`.
 | One `messageId` per live assistant message, cleared when that message ends | `#getLiveMessageId`, `#clearLiveAssistantMessageAfterEvent` | a turn that calls a tool legitimately streams under two ids |
 | `session/prompt` resolves only after the end-of-turn updates are flushed and awaited | `AcpAgent.#trackPromptEvent` on `agent_end` | the answer is complete when the turn goes idle; no settle delay is needed |
 | `initialize` advertises `promptCapabilities.image`, and prompts accept `{type:"image", mimeType, data}` | `AcpAgent.initialize`, `#convertPromptBlocks` | the composer's attachment picker |
-| `session/list` returns `title`, `updatedAt` and `_meta.messageCount` | `AcpAgent.#toSessionInfo` | Session list metadata |
+| `session/list` returns `title`, `updatedAt` and `_meta.messageCount` | `AcpAgent.#toSessionInfo` | Session list metadata, and the Session index the app reads |
+| `/rename <title>` calls `setSessionName(title, "user")`, which rewrites the title slot, appends a `title_change` entry and marks the name user-set so auto-titling leaves it alone | `builtin-lifecycle.ts`, `SessionManager.setSessionName` | a Session's name is stored by OMP rather than only in this bridge; it is sent only when the command catalog advertises `rename` |
 | `available_commands_update` and `session_info_update` are pushed after new/load/resume | `#emitBootstrapUpdates` | optional extension actions are discovered from the command catalog |
 
 **The journal format, from `session-entries.ts`, `session-manager.ts` and `session-migrations.ts`:**

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -20,31 +20,42 @@ after 30s of silence, so a server that stops beating looks dead.
 
 ### Oh My Pi (OMP) — ACP over stdio, via `omp acp`
 
-First-party command, no third party in the path. The bridge uses `session/new`, `session/load`,
-`session/list`, `session/prompt`, `session/cancel` and `session/set_config_option`.
+First-party command, no third party in the path. The bridge uses `session/new`, `session/resume`,
+`session/list`, `session/prompt`, `session/cancel` and `session/set_config_option`, and reads the
+Session's own JSONL journal directly. `session/load` is used only by an OMP old enough not to
+advertise `session/resume`.
 
-**Assumed, all observed on OMP 17.1.3 rather than read from a spec:**
+**Read from the OMP source (`can1357/oh-my-pi`, verified at 18.0.7) rather than observed:**
 
-| Assumption | What breaks if it changes |
-|---|---|
-| `session/list` returns no `title` | titles are derived from the first prompt; a real title would be ignored |
-| A submitted prompt is never echoed back as `user_message_chunk` | the deduplication acknowledgement would swallow the user's message |
-| Chunks carry a `messageId` | without one, chunk aggregation falls back to per-turn tracking |
-| No `agent_plan` is emitted | the todo panel stays empty by design |
-| The agent approves its own tool calls and never sends `session/request_permission` | the permission path would start being exercised |
-| `available_commands_update` is emitted after extension initialization and contains registered command names | optional extension actions are not discovered |
+| Fact | Where it comes from | What depends on it |
+|---|---|---|
+| `session/load` replays the whole stored transcript back over the wire, minting `crypto.randomUUID()` per replayed message | `AcpAgent.loadSession` → `#replaySessionHistory` | replay can never be a transcript identity, so the bridge does not use `session/load` to read |
+| Replay flattens `developer`, `custom`, `hookMessage`, tool results and bash/python output into `user_message_chunk` | `#messageToReplayNotifications` | a replayed Session would grow turn boundaries nobody typed |
+| `session/resume` opens the same stored Session and returns the same `configOptions` with no replay | `AcpAgent.resumeSession` → `#resumeManagedSession` (identical to `#loadManagedSession`, minus the replay) | this is how the bridge takes the writer |
+| `initialize` advertises `agentCapabilities.sessionCapabilities.resume` | `AcpAgent.initialize` | the bridge falls back to `session/load` when it is absent, so an older OMP still works |
+| The live path never emits `user_message_chunk`; only `agent_message_chunk`, `agent_thought_chunk`, `tool_call`, `tool_call_update` and `plan` | `acp-event-mapper.ts` | a submitted prompt is not echoed back, so the transport echo filter is a guard rather than a workaround |
+| One `messageId` per live assistant message, cleared when that message ends | `#getLiveMessageId`, `#clearLiveAssistantMessageAfterEvent` | a turn that calls a tool legitimately streams under two ids |
+| `session/prompt` resolves only after the end-of-turn updates are flushed and awaited | `AcpAgent.#trackPromptEvent` on `agent_end` | the answer is complete when the turn goes idle; no settle delay is needed |
+| `initialize` advertises `promptCapabilities.image`, and prompts accept `{type:"image", mimeType, data}` | `AcpAgent.initialize`, `#convertPromptBlocks` | the composer's attachment picker |
+| `session/list` returns `title`, `updatedAt` and `_meta.messageCount` | `AcpAgent.#toSessionInfo` | Session list metadata |
+| `available_commands_update` and `session_info_update` are pushed after new/load/resume | `#emitBootstrapUpdates` | optional extension actions are discovered from the command catalog |
 
-**Also assumed, observed on OMP 17.2.10 while adding image attachments:**
+**The journal format, from `session-entries.ts`, `session-manager.ts` and `session-migrations.ts`:**
 
-| Assumption | What breaks if it changes |
-|---|---|
-| `initialize` advertises `agentCapabilities.promptCapabilities.image` | the composer hides its attachment picker and the bridge refuses attachments; a harness that dropped the flag would lose the feature rather than fail a prompt |
-| A prompt may carry `{type:"image", mimeType, data}` blocks alongside text, and an image with no text is accepted | sending a bare screenshot would need a synthetic caption |
-| No `audio` prompt capability is advertised | voice would have to be transcribed before it reaches a prompt |
-| `session/load` replays a stored image as `user_message_chunk` with `content: {type:"image", data, mimeType}`, sharing the `messageId` of the text chunk in that turn | the thumbnail stops reappearing when a session is reopened, or lands in a message of its own |
-| Images are re-encoded on the way in: a PNG upload replays and persists as `image/webp` | a mime taken from the upload rather than from the record would mislabel the part |
-| The persisted transcript stores no filename for an image | the app labels a replayed thumbnail generically instead of by name |
-| `session/load` mints a fresh `messageId` on every load | ids cannot be used to recognise the same message across two loads, which is why history dedup elsewhere falls back to text and timestamps |
+| Fact | Where it comes from | What depends on it |
+|---|---|---|
+| Line 1 is a fixed-width `type:"title"` slot with no `id`; line 2 is a `type:"session"` header with an `id` but no `parentId` | `SessionTitleSlotEntry`, `SessionHeader` | neither is a node in the branch graph |
+| The persisted branch leaf is the last entry in file order | `SessionEntryIndex.insert` sets `#leaf` per entry; `rebuild()` replays them in order | the bridge selects the same branch OMP would resume, with no ACP round trip |
+| A branch is `parentId` walked back from the leaf | `SessionEntryIndex.pathTo` | abandoned sibling branches are not rendered |
+| v1 journals carry no `id`/`parentId`; OMP adds them in memory on first open and rewrites the file | `migrateToCurrentVersion` → `migrateV1ToV2` | an old Session must be reconstructed linearly to be readable before that rewrite, or it reads as empty |
+| A `user` message can be `synthetic` (injected) or `steering` (documented as never rendered) | `UserMessage` in `packages/ai/src/types.ts` | neither may open a conversation turn |
+| `Interrupted by user` and `__omp.silent_abort__` are abort reasons OMP's own renderers suppress | `shouldRenderAbortReason`, `isSilentAbort`, `isUserInterruptAbort` | a Stop must not leave a red error banner in the reopened transcript |
+| An assistant message carries `toolCall` blocks and the matching `toolResult` arrives as its own entry | `AssistantMessage`, `ToolResultMessage` | Activity is reconstructed from the journal instead of from replay |
+| Large images are externalised to `blob:sha256:<hash>` in `~/.omp/agent/blobs/data` | `blob-store.ts` | such a payload is not base64 and is skipped rather than rendered as a broken data URL |
+| Session files are `<timestamp>_<sessionId>.jsonl` under `~/.omp/agent/sessions`, created lazily | `SessionManager#assignSessionFile`, `getSessionsDir` | lookups match by id suffix and a miss is retried rather than remembered |
+
+**Assumed rather than read:** the agent approves its own tool calls and never sends
+`session/request_permission`.
 
 **Watch:** any of the above and new `sessionUpdate` kinds; unknown updates are ignored by design.
 

--- a/web/scripts/native-opencode-browser-smoke.mjs
+++ b/web/scripts/native-opencode-browser-smoke.mjs
@@ -467,7 +467,9 @@ async function assertCreateContract(browser, viewport, mobile) {
   await page.getByRole("button", { name: "New Session" }).click()
   const panel = page.getByRole("group", { name: "Create native Session" })
   await panel.waitFor({ state: "visible" })
-  await panel.getByRole("combobox").nth(1).selectOption("opencode")
+  // Machine, Project, then Coding agent: New Session became machine-scoped, so the harness select
+  // is the third combobox in the panel.
+  await panel.getByLabel("Coding agent").selectOption("opencode")
   await panel.getByPlaceholder("New OpenCode Session").fill(CREATE_TITLE)
   await page.getByRole("button", { name: "Create Session" }).click()
 

--- a/web/scripts/v3-browser-controls-smoke.mjs
+++ b/web/scripts/v3-browser-controls-smoke.mjs
@@ -257,19 +257,23 @@ async function newSessionAudit(page, label) {
   const group = page.getByRole("group", { name: "Create native Session" })
   await group.waitFor({ state: "visible" })
 
+  // New Session is machine-scoped: one machine is chosen first and the Projects and agents offered
+  // are that machine's. The Project list is therefore one machine's Projects, not both machines'.
+  const machine = group.getByLabel("Filter by machine")
   const project = group.getByLabel("Project")
   const agent = group.getByLabel("Coding agent")
   const title = group.getByLabel("Title optional")
   const cancel = group.getByRole("button", { name: "Cancel" })
   const create = group.getByRole("button", { name: /Create Session/ })
-  for (const [locator, name] of [[project, "Project"], [agent, "Coding agent"], [title, "Title"], [cancel, "Cancel"], [create, "Create Session"]]) {
+  for (const [locator, name] of [[machine, "Machine"], [project, "Project"], [agent, "Coding agent"], [title, "Title"], [cancel, "Cancel"], [create, "Create Session"]]) {
     await locator.waitFor({ state: "visible" })
     await locator.scrollIntoViewIfNeeded()
     await insideViewport(page, locator, `${label} ${name}`)
   }
 
-  assert.equal(await project.locator("option").count(), 2, `${label}: New Session must expose Projects from both machines`)
-  assert.equal(await agent.locator("option").count(), 2, `${label}: New Session must expose the supported native create agents`)
+  assert.equal(await machine.locator("option").count(), 2, `${label}: New Session must offer every configured machine`)
+  assert.equal(await project.locator("option").count(), 1, `${label}: New Session must expose the selected machine's Projects`)
+  assert.ok(await agent.locator("option").count() >= 2, `${label}: New Session must expose the machine's native create agents`)
   await title.fill("Session-first UI audit")
   assert.equal(await create.isDisabled(), false, `${label}: a valid Project and agent must enable Create Session`)
   await noOverflow(page, `${label} New Session`)

--- a/web/src/native-session-v3-adapter.ts
+++ b/web/src/native-session-v3-adapter.ts
@@ -166,19 +166,33 @@ function sameModel(left: ModelSelection | null, right: ModelSelection | null): b
     && (left.variant || "") === (right.variant || ""))
 }
 
+/** Backends whose transcript reads report the Session's own current model on the page itself. */
+const PAGE_MODEL_BACKENDS = new Set(["opencode", "codex", "omp"])
+
 /**
  * Model enrichment is not a mount-only read. A user can leave immediately after Send, before the
  * new native envelope is durable, then return while the reply is still streaming. Every current-tail
  * page can therefore advance the projection from stale/default metadata to the model on the newest
  * native turn.
+ *
+ * A Run minted before that answer arrived carries no model at all, and the timeline reads two
+ * adjacent Runs whose models differ as a model change - which is how continuing on the very same
+ * model announced "Model changed to ..." in the conversation. Enrichment therefore fills in the
+ * Runs that never had one; a Run that recorded a different model keeps it, because that one is a
+ * real change the user made.
  */
 function reconcileNativeSessionModel(entry: ProjectionEntry, page: MessagePage, before?: string): void {
-  if (before || (entry.target.backend !== "opencode" && entry.target.backend !== "codex")) return
+  if (before || !PAGE_MODEL_BACKENDS.has(entry.target.backend)) return
   const model = page.model ?? (entry.target.backend === "opencode" ? lastNativeMessageModel(page.messages) : null)
   if (!model) return
 
   let changed = !sameModel(entry.currentModel, model)
   entry.currentModel = model
+  for (const run of entry.runs.values()) {
+    if (run.model) continue
+    run.model = model
+    changed = true
+  }
   const latestUser = [...page.messages].reverse().find((message) => message.info.role === "user" && message.info.id)
   if (latestUser) {
     const run = entry.runs.get(`${projectionID(entry.target)}:native-user:${latestUser.info.id}`)

--- a/web/src/omp-session-model-projection.test.mjs
+++ b/web/src/omp-session-model-projection.test.mjs
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+/*
+ * What the model picker and the conversation are told about an OMP Session's model.
+ *
+ * Two symptoms came from the same gap: OMP reported its model on the transcript page, but the
+ * projection only listened for that on the two backends it was written for. So returning to a
+ * working Session showed "Harness default" until something else filled it in, and a Run minted
+ * before the answer arrived carried no model at all - which the timeline reads as a model change
+ * and announces in the conversation, on the very turn where nothing changed.
+ */
+
+globalThis.window ??= globalThis
+globalThis.localStorage ??= {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {}
+}
+
+const { api } = await import('./api.ts')
+const { buildWorkThreadTimeline } = await import('./work-thread-timeline.ts')
+
+const pages = []
+api.loadMessagePage = async () => pages.shift() ?? { messages: [], hasMore: false }
+
+const { registerNativeSessionV3Adapter } = await import('./native-session-v3-adapter.ts')
+
+const CONFIG = { backend: 'omp', host: '127.0.0.1', port: 4099, username: 'harness', password: 'pw', agentId: 'omp' }
+const MODEL = { providerID: 'anthropic', modelID: 'claude-sonnet-4' }
+
+function target(overrides = {}) {
+  return {
+    key: 'machine:omp:omp-1',
+    ref: { machineID: 'machine', agentID: 'omp', sessionID: 'omp-1', directory: '/repo' },
+    machineID: 'machine',
+    agentID: 'omp',
+    agentLabel: 'Oh My Pi',
+    backend: 'omp',
+    transport: 'acp',
+    sessionID: 'omp-1',
+    directory: '/repo',
+    title: 'Session',
+    external: false,
+    modelsSupported: true,
+    model: null,
+    requiresExplicitClaim: true,
+    canStop: true,
+    config: CONFIG,
+    ...overrides
+  }
+}
+
+function message(id, role, text) {
+  return { info: { id, role, sessionID: 'omp-1', time: { created: 1 } }, parts: [{ id: `${id}:t`, messageID: id, type: 'text', text }] }
+}
+
+test('an OMP transcript page carries the Session model into the open projection', async () => {
+  const updates = []
+  const registration = registerNativeSessionV3Adapter(target(), (task) => updates.push(task))
+  try {
+    assert.equal(registration.task.model, null, 'the Session mounts before its model is known')
+
+    pages.push({
+      messages: [
+        message('u1', 'user', 'Earlier question'),
+        message('a1', 'assistant', 'Earlier answer'),
+        message('u2', 'user', 'Follow-up question'),
+        message('a2', 'assistant', 'Follow-up answer')
+      ],
+      hasMore: false,
+      model: MODEL
+    })
+    await api.loadMessagePage(CONFIG, 'omp-1', '/repo')
+
+    const latest = updates.at(-1)
+    assert.deepEqual(latest.model, MODEL, 'the picker must show the model OMP is actually on')
+    assert.deepEqual(
+      latest.runs.map((run) => run.model),
+      [MODEL, MODEL],
+      'the Runs recovered from the transcript adopt it too'
+    )
+  } finally {
+    registration.dispose()
+  }
+})
+
+test('continuing a recovered OMP Session announces no model change', async () => {
+  const updates = []
+  const registration = registerNativeSessionV3Adapter(target(), (task) => updates.push(task))
+  try {
+    // The first page lands before the model is known, which is what mints Runs without one.
+    pages.push({
+      messages: [
+        message('u1', 'user', 'Earlier question'),
+        message('a1', 'assistant', 'Earlier answer'),
+        message('u2', 'user', 'Follow-up question'),
+        message('a2', 'assistant', 'Follow-up answer')
+      ],
+      hasMore: false
+    })
+    await api.loadMessagePage(CONFIG, 'omp-1', '/repo')
+    assert.deepEqual(updates.at(-1).runs.map((run) => run.model), [null, null])
+
+    pages.push({ messages: [], hasMore: false, model: MODEL })
+    await api.loadMessagePage(CONFIG, 'omp-1', '/repo')
+
+    const task = updates.at(-1)
+    assert.deepEqual(
+      task.runs.map((run) => run.model),
+      [MODEL, MODEL],
+      'a Run that never had a model must adopt the recovered one'
+    )
+
+    // Continuing on that same model adds a Run carrying it. Against Runs that still had none, the
+    // timeline read the pair as a switch and wrote "Model changed to ..." into the conversation.
+    const next = {
+      id: `${task.id}:request:new`,
+      sequence: task.runs.length + 1,
+      agentId: 'omp',
+      model: MODEL,
+      role: 'continue',
+      sessionId: 'omp-1',
+      status: 'running',
+      directory: '/repo',
+      prompt: 'Next question',
+      startedAt: new Date(3000).toISOString()
+    }
+    const continued = { ...task, runs: [...task.runs, next], run: next, status: 'running' }
+    const timeline = buildWorkThreadTimeline(continued, { 'omp-1': [] }, { omp: { label: 'Oh My Pi', backend: 'omp' } })
+    assert.equal(
+      timeline.filter((entry) => entry.taskdesk?.kind === 'event').length,
+      0,
+      'continuing on the same model must announce nothing'
+    )
+  } finally {
+    registration.dispose()
+  }
+})

--- a/web/src/omp-session-multi-turn.test.mjs
+++ b/web/src/omp-session-multi-turn.test.mjs
@@ -1,0 +1,188 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+/*
+ * The browser half of an OMP conversation, over several consecutive turns.
+ *
+ * The failure this covers was never in one module: the bridge answered a live read from its ACP
+ * stream and an idle read from OMP's journal, the two describe the same messages under different
+ * ids, and the newest-page merge keeps every id it is given. The transcript therefore grew a second
+ * copy of each finished turn, and the timeline - which binds a Run to a turn by walking the user
+ * messages - bound the running Run to the wrong one. On screen that is a second prompt that answers
+ * nowhere and a conversation stuck on "getting started" until it is reopened.
+ *
+ * These cases pin the contract that removes it: one identity per message, for the whole life of the
+ * Session. The last case states what the alternative produces, so the rule cannot be quietly undone.
+ */
+
+globalThis.window ??= globalThis
+globalThis.localStorage ??= {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {}
+}
+
+const { mergeLatestMessagePage } = await import('./message-pages.ts')
+const { buildWorkThreadTimeline } = await import('./work-thread-timeline.ts')
+
+const SESSION = 'omp-1'
+const AGENTS = { omp: { label: 'Oh My Pi', backend: 'omp' } }
+
+function user(id, text) {
+  return { info: { id, role: 'user', sessionID: SESSION, time: { created: 1 } }, parts: [{ id: `${id}:t`, messageID: id, type: 'text', text }] }
+}
+
+function assistant(id, { reasoning, tool, text }) {
+  const parts = []
+  if (reasoning) parts.push({ id: `${id}:r`, messageID: id, type: 'reasoning', text: reasoning })
+  if (tool) parts.push({ id: `${id}:c`, messageID: id, type: 'tool', tool, callID: `${id}:call`, state: { status: 'completed' } })
+  if (text) parts.push({ id: `${id}:t`, messageID: id, type: 'text', text })
+  return { info: { id, role: 'assistant', sessionID: SESSION, time: { created: 2 } }, parts }
+}
+
+/** A projected native Session: one Run per accepted prompt, exactly as the v3 adapter mints them. */
+function task(prompts, { status = 'completed', model = null } = {}) {
+  const runs = prompts.map((prompt, index) => ({
+    id: `native-session-v3:omp:${SESSION}:request:${index + 1}`,
+    sequence: index + 1,
+    agentId: 'omp',
+    model,
+    role: index === 0 ? 'implement' : 'continue',
+    sessionId: SESSION,
+    status: index === prompts.length - 1 ? status : 'completed',
+    directory: '/repo',
+    prompt,
+    startedAt: new Date(1000 + index).toISOString()
+  }))
+  return {
+    id: `native-session-v3:omp:${SESSION}`,
+    machineId: 'machine',
+    projectId: 'native:/repo',
+    project: { name: 'repo', path: '/repo', kind: 'directory' },
+    title: 'Session',
+    agentId: 'omp',
+    prompt: prompts[0] ?? '',
+    model,
+    status: status === 'running' ? 'running' : 'completed',
+    workspace: { mode: 'project', path: '/repo' },
+    run: runs[runs.length - 1] ?? null,
+    runs,
+    error: null,
+    createdAt: new Date(1000).toISOString(),
+    updatedAt: new Date(2000).toISOString()
+  }
+}
+
+function assistantFor(timeline, task) {
+  const runID = task.run?.id
+  return timeline.find((message) => message.info.role === 'assistant' && message.taskdesk?.runId === runID) ?? null
+}
+
+/** The one the conversation reads to decide between "getting started" and the live Activity row. */
+function hasAssistantSignal(timeline, task) {
+  const message = assistantFor(timeline, task)
+  return Boolean(message?.parts.some((part) => {
+    if (part.type === 'tool') return true
+    if (part.type === 'reasoning') return Boolean(part.text?.trim())
+    return part.type === 'text' && Boolean(part.text?.trim())
+  }))
+}
+
+function answerText(timeline, task) {
+  return (assistantFor(timeline, task)?.parts ?? [])
+    .filter((part) => part.type === 'text')
+    .map((part) => part.text)
+    .join('')
+}
+
+test('five consecutive OMP turns each keep their own Activity and complete answer', () => {
+  let feed = []
+  const prompts = []
+
+  for (let turn = 1; turn <= 5; turn += 1) {
+    prompts.push(`Prompt ${turn}`)
+    // Send: the turn's prompt is on the transcript, nothing has answered it yet.
+    feed = mergeLatestMessagePage(feed, [...feed, user(`u${turn}`, `Prompt ${turn}`)])
+    const working = task(prompts, { status: 'running' })
+    let timeline = buildWorkThreadTimeline(working, { [SESSION]: feed }, AGENTS)
+    assert.equal(hasAssistantSignal(timeline, working), false, `turn ${turn} starts with nothing from the agent yet`)
+
+    // Reasoning arrives, then the tool, then the answer in two chunks - one message throughout.
+    feed = mergeLatestMessagePage(feed, [...feed.slice(0, -1), feed.at(-1), assistant(`a${turn}`, { reasoning: `Thinking ${turn}` })])
+    timeline = buildWorkThreadTimeline(working, { [SESSION]: feed }, AGENTS)
+    assert.equal(hasAssistantSignal(timeline, working), true, `turn ${turn} must leave "getting started" as soon as it reasons`)
+
+    feed = mergeLatestMessagePage(feed, [assistant(`a${turn}`, { reasoning: `Thinking ${turn}`, tool: 'read' })])
+    feed = mergeLatestMessagePage(feed, [assistant(`a${turn}`, { reasoning: `Thinking ${turn}`, tool: 'read', text: `Answer ${turn} ` })])
+    feed = mergeLatestMessagePage(feed, [assistant(`a${turn}`, { reasoning: `Thinking ${turn}`, tool: 'read', text: `Answer ${turn} part two` })])
+
+    const ready = task(prompts)
+    timeline = buildWorkThreadTimeline(ready, { [SESSION]: feed }, AGENTS)
+    assert.equal(answerText(timeline, ready), `Answer ${turn} part two`, `turn ${turn} must show its complete answer`)
+    assert.ok(
+      assistantFor(timeline, ready).parts.some((part) => part.type === 'tool'),
+      `turn ${turn} must keep its Activity`
+    )
+  }
+
+  const settled = task(prompts)
+  const timeline = buildWorkThreadTimeline(settled, { [SESSION]: feed }, AGENTS)
+  assert.deepEqual(
+    timeline.filter((message) => message.info.role === 'user').map((message) => message.parts[0].text),
+    prompts,
+    'the conversation shows five prompts and no repeats'
+  )
+  assert.equal(feed.length, 10, 'five turns are ten messages, not twenty')
+  assert.equal(new Set(feed.map((message) => message.info.id)).size, 10)
+  assert.equal(
+    timeline.filter((message) => message.taskdesk?.kind === 'event').length,
+    0,
+    'continuing in one Session announces nothing'
+  )
+})
+
+test('repeated identical prompts stay separate turns with their own answers', () => {
+  const feed = [
+    user('u1', 'Same question'),
+    assistant('a1', { text: 'First answer' }),
+    user('u2', 'Same question'),
+    assistant('a2', { text: 'Second answer' })
+  ]
+  const settled = task(['Same question', 'Same question'])
+  const timeline = buildWorkThreadTimeline(settled, { [SESSION]: feed }, AGENTS)
+  assert.equal(answerText(timeline, settled), 'Second answer', 'the newest Run must bind to the newest turn')
+  assert.deepEqual(
+    timeline.filter((message) => message.info.role === 'assistant').map((message) => message.parts.map((part) => part.text)),
+    [['First answer'], ['Second answer']],
+    'the earlier identical prompt keeps its own answer'
+  )
+})
+
+test('a complete reply is never replaced by a shorter one that arrives afterwards', () => {
+  const complete = mergeLatestMessagePage(
+    [user('u1', 'Prompt 1'), assistant('a1', { text: 'Answer with its last words' })],
+    [assistant('a1', { text: 'Answer with its' })]
+  )
+  const settled = task(['Prompt 1'])
+  assert.equal(
+    answerText(buildWorkThreadTimeline(settled, { [SESSION]: complete }, AGENTS), settled),
+    'Answer with its last words'
+  )
+})
+
+test('handing the same turn a second identity is what makes a live turn read as blank', () => {
+  // Not a supported shape - it is the shape the bridge must never produce, kept here so the reason
+  // the OMP read path has a single authority stays legible.
+  const withDuplicate = mergeLatestMessagePage(
+    [user('u1', 'Prompt 1'), assistant('a1', { text: 'Answer 1' })],
+    [user('journal-u1', 'Prompt 1'), assistant('journal-a1', { text: 'Answer 1' })]
+  )
+  const feed = mergeLatestMessagePage(withDuplicate, [...withDuplicate, user('u2', 'Prompt 2')])
+  const working = task(['Prompt 1', 'Prompt 2'], { status: 'running' })
+  const timeline = buildWorkThreadTimeline(working, { [SESSION]: feed }, AGENTS)
+  assert.equal(
+    answerText(timeline, working),
+    '',
+    'a duplicated first turn leaves the second Run bound to a turn nobody answered'
+  )
+})

--- a/web/src/session-first-regression.test.mjs
+++ b/web/src/session-first-regression.test.mjs
@@ -39,8 +39,8 @@ assert.ok(continuation.includes('client.claimSession(target.config, target.direc
 assert.equal(continuation.includes('createSession('), false, 'same-Session continuation must not create a replacement Session')
 
 assert.ok(create.includes('api.createSession(config'), 'New Session must reuse the existing native /session create primitive')
-assert.ok(create.includes('agent.backend === "pi" && agent.transport === "acp"'), 'PI native create must remain on its validated ACP transport')
-assert.ok(create.includes('agent.backend === "opencode" && agent.transport === "http"'), 'OpenCode native create must remain on its validated managed HTTP transport')
+assert.ok(create.includes('agent.transport === "acp" || agent.transport === "http"'), 'native create must stay on the two validated transports')
+assert.ok(create.includes('agent.capabilities?.sessions !== false') && create.includes('agent.capabilities?.prompt !== false'), 'native create must follow the harness capability contract rather than a per-harness rollout gate')
 assert.ok(create.includes('writerOwned: true'), 'a freshly created native Session must enter the v3 controller as already writable')
 assert.equal(create.includes('createTask('), false, 'native create must not create a Task')
 assert.equal(create.includes('Conversation'), true, 'native create comments must explicitly document the no-Conversation boundary')

--- a/web/src/taskdesk-conversation-component.test.mjs
+++ b/web/src/taskdesk-conversation-component.test.mjs
@@ -41,8 +41,10 @@ test("composer keystrokes do not walk or rerender the long transcript", () => {
 test("shared conversation owns paging and scroll preservation", () => {
   assert.match(component, /hasMore/)
   assert.match(component, /onLoadOlder/)
-  assert.match(component, /previousHeight/)
-  assert.match(component, /current\.scrollHeight - previousHeight/)
+  // Older pages are revealed by keeping the same top-relative position rather than by compensating
+  // for their added height, which could drop a short first page straight back to the newest turn.
+  assert.match(component, /previousTop/)
+  assert.match(component, /Math\.min\(previousTop, current\.scrollHeight - current\.clientHeight\)/)
   assert.match(component, /NEAR_BOTTOM_PX/)
   assert.match(component, /nearBottomRef/)
 })

--- a/web/src/v3-workspace-navigation.test.mjs
+++ b/web/src/v3-workspace-navigation.test.mjs
@@ -48,7 +48,7 @@ test("opening a native Session updates selection and mobile detail explicitly", 
 })
 
 test("Session list navigation groups real native Sessions by machine and Project", () => {
-  assert.match(home, /projectGroups\(records\)/)
+  assert.match(home, /projectGroups\(records, selectedActivityAnchor\)/)
   assert.match(home, /collapsedMachines/)
   assert.match(home, /collapsedProjects/)
   assert.match(home, /sessionTreeRows\(group\.sessions\)/)


### PR DESCRIPTION
Rebuilt from `checkpoint/v3-session-first-working-2026-08-25`. #313 was read as diagnostic material only; none of its code is carried over. `main` and the checkpoint are untouched, and no other harness's path changed.

**Validated against a real OMP installation**: all six manual scenarios pass (five consecutive turns, Session switch mid-turn, old Sessions, continuation, Stop and resend, Session created in the OMP TUI), plus Session naming.

## The question first: why did OMP need so much special logic?

It did not. Almost everything OMP-specific in the checkpoint exists to work around one fact that is never stated anywhere: **OMP has two different identities for the same message, and the bridge was handing the app one of each.**

- OMP's journal keys a message by the entry id it wrote.
- OMP's ACP stream mints `crypto.randomUUID()` per live assistant message (`#getLiveMessageId`) and mints new ones *again* on every `session/load` replay (`#replaySessionHistory`).

The checkpoint answered a live read from the stream and an idle read from the journal. The app reconciles pages by id and keeps every id it is given (`mergeLatestMessagePage`), so every finished turn silently grew a second copy. `buildWorkThreadTimeline` binds a Run to a turn by walking the user messages in order, so the running Run then bound to the duplicate that nobody had answered.

That single fact explains bugs 1, 2, 4, 5 and 6 at once: the second prompt reads blank, the conversation stays on "getting started", the answer looks cut, Activity is missing — and all of it appears at once on remount, because a remount rebuilds the feed from one read.

`web/src/omp-session-multi-turn.test.mjs` contains that mechanism as an executable statement, so the reason the rule exists stays legible.

## What was audited

HR2 (`v2.11.1`), the checkpoint, #313, and the current PI path — plus the OMP source at `can1357/oh-my-pi` HEAD (18.0.7), cloned and read rather than assumed.

What HR2 did that HR3 stopped doing: HR2's OMP loader was 128 lines, refused to guess a branch without the undo extension, and let ACP replay be the authority. That worked because HR2 had no Run-to-turn projection to confuse — the transcript was the chat. HR3 added the projection, which is what makes a stable identity mandatory. HR2 is therefore not a design to copy back, but it did prove that OMP needs no reconciler.

What PI does that OMP should not copy: PI's journal is authoritative on *every* read, which forces the browser to map live ACP ids onto journal ids afterwards (`stabilizePiTailMessageIDs`). That hack is the same problem solved one layer too late. OMP does not get one.

## The architecture now

> The journal is the transcript while nothing here is writing the Session. This bridge's own stream is the transcript from the moment it takes the writer. Never both, and never merged.

A paged read follows the same rule as a whole read — that is the whole fix for the id split. It is expressed as one service option, `journalPageWhileOwned` (default `true`, i.e. unchanged for everyone else), and OMP is the one harness that sets it to `false`.

Writer acquisition uses **`session/resume`**, not `session/load`. From the OMP source: `#loadManagedSession` and `#resumeManagedSession` are the same function; `loadSession` then calls `#replaySessionHistory` and `resumeSession` does not. Both return the same `configOptions`. So `session/load` was pure cost (minutes of notifications on a long conversation) and pure harm (ids that do not match what the app was just given, plus `developer`/`hookMessage`/tool-output records flattened into `user_message_chunk`s — turn boundaries nobody typed). `session/resume` is sent only when `initialize` advertises `sessionCapabilities.resume`, so an OMP old enough not to offer it keeps opening through `session/load` exactly as before.

Net shape: **OMP = the generic ACP path + a journal that seeds it + `resume` instead of `load`.** That is a *smaller* divergence than PI's, not a bigger one.

## What was deleted

| Removed | Why |
|---|---|
| the second, byte-scanning JSONL pager and its opaque cursor | a separate parser of the same format with its own idea of the branch; paging now slices the one reader's output and addresses pages by message id like every other harness |
| `deferAcpReplayWithoutActiveLeaf` | it existed to avoid an ACP replay that no longer happens at all |
| leaf inference from "which id is not referenced as a parent" | OMP's own `SessionEntryIndex.rebuild()` takes the last entry in file order; the bridge now does the same thing |
| throwing when the extension's active leaf is missing | a leaf published for a journal that has since been compacted is stale, not a reason to refuse the Session |
| snapshotting an OMP transcript | the snapshot could only restore it under this process's ids, and the next read replaces it from the journal anyway |
| re-sending the model on every prompt | continuing on the same model is not a model change |
| the invented `"Remote session"` placeholder | the harness names an unnamed Session from its first message; nothing ever replaced the placeholder |

Nothing from #313 was preserved: no `mergeLiveHistory`, no stable-id pass, no transcript-driven lifecycle, no `nativeResumeOnClaim`/`neverReplayOnRead` flags, no custom migration writer.

## Session naming

A name given in New Session, or a later rename, only ever lived in this bridge's own snapshot. The Session index the app renders is the harness's lightweight listing (`listVisibleSessionMetadata` calls `acp.listSessions()` directly, deliberately, so opening the app does not restore every transcript), so the sidebar showed `Session 01a0429d` while the chat header showed the real name — and reopening the Session lost it entirely, as did opening it from OMP, which had never been told.

OMP stores names itself: `/rename <title>` calls `setSessionName(title, "user")`, which rewrites the fixed-width title slot, appends a `title_change` entry, and marks the name user-set so OMP's own auto-titling leaves it alone. `session/new` carries no title in ACP, so a Session created with a name is named through the same command immediately after creation.

- The command is only ever sent when the running adapter advertised it in its command catalog: an unrecognised slash command is not refused, it is a prompt the model would try to answer. A harness that does not advertise one keeps the name here exactly as before — and a name kept here now outranks the harness's listing, otherwise renaming on such a harness would appear to do nothing.
- Naming a Session is a command sent into it, so a rename opens the Session first. The confirmation line the harness answers with is not conversation: the transcript and todos are restored around it, and the Session does not read as Working while it happens.

## The OMP differences that remain, and why PI does not need them

1. **`journalPageWhileOwned: false`** — PI's journal and live stream are reconciled because PI's journal is authoritative throughout; OMP's two id spaces cannot be reconciled at all, only used one after the other. Documented on the constructor option.
2. **`session/resume` instead of `session/load`** — PI's adapter rejects a second open and has no `resume`; OMP advertises one and defines `load` as a replay. Documented on `#openWithoutReplay`.
3. **`nativeRenameCommand: "rename"` and `preferListedTitles`** — OMP owns its Session names and exposes the command to set them; PI's adapter has its own journal-level rename instead.
4. **A journal reader that understands OMP's format** — the title slot, the session header, the v1 tree, branch selection, tool rejoining, suppressed abort reasons. Each rule cites the upstream file it comes from.

Everything else — prompting, queueing, cancel, streaming, `settleUnfinishedActivity`, snapshots, the status layer, the timeline — is the shared path, unchanged.

## Journal facts the reader now gets right

Read out of oh-my-pi 18.x, not observed:

- **v1 journals carry no `id`/`parentId`.** OMP adds them in memory on first open and rewrites the file (`migrateV1ToV2`). Requiring ids reported every pre-migration Session as empty — and sending a prompt made OMP migrate it, which is exactly why the whole history reappeared afterwards. **This is bug 3.**
- The fixed-width `title` slot and the `type:"session"` header are not entries and never belonged in the branch graph.
- `synthetic` / `steering` user turns are injections OMP does not render; each would open a turn nobody typed.
- `Interrupted by user` and `__omp.silent_abort__` are the two reasons `shouldRenderAbortReason()` suppresses. **This is the false "Interrupted by user".**
- `toolCall` blocks and their `toolResult` entries are rejoined into Activity, so a reopened Session shows the work and not only the answers.
- A `blob:sha256:` image payload is not base64 and is skipped instead of rendering as a broken thumbnail.

`docs/DEPENDENCIES.md` now cites the OMP source for each fact the bridge depends on.

## History authority, stated once

| Phase | Authority |
|---|---|
| Session this bridge does not write | OMP journal, re-read on every request |
| Taking the writer | journal read once more, then `session/resume` |
| Turn running, and afterwards in this process | this bridge's own ACP stream |
| Undo/redo (the branch itself moved) | journal, re-read |
| Session name | OMP, through `/rename`; only a harness that cannot store one falls back to this bridge |
| Journal unreadable | the read fails; there is no replay to fall back to, and answering empty is how an unreadable Session came to look deleted |

No text or timestamp deduplication was added. No synthetic Runs. Two real turns with identical text stay two turns (test).

## Tests

`bridge/test/omp-acp-lifecycle.test.js` — 16 cases driving several consecutive turns through the real `AcpService`, `AcpPromptEchoFilter`, the real loader and the real profile options. The fake follows the upstream ACP agent, not this bridge's reading of it: replay under fresh uuids on `session/load`, none on `session/resume`, no live `user_message_chunk`, one message id per assistant message, `session/prompt` resolving only after the last chunk, `/rename` consumed as a command rather than a turn, and JSONL appended the way `SessionManager` appends it.

**Six of them fail against the checkpoint's own code**, which is what makes them regression coverage rather than a description of what it already did.

Covered: new Session + first prompt · second prompt · five consecutive prompts · reasoning + tool + final text · final text in several chunks · the answer converging when the turn ends · reads taken during Working and after Ready · resume of an existing Session · a Session OMP wrote elsewhere, including one it kept writing while we watched · a v1 journal · repeated identical prompts · unchanged model vs a real change · the reasoning variant surviving · cancel · no false interruption · no empty transcript · no duplication · no cut answer · an OMP without `resume` · a created name stored by OMP and readable by a second bridge · a later rename that leaves no trace in the conversation · a Session named in the OMP TUI · an unadvertised slash command never sent as a prompt.

`bridge/test/omp-session-history.test.js` — 8 new journal-format cases (title slot, header, v1, tool rejoining, an unfinished tool call, suppressed aborts, synthetic/steering turns, blob refs, role-scoped `model_change`).

`web/src/omp-session-multi-turn.test.mjs`, `web/src/omp-session-model-projection.test.mjs` — the browser half. Both projection cases fail against the checkpoint's adapter.

**Real OMP:** `npm run smoke:omp` in `bridge/` runs the same lifecycle against a real `omp` on PATH and reports the five facts the fake asserts. It writes real Sessions and spends real tokens, so it is opt-in and deliberately not in CI; it exits with a clear message when OMP is not installed.

## PI, and CI

PI's path is untouched: both new service options default to today's behaviour, and every PI suite is green before and after. The full bridge suite (451), every web suite in `pr-checks.yml`, and all seven Chromium smokes were run locally on this branch.

Five assertions were already failing on the checkpoint before this branch — native create moved to the capability contract, scroll preservation moved to top-relative, Session grouping takes an activity anchor, and New Session became machine-scoped (which added a select before the harness one). They are realigned in a separate commit; tests and smokes only, no product change to satisfy them.

Known and out of scope by instruction: Codex has the same paged-read-vs-whole-read split. Worth a follow-up. On an OMP too old to advertise `rename`, a name still lives only in this bridge and the Session index will not show it.
