### PR TITLE
Mark native Session handoff as experimental

### DIFF
--- a/web/src/components/native-session-handoff-control.tsx
+++ b/web/src/components/native-session-handoff-control.tsx
@@ -146,6 +146,7 @@ export function NativeSessionHandoffControl({ source, agents, onOpen }: Props) {
       >
         <ChatIcon size={14} />
         {t("sf.continueWithAgent")}
+        <span className="hr-experimental-badge">Experimental</span>
       </button>
 
       {open ? <div className="hr-session-action-backdrop" role="presentation" onMouseDown={close} /> : null}
@@ -154,7 +155,7 @@ export function NativeSessionHandoffControl({ source, agents, onOpen }: Props) {
         <div className="hr-session-action-panel" role="dialog" aria-modal="true" aria-label={t("sf.continueWithAgent")} ref={panelRef}>
           <div className="hr-session-action-heading">
             <div>
-              <strong>{t("sf.continueWithAgent")}</strong>
+              <strong>{t("sf.continueWithAgent")} <span className="hr-experimental-badge">Experimental</span></strong>
               <small>{t("sf.handoffSubtitle")}</small>
             </div>
             <button type="button" className="tdw-icon-button" data-dismiss="session-actions" onClick={close} disabled={busy} aria-label={t("sf.cancel")}>×</button>

--- a/web/src/session-first-workbench.css
+++ b/web/src/session-first-workbench.css
@@ -1063,6 +1063,23 @@
   white-space: nowrap;
 }
 
+.hr-experimental-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 17px;
+  padding: 0 5px;
+  border: 1px solid var(--td3-blue-border);
+  border-radius: 999px;
+  color: var(--td3-blue-text);
+  background: var(--td3-blue-soft);
+  font-size: 8px;
+  font-weight: 800;
+  letter-spacing: .04em;
+  line-height: 1;
+  text-transform: uppercase;
+  vertical-align: middle;
+}
+
 .hr-session-handoff .hr-session-action-panel {
   position: absolute;
   z-index: 60;


### PR DESCRIPTION
Superseded by refreshed PR #328 rebased conceptually onto the current checkpoint/UI.