### PR TITLE
Fix OpenCode terminal errors stuck in Working

### DIFF
--- a/web/scripts/native-opencode-browser-smoke.mjs
+++ b/web/scripts/native-opencode-browser-smoke.mjs
@@ -446,7 +446,7 @@ function startFakeDaemon() {
         // OpenCode's legacy status endpoint omits this child Session entirely. The mounted Session
         // must settle from the durable error envelope without requiring navigation away and back.
         emitLiveEvent(sessionID, "message.updated")
-        emitLiveEvent(sessionID, "session.status")
+        emitLiveEvent(sessionID, "session.error")
         return
       }
       json(response, 200, { status: "accepted", clientRequestId: requestId })

--- a/web/scripts/native-opencode-browser-smoke.mjs
+++ b/web/scripts/native-opencode-browser-smoke.mjs
@@ -18,6 +18,8 @@ const SECOND_REPLY = "OPENCODE-SECOND-REPLY"
 const INTERRUPT_PROMPT = "OPENCODE-TRANSIENT-INTERRUPTION-PROMPT"
 const INTERRUPT_REPLY = "OPENCODE-RECOVERED-FINAL-REPLY"
 const TERMINAL_INTERRUPT_PROMPT = "OPENCODE-TERMINAL-INTERRUPTION-PROMPT"
+const TERMINAL_ERROR_PROMPT = "OPENCODE-TERMINAL-PROVIDER-ERROR-PROMPT"
+const TERMINAL_ERROR_MESSAGE = "Error from provider (Console): Upstream request failed: Endpoint is unavailable."
 const LATE_RECOVERY_PROMPT = "OPENCODE-LATE-RECOVERY-PROMPT"
 const LATE_RECOVERY_REPLY = "OPENCODE-LATE-RECOVERY-FINAL-REPLY"
 const CREATE_TITLE = "OpenCode created from Harness Remote"
@@ -53,6 +55,7 @@ function initialTranscript() {
 
 let sessionCatalog
 let sessionStatuses
+let statusOmissions
 let transcripts
 let modelCatalogReads
 let promptHttpBodies
@@ -73,6 +76,7 @@ function resetFakeState() {
     time: { created: 1_000, updated: 1_001 }
   }]])
   sessionStatuses = new Map([[SESSION_ID, { type: "idle" }]])
+  statusOmissions = new Set()
   transcripts = new Map([[SESSION_ID, initialTranscript()]])
   modelCatalogReads = 0
   promptHttpBodies = []
@@ -148,6 +152,26 @@ function finishInterruptedTurn(sessionID, prompt, requestId) {
   ))
   const entry = sessionCatalog.get(sessionID)
   if (entry) entry.time.updated = completed
