### PR TITLE
ci: remove retired markdown test from packaging workflows

### DIFF
--- a/.github/workflows/android-aab.yml
+++ b/.github/workflows/android-aab.yml
@@ -43,7 +43,6 @@ jobs:
           npm run test:model
           npm run test:events
           npm run test:profiles
-          npm run test:markdown
         working-directory: web
 
       - name: Run bridge tests

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -59,7 +59,6 @@ jobs:
           npm run test:model
           npm run test:events
           npm run test:profiles
-          npm run test:markdown
         working-directory: web
 
       - name: Run bridge tests

--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -92,7 +92,6 @@ jobs:
           npm run test:model
           npm run test:events
           npm run test:profiles
-          npm run test:markdown
           npm run test:desktop
         working-directory: web
 


### PR DESCRIPTION
Fixes the post-merge CI failure introduced after #358. The retired `test:markdown` script was removed from `web/package.json`, but three packaging workflows still referenced it.

This PR removes only those three stale invocations from:
- `.github/workflows/android-apk.yml`
- `.github/workflows/android-aab.yml`
- `.github/workflows/desktop-apps.yml`

No runtime, ACP, bridge, harness, UI, or packaging logic changes.