### PR TITLE
Enable safe native Session handoff between harnesses

### DIFF
--- a/web/src/components/native-session-handoff-control.tsx
+++ b/web/src/components/native-session-handoff-control.tsx
@@ -1,5 +1,17 @@
-import type { NativeSessionSurfaceTarget } from "../native-session-discovery"
+import { useEffect, useMemo, useRef, useState } from "react"
+import { api } from "../api"
+import { ChatIcon, LoadingIcon } from "../Icons"
+import { canCreateNativeSession } from "../native-session-create"
+import {
+  nativeSessionSurfaceTarget,
+  type NativeSessionHistoryEntry,
+  type NativeSessionRecord,
+  type NativeSessionSurfaceTarget
+} from "../native-session-discovery"
+import { handoffNativeSession } from "../native-session-handoff"
 import type { MachineAgentHost } from "../types"
+import { useDialogDismiss } from "../useDialogDismiss"
+import { useTranslator } from "../useTranslator"
 
 type Props = {
   source: NativeSessionSurfaceTarget
@@ -7,11 +19,166 @@ type Props = {
   onOpen: (target: NativeSessionSurfaceTarget) => void
 }
 
+function historyEntry(source: NativeSessionSurfaceTarget, messages: NativeSessionHistoryEntry["messages"]): NativeSessionHistoryEntry {
+  return {
+    ref: source.ref,
+    title: source.title,
+    agentID: source.agentID,
+    agentLabel: source.agentLabel,
+    backend: source.backend,
+    messages
+  }
+}
+
 /**
- * Cross-agent handoff is intentionally disabled while single native Session parity is being proven.
- * Keeping this component as a no-op preserves the surrounding Session workspace API without touching
- * the handoff protocol or creating a second timeline during the v3-first stabilization phase.
+ * Explicit cross-agent continuation for one native Session.
+ *
+ * Handoff creates a second real native Session on another harness; it never retargets the current
+ * Session and never routes a prompt through the retired Task/Conversation pipeline. Before creating
+ * that target we read the already-visible source transcript without refresh. This is deliberately
+ * important for OMP and the other ACP adapters: opening this panel must never issue session/load,
+ * resume a writer or touch replay/ownership state.
  */
-export function NativeSessionHandoffControl(_props: Props) {
-  return null
+export function NativeSessionHandoffControl({ source, agents, onOpen }: Props) {
+  const t = useTranslator()
+  const candidates = useMemo(
+    () => agents.filter((agent) => agent.id !== source.agentID && canCreateNativeSession(agent)),
+    [agents, source.agentID]
+  )
+  const [open, setOpen] = useState(false)
+  const [targetAgentID, setTargetAgentID] = useState("")
+  const [busy, setBusy] = useState(false)
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    setOpen(false)
+    setTargetAgentID("")
+    setBusy(false)
+    setPending(false)
+    setError(null)
+  }, [source.key])
+
+  useEffect(() => {
+    if (!open) return
+    setTargetAgentID((current) => candidates.some((agent) => agent.id === current) ? current : (candidates[0]?.id || ""))
+  }, [open, candidates])
+
+  const close = () => {
+    if (busy) return
+    setOpen(false)
+    setError(null)
+  }
+
+  useDialogDismiss(panelRef, close, { enabled: open })
+
+  if (!source.directory || candidates.length === 0) return null
+
+  async function continueWithAgent() {
+    const agent = candidates.find((candidate) => candidate.id === targetAgentID)
+    if (!agent || busy) return
+    setBusy(true)
+    setPending(false)
+    setError(null)
+
+    try {
+      // refreshHistory=false is a hard ACP-safety boundary. The existing transcript cache/journal
+      // is enough for handoff context and must not cause a second OMP replay or writer acquisition.
+      const sourcePage = await api.loadMessagePage(source.config, source.sessionID, source.directory, undefined, 100, false)
+      const result = await handoffNativeSession(source, agent.id, source.title)
+      if (result.status !== "accepted" || !result.result?.target) {
+        setPending(true)
+        return
+      }
+
+      const nativeTarget = result.result.target
+      const now = Date.now()
+      const record: NativeSessionRecord = {
+        key: `${agent.id}:${nativeTarget.sessionID}`,
+        agentId: agent.id,
+        agentLabel: agent.label || agent.id,
+        backend: agent.backend === "omp" || agent.backend === "pi" || agent.backend === "claude" || agent.backend === "codex"
+          ? agent.backend
+          : "opencode",
+        transport: agent.transport,
+        stopCapability: agent.contract?.sessions?.stop,
+        abortSupported: agent.capabilities?.abort === true,
+        modelsSupported: agent.capabilities?.models === true,
+        renameSupported: agent.capabilities?.sessionRename === true,
+        deleteSupported: agent.capabilities?.sessionDelete === true,
+        writerOwned: true,
+        session: {
+          id: nativeTarget.sessionID,
+          title: source.title,
+          directory: nativeTarget.directory,
+          time: { created: now, updated: now },
+          external: false
+        }
+      }
+      const target = nativeSessionSurfaceTarget(nativeTarget.machineID, source.config, record)
+      const inherited = [
+        ...(source.history || []),
+        historyEntry(source, sourcePage.messages)
+      ]
+      setOpen(false)
+      onOpen({
+        ...target,
+        history: inherited,
+        handoffContextPending: true,
+        requiresExplicitClaim: false
+      })
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="hr-session-actions hr-session-handoff">
+      <button
+        type="button"
+        className="tdw-button secondary hr-session-handoff-trigger"
+        onClick={() => { setError(null); setPending(false); setOpen(true) }}
+        disabled={busy}
+        aria-expanded={open}
+      >
+        <ChatIcon size={14} />
+        {t("sf.continueWithAgent")}
+      </button>
+
+      {open ? <div className="hr-session-action-backdrop" role="presentation" onMouseDown={close} /> : null}
+
+      {open ? (
+        <div className="hr-session-action-panel" role="dialog" aria-modal="true" aria-label={t("sf.continueWithAgent")} ref={panelRef}>
+          <div className="hr-session-action-heading">
+            <div>
+              <strong>{t("sf.continueWithAgent")}</strong>
+              <small>{t("sf.handoffSubtitle")}</small>
+            </div>
+            <button type="button" className="tdw-icon-button" data-dismiss="session-actions" onClick={close} disabled={busy} aria-label={t("sf.cancel")}>×</button>
+          </div>
+
+          <label className="hr-session-handoff-agent">
+            <span>{t("sf.codingAgent")}</span>
+            <select value={targetAgentID} onChange={(event) => { setTargetAgentID(event.target.value); setPending(false); setError(null) }} disabled={busy || pending}>
+              {candidates.map((agent) => <option key={agent.id} value={agent.id}>{agent.label || agent.id}</option>)}
+            </select>
+          </label>
+
+          {pending ? <div className="hr-session-action-error" role="status">{t("sf.handoffPending")}</div> : null}
+          {error ? <div className="hr-session-action-error" role="alert">{error}</div> : null}
+
+          <div className="hr-session-action-buttons">
+            <button type="button" className="tdw-button secondary" data-autofocus onClick={close} disabled={busy}>{t("sf.cancel")}</button>
+            <button type="button" className="tdw-button primary" onClick={() => void continueWithAgent()} disabled={busy || !targetAgentID}>
+              {busy ? <LoadingIcon size={15} /> : null}
+              {busy ? t("sf.handingOff") : pending ? t("sf.retry") : t("sf.continueSession")}
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
 }

--- a/web/src/native-session-handoff.ts
+++ b/web/src/native-session-handoff.ts
@@ -122,7 +122,11 @@ export async function handoffNativeSession(
   let parsed: { status: NativeSessionHandoffStatus; result?: NativeSessionHandoffResult }
   if (isDesktopPlatform()) {
     const result = await desktopRequestResult(source.config, { path, method: "POST", body })
-    if (!result.ok) throw new Error(result.error.message)
+    if (!result.ok) {
+      const status = Number(result.error.status)
+      if (result.error.code === "http" && status >= 400 && status < 500) clearPending(source)
+      throw new Error(result.error.message)
+    }
     parsed = responseData(result.response.data)
   } else {
     const headers: Record<string, string> = {
@@ -147,7 +151,10 @@ export async function handoffNativeSession(
       } catch {
         throw new Error(`Cannot reach ${source.config.host}:${source.config.port}. Handoff delivery status is unknown; retry will use the same request id.`)
       }
-      if (response.status >= 400) throw new Error(errorDetail(response.data, response.status))
+      if (response.status >= 400) {
+        if (response.status < 500) clearPending(source)
+        throw new Error(errorDetail(response.data, response.status))
+      }
       parsed = responseData(response.data)
     } else {
       let response: Response
@@ -161,7 +168,10 @@ export async function handoffNativeSession(
         const raw = await response.text()
         data = raw ? JSON.parse(raw) : undefined
       } catch {}
-      if (!response.ok) throw new Error(errorDetail(data, response.status))
+      if (!response.ok) {
+        if (response.status < 500) clearPending(source)
+        throw new Error(errorDetail(data, response.status))
+      }
       parsed = responseData(data)
     }
   }

--- a/web/src/session-first-regression.test.mjs
+++ b/web/src/session-first-regression.test.mjs
@@ -139,7 +139,11 @@ for (const retiredPath of [
   assert.equal(existsSync(new URL(retiredPath, import.meta.url)), false, `${retiredPath} must not return as a parallel Session-first chat path`)
 }
 
-assert.match(handoff, /export function NativeSessionHandoffControl\(_props: Props\)\s*\{\s*return null\s*\}/, 'cross-agent handoff UI must remain disabled during single-Session stabilization')
+assert.ok(handoff.includes('handoffNativeSession(source, agent.id, source.title)'), 'cross-agent continuation must use the idempotent native handoff primitive')
+assert.ok(handoff.includes('api.loadMessagePage(source.config, source.sessionID, source.directory, undefined, 100, false)'), 'handoff context reads must never force ACP history refresh or replay')
+assert.ok(handoff.includes('writerOwned: true') && handoff.includes('requiresExplicitClaim: false'), 'a handoff-created native Session must remain owned without a redundant ACP claim')
+assert.ok(handoff.includes('canCreateNativeSession(agent)'), 'handoff choices must follow the same validated native create capability gate')
+assert.equal(handoff.includes('createTask('), false, 'native handoff must not recreate the retired Task/Conversation path')
 assert.ok(standalone.includes('<NativeSessionObserver'), 'integrated Sessions workspace must still open native Sessions')
 assert.ok(standalone.includes('<NativeSessionHome'), 'Session-first navigation must remain native discovery based')
 assert.ok(standalone.includes('<NativeSessionActions target={selected} onDeleted={handleSessionDeleted} />'), 'open Session header must own the delete action')


### PR DESCRIPTION
Enables the existing Session-first "Continue with another coding agent" path without changing ACP replay, resume, prompt ownership or the mature v3 conversation controller.

What it does:
- activates the existing NativeSessionHandoffControl in the open Session header
- offers only other agents on the same machine that pass the existing native Session create capability gate
- uses the already implemented idempotent /session/:id/handoff primitive to create exactly one real target native Session
- opens that target Session directly after acceptance
- transfers bounded source transcript context for the first target prompt
- reads source context with refreshHistory=false, so handoff never forces OMP/PI/Codex history replay or session/load
- marks the newly created target as writer-owned, avoiding a redundant ACP claim
- preserves unresolved handoff retry identity; a definite 4xx rejection releases the pending key so the user is not trapped on a failed target
- keeps cross-agent switching OUT of the shared WorkThread controller. The handoff remains an explicit native Session lifecycle operation.

Scope intentionally remains same-machine. Cross-machine continuation is not advertised by this PR.

Regression guard:
- no createTask/Conversation route
- no parallel Session-first timeline/renderer
- no ACP history refresh from the handoff UI
- existing native prompt/Stop idempotency and v3 controller stay unchanged

Base: checkpoint/v3-session-first-working-2026-08-25
main is untouched.