+}
+
+function appendProviderErrorTurn(sessionID, prompt, requestId) {
+  const base = clock
+  clock += 10
+  transcript(sessionID).push(
+    message(sessionID, `oc-user-${requestId}`, "user", prompt, base),
+    {
+      info: {
+        id: `oc-assistant-${requestId}-provider-error`,
+        role: "assistant",
+        sessionID,
+        time: { created: base + 1, completed: base + 2 },
+        error: { name: "ProviderError", message: TERMINAL_ERROR_MESSAGE }
+      },
+      parts: []
+    }
+  )
+  const entry = sessionCatalog.get(sessionID)
+  if (entry) entry.time.updated = base + 2
 }
 
 function appendPendingTurn(sessionID, prompt, requestId) {
@@ -274,10 +298,12 @@ function startFakeDaemon() {
     }
 
     if (request.method === "GET" && url.pathname === "/v1/agents/opencode/session/status") {
-      json(response, 200, Object.fromEntries([...sessionCatalog.keys()].map((sessionID) => [
-        sessionID,
-        sessionStatuses.get(sessionID) || { type: "idle" }
-      ])))
+      json(response, 200, Object.fromEntries([...sessionCatalog.keys()]
+        .filter((sessionID) => !statusOmissions.has(sessionID))
+        .map((sessionID) => [
+          sessionID,
+          sessionStatuses.get(sessionID) || { type: "idle" }
+        ])))
       return
     }
 
@@ -347,6 +373,7 @@ function startFakeDaemon() {
         nativePromptDispatches += 1
         ledger.set(ledgerKey, body)
         if (body.text === SUCCESS_PROMPT) appendPendingTurn(sessionID, body.text, requestId)
+        else if (body.text === TERMINAL_ERROR_PROMPT) appendProviderErrorTurn(sessionID, body.text, requestId)
         else if (body.text === INTERRUPT_PROMPT || body.text === TERMINAL_INTERRUPT_PROMPT || body.text === LATE_RECOVERY_PROMPT) appendInterruptedTurn(sessionID, body.text, requestId)
         else appendTurn(sessionID, body.text, requestId)
       }
@@ -409,6 +436,17 @@ function startFakeDaemon() {
         // A second stable idle edge proves this one really stopped; unlike the transient case there
         // is no intervening busy edge and no recovered final assistant envelope.
         setTimeout(() => emitLiveEvent(sessionID, "session.status"), 1_100)
+        return
+      }
+      if (body.text === TERMINAL_ERROR_PROMPT) {
+        sessionStatuses.set(sessionID, { type: "idle" })
+        statusOmissions.add(sessionID)
+        json(response, 200, { status: "accepted", clientRequestId: requestId })
+        // Reproduce the field bug: the transcript contains a real terminal provider/model error, but
+        // OpenCode's legacy status endpoint omits this child Session entirely. The mounted Session
+        // must settle from the durable error envelope without requiring navigation away and back.
+        emitLiveEvent(sessionID, "message.updated")
+        emitLiveEvent(sessionID, "session.status")
         return
       }
       json(response, 200, { status: "accepted", clientRequestId: requestId })
@@ -641,6 +679,19 @@ async function assertExistingContract(browser, viewport, mobile) {
     1,
     "a stable terminal OpenCode interruption must remain visible"
   )
+
+  await waitForReady(page)
+  await sendPrompt(page, TERMINAL_ERROR_PROMPT)
+  await page.getByText("Turn failed", { exact: true }).waitFor({ state: "visible", timeout: 12_000 })
+  await page.getByText(TERMINAL_ERROR_MESSAGE, { exact: true }).waitFor({ state: "visible", timeout: 12_000 })
+  await waitForReady(page)
+  assert.equal(
+    await page.locator(".tdw-conversation-state.working").count(),
+    0,
+    "a terminal OpenCode provider error must stop Working while the Session remains mounted even when /session/status omits it"
+  )
+  assert.equal(await page.getByText(TERMINAL_ERROR_PROMPT, { exact: true }).count(), 1)
+  assert.equal(await page.getByText("Turn failed", { exact: true }).count(), 1)
 
   assert.equal(await page.getByRole("button", { name: "Continue with another agent" }).count(), 0, "handoff UI must stay disabled")
 

--- a/web/src/native-session-v3-adapter.ts
+++ b/web/src/native-session-v3-adapter.ts
@@ -16,9 +16,10 @@ import type { MessageEnvelope, ModelSelection, ServerConfig } from "./types"
 // Keep the value stable so drafts/local UI identity survive the architecture migration.
 const NATIVE_CONVERSATION_ID_PREFIX = "native-session-v3:"
 const PENDING_TRANSCRIPT_CLOCK_SKEW_MS = 2 * 60 * 1000
-// OpenCode can briefly report an idle/interrupted edge while an automatic provider retry is already
-// about to continue the same native turn. Require that non-working state to survive the bounded
-// lifecycle settle pass before turning it into a terminal Conversation state.
+// OpenCode can briefly report an idle/interrupted edge or a provider error envelope while an
+// automatic retry is already about to continue the same native turn. Require terminal-looking
+// evidence to survive the bounded lifecycle settle pass before turning it into a completed
+// Conversation. The transcript fallback matters because /session/status can omit a child Session.
 const OPENCODE_IDLE_CONFIRM_MS = 750
 // If a provider/router retries after that confirmation window, a later busy edge must still retract
 // the terminal-looking interruption. This watch is event-driven in the normal case; it does not add
@@ -40,6 +41,8 @@ type NativeConversationEntry = {
   updatedAt: number
   statusType: string
   forcedStatus: "running" | "cancelled" | null
+  // First terminal-looking OpenCode observation. Normally this is an idle status edge; when the
+  // legacy status endpoint omits the Session it can instead be the newest assistant error envelope.
   openCodeIdleObservedAt: number | null
   openCodeRecoveryWatchUntil: number
   currentModel: ModelSelection | null
@@ -322,13 +325,30 @@ function reconcileOpenCodeTranscriptStatus(entry: NativeConversationEntry, page:
     if (message.info.role === "user") break
     if (message.info.role === "assistant") latestAssistant = message
   }
-  if (!latestAssistant || !openCodeAssistantProvesTurnCompleted(latestAssistant)) return
+  if (!latestAssistant) return
+
+  const now = Date.now()
+  const completedByTranscript = openCodeAssistantProvesTurnCompleted(latestAssistant)
+  const terminalError = Boolean(latestAssistant.info.error)
+  if (!completedByTranscript) {
+    // A provider/model error envelope is terminal-looking but not definitive on its first edge:
+    // OpenCode may still automatically retry the same turn. Keep the exact #351 debounce semantics,
+    // but let the transcript supply the second observation when /session/status omits this Session.
+    // A real busy status clears openCodeIdleObservedAt in refreshStatus(), so active retries cannot
+    // be completed by this fallback while the status endpoint is actually reporting them.
+    if (!terminalError || entry.forcedStatus !== "running") return
+    if (entry.openCodeIdleObservedAt === null) {
+      entry.openCodeIdleObservedAt = now
+      return
+    }
+    if (now - entry.openCodeIdleObservedAt < OPENCODE_IDLE_CONFIRM_MS) return
+  }
 
   const priorStatus = conversationStatus(entry)
   entry.statusType = "idle"
   entry.forcedStatus = null
   entry.openCodeIdleObservedAt = null
-  entry.openCodeRecoveryWatchUntil = 0
+  entry.openCodeRecoveryWatchUntil = terminalError ? now + OPENCODE_RECOVERY_WATCH_MS : 0
   const completedAt = Number(latestAssistant.info.time?.completed) || Number(latestAssistant.info.time?.created) || 0
   if (completedAt) entry.updatedAt = Math.max(entry.updatedAt, completedAt)
   if (conversationStatus(entry) !== priorStatus) notify(entry)

--- a/web/src/session-first-regression.test.mjs
+++ b/web/src/session-first-regression.test.mjs
@@ -114,6 +114,8 @@ assert.ok(adapter.includes('message.info.time?.completed'), 'OpenCode transcript
 assert.ok(adapter.includes('entry.forcedStatus !== "running" && !openCodeRecoveryWatchActive'), 'OpenCode ordinary idle/pre-Send reconciliation must not block on the legacy status endpoint outside a bounded recovery watch')
 assert.ok(adapter.includes('openCodeAssistantProvesTurnCompleted') && adapter.includes('latestAssistant'), 'OpenCode must decide turn completion from the newest assistant envelope, not any intermediate completed step')
 assert.ok(adapter.includes('OPENCODE_IDLE_CONFIRM_MS = 750') && adapter.includes('openCodeIdleObservedAt'), 'OpenCode ambiguous interruptions must require a stable idle state before becoming terminal')
+assert.ok(adapter.includes('const terminalError = Boolean(latestAssistant.info.error)') && adapter.includes('if (!terminalError || entry.forcedStatus !== "running") return'), 'OpenCode terminal provider/model errors must have a transcript fallback when the legacy status endpoint omits the Session')
+assert.ok(adapter.includes('terminalError ? now + OPENCODE_RECOVERY_WATCH_MS : 0'), 'OpenCode transcript-confirmed errors must retain the bounded late-retry recovery window')
 assert.ok(adapter.includes('OPENCODE_RECOVERY_WATCH_MS') && adapter.includes('openCodeRecoveryWatchUntil'), 'OpenCode must retract a terminal-looking interruption when a bounded late retry becomes busy again')
 assert.ok(adapter.includes('const statuses = await api.listStatuses(entry.target.config)'), 'non-OpenCode projections must retain native status enrichment')
 assert.equal(adapter.includes('WORKING_STATUS_GRACE_MS'), false, 'web adapter must not invent a generic stale-working timeout across harnesses')

--- a/web/src/session-first-regression.test.mjs
+++ b/web/src/session-first-regression.test.mjs
@@ -127,6 +127,7 @@ assert.ok(liveRefresh.includes('const LIFECYCLE_SETTLE_MS = 900'), 'live refresh
 assert.ok(liveRefresh.includes('const settleAfterLifecycle = () =>'), 'lifecycle recovery must schedule a single coalesced settle pass')
 assert.ok(liveRefresh.includes('onMessage()') && liveRefresh.includes('onIndex()'), 'the settle pass must reconcile transcript and projected lifecycle together')
 assert.ok(liveRefresh.includes('if (lifecycleSettleTimer !== undefined) clearTimeout(lifecycleSettleTimer)'), 'multiple status edges must coalesce instead of creating a polling loop')
+assert.ok(liveRefresh.includes('event.type === "session.error"') && liveRefresh.includes('target.config.backend === "opencode"') && liveRefresh.includes('settleAfterLifecycle()'), 'OpenCode session.error must trigger the bounded lifecycle settle path')
 
 assert.ok(daemon.includes('/prompt_async${query}'), 'managed OpenCode must keep its native asynchronous prompt endpoint')
 assert.ok(daemon.includes('/command${query}'), 'managed OpenCode slash commands must use its native command endpoint')

--- a/web/src/taskdesk-session-live-refresh.ts
+++ b/web/src/taskdesk-session-live-refresh.ts
@@ -190,6 +190,10 @@ export function startTaskDeskSessionLiveRefresh({
       if (event.type === "session.error" && selectedEvent) {
         throttle("message", 140, onMessage)
         throttle("detail", 250, onDetail)
+        if (target.config.backend === "opencode") {
+          throttle("index", 120, onIndex)
+          settleAfterLifecycle()
+        }
       }
     },
     onStatus: (status) => {


### PR DESCRIPTION
## Problem

Some real OpenCode provider/model failures already exist in the native transcript as a red `Turn failed` error, but Harness Remote can keep the mounted Session in `Working` indefinitely. Navigating to another Session and back fixes it because the Session runtime is remounted from the native idle state.

The gap is in the #351 recovery logic: OpenCode assistant error envelopes are deliberately treated as ambiguous because OpenCode can automatically retry, so terminal completion waits for `/session/status`. That endpoint can omit child Sessions. When it does, the durable error transcript is never allowed to settle the live runtime.

## Fix

- Keep the existing #351 debounce: the first provider/model error edge does not immediately terminate the turn.
- If `/session/status` reports the Session as busy, the error fallback is reset and the Session remains Working.
- If the status endpoint omits the Session but the same newest assistant error survives the bounded settle window, let the durable transcript settle the Conversation to idle/completed while it is still mounted.
- Treat OpenCode `session.error` as a lifecycle reconciliation edge too, using the same single bounded settle pass rather than generic fast polling.
- Preserve the existing bounded late-retry recovery watch, so a later real busy edge can still resurrect an automatically retried turn.
- No ACP/bridge changes and no behavior changes for Codex, Claude Code, PI or OMP.

## Regression

The production-browser OpenCode smoke now reproduces the field failure directly: a terminal provider error (`Upstream request failed: Endpoint is unavailable`) is written to the transcript while `/session/status` intentionally omits the Session. The test requires the red `Turn failed` state and `Ready` runtime to appear without navigating away.