### PR TITLE
Show prompt attachments inside user chat turns

### DIFF
--- a/web/src/components/taskdesk-message-content.tsx
+++ b/web/src/components/taskdesk-message-content.tsx
@@ -4,7 +4,7 @@ import remarkGfm from "remark-gfm"
 import { copyToClipboard } from "../clipboard"
 import { activityLabel, groupConversationParts, type ConversationPartGroup } from "../conversation-parts"
 import {
-  AlertIcon, CheckIcon, CommandIcon, CopyIcon, FolderIcon, PencilIcon, SearchIcon, ServerIcon,
+  AlertIcon, CheckIcon, CommandIcon, CopyIcon, FolderIcon, PaperclipIcon, PencilIcon, SearchIcon, ServerIcon,
   SparkIcon, TaskListIcon
 } from "../Icons"
 import type { MessageEnvelope, MessagePart, TodoItem } from "../types"
@@ -287,6 +287,20 @@ function ToolPartCard({ part }: { part: MessagePart }) {
   )
 }
 
+function AttachmentPartCard({ part }: { part: MessagePart }) {
+  const label = part.filename || "Attached image"
+  const isImage = (part.mime || "").startsWith("image/") && typeof part.url === "string" && part.url.startsWith("data:")
+  return (
+    <div className="uw-message-attachment" title={label}>
+      {isImage ? <img src={part.url} alt={label} /> : <span className="uw-message-attachment-icon"><PaperclipIcon size={14} /></span>}
+      <span>
+        <strong>{label}</strong>
+        <small>{part.mime || "attachment"}</small>
+      </span>
+    </div>
+  )
+}
+
 function UnsupportedPart({ part }: { part: MessagePart }) {
   const label = part.filename || part.tool || part.type || "unknown"
   return <div className="uw-unsupported-part" title={`Unsupported message part: ${part.type}`}>{label}</div>
@@ -313,7 +327,15 @@ function ContentGroup({ group }: { group: ContentGroupValue }) {
           </div>
         </>
       ) : null}
