### PR TITLE
chore: prepare Harness Remote 3.0.0 release

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harness-remote-web",
   "private": true,
-  "version": "2.11.1",
+  "version": "3.0.0",
   "description": "Companion app for controlling coding-agent harnesses from phone or desktop",
   "homepage": "https://github.com/giuliastro/harness-remote",
   "author": {


### PR DESCRIPTION
Bump the application release version from 2.11.1 to 3.0.0. No README or documentation files are changed.