### PR TITLE
Fix legacy Session delete tombstones surviving restart

### DIFF
--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -603,7 +603,19 @@ export class AcpService {
   }
 
   async deleteSession(sessionID) {
-    await this.#requireSession(sessionID)
+    // A Session deleted by a pre-index Harness Remote may already carry deleted:true only in its
+    // per-Session snapshot. Restoring that snapshot must migrate the tombstone into the lightweight
+    // deletion index instead of failing before the index can be written. This keeps DELETE
+    // idempotent across upgrades without issuing any new ACP request.
+    await this.#restoreDeletedSessionIndex()
+    await this.#refreshSessions()
+    await this.#restoreSnapshot(sessionID)
+    if (this.#deletedSessions.has(sessionID)) {
+      await this.#persistDeletedSessionIndex()
+      return
+    }
+    if (!this.#sessions.has(sessionID)) throw new Error("Harness session not found")
+
     if (this.#isBusy(sessionID)) this.abort(sessionID)
     this.#deletedSessions.add(sessionID)
     await this.#persistDeletedSessionIndex()

--- a/bridge/test/session-delete-visibility.test.js
+++ b/bridge/test/session-delete-visibility.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { EventEmitter } from "node:events"
-import { mkdtemp, rm } from "node:fs/promises"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import test from "node:test"
@@ -104,6 +104,61 @@ test("ACP deletion disappears from Session-first discovery and survives a daemon
     const fullList = await fullListResponse.json()
     assert.deepEqual(fullList.map((session) => session.id), ["session-to-keep"])
 
+    assert.deepEqual(secondAcp.requests, [])
+  } finally {
+    await close(secondServer)
+    await rm(stateDirectory, { recursive: true, force: true })
+  }
+})
+
+
+test("legacy deleted snapshot is migrated into the persistent Session-first deletion index", async () => {
+  const stateDirectory = await mkdtemp(path.join(tmpdir(), "harness-remote-delete-legacy-"))
+  const snapshotDirectory = path.join(stateDirectory, "omp")
+  const serviceOptions = { snapshotDirectory }
+  const sessionID = "session-to-delete"
+  const snapshotName = Buffer.from(sessionID).toString("base64url")
+  await mkdir(snapshotDirectory, { recursive: true })
+  await writeFile(path.join(snapshotDirectory, `${snapshotName}.json`), JSON.stringify({
+    version: 1,
+    messages: [],
+    todos: [],
+    title: "Delete me",
+    deleted: true
+  }))
+
+  const firstAcp = new FakeAcp()
+  const firstServer = createBridgeServer({ config, acp: firstAcp, serviceOptions })
+  const firstBase = await listen(firstServer)
+
+  try {
+    // The lightweight list intentionally does not read every legacy per-Session snapshot at startup,
+    // so this reproduces the real upgrade case: the old tombstone is not known until DELETE touches
+    // that Session.
+    const beforeResponse = await fetch(`${firstBase}/experimental/session`)
+    assert.equal(beforeResponse.status, 200)
+    const before = await beforeResponse.json()
+    assert.deepEqual(before.map((session) => session.id), ["session-to-delete", "session-to-keep"])
+
+    // Before this regression fix, restoring deleted:true here threw "Harness session not found"
+    // before deleted-sessions.json could be written. The Session disappeared only in memory and
+    // returned after restart.
+    const deleteResponse = await fetch(`${firstBase}/session/${sessionID}`, { method: "DELETE" })
+    assert.equal(deleteResponse.status, 200)
+    assert.equal(await deleteResponse.json(), true)
+    assert.deepEqual(firstAcp.requests, [])
+  } finally {
+    await close(firstServer)
+  }
+
+  const secondAcp = new FakeAcp()
+  const secondServer = createBridgeServer({ config, acp: secondAcp, serviceOptions })
+  const secondBase = await listen(secondServer)
+  try {
+    const restoredResponse = await fetch(`${secondBase}/experimental/session`)
+    assert.equal(restoredResponse.status, 200)
+    const restored = await restoredResponse.json()
+    assert.deepEqual(restored.map((session) => session.id), ["session-to-keep"])
     assert.deepEqual(secondAcp.requests, [])
   } finally {
     await close(secondServer)


### PR DESCRIPTION
Fixes the real deletion failure reproduced from an existing Harness Remote state.

Root cause:
A Session deleted before PR #319 can already have `deleted: true` in its per-Session snapshot but no `deleted-sessions.json` index. On a later DELETE, `deleteSession()` restored that legacy snapshot and `#requireSession()` threw `Harness session not found` before the new persistent index was written. The Session therefore disappeared only from the current process and returned after restart.

Fix:
- make DELETE idempotently migrate a legacy per-Session tombstone into the lightweight persistent deletion index
- keep a genuinely unknown/nonexistent Session as an error
- issue no new ACP requests and do not touch load/replay/prompt/ownership behavior
- add a regression test that pre-populates the exact legacy on-disk state, confirms DELETE succeeds, restarts the server, and confirms the Session stays hidden

Base is `checkpoint/v3-session-first-working-2026-08-25`. `main` is untouched.