-      {other.map((part) => <UnsupportedPart key={part.id} part={part} />)}
+      {other.length ? (
+        <div className="uw-message-attachments" aria-label="Attachments">
+          {other.map((part) => (
+            part.type === "file" || part.type === "image" || Boolean(part.mime && part.url)
+              ? <AttachmentPartCard key={part.id} part={part} />
+              : <UnsupportedPart key={part.id} part={part} />
+          ))}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/web/src/components/work-thread-conversation.tsx
+++ b/web/src/components/work-thread-conversation.tsx
@@ -296,7 +296,7 @@ export function WorkThreadConversation({
   const [sending, setSending] = useState(false)
   // The prompt that has been sent but is not yet in the transcript, with the Run that was current
   // when it was sent. See `visibleTimeline`.
-  const [pendingPrompt, setPendingPrompt] = useState<{ text: string; priorRunID: string | null } | null>(null)
+  const [pendingPrompt, setPendingPrompt] = useState<{ text: string; priorRunID: string | null; attachments: AttachmentPart[] } | null>(null)
   const [stopping, setStopping] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [modelError, setModelError] = useState<string | null>(null)
@@ -467,7 +467,14 @@ export function WorkThreadConversation({
     const id = `work-thread:${task.id}:pending-user`
     return [...timeline, {
       info: { id, role: "user", sessionID: `work-thread:${task.id}`, time: { created: Date.now() } },
-      parts: [{ id: `${id}:text`, messageID: id, type: "text", text: pendingPrompt.text }],
+      parts: [
+        ...(pendingPrompt.text ? [{ id: `${id}:text`, messageID: id, type: "text", text: pendingPrompt.text }] : []),
+        ...pendingPrompt.attachments.map((attachment, index) => ({
+          ...attachment,
+          id: `${id}:attachment:${index}`,
+          messageID: id
+        }))
+      ],
       taskdesk: { kind: "synthetic-user" as const }
     } as WorkThreadMessage]
   }, [timeline, pendingPrompt, settledPrompt, task.id])
@@ -702,7 +709,7 @@ export function WorkThreadConversation({
     setSending(true)
     setError(null)
     setDraft("")
-    setPendingPrompt({ text, priorRunID: taskRef.current.run?.id ?? null })
+    setPendingPrompt({ text, priorRunID: taskRef.current.run?.id ?? null, attachments: promptAttachments })
     try {
       const latest = await taskClient.getWorkThread(baseConfig, task.id)
       if (isActive(latest)) {

--- a/web/src/session-first-regression.test.mjs
+++ b/web/src/session-first-regression.test.mjs
@@ -120,12 +120,14 @@ assert.ok(workThread.includes('api.loadMessagePage'), 'v3 WorkThreadConversation
 assert.ok(workThread.includes('buildWorkThreadTimeline'), 'v3 WorkThreadConversation must remain timeline authority')
 assert.ok(workThread.includes('startTaskDeskSessionLiveRefresh'), 'v3 WorkThreadConversation must remain live-event authority')
 assert.ok(workThread.includes('taskClient.continueTask'), 'v3 WorkThreadConversation must remain send controller')
+assert.ok(workThread.includes('pendingPrompt.attachments.map'), 'optimistic user turns must keep sent attachments visible immediately')
 assert.ok(workThread.includes('command: slashCommand'), 'recognized slash commands must travel through the same continueTask controller call')
 assert.equal(workThread.includes('api.sendCommand('), false, 'slash commands must not bypass Session-first with the legacy mutation endpoint')
 assert.ok(workThread.includes('taskClient.cancelWorkThread'), 'v3 WorkThreadConversation must remain Stop controller')
 assert.ok(workThread.includes('<TaskDeskConversation'), 'v3 WorkThreadConversation must remain the renderer owner')
 assert.ok(workThread.includes('createCoalescedTailRefresh'), 'native Session tail refreshes must preserve a final authoritative read arriving during an in-flight read')
 assert.ok(timeline.includes('Native user messages are the only conversation boundary'), 'mature v3 native turn boundary semantics must remain authoritative')
+assert.ok(timeline.includes('attachmentParts = nativeUserParts.filter'), 'native attachment parts must survive the synthetic user-turn projection')
 assert.ok(timeline.includes('part.type === "tool" && part.callID'), 'mature v3 tool update identity must remain authoritative')
 assert.ok(timeline.includes('terminalNativeAssistantError'), 'a recovered OpenCode retry must be able to supersede a transient interrupted attempt in the same turn')
 
@@ -133,6 +135,7 @@ assert.equal(conversation.includes('MessageAgentMeta'), false, 'Session-first mu
 assert.equal(messageContent.includes('conversation-turn-state'), false, 'Session-first must not replace mature v3 reasoning/error semantics')
 assert.ok(messageContent.includes('hasTerminalAssistantText'), 'mature v3 assistant terminal-state semantics must remain intact')
 assert.ok(messageContent.includes('messageErrorText'), 'mature v3 error rendering must remain intact')
+assert.ok(messageContent.includes('AttachmentPartCard') && messageContent.includes('uw-message-attachments'), 'user turns must visibly render attached files/images')
 
 for (const retiredPath of [
   './native-session-feed.ts',

--- a/web/src/taskdesk-conversation.css
+++ b/web/src/taskdesk-conversation.css
@@ -609,3 +609,64 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+
+.tdw-work-thread-conversation .uw-message-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.tdw-work-thread-conversation .uw-message-attachment {
+  min-width: 0;
+  max-width: min(320px, 100%);
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  align-items: center;
+  gap: 9px;
+  padding: 7px 9px;
+  border: 1px solid var(--td3-border);
+  border-radius: 10px;
+  background: var(--td3-raise-1);
+}
+
+.tdw-work-thread-conversation .uw-message-attachment img,
+.tdw-work-thread-conversation .uw-message-attachment-icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 8px;
+}
+
+.tdw-work-thread-conversation .uw-message-attachment img {
+  display: block;
+  object-fit: cover;
+  border: 1px solid var(--td3-border-soft);
+}
+
+.tdw-work-thread-conversation .uw-message-attachment-icon {
+  display: grid;
+  place-items: center;
+  color: var(--td3-muted);
+  background: var(--td3-raise-2);
+}
+
+.tdw-work-thread-conversation .uw-message-attachment > span:last-child {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.tdw-work-thread-conversation .uw-message-attachment strong {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--td3-text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+}
+
+.tdw-work-thread-conversation .uw-message-attachment small {
+  color: var(--td3-muted);
+  font-size: 10px;
+}

--- a/web/src/work-thread-timeline.ts
+++ b/web/src/work-thread-timeline.ts
@@ -77,6 +77,7 @@ function syntheticMessage({
   sessionID,
   created,
   text,
+  parts,
   meta,
   error
 }: {
@@ -85,6 +86,7 @@ function syntheticMessage({
   sessionID: string
   created: number
   text?: string
+  parts?: MessagePart[]
   meta: WorkThreadMessageMeta
   error?: { name?: string; message?: string; data?: Record<string, unknown> }
 }): WorkThreadMessage {
@@ -96,7 +98,14 @@ function syntheticMessage({
       time: { created },
       ...(error ? { error } : {})
     },
-    parts: text ? [{ id: `${id}:text`, messageID: id, type: "text", text }] : [],
+    parts: [
+      ...(text ? [{ id: `${id}:text`, messageID: id, type: "text", text }] : []),
+      ...(parts ?? []).map((part, index) => ({
+        ...part,
+        id: `${id}:attachment:${index}:${part.id || index}`,
+        messageID: id
+      }))
+    ],
     taskdesk: meta
   }
 }
@@ -363,12 +372,17 @@ export function buildWorkThreadTimeline(
 
     const prompt = (run.prompt || (index === 0 ? task.prompt : "")).trim()
     if (prompt) {
+      const nativeUserParts = turnByRunIndex.get(index)?.user?.parts ?? []
+      const attachmentParts = nativeUserParts.filter((part) =>
+        part.type === "file" || part.type === "image" || Boolean(part.mime && part.url)
+      )
       timeline.push(syntheticMessage({
         id: `work-thread:${task.id}:run:${run.id || index}:user`,
         role: "user",
         sessionID: session,
         created: start,
         text: prompt,
+        parts: attachmentParts,
         meta: { kind: "synthetic-user", runId: run.id, agentId: agentID, agentLabel: agent?.label, agentBackend: agent?.backend }
       }))
     }


### PR DESCRIPTION
Refresh of #327 on the current Session-first checkpoint/UI.

- sent attachments stay visible immediately in the optimistic user turn
- native file/image parts are preserved when the v3 timeline projects the user turn
- renders compact thumbnail, filename and MIME type using the current chat UI
- respects the current 10px minimum text-size regression rule
- no backend, ACP, OMP, replay, ownership or prompt transport changes

This does not yet solve attachment persistence after backend restart; that remains a separate follow-up.