### PR TITLE
Fix persistent Session-first deletion visibility without ACP mutations

### DIFF
--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -305,6 +305,8 @@ export class AcpService {
   #promptAcknowledgements = new Map()
   #titles = new Map()
   #deletedSessions = new Set()
+  #deletedSessionIndexLoaded = false
+  #deletedSessionIndexWrite = Promise.resolve()
   #queues = new Map()
   #active = new Set()
   #listeners = new Set()
@@ -385,6 +387,7 @@ export class AcpService {
   }
 
   async listSessions(directory) {
+    await this.#restoreDeletedSessionIndex()
     const sessions = await this.#refreshSessions()
     await Promise.all(sessions.map((session) => this.#restoreSnapshot(session.sessionId)))
     return sessions
@@ -603,6 +606,7 @@ export class AcpService {
     await this.#requireSession(sessionID)
     if (this.#isBusy(sessionID)) this.abort(sessionID)
     this.#deletedSessions.add(sessionID)
+    await this.#persistDeletedSessionIndex()
     this.#messages.delete(sessionID)
     this.#todos.delete(sessionID)
     this.#titles.delete(sessionID)
@@ -1115,6 +1119,58 @@ export class AcpService {
     while (this.#snapshotWrites.size > 0) {
       await Promise.all(this.#snapshotWrites.values())
     }
+    await this.#deletedSessionIndexWrite
+  }
+
+  /**
+   * Return the lightweight deletion tombstones used by Session-first discovery.
+   *
+   * The Session list deliberately avoids restoring every transcript snapshot because doing so can
+   * retain gigabytes of historical messages. Deletion therefore has its own tiny index: one read
+   * per process, no session/load, no history loader, and no ACP ownership changes.
+   */
+  async deletedSessionIDs() {
+    await this.#restoreDeletedSessionIndex()
+    return new Set(this.#deletedSessions)
+  }
+
+  #deletedSessionIndexPath() {
+    return path.join(this.#snapshotDirectory, "deleted-sessions.json")
+  }
+
+  async #restoreDeletedSessionIndex() {
+    if (!this.#snapshotDirectory || this.#deletedSessionIndexLoaded) return
+    this.#deletedSessionIndexLoaded = true
+    try {
+      const state = JSON.parse(await readFile(this.#deletedSessionIndexPath(), "utf8"))
+      if (state?.version !== 1 || !Array.isArray(state.sessionIDs)) return
+      for (const sessionID of state.sessionIDs) {
+        if (typeof sessionID === "string" && sessionID) this.#deletedSessions.add(sessionID)
+      }
+    } catch (error) {
+      if (error?.code !== "ENOENT") {
+        this.#deletedSessionIndexLoaded = false
+        throw error
+      }
+    }
+  }
+
+  async #persistDeletedSessionIndex() {
+    if (!this.#snapshotDirectory) return
+    const previous = this.#deletedSessionIndexWrite
+    const writing = previous.catch(() => undefined).then(async () => {
+      await mkdir(this.#snapshotDirectory, { recursive: true })
+      const target = this.#deletedSessionIndexPath()
+      const temporary = `${target}.${process.pid}.${randomUUID()}.tmp`
+      const state = JSON.stringify({
+        version: 1,
+        sessionIDs: [...this.#deletedSessions].sort()
+      })
+      await writeFile(temporary, state, { mode: 0o600 })
+      await rename(temporary, target)
+    })
+    this.#deletedSessionIndexWrite = writing
+    await writing
   }
 
   #snapshotPath(sessionID) {
@@ -1225,6 +1281,7 @@ export class AcpService {
   }
 
   async #requireSession(sessionID) {
+    await this.#restoreDeletedSessionIndex()
     await this.#refreshSessions()
     await this.#restoreSnapshot(sessionID)
     if (this.#deletedSessions.has(sessionID) || !this.#sessions.has(sessionID)) {

--- a/bridge/src/server.js
+++ b/bridge/src/server.js
@@ -228,10 +228,14 @@ export function createBridgeServer({ config, acp, serviceOptions, machineRegistr
   // its transcript. Invalid or missing harness timestamps stay at zero instead of pretending to be
   // freshly updated on every poll.
   const listVisibleSessionMetadata = async (directory) => {
-    const sessions = await acp.listSessions()
+    const [sessions, deletedSessionIDs] = await Promise.all([
+      acp.listSessions(),
+      service.deletedSessionIDs()
+    ])
     return sessions
       .filter((session) => !directory || sameListedDirectory(session.cwd, directory))
       .filter((session) => !hiddenSessionIDs?.has(session.sessionId))
+      .filter((session) => !deletedSessionIDs.has(session.sessionId))
       .map((session) => {
         const liveUpdatedAt = liveSessionActivity.get(session.sessionId) ?? 0
         const listedUpdated = Date.parse(session.updatedAt ?? "")

--- a/bridge/test/session-delete-visibility.test.js
+++ b/bridge/test/session-delete-visibility.test.js
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import test from "node:test"
+import { createBridgeServer } from "../src/server.js"
+
+class FakeAcp extends EventEmitter {
+  agentInfo = { version: "17.1.3" }
+  requests = []
+
+  async start() {}
+
+  async listSessions() {
+    return [
+      {
+        sessionId: "session-to-delete",
+        title: "Delete me",
+        cwd: process.cwd(),
+        updatedAt: "2026-08-28T06:00:00.000Z"
+      },
+      {
+        sessionId: "session-to-keep",
+        title: "Keep me",
+        cwd: process.cwd(),
+        updatedAt: "2026-08-28T06:01:00.000Z"
+      }
+    ]
+  }
+
+  async request(method, params) {
+    this.requests.push({ method, params })
+    return {}
+  }
+
+  notify() {}
+}
+
+function listen(server) {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address()
+      resolve(`http://127.0.0.1:${address.port}`)
+    })
+  })
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+}
+
+const config = {
+  backend: "omp",
+  username: "",
+  password: "",
+  corsOrigins: [],
+  roots: [process.cwd()]
+}
+
+test("ACP deletion disappears from Session-first discovery and survives a daemon restart without mutating the harness", async () => {
+  const stateDirectory = await mkdtemp(path.join(tmpdir(), "harness-remote-delete-"))
+  const serviceOptions = { snapshotDirectory: path.join(stateDirectory, "omp") }
+  const firstAcp = new FakeAcp()
+  const firstServer = createBridgeServer({ config, acp: firstAcp, serviceOptions })
+  const firstBase = await listen(firstServer)
+
+  try {
+    const beforeResponse = await fetch(`${firstBase}/experimental/session`)
+    assert.equal(beforeResponse.status, 200)
+    const before = await beforeResponse.json()
+    assert.deepEqual(before.map((session) => session.id), ["session-to-delete", "session-to-keep"])
+
+    const deleteResponse = await fetch(`${firstBase}/session/session-to-delete`, { method: "DELETE" })
+    assert.equal(deleteResponse.status, 200)
+    assert.equal(await deleteResponse.json(), true)
+
+    const afterResponse = await fetch(`${firstBase}/experimental/session`)
+    assert.equal(afterResponse.status, 200)
+    const after = await afterResponse.json()
+    assert.deepEqual(after.map((session) => session.id), ["session-to-keep"])
+
+    const statusResponse = await fetch(`${firstBase}/session/status`)
+    assert.equal(statusResponse.status, 200)
+    assert.deepEqual(Object.keys(await statusResponse.json()), ["session-to-keep"])
+
+    assert.deepEqual(firstAcp.requests, [])
+  } finally {
+    await close(firstServer)
+  }
+
+  const secondAcp = new FakeAcp()
+  const secondServer = createBridgeServer({ config, acp: secondAcp, serviceOptions })
+  const secondBase = await listen(secondServer)
+
+  try {
+    const restoredResponse = await fetch(`${secondBase}/experimental/session`)
+    assert.equal(restoredResponse.status, 200)
+    const restored = await restoredResponse.json()
+    assert.deepEqual(restored.map((session) => session.id), ["session-to-keep"])
+
+    const fullListResponse = await fetch(`${secondBase}/session`)
+    assert.equal(fullListResponse.status, 200)
+    const fullList = await fullListResponse.json()
+    assert.deepEqual(fullList.map((session) => session.id), ["session-to-keep"])
+
+    assert.deepEqual(secondAcp.requests, [])
+  } finally {
+    await close(secondServer)
+    await rm(stateDirectory, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
Fixes the Session-first delete button for ACP-backed harnesses without changing OMP/PI/Claude/Codex protocol behavior.

What changes:
- persists deleted ACP Session ids in a tiny per-harness index, separate from transcript snapshots
- filters deleted ids from the lightweight /experimental/session and /session/status paths used by Session-first
- keeps the existing full /session filtering
- does not send session/load, session/prompt, session/close or any new ACP method during deletion
- adds a regression test proving immediate disappearance, persistence across daemon restart, and zero ACP requests

Why this shape:
The previous delete tombstone lived only in the per-Session snapshot. The lightweight Session-first listing intentionally does not restore those snapshots, so deleted Sessions could remain visible/reappear. Reading all snapshots would regress the memory/performance work, while inventing native delete commands would risk OMP and other ACP adapters.

Base is intentionally checkpoint/v3-session-first-working-2026-08-25. main is untouched.