### PR TITLE
Restore image attachments on the Session-first prompt path

### DIFF
--- a/bridge/src/machine-daemon.js
+++ b/bridge/src/machine-daemon.js
@@ -36,6 +36,14 @@ function modelWireName(model) {
   return model ? `${model.providerID}/${model.modelID}` : undefined
 }
 
+function acpPromptAttachments(attachments = []) {
+  return attachments.map((attachment) => {
+    const match = /^data:[^;,]+;base64,(.+)$/s.exec(attachment.url)
+    if (!match) throw daemonError("session_prompt_rejected", "An attachment must be a base64 data URL")
+    return { mime: attachment.mime, filename: attachment.filename, data: match[1] }
+  })
+}
+
 /** Only a variant the catalog actually resolved from adapter-advertised options is applied. */
 function acpModelVariant(model) {
   return model?.variant && model?.variantConfigId
@@ -260,7 +268,7 @@ export function createMachineDaemonServer({
     }
     claimedAcpSessions.add(nativeSessionKey(agentID, sessionID))
   }
-  const promptSession = async (agentID, sessionID, { text, directory, model, variant }) => {
+  const promptSession = async (agentID, sessionID, { text, directory, model, variant, attachments = [] }) => {
     const entry = daemon.hostEntry(agentID)
     if (!entry) throw daemonError("unknown_agent", `Unknown agent: ${agentID}`)
     const requestedModel = model ? { ...model, ...(variant ? { variant } : {}) } : null
@@ -273,7 +281,7 @@ export function createMachineDaemonServer({
       // place that already loads configOptions, orders the model before its variant, and defers both
       // to dequeue when a turn is still running. Setting them here directly reordered the model
       // after the variant and mutated a live turn's configuration.
-      await service.prompt(sessionID, text, modelWireName(resolvedModel), [], acpModelVariant(resolvedModel))
+      await service.prompt(sessionID, text, modelWireName(resolvedModel), acpPromptAttachments(attachments), acpModelVariant(resolvedModel))
       return
     }
 
@@ -294,7 +302,15 @@ export function createMachineDaemonServer({
         method: "POST",
         headers,
         body: JSON.stringify({
-          parts: [{ type: "text", text }],
+          parts: [
+            { type: "text", text },
+            ...attachments.map((attachment) => ({
+              type: "file",
+              mime: attachment.mime,
+              filename: attachment.filename,
+              url: attachment.url
+            }))
+          ],
           model: resolvedModel ? { providerID: resolvedModel.providerID, modelID: resolvedModel.modelID } : undefined,
           variant: resolvedModel?.variant || undefined
         })

--- a/bridge/src/session-claim-server.js
+++ b/bridge/src/session-claim-server.js
@@ -3,6 +3,10 @@ import http from "node:http"
 import { authenticateDaemonRequest, writeJSON } from "./http-policy.js"
 
 const SESSION_OPERATION_ROUTE = /^\/v1\/agents\/([^/]+)\/session\/([^/]+)\/(claim|prompt|stop|handoff)$/
+const ATTACHMENT_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/webp", "image/gif"])
+const MAX_ATTACHMENTS = 8
+const MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024
+const MAX_ATTACHMENT_TOTAL_BYTES = 15 * 1024 * 1024
 
 function requestError(message) {
   const error = new Error(message)
@@ -36,7 +40,7 @@ async function readJSONBody(request) {
   let body = ""
   for await (const chunk of request) {
     body += chunk
-    if (body.length > 2_000_000) throw requestError("Request body is too large")
+    if (body.length > 25_000_000) throw requestError("Request body is too large")
   }
   if (!body) return {}
   try {
@@ -63,13 +67,44 @@ function promptModelInput(body) {
   return { providerID, modelID }
 }
 
+function base64ByteLength(value) {
+  const padding = value.endsWith("==") ? 2 : value.endsWith("=") ? 1 : 0
+  return Math.max(0, Math.floor(value.length * 3 / 4) - padding)
+}
+
+function promptAttachmentsInput(value) {
+  if (value === undefined || value === null) return []
+  if (!Array.isArray(value)) throw requestError("Prompt attachments must be an array")
+  if (value.length > MAX_ATTACHMENTS) throw requestError(`At most ${MAX_ATTACHMENTS} attachments per prompt`)
+  let total = 0
+  return value.map((attachment) => {
+    if (!attachment || typeof attachment !== "object" || Array.isArray(attachment)) {
+      throw requestError("Prompt attachment must be an object")
+    }
+    const mime = typeof attachment.mime === "string" ? attachment.mime.toLowerCase() : ""
+    if (!ATTACHMENT_MIME_TYPES.has(mime)) throw requestError(`Unsupported attachment type ${mime || "unknown"}`)
+    const filename = typeof attachment.filename === "string" && attachment.filename.trim()
+      ? attachment.filename.trim().slice(0, 255)
+      : "attachment"
+    const url = typeof attachment.url === "string" ? attachment.url : ""
+    const match = /^data:[^;,]+;base64,([A-Za-z0-9+/=]+)$/s.exec(url)
+    if (!match) throw requestError("An attachment must be a base64 data URL")
+    const bytes = base64ByteLength(match[1])
+    if (bytes > MAX_ATTACHMENT_BYTES) throw requestError("Each attachment must stay under 5MB")
+    total += bytes
+    if (total > MAX_ATTACHMENT_TOTAL_BYTES) throw requestError("Attachments must stay under 15MB in total")
+    return { mime, filename, url }
+  })
+}
+
 function promptInput(body) {
   const common = operationIdentityInput(body)
   const text = typeof body.text === "string" ? body.text.trim() : ""
   const model = promptModelInput(body)
   const variant = typeof body.variant === "string" && body.variant.trim() ? body.variant.trim() : undefined
+  const attachments = promptAttachmentsInput(body.attachments)
   if (!text) throw requestError("A text prompt is required")
-  return { ...common, text, model, variant }
+  return { ...common, text, model, variant, attachments }
 }
 
 function stopInput(body) {
@@ -176,7 +211,17 @@ export function createSessionClaimServer({
 
       const identity = { agentID, sessionID, clientRequestId: input.clientRequestId }
       const signaturePayload = operation === "prompt"
-        ? { text: input.text, directory: input.directory, model: input.model, variant: input.variant ?? null }
+        ? {
+            text: input.text,
+            directory: input.directory,
+            model: input.model,
+            variant: input.variant ?? null,
+            attachments: input.attachments.map((attachment) => ({
+              mime: attachment.mime,
+              filename: attachment.filename,
+              digest: createHash("sha256").update(attachment.url).digest("hex")
+            }))
+          }
         : operation === "stop"
           ? { directory: input.directory, operationToken: input.operationToken }
           : {

--- a/bridge/test/machine-daemon.test.js
+++ b/bridge/test/machine-daemon.test.js
@@ -215,7 +215,7 @@ test("machine Session mutations acquire ACP ownership lazily and reuse it", asyn
     createServer: (options) => ({
       acpService: {
         async claimSession(sessionID) { calls.push(["claim", options.config.backend, sessionID]); return true },
-        async prompt(sessionID, text) { calls.push(["prompt", options.config.backend, sessionID, text]) },
+        async prompt(sessionID, text, _model, attachments) { calls.push(["prompt", options.config.backend, sessionID, text, attachments]) },
         async abort(sessionID) { calls.push(["stop", options.config.backend, sessionID]) }
       },
       emit() {}
@@ -229,12 +229,16 @@ test("machine Session mutations acquire ACP ownership lazily and reuse it", asyn
   })
 
   await claimOptions.stopSession("pi", "native-pi-1", { directory: "/repo" })
-  await claimOptions.promptSession("pi", "native-pi-1", { text: "Continue once", directory: "/repo" })
+  await claimOptions.promptSession("pi", "native-pi-1", {
+    text: "Continue once",
+    directory: "/repo",
+    attachments: [{ mime: "image/png", filename: "screen.png", url: "data:image/png;base64,aGVsbG8=" }]
+  })
   await claimOptions.stopSession("pi", "native-pi-1", { directory: "/repo" })
   assert.deepEqual(calls, [
     ["claim", "pi", "native-pi-1"],
     ["stop", "pi", "native-pi-1"],
-    ["prompt", "pi", "native-pi-1", "Continue once"],
+    ["prompt", "pi", "native-pi-1", "Continue once", [{ mime: "image/png", filename: "screen.png", data: "aGVsbG8=" }]],
     ["stop", "pi", "native-pi-1"]
   ])
   await assert.rejects(() => claimOptions.claimSession("opencode", "native-http-1"), (error) => error.code === "unsupported_agent")

--- a/bridge/test/machine-daemon.test.js
+++ b/bridge/test/machine-daemon.test.js
@@ -243,6 +243,28 @@ test("machine Session mutations acquire ACP ownership lazily and reuse it", asyn
   ])
   await assert.rejects(() => claimOptions.claimSession("opencode", "native-http-1"), (error) => error.code === "unsupported_agent")
   await assert.rejects(() => claimOptions.promptSession("missing", "native-1", { text: "x", directory: "/repo" }), (error) => error.code === "unknown_agent")
+
+  const originalFetch = globalThis.fetch
+  const requests = []
+  globalThis.fetch = async (url, options) => {
+    requests.push({ url: String(url), options })
+    return new Response(null, { status: 204 })
+  }
+  try {
+    await claimOptions.promptSession("opencode", "native-http-1", {
+      text: "Inspect this screenshot",
+      directory: "/repo",
+      attachments: [{ mime: "image/jpeg", filename: "screen.jpg", url: "data:image/jpeg;base64,aGVsbG8=" }]
+    })
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+  assert.equal(requests.length, 1)
+  const openCodeBody = JSON.parse(requests[0].options.body)
+  assert.deepEqual(openCodeBody.parts, [
+    { type: "text", text: "Inspect this screenshot" },
+    { type: "file", mime: "image/jpeg", filename: "screen.jpg", url: "data:image/jpeg;base64,aGVsbG8=" }
+  ])
 })
 
 test("machine Session claim fails if the native Session disappears before ownership is retained", async () => {

--- a/bridge/test/session-claim-server.test.js
+++ b/bridge/test/session-claim-server.test.js
@@ -124,6 +124,63 @@ test("replaying one accepted client request id dispatches one native prompt", as
   }
 }))
 
+test("native Session prompt validates and includes image attachments in the idempotent operation", async () => withLedger(async (operationLedger) => {
+  const calls = []
+  const server = createSessionClaimServer({
+    innerServer: new EventEmitter(),
+    config: { username: "", password: "", corsOrigins: [] },
+    async claimSession() {},
+    operationLedger,
+    async promptSession(agentID, sessionID, input) { calls.push([agentID, sessionID, input.attachments]) }
+  })
+  const port = await listen(server)
+  const attachment = { mime: "image/png", filename: "screen.png", url: "data:image/png;base64,aGVsbG8=" }
+  try {
+    const first = await postPrompt(port, promptBody({ attachments: [attachment] }))
+    assert.equal(first.status, 200)
+    assert.deepEqual(calls, [["codex", "native-123", [attachment]]])
+
+    const replay = await postPrompt(port, promptBody({ attachments: [attachment] }))
+    assert.equal(replay.status, 200)
+    assert.equal(calls.length, 1)
+
+    const conflict = await postPrompt(port, promptBody({
+      attachments: [{ ...attachment, url: "data:image/png;base64,d29ybGQ=" }]
+    }))
+    assert.equal(conflict.status, 409)
+    assert.match((await conflict.json()).error, /already used for a different native Session operation/)
+    assert.equal(calls.length, 1)
+  } finally {
+    await close(server)
+  }
+}))
+
+test("native Session prompt rejects unsupported or oversized attachment input before dispatch", async () => withLedger(async (operationLedger) => {
+  let dispatches = 0
+  const server = createSessionClaimServer({
+    innerServer: new EventEmitter(),
+    config: { username: "", password: "", corsOrigins: [] },
+    async claimSession() {},
+    operationLedger,
+    async promptSession() { dispatches += 1 }
+  })
+  const port = await listen(server)
+  try {
+    const unsupported = await postPrompt(port, promptBody({
+      attachments: [{ mime: "text/plain", filename: "note.txt", url: "data:text/plain;base64,aGVsbG8=" }]
+    }))
+    assert.equal(unsupported.status, 400)
+
+    const malformed = await postPrompt(port, promptBody({
+      attachments: [{ mime: "image/png", filename: "screen.png", url: "https://example.invalid/image.png" }]
+    }))
+    assert.equal(malformed.status, 400)
+    assert.equal(dispatches, 0)
+  } finally {
+    await close(server)
+  }
+}))
+
 test("concurrent retries converge before a second native prompt can start", async () => withLedger(async (operationLedger) => {
   let dispatches = 0
   let releaseDispatch

--- a/web/src/components/native-session-observer.tsx
+++ b/web/src/components/native-session-observer.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { api } from "../api"
 import type { NativeSessionSurfaceTarget } from "../native-session-discovery"
 import { resolveNativeSessionTargetModel } from "../native-session-model"
 import {
@@ -58,6 +59,7 @@ function targetForInitialProjection(target: NativeSessionSurfaceTarget): NativeS
  */
 export function NativeSessionObserver({ target, onSessionRefresh, onStateChange }: Props) {
   const [task, setTask] = useState<MachineTask | null>(null)
+  const [attachmentsSupported, setAttachmentsSupported] = useState(false)
   const taskRef = useRef<MachineTask | null>(null)
   const attentionRef = useRef(false)
   const onStateChangeRef = useRef(onStateChange)
@@ -75,6 +77,15 @@ export function NativeSessionObserver({ target, onSessionRefresh, onStateChange 
     if (current) onStateChangeRef.current?.(visualState(current, attention))
   }, [])
 
+  useEffect(() => {
+    let disposed = false
+    setAttachmentsSupported(false)
+    void api.capabilities(target.config)
+      .then((capabilities) => { if (!disposed) setAttachmentsSupported(capabilities.attachments === true) })
+      .catch(() => { if (!disposed) setAttachmentsSupported(false) })
+    return () => { disposed = true }
+  }, [target.key, target.config.host, target.config.port, target.config.agentId])
+
   const agent = useMemo<MachineAgentHost>(() => ({
     id: target.agentID,
     label: target.agentLabel,
@@ -86,9 +97,10 @@ export function NativeSessionObserver({ target, onSessionRefresh, onStateChange 
       sessions: true,
       prompt: true,
       abort: target.canStop,
-      models: target.modelsSupported
+      models: target.modelsSupported,
+      attachments: attachmentsSupported
     }
-  }), [target.agentID, target.agentLabel, target.backend, target.transport, target.canStop, target.modelsSupported])
+  }), [target.agentID, target.agentLabel, target.backend, target.transport, target.canStop, target.modelsSupported, attachmentsSupported])
 
   useEffect(() => {
     let disposed = false

--- a/web/src/components/taskdesk-conversation.tsx
+++ b/web/src/components/taskdesk-conversation.tsx
@@ -1,6 +1,7 @@
 import { memo, useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from "react"
+import { ATTACHMENT_MAX_COUNT, fileToAttachment, type AttachmentPart } from "../attachments"
 import type { MessageEnvelope } from "../types"
-import { ChatIcon, JumpToBottomIcon, JumpToTopIcon, LoadingIcon, StopCircleIcon } from "../Icons"
+import { ChatIcon, CloseIcon, JumpToBottomIcon, JumpToTopIcon, LoadingIcon, PaperclipIcon, StopCircleIcon } from "../Icons"
 import "../taskdesk-conversation.css"
 import "../taskdesk-conversation-fixes.css"
 import "../taskdesk-history-loader.css"
@@ -37,6 +38,10 @@ type Props = {
   onLoadOlder?: () => Promise<void> | void
   draft: string
   onDraftChange: (value: string) => void
+  attachments?: AttachmentPart[]
+  attachmentsSupported?: boolean
+  onAttachmentsChange?: (attachments: AttachmentPart[]) => void
+  onAttachmentError?: (message: string) => void
   onSend: () => Promise<void> | void
   sending?: boolean
   sendDisabled?: boolean
@@ -345,6 +350,10 @@ export function TaskDeskConversation({
   onLoadOlder,
   draft,
   onDraftChange,
+  attachments = [],
+  attachmentsSupported = false,
+  onAttachmentsChange,
+  onAttachmentError,
   onSend,
   sending = false,
   sendDisabled = false,
@@ -359,9 +368,10 @@ export function TaskDeskConversation({
   renderMessage
 }: Props) {
   const composerRef = useRef<HTMLTextAreaElement>(null)
+  const attachmentInputRef = useRef<HTMLInputElement>(null)
   const composerFrameRef = useRef<number | undefined>(undefined)
   const touchFirst = hasTouchFirstPointer()
-  const canSend = Boolean(draft.trim() && !sending && !waiting && !sendDisabled && ready)
+  const canSend = Boolean((draft.trim() || attachments.length) && !sending && !waiting && !sendDisabled && ready)
   // A phone has no Ctrl or Cmd key, so telling a touch user to press Ctrl/Cmd+Enter named the one
   // way to send that they do not have. Enter inserts a newline there; the Send button is the action.
   const hint = footerHint ?? (touchFirst ? "Enter adds a line. Tap Send to send." : "Enter to send · Shift+Enter for a newline")
@@ -414,6 +424,22 @@ export function TaskDeskConversation({
       />
 
       <div className="uw-composer-shell">
+        {attachments.length ? (
+          <div className="uw-composer-attachments" aria-label="Attached images">
+            {attachments.map((attachment, index) => (
+              <span className="uw-composer-attachment" key={`${attachment.filename}:${index}`}>
+                <strong>{attachment.filename}</strong>
+                <button
+                  type="button"
+                  onClick={() => onAttachmentsChange?.(attachments.filter((_, position) => position !== index))}
+                  aria-label={`Remove ${attachment.filename}`}
+                >
+                  <CloseIcon size={12} />
+                </button>
+              </span>
+            ))}
+          </div>
+        ) : null}
         {/* A placeholder is not a label: it disappears as soon as the field has content, which left
             the product's primary input unnamed for a screen reader.
 
@@ -434,6 +460,39 @@ export function TaskDeskConversation({
         <div className="uw-composer-footer">
           <span className="uw-composer-directory">{directory || ""}</span>
           <div>
+            {attachmentsSupported ? (
+              <>
+                <input
+                  ref={attachmentInputRef}
+                  type="file"
+                  accept="image/*"
+                  multiple
+                  hidden
+                  onChange={async (event) => {
+                    const room = Math.max(0, ATTACHMENT_MAX_COUNT - attachments.length)
+                    const chosen = Array.from(event.target.files ?? []).slice(0, room)
+                    event.target.value = ""
+                    if (!chosen.length) return
+                    try {
+                      const prepared = await Promise.all(chosen.map((file) => fileToAttachment(file)))
+                      onAttachmentsChange?.([...attachments, ...prepared])
+                    } catch (reason) {
+                      onAttachmentError?.(reason instanceof Error ? reason.message : String(reason))
+                    }
+                  }}
+                />
+                <button
+                  type="button"
+                  className="uw-button"
+                  disabled={!ready || sending || waiting || attachments.length >= ATTACHMENT_MAX_COUNT}
+                  onClick={() => attachmentInputRef.current?.click()}
+                  aria-label="Attach image"
+                  title="Attach image"
+                >
+                  <PaperclipIcon size={15} />
+                </button>
+              </>
+            ) : null}
             <small id="uw-composer-hint">{hint}</small>
             {waiting && onStop ? (
               <button

--- a/web/src/components/taskdesk-conversation.tsx
+++ b/web/src/components/taskdesk-conversation.tsx
@@ -371,7 +371,7 @@ export function TaskDeskConversation({
   const attachmentInputRef = useRef<HTMLInputElement>(null)
   const composerFrameRef = useRef<number | undefined>(undefined)
   const touchFirst = hasTouchFirstPointer()
-  const canSend = Boolean((draft.trim() || attachments.length) && !sending && !waiting && !sendDisabled && ready)
+  const canSend = Boolean(draft.trim() && !sending && !waiting && !sendDisabled && ready)
   // A phone has no Ctrl or Cmd key, so telling a touch user to press Ctrl/Cmd+Enter named the one
   // way to send that they do not have. Enter inserts a newline there; the Send button is the action.
   const hint = footerHint ?? (touchFirst ? "Enter adds a line. Tap Send to send." : "Enter to send · Shift+Enter for a newline")

--- a/web/src/components/work-thread-conversation.tsx
+++ b/web/src/components/work-thread-conversation.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { api } from "../api"
+import type { AttachmentPart } from "../attachments"
 import { createCoalescedTailRefresh } from "../coalesced-tail-refresh"
 import { mergeLatestMessagePage, prependOlderMessagePage } from "../message-pages"
 import type { SavedServerProfile } from "../serverProfiles"
@@ -288,6 +289,7 @@ export function WorkThreadConversation({
   const [loading, setLoading] = useState(true)
   const [loadingOlder, setLoadingOlder] = useState(false)
   const [draft, setDraft] = useState(() => localStorage.getItem(draftStorageKey) || "")
+  const [attachments, setAttachments] = useState<AttachmentPart[]>([])
   const [sending, setSending] = useState(false)
   // The prompt that has been sent but is not yet in the transcript, with the Run that was current
   // when it was sent. See `visibleTimeline`.
@@ -369,6 +371,7 @@ export function WorkThreadConversation({
     setModelError(null)
     setQuestions([])
     setPermissions([])
+    setAttachments([])
     setPendingPrompt(null)
     setTargetAgentID(currentAgentID)
     setTargetModelKey(currentTaskModelKey)
@@ -683,7 +686,8 @@ export function WorkThreadConversation({
 
   async function send() {
     const text = draft.trim()
-    if (!text || sending || working || sendInFlightRef.current) return
+    const promptAttachments = attachments
+    if ((!text && !promptAttachments.length) || sending || working || sendInFlightRef.current) return
     sendInFlightRef.current = true
     setSending(true)
     setError(null)
@@ -697,10 +701,12 @@ export function WorkThreadConversation({
       }
       const next = await taskClient.continueTask(baseConfig, task.id, {
         prompt: text,
+        attachments: promptAttachments,
         agentId: targetAgentID,
         model: selectedModel ? { providerID: selectedModel.providerID, modelID: selectedModel.modelID, variant: selectedModel.variant } : null
       })
       localStorage.removeItem(draftStorageKey)
+      setAttachments([])
       onTaskUpdateRef.current(next)
       taskRef.current = next
       modelSelectionTouchedRef.current = false
@@ -710,7 +716,8 @@ export function WorkThreadConversation({
       // The prompt goes back to the composer, so it must also stop standing in for a turn that was
       // never accepted.
       setPendingPrompt(null)
-      setDraft((current) => current ? `${text}\n${current}` : text)
+      setDraft((current) => text ? (current ? `${text}\n${current}` : text) : current)
+      setAttachments(promptAttachments)
       setError(reason instanceof Error ? reason.message : String(reason))
     } finally {
       sendInFlightRef.current = false
@@ -737,6 +744,8 @@ export function WorkThreadConversation({
   }
 
   const currentLabel = agentLabel(agents, currentAgentID)
+  const attachmentAgent = agents.find((agent) => agent.id === targetAgentID)
+  const attachmentsSupported = attachmentAgent?.capabilities?.attachments === true
   const hasAttention = questions.length > 0 || permissions.length > 0
   const preparingReply = sending || (working && !currentRunHasAssistantSignal)
   const pendingAgentLabel = sending ? agentLabel(agents, targetAgentID) : currentLabel
@@ -819,6 +828,10 @@ export function WorkThreadConversation({
         onLoadOlder={loadOlder}
         draft={draft}
         onDraftChange={setDraft}
+        attachments={attachments}
+        attachmentsSupported={attachmentsSupported}
+        onAttachmentsChange={setAttachments}
+        onAttachmentError={setError}
         onSend={send}
         sending={preparingReply}
         sendDisabled={working || hasAttention}

--- a/web/src/native-session-prompt.ts
+++ b/web/src/native-session-prompt.ts
@@ -1,5 +1,6 @@
 import { Capacitor, CapacitorHttp } from "@capacitor/core"
 import { desktopRequestResult, isDesktopPlatform } from "./desktopBridge"
+import type { AttachmentPart } from "./attachments"
 import type { NativeSessionSurfaceTarget } from "./native-session-discovery"
 import { authHeader, baseUrl, hasCredentials, routingHeaders } from "./serverConfig"
 import type { MessageEnvelope, ModelSelection } from "./types"
@@ -11,6 +12,7 @@ export type PendingNativeSessionPrompt = {
   text: string
   wireText?: string
   model?: ModelSelection | null
+  attachmentKeys?: string[]
   createdAt: number
 }
 
@@ -57,6 +59,19 @@ function sameModel(left?: ModelSelection | null, right?: ModelSelection | null):
   if (!left && !right) return true
   if (!left || !right) return false
   return left.providerID === right.providerID && left.modelID === right.modelID && (left.variant || "") === (right.variant || "")
+}
+
+function attachmentKeys(attachments: AttachmentPart[]): string[] {
+  return attachments.map((attachment) => [
+    attachment.mime,
+    attachment.filename,
+    String(attachment.url.length),
+    attachment.url.slice(-96)
+  ].join("\u0000"))
+}
+
+function sameAttachmentKeys(left: string[] = [], right: string[] = []): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index])
 }
 
 function messageText(message: MessageEnvelope): string {
@@ -122,6 +137,9 @@ export function loadPendingNativeSessionPrompt(target: NativeSessionSurfaceTarge
       text: parsed.text,
       wireText: typeof parsed.wireText === "string" && parsed.wireText.trim() ? parsed.wireText : undefined,
       model: normalizeModel(parsed.model),
+      attachmentKeys: Array.isArray(parsed.attachmentKeys)
+        ? parsed.attachmentKeys.filter((value): value is string => typeof value === "string")
+        : [],
       createdAt: typeof parsed.createdAt === "number" ? parsed.createdAt : Date.now()
     }
   } catch {
@@ -167,24 +185,31 @@ function errorDetail(body: unknown, status: number): string {
 export async function sendNativeSessionPrompt(
   target: NativeSessionSurfaceTarget,
   text: string,
-  model?: ModelSelection | null
+  model?: ModelSelection | null,
+  attachments: AttachmentPart[] = []
 ): Promise<{ status: NativeSessionPromptStatus; clientRequestId: string }> {
   const normalized = text.trim()
   if (!normalized) throw new Error("A text prompt is required")
   const requestedModel = normalizeModel(model)
+  const requestedAttachmentKeys = attachmentKeys(attachments)
 
   const stored = loadPendingNativeSessionPrompt(target)
   // A record whose retry window has passed is superseded rather than blocking forever.
   const existing = stored && Date.now() - stored.createdAt <= PENDING_DELIVERY_TTL_MS ? stored : null
   if (stored && !existing) clearPendingNativeSessionPrompt(target)
-  if (existing && (existing.text !== normalized || !sameModel(existing.model, requestedModel))) {
-    throw new Error("A previous prompt still has an unresolved delivery status. Retry that exact prompt and model selection before sending a different request.")
+  if (existing && (
+    existing.text !== normalized
+    || !sameModel(existing.model, requestedModel)
+    || !sameAttachmentKeys(existing.attachmentKeys, requestedAttachmentKeys)
+  )) {
+    throw new Error("A previous prompt still has an unresolved delivery status. Retry that exact prompt, model and image selection before sending a different request.")
   }
   const pending = existing ?? {
     clientRequestId: requestID(),
     text: normalized,
     wireText: wirePrompt(target, normalized),
     model: requestedModel,
+    attachmentKeys: requestedAttachmentKeys,
     createdAt: Date.now()
   }
   persistPending(target, pending)
@@ -195,7 +220,8 @@ export async function sendNativeSessionPrompt(
     text: pending.wireText || pending.text,
     directory: target.directory,
     model: pending.model ? { providerID: pending.model.providerID, modelID: pending.model.modelID } : undefined,
-    variant: pending.model?.variant || undefined
+    variant: pending.model?.variant || undefined,
+    attachments
   }
 
   let status: NativeSessionPromptStatus

--- a/web/src/native-session-v3-adapter.ts
+++ b/web/src/native-session-v3-adapter.ts
@@ -468,7 +468,7 @@ function installAdapter(): void {
     // preserve the model already recovered from the authoritative Session instead of silently
     // switching the next turn to the harness default. A concrete ModelSelection still wins.
     const model = body.model ?? entry.currentModel
-    const result = await sendNativeSessionPrompt(entry.target, prompt, model)
+    const result = await sendNativeSessionPrompt(entry.target, prompt, model, body.attachments ?? [])
     if (result.status !== "accepted") {
       throw new Error(`Prompt delivery is ${result.status}. Retry the same prompt to reconcile the existing request id.`)
     }

--- a/web/src/session-first-regression.test.mjs
+++ b/web/src/session-first-regression.test.mjs
@@ -88,7 +88,7 @@ assert.ok(adapter.includes('taskClient.continueTask = async function patchedCont
 assert.ok(adapter.includes('taskClient.cancelWorkThread = async function patchedCancelWorkThread'), 'native Stop must enter the same v3 controller call site')
 assert.ok(adapter.includes('probeNativeSessionContinuation(entry.target)'), 'ACP writer claim must happen lazily at the mutation boundary')
 assert.ok(adapter.includes('await ensureWriter(entry)'), 'native Send and Stop must acquire writer ownership transparently')
-assert.ok(adapter.includes('sendNativeSessionPrompt(entry.target, prompt, model)'), 'the v3 controller adapter must preserve native prompt idempotency')
+assert.ok(adapter.includes('sendNativeSessionPrompt(entry.target, prompt, model, body.attachments ?? [])'), 'the v3 controller adapter must preserve native prompt idempotency while carrying attachments')
 assert.ok(adapter.includes('stopNativeSession(entry.target, operationToken)'), 'the v3 controller adapter must preserve native Stop idempotency')
 assert.ok(adapter.includes('Cross-agent continuation is disabled until single-Session parity is validated'), 'single-Session validation must block cross-agent continuation')
 assert.ok(adapter.includes('value === "retry"') && adapter.includes('value === "waiting"'), 'native retry and waiting states must remain working')

--- a/web/src/taskClient.ts
+++ b/web/src/taskClient.ts
@@ -2,6 +2,7 @@ import { Capacitor, CapacitorHttp } from "@capacitor/core"
 import { desktopRequestResult, isDesktopPlatform } from "./desktopBridge"
 import { unwrapPayload } from "./machinePayload"
 import { authHeader, hasCredentials, machineBaseUrl } from "./serverConfig"
+import type { AttachmentPart } from "./attachments"
 import type { ModelOption, ModelSelection, ServerConfig } from "./types"
 
 const BROWSER_MACHINE_REQUEST_TIMEOUT_MS = 12_000
@@ -144,6 +145,7 @@ export type AgentModelScope = {
 
 export type TaskContinueInput = {
   prompt: string
+  attachments?: AttachmentPart[]
   agentId?: string
   model?: ModelSelection | null
   mode?: "fresh" | "resume"

--- a/web/src/taskdesk-conversation.css
+++ b/web/src/taskdesk-conversation.css
@@ -349,6 +349,54 @@
   line-height: 1.48;
 }
 
+.tdw-work-thread-conversation .uw-composer-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 10px 12px 0;
+}
+
+.tdw-work-thread-conversation .uw-composer-attachment {
+  min-width: 0;
+  max-width: min(260px, 100%);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 6px 5px 9px;
+  border: 1px solid var(--td3-border);
+  border-radius: 999px;
+  background: var(--td3-raise-1);
+}
+
+.tdw-work-thread-conversation .uw-composer-attachment strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 10px;
+  font-weight: 650;
+}
+
+.tdw-work-thread-conversation .uw-composer-attachment button {
+  width: 24px;
+  height: 24px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  color: var(--td3-muted);
+  background: transparent;
+  cursor: pointer;
+}
+
+.tdw-work-thread-conversation .uw-composer-attachment button:hover,
+.tdw-work-thread-conversation .uw-composer-attachment button:focus-visible {
+  color: var(--td3-text);
+  background: var(--td3-raise-2);
+}
+
 .tdw-work-thread-conversation .uw-composer-footer {
   min-height: 44px;
   padding: 5px 8px 8px 14px;

--- a/web/src/v3-v2-parity.test.mjs
+++ b/web/src/v3-v2-parity.test.mjs
@@ -7,13 +7,10 @@
  * the audit made executable: each restored capability gets a guard, so it cannot be lost a second
  * time by the same route.
  *
- * Still outstanding, deliberately not asserted here because asserting a gap would lock it in:
- * prompt image attachments. `attachments.ts` and the bridge path behind it are both intact — the
- * bridge validates `file` parts, forwards them as ACP image blocks and reports the capability from
- * the live handshake — but 3.0 routes conversation turns through the task pipeline
- * (`/v1/tasks/:id/continue`), which carries `prompt` as a bare string. Restoring it needs the run
- * options, the run store and all three transports in `task-launcher.js` to carry attachments, so it
- * is a feature change across client and bridge rather than a UI fix.
+ * Prompt image attachments are restored on the active Session-first path. The live harness
+ * capability gates the paperclip, the shared v3 composer prepares the same bounded images as 2.x,
+ * and the native Session operation carries them through the daemon without routing them through the
+ * retired Task launch pipeline.
  */
 
 import assert from "node:assert/strict"
@@ -30,6 +27,10 @@ const content = read("components/taskdesk-message-content.tsx")
 const conversationCss = read("taskdesk-conversation.css")
 const mobileParity = read("v3-mobile-product-parity.css")
 const clipboard = read("clipboard.ts")
+const conversation = read("components/taskdesk-conversation.tsx")
+const workThread = read("components/work-thread-conversation.tsx")
+const nativePrompt = read("native-session-prompt.ts")
+const nativeObserver = read("components/native-session-observer.tsx")
 
 test("a conversation can be copied out of, as it could in 2.x", () => {
   // 3.0 shipped with no copy affordance anywhere: `clipboard.ts` existed but only the retired shell
@@ -84,4 +85,15 @@ test("code blocks stay outside the reading measure", () => {
   assert.match(conversationCss, /\.tdw-work-thread-conversation \.uw-code-block \{[^}]*position: relative;/)
   const measured = conversationCss.match(/\.tdw-work-thread-conversation \.uw-markdown > p,[\s\S]*?\n\}/)[0]
   assert.doesNotMatch(measured, /uw-code-block|> pre|> table/)
+})
+
+test("Session-first restores capability-gated image attachments without reviving the 2.x shell", () => {
+  assert.match(conversation, /fileToAttachment/)
+  assert.match(conversation, /accept="image\/\*"/)
+  assert.match(conversation, /attachmentsSupported \? \(/)
+  assert.match(workThread, /attachments: promptAttachments/)
+  assert.match(nativePrompt, /attachments: AttachmentPart\[\] = \[\]/)
+  assert.match(nativePrompt, /attachmentKeys/)
+  assert.match(nativeObserver, /api\.capabilities\(target\.config\)/)
+  assert.doesNotMatch(nativeObserver, /SessionComposer/)
 })


### PR DESCRIPTION
Restores the v2.11 image attachment capability on the active v3 Session-first conversation path without reviving the retired 2.x shell or changing the Task launcher.

Scope:
- reuses the existing 1568px / 5MB / max-8 image preparation logic
- adds a capability-gated paperclip and removable image chips to the shared v3 composer
- queries the exact routed harness live capability before exposing attachments
- carries images through the existing native Session idempotent prompt operation
- validates attachment count/type/size at the daemon boundary
- ACP: converts validated data URLs into the existing AcpService image blocks
- OpenCode: forwards native file parts to prompt_async
- retry identity includes image content digests, so a request id cannot be reused with different images
- pending prompt storage keeps only compact image identities, never multi-megabyte base64 blobs

Regression protection:
- no changes to OMP/PI/Claude/Codex session load/resume/replay/ownership logic
- no changes to task-launcher.js
- tests cover ACP image payload, OpenCode file parts, attachment validation, and idempotent retry/conflict behavior

Base: checkpoint/v3-session-first-working-2026-08-25
main is untouched.