### PR TITLE
docs: align plans and developer notes with Harness Remote 3.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,49 +203,39 @@ your change is silently dropped and the app runs the previous version of the nat
 
 ## Cutting a release
 
-Bump `version` in `web/package.json`, commit it as `chore: release vX.Y.Z`, then tag that commit and
-push both. Everything else — the version code, the Android metadata, the signed APK, the GitHub
-release — is derived from that one field by CI.
+The release version is still sourced from `web/package.json`, but tags are now created by CI rather
+than by hand.
 
-```bash
-git tag -a v3.0.0 --cleanup=verbatim -F release-notes.txt
-git push origin main && git push origin v3.0.0
-```
+1. Bump `version` in `web/package.json`.
+2. Merge the fully validated release candidate to `main`.
+3. Make the final merge commit title exactly `Release Harness Remote X.Y.Z` (or begin with that
+   phrase) and give it a non-empty body containing the curated release summary.
+4. `.github/workflows/cut-release-tag.yml` reads the package version, creates the annotated
+   `vX.Y.Z` tag if it does not already exist, and explicitly dispatches the Android and Desktop
+   builders on that tag.
+5. The Android tagged build publishes the GitHub Release and signed APK. The Desktop tagged build
+   waits for that release and attaches Windows, macOS and Linux artifacts.
 
-**`--cleanup=verbatim` is not optional.** Git's default cleanup strips every line that starts with
-`#` as a comment, which silently deletes both `##` headings out of the message below — the tag looks
-fine, and the release renders two bullet lists with nothing naming them. Check before pushing:
+Why the explicit dispatch? GitHub intentionally does not trigger other workflows from a tag pushed
+with the repository `GITHUB_TOKEN`. Do not remove the dispatch step and assume the tag push will
+fan out by itself.
 
-```bash
-git tag -l --format='%(contents:body)' v3.0.0
-```
+**The release commit body becomes the annotated tag body and therefore the curated release notes.**
+Keep it useful to people installing the release: describe user-visible changes first, mention
+important compatibility/reliability work, and credit external contributors by name/handle when
+their work is included.
 
-**The tag annotation is the release notes.** CI publishes its body verbatim between its own
-`## Release` heading and the build notes, so write those two sections as bullets and nothing else:
+Before calling a release complete, verify all of these independently:
 
-```
-Harness Remote v2.4.0
+- `main` points at the intended release tree;
+- the `vX.Y.Z` annotated tag points at the release commit;
+- the tag annotation is non-empty;
+- the Android tagged workflow publishes the GitHub Release and signed APK;
+- the Desktop tagged workflow attaches Windows/macOS/Linux artifacts;
+- hosted GitHub Pages deployment is green.
 
-## What's Changed
-
-* One line per user-visible change, most interesting first
-* No "by @someone", no pull request numbers
-
-## Contributors
-
-* **Special thanks to [@handle](https://github.com/handle)** (Real Name) — what they built, and why it stands out
-* [@handle](https://github.com/handle) (Real Name) — what they contributed
-```
-
-The first line is the subject and is dropped from the body, so it can repeat the version.
-
-**Credit contributors, not the merge.** GitHub's generated notes are switched off deliberately. They
-list one bullet per pull request ending in `by @<whoever pressed merge>`, which on this repo means
-the maintainer collects credit for work other people did — v2.3.0 read as though the maintainer had
-written the desktop layout. Keep the bullets; they are the right format. Just describe the change and
-stop there. Then name the people whose work is in the release, say what each contributed, and give
-the largest contribution a `Special thanks`. Anyone who wants it attributed commit by commit has the
-full changelog link that CI appends.
+Do not manually move or recreate an already-published release tag to fix packaging. Fix the workflow
+or release metadata, then rerun the builders against the existing immutable tag whenever possible.
 
 ## The bridge is a network service
 

--- a/README.md
+++ b/README.md
@@ -280,13 +280,13 @@ That makes it possible to add new harnesses without forcing existing ones into a
 
 ## Harness Remote 3 status
 
-Harness Remote 3 is currently the **Session-first development line**.
+Harness Remote **3.0.0 is the current stable release** and the Session-first architecture now ships from `main`.
 
-The stable release line on `main` remains Harness Remote 2.x while the v3 runtime contract is validated against real installations of OpenCode, OMP, PI, Codex and Claude Code.
+The official `v3.0.0` release supports OpenCode, OMP, PI, Codex CLI and Claude Code while preserving each harness's native Session identity and behavior. The validated release scope includes native Session discovery and continuation, multi-machine Session creation, same-machine cross-harness handoff with durable lineage, model selection, live Activity, Stop, rename/delete, transcript paging and reconnect recovery.
 
-Current v3 work intentionally prioritizes Session correctness, resume/reconnect behavior, native transcript fidelity and cross-agent continuation over adding broad orchestration features.
+Post-release work intentionally prioritizes Session correctness and maintainability over broad orchestration. Cross-machine handoff is a separate follow-up, and architectural cleanup must start from current `main` rather than reviving pre-release checkpoint/draft branches.
 
-The automatic multi-agent launcher is also still being expanded: the current checkpoint can expose one selected ACP-backed primary alongside managed OpenCode, while additional concurrent ACP host instances remain follow-up work.
+The automatic multi-agent launcher is still being expanded: the current release can expose one selected ACP-backed primary alongside managed OpenCode, while additional concurrent ACP host instances remain follow-up work.
 
 That focus is deliberate. A remote coding-agent UI is only useful if you can trust that the Session you see is the Session that actually exists.
 

--- a/docs/HARNESS_3_ROADMAP.md
+++ b/docs/HARNESS_3_ROADMAP.md
@@ -3,6 +3,14 @@
 This document describes the durable product model and engineering boundaries for Harness Remote as
 they ship on `main`.
 
+> **Status (2026-08-30):** Harness Remote 3.0.0 is released and `main` is the canonical 3.x
+> development baseline. The `v3.0.0` tag is the immutable release point. The former
+> `checkpoint/v3-session-first-working-2026-08-25` branch is retained as release-development
+> history/reference, not as the branch for new feature work.
+>
+> Post-release work is tracked as focused follow-ups: architecture simplification (#330),
+> repository branch hygiene (#290), and cross-machine native Session handoff (#347).
+
 ## 1. Product thesis
 
 Harness Remote 3.0 is a **vendor-neutral, local-first control plane for native coding-agent Sessions**.

--- a/docs/NITSUGA_TASKDESK_INTEGRATION_PLAN.md
+++ b/docs/NITSUGA_TASKDESK_INTEGRATION_PLAN.md
@@ -1,12 +1,17 @@
 # Nitsuga → TaskDesk Integration Plan
 
-> **Status:** active integration plan
+> **Historical document — do not use as a current development plan.**
 >
-> **Working branch:** `integration/nitsuga-taskdesk`
+> This plan records the pre-Session-first TaskDesk integration work that led into Harness Remote 3.
+> Harness Remote 3.0.0 has since shipped from `main`; TaskDesk is historical/internal naming and
+> new work must start from current `main`, following the Session-first architecture in
+> `docs/HARNESS_3_ROADMAP.md`.
 >
-> **Baseline:** `archive/harness-3-2026-08-15`
+> Original working branch: `integration/nitsuga-taskdesk`
 >
-> **Tracking issue:** #197
+> Original baseline: `archive/harness-3-2026-08-15`
+>
+> Historical tracking issue: #197 (completed)
 
 ## Goal
 

--- a/docs/TASKDESK_LOCAL_TEST_PLAN.md
+++ b/docs/TASKDESK_LOCAL_TEST_PLAN.md
@@ -1,8 +1,14 @@
 # TaskDesk local test plan
 
-> Target branch: `v3/taskdesk`
+> **Historical test plan — not the current Harness Remote 3 development workflow.**
 >
-> Purpose: validate TaskDesk/Harness 3 locally against real harness CLIs before Android/network variables are introduced.
+> This document is preserved for reproducing the old TaskDesk integration surface and regressions.
+> Harness Remote 3.0.0 is Session-first and ships from `main`; new development and validation
+> should use current `main` plus the active v3 regression/browser/real-harness test suites.
+>
+> Historical target branch: `v3/taskdesk`
+>
+> Original purpose: validate TaskDesk/Harness 3 locally against real harness CLIs before Android/network variables were introduced.
 
 ## Important: New Task is still hidden in the normal app
 


### PR DESCRIPTION
Post-release documentation cleanup.

- README: Harness Remote 3.0.0 is now the stable Session-first line on main.
- CONTRIBUTING: document the automated annotated-tag + explicit Android/Desktop dispatch release flow.
- HARNESS_3_ROADMAP: mark v3.0.0 released, main canonical, checkpoint historical/reference.
- NITSUGA_TASKDESK_INTEGRATION_PLAN and TASKDESK_LOCAL_TEST_PLAN: clearly mark as historical, not active instructions.

No runtime code changes.