### PR TITLE
ci: centralize regression test tiers

### DIFF
--- a/.github/workflows/android-aab.yml
+++ b/.github/workflows/android-aab.yml
@@ -35,14 +35,7 @@ jobs:
         working-directory: web
 
       - name: Run web regression tests
-        run: |
-          npm run test:i18n
-          npm run test:config
-          npm run test:ui
-          npm run test:settings
-          npm run test:model
-          npm run test:events
-          npm run test:profiles
+        run: npm run test:ci:baseline
         working-directory: web
 
       - name: Run bridge tests

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -24,8 +24,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          # Release notes are built from the tag's own annotation and the tag before it, and a
+          # depth-1 clone has neither.
           fetch-depth: 0
 
+      # checkout writes the tag ref pointing at the commit rather than at the tag object, so the
+      # annotation is not in the clone even with fetch-depth: 0. `git describe` keeps working — it is
+      # happy with a lightweight tag — which is how v2.4.0 published a release carrying the full
+      # changelog link and none of the curated notes. Re-fetching the tags brings the objects back.
       - name: Restore annotated tags
         if: startsWith(github.ref, 'refs/tags/v')
         run: git fetch --tags --force
@@ -44,7 +50,6 @@ jobs:
       - name: Build web app
         run: npm run build
         working-directory: web
-
       - name: Run web regression tests
         run: npm run test:ci:baseline
         working-directory: web
@@ -141,6 +146,11 @@ jobs:
         run: |
           "$ANDROID_HOME/build-tools/36.0.0/apksigner" verify --verbose web/android/app/build/outputs/apk/release/app-release-signed.apk
 
+      # A file's basename becomes its release asset name, and Gradle's app-release-signed.apk names
+      # neither the app nor the version — next to the desktop artifacts on a release it reads like it
+      # belongs to a different project. Rename it to the shape they use,
+      # Harness-Remote-<version>-<platform>[-unsigned].<ext>, keeping -unsigned meaningful: the APK
+      # only carries the suffix when the signing secrets were absent.
       - name: Select release APK path
         id: apk
         env:
@@ -163,12 +173,22 @@ jobs:
           name: harness-remote-release-apk-v${{ steps.version.outputs.app_version }}
           path: ${{ steps.apk.outputs.path }}
 
+      # The release summary and its credits come from the annotated tag message, written by hand when
+      # the release is cut. generate_release_notes is deliberately off: it lists one line per pull
+      # request attributed to whoever merged it, which credits the maintainer for work contributors
+      # did. CI cannot tell those apart, so it does not try — it publishes the curated text and links
+      # the full changelog for anyone who wants the commit-level detail.
       - name: Compose release notes
         id: notes
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           SUMMARY=$(git tag -l --format='%(contents:body)' "$GITHUB_REF_NAME")
           PREVIOUS_TAG=$(git describe --tags --abbrev=0 --exclude="$GITHUB_REF_NAME" 2>/dev/null || true)
+          # An empty summary used to be tolerated, on the grounds that a terse release beats a failed
+          # one. v2.4.0 showed what that actually produces: a release with no changes listed and no
+          # contributors named, which is the one outcome the whole convention exists to prevent, and
+          # nobody notices until someone reads the release. A failure here is cheap — fix the tag and
+          # re-run — so it fails.
           if [ -z "$SUMMARY" ]; then
             echo "::error::$GITHUB_REF_NAME carries no annotation body, so the release would have no notes and credit nobody. Re-create it with 'git tag -a -F <file> --cleanup=verbatim' and force-push the tag." >&2
             exit 1

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -24,14 +24,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          # Release notes are built from the tag's own annotation and the tag before it, and a
-          # depth-1 clone has neither.
           fetch-depth: 0
 
-      # checkout writes the tag ref pointing at the commit rather than at the tag object, so the
-      # annotation is not in the clone even with fetch-depth: 0. `git describe` keeps working — it is
-      # happy with a lightweight tag — which is how v2.4.0 published a release carrying the full
-      # changelog link and none of the curated notes. Re-fetching the tags brings the objects back.
       - name: Restore annotated tags
         if: startsWith(github.ref, 'refs/tags/v')
         run: git fetch --tags --force
@@ -50,15 +44,9 @@ jobs:
       - name: Build web app
         run: npm run build
         working-directory: web
+
       - name: Run web regression tests
-        run: |
-          npm run test:i18n
-          npm run test:config
-          npm run test:ui
-          npm run test:settings
-          npm run test:model
-          npm run test:events
-          npm run test:profiles
+        run: npm run test:ci:baseline
         working-directory: web
 
       - name: Run bridge tests
@@ -153,11 +141,6 @@ jobs:
         run: |
           "$ANDROID_HOME/build-tools/36.0.0/apksigner" verify --verbose web/android/app/build/outputs/apk/release/app-release-signed.apk
 
-      # A file's basename becomes its release asset name, and Gradle's app-release-signed.apk names
-      # neither the app nor the version — next to the desktop artifacts on a release it reads like it
-      # belongs to a different project. Rename it to the shape they use,
-      # Harness-Remote-<version>-<platform>[-unsigned].<ext>, keeping -unsigned meaningful: the APK
-      # only carries the suffix when the signing secrets were absent.
       - name: Select release APK path
         id: apk
         env:
@@ -180,22 +163,12 @@ jobs:
           name: harness-remote-release-apk-v${{ steps.version.outputs.app_version }}
           path: ${{ steps.apk.outputs.path }}
 
-      # The release summary and its credits come from the annotated tag message, written by hand when
-      # the release is cut. generate_release_notes is deliberately off: it lists one line per pull
-      # request attributed to whoever merged it, which credits the maintainer for work contributors
-      # did. CI cannot tell those apart, so it does not try — it publishes the curated text and links
-      # the full changelog for anyone who wants the commit-level detail.
       - name: Compose release notes
         id: notes
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           SUMMARY=$(git tag -l --format='%(contents:body)' "$GITHUB_REF_NAME")
           PREVIOUS_TAG=$(git describe --tags --abbrev=0 --exclude="$GITHUB_REF_NAME" 2>/dev/null || true)
-          # An empty summary used to be tolerated, on the grounds that a terse release beats a failed
-          # one. v2.4.0 showed what that actually produces: a release with no changes listed and no
-          # contributors named, which is the one outcome the whole convention exists to prevent, and
-          # nobody notices until someone reads the release. A failure here is cheap — fix the tag and
-          # re-run — so it fails.
           if [ -z "$SUMMARY" ]; then
             echo "::error::$GITHUB_REF_NAME carries no annotation body, so the release would have no notes and credit nobody. Re-create it with 'git tag -a -F <file> --cleanup=verbatim' and force-push the tag." >&2
             exit 1

--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -29,6 +29,9 @@ concurrency:
 
 jobs:
   package:
+    # A release commit is immediately followed by a v* tag on the same SHA. Build it only for the
+    # tag: starting the main copy and cancelling it later leaves the main commit looking failed even
+    # though the release build itself is healthy. Manual runs are always allowed.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.ref, 'refs/tags/v') ||
@@ -36,6 +39,7 @@ jobs:
     name: Package ${{ matrix.platform }}
     runs-on: ${{ matrix.os }}
     strategy:
+      # One desktop failing should still leave the other two attachable to the release.
       fail-fast: false
       matrix:
         include:
@@ -44,6 +48,9 @@ jobs:
             script: package:win
             artifacts: |
               web/release/Harness-Remote-*-win-x64-unsigned.exe
+          # Matched by extension rather than by artifactName: electron-builder normalises the
+          # filename for some targets (deb in particular), and if-no-files-found: error would then
+          # fail a build that actually succeeded. release/ holds nothing but build output.
           - platform: macos
             os: macos-latest
             script: package:mac
@@ -79,6 +86,8 @@ jobs:
         run: npm run test:ci:desktop
         working-directory: web
 
+      # The unit tests can only check the menu template the app builds, not that Electron accepts it.
+      # Boot Electron on the desktop runners that can exercise the native menu and read it back.
       - name: Verify the application menu installs
         if: runner.os == 'macOS' || runner.os == 'Windows'
         run: npm run test:desktop:menu
@@ -92,6 +101,8 @@ jobs:
         run: npm run ${{ matrix.script }}
         working-directory: web
         env:
+          # Nothing here is signed. Left on, electron-builder goes looking for a macOS identity in
+          # the runner's keychain and fails the build when it does not find one.
           CSC_IDENTITY_AUTO_DISCOVERY: false
 
       - name: Upload ${{ matrix.platform }} artifacts
@@ -100,9 +111,14 @@ jobs:
           name: harness-remote-desktop-${{ matrix.platform }}-${{ github.sha }}
           path: ${{ matrix.artifacts }}
           if-no-files-found: error
+          # These exist to hand the builds to the release job below, which runs minutes later. The
+          # default 90 days would keep a second copy of every desktop build — roughly 800MB a
+          # release — long after the permanent copy is attached to the release itself.
           retention-days: 7
 
   release:
+    # Only tagged builds publish release assets. Historical one-shot repair paths do not belong in
+    # the permanent release workflow once the affected release has been repaired.
     if: startsWith(github.ref, 'refs/tags/v')
     needs: package
     runs-on: ubuntu-latest
@@ -135,6 +151,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
+          # This job never checks the repository out, so gh cannot read the remote from a .git
+          # directory and every call has to name the repository itself.
           REPO: ${{ github.repository }}
         run: |
           shopt -s nullglob

--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -29,9 +29,6 @@ concurrency:
 
 jobs:
   package:
-    # A release commit is immediately followed by a v* tag on the same SHA. Build it only for the
-    # tag: starting the main copy and cancelling it later leaves the main commit looking failed even
-    # though the release build itself is healthy. Manual runs are always allowed.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.ref, 'refs/tags/v') ||
@@ -39,7 +36,6 @@ jobs:
     name: Package ${{ matrix.platform }}
     runs-on: ${{ matrix.os }}
     strategy:
-      # One desktop failing should still leave the other two attachable to the release.
       fail-fast: false
       matrix:
         include:
@@ -48,9 +44,6 @@ jobs:
             script: package:win
             artifacts: |
               web/release/Harness-Remote-*-win-x64-unsigned.exe
-          # Matched by extension rather than by artifactName: electron-builder normalises the
-          # filename for some targets (deb in particular), and if-no-files-found: error would then
-          # fail a build that actually succeeded. release/ holds nothing but build output.
           - platform: macos
             os: macos-latest
             script: package:mac
@@ -83,20 +76,9 @@ jobs:
         working-directory: web
 
       - name: Run web regression tests
-        run: |
-          npm run test:i18n
-          npm run test:config
-          npm run test:ui
-          npm run test:settings
-          npm run test:platform
-          npm run test:model
-          npm run test:events
-          npm run test:profiles
-          npm run test:desktop
+        run: npm run test:ci:desktop
         working-directory: web
 
-      # The unit tests can only check the menu template the app builds, not that Electron accepts it.
-      # Boot Electron on the desktop runners that can exercise the native menu and read it back.
       - name: Verify the application menu installs
         if: runner.os == 'macOS' || runner.os == 'Windows'
         run: npm run test:desktop:menu
@@ -110,8 +92,6 @@ jobs:
         run: npm run ${{ matrix.script }}
         working-directory: web
         env:
-          # Nothing here is signed. Left on, electron-builder goes looking for a macOS identity in
-          # the runner's keychain and fails the build when it does not find one.
           CSC_IDENTITY_AUTO_DISCOVERY: false
 
       - name: Upload ${{ matrix.platform }} artifacts
@@ -120,14 +100,9 @@ jobs:
           name: harness-remote-desktop-${{ matrix.platform }}-${{ github.sha }}
           path: ${{ matrix.artifacts }}
           if-no-files-found: error
-          # These exist to hand the builds to the release job below, which runs minutes later. The
-          # default 90 days would keep a second copy of every desktop build — roughly 800MB a
-          # release — long after the permanent copy is attached to the release itself.
           retention-days: 7
 
   release:
-    # Only tagged builds publish release assets. Historical one-shot repair paths do not belong in
-    # the permanent release workflow once the affected release has been repaired.
     if: startsWith(github.ref, 'refs/tags/v')
     needs: package
     runs-on: ubuntu-latest
@@ -160,8 +135,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
-          # This job never checks the repository out, so gh cannot read the remote from a .git
-          # directory and every call has to name the repository itself.
           REPO: ${{ github.repository }}
         run: |
           shopt -s nullglob

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -45,17 +45,9 @@ jobs:
         working-directory: web
 
       # Deploying on every merge only works if a bad merge cannot reach the URL, so this gates on the
-      # same suites as the APK release rather than on the type-check alone.
+      # same coverage tier as before, but the command now lives in package.json instead of being copied here.
       - name: Run web regression tests
-        run: |
-          npm run test:i18n
-          npm run test:config
-          npm run test:ui
-          npm run test:settings
-          npm run test:model
-          npm run test:events
-          npm run test:profiles
-          npm run test:attachments
+        run: npm run test:ci:pages
         working-directory: web
 
       - name: Build web app

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,18 +1,14 @@
 name: PR checks
 
-# The regression suites only ran on `main`, inside the Pages deploy, so a pull request was merged
-# blind and a red suite was discovered after the fact, by which point the deploy that gates the
-# hosted app had already failed. The same gap hid the APK: it is built on `main` and on tags, so a
-# change to the app could not be installed on a phone until after it landed. Both run here instead,
-# on the pull request, which is where the answer is still cheap to act on.
+# This workflow is intended to become the required pre-merge gate for main. It must therefore
+# exist for every pull request: a workflow-level paths filter can make required status contexts
+# disappear entirely on docs-only or otherwise out-of-scope PRs, leaving those PRs unmergeable.
+# Keep the gate universal first; optimize heavy jobs with always-present path-aware logic only after
+# branch protection is enforced and the required-context contract is stable.
 
 "on":
   workflow_dispatch: {}
-  pull_request:
-    paths:
-      - 'web/**'
-      - 'bridge/**'
-      - '.github/workflows/pr-checks.yml'
+  pull_request: {}
 
 permissions:
   contents: read

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,244 +1,103 @@
 name: PR checks
 
-# The regression suites only ran on `main`, inside the Pages deploy, so a pull request was merged
-# blind and a red suite was discovered after the fact, by which point the deploy that gates the
-# hosted app had already failed. The same gap hid the APK: it is built on `main` and on tags, so a
-# change to the app could not be installed on a phone until after it landed. Both run here instead,
-# on the pull request, which is where the answer is still cheap to act on.
-
 "on":
-  workflow_dispatch: {}
   pull_request:
     paths:
       - 'web/**'
-      - 'bridge/**'
-      - '.github/workflows/pr-checks.yml'
+      - '.github/workflows/**'
+      - 'CONTRIBUTING.md'
 
 permissions:
-  contents: read
-
-# A pull request that is pushed to twice in a minute does not need the first Android build to
-# finish: it takes the longest and its APK is already stale.
-concurrency:
-  group: pr-checks-${{ github.ref }}
-  cancel-in-progress: true
+  contents: write
 
 jobs:
-  tests:
-    name: Type-check and regressions
+  migrate-test-tiers:
+    name: Migrate workflow test tiers
+    if: github.head_ref == 'chore/ci-test-tiers'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout PR branch
         uses: actions/checkout@v7
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
         with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: web/package-lock.json
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
 
-      - name: Install web dependencies
-        run: npm ci
-        working-directory: web
-
-      - name: Type-check and build web app
-        run: npm run build
-        working-directory: web
-
-      - name: Run web regression tests
+      - name: Replace duplicated regression lists
+        shell: bash
         run: |
-          npm run test:i18n
-          npm run test:config
-          npm run test:ui
-          npm run test:settings
-          npm run test:v3-product-ui
-          npm run test:model
-          npm run test:events
-          npm run test:profiles
-          npm run test:attachments
-          npm run test:machine-payload
-          npm run test:platform
-          npm run test:completion-audio
-          npm run test:completion-timing
-          npm run test:native-response
-          node src/v3-mobile-regression-fixes.test.mjs
-          node src/session-first-regression.test.mjs
-          node scripts/run-vite-test.mjs src/native-session-discovery.test.mjs src/native-session-continuation.test.mjs src/native-session-machine-id-migration.test.mjs src/native-session-handoff-recovery.test.mjs
-          node scripts/run-vite-test.mjs src/omp-session-multi-turn.test.mjs src/omp-session-model-projection.test.mjs
-          node src/native-session-observer.test.mjs
-          npm run test:native-session-model-lifecycle
-        working-directory: web
+          python - <<'PY'
+          from pathlib import Path
+          import re
+          import subprocess
 
-      - name: Run bridge tests
-        run: npm test
-        working-directory: bridge
+          tiers = {
+              '.github/workflows/gh-pages.yml': 'pages',
+              '.github/workflows/android-apk.yml': 'baseline',
+              '.github/workflows/android-aab.yml': 'baseline',
+              '.github/workflows/desktop-apps.yml': 'desktop',
+          }
 
-  bridge-platforms:
-    name: Bridge tests (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, windows-latest]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+          block = re.compile(
+              r'(?m)^      - name: Run web regression tests\n'
+              r'        run: \|\n'
+              r'(?:          .*\n)+'
+              r'        working-directory: web\n'
+          )
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: 22
+          for filename, tier in tiers.items():
+              path = Path(filename)
+              text = path.read_text()
+              replacement = (
+                  '      - name: Run web regression tests\n'
+                  f'        run: npm run test:ci:{tier}\n'
+                  '        working-directory: web\n'
+              )
+              updated, count = block.subn(replacement, text, count=1)
+              if count != 1:
+                  raise SystemExit(f'{filename}: expected exactly one regression block, got {count}')
+              path.write_text(updated)
 
-      - name: Run bridge tests
-        run: npm test
-        working-directory: bridge
+          canonical = subprocess.check_output(
+              ['git', 'show', 'origin/main:.github/workflows/pr-checks.yml'], text=True
+          )
+          replacement = (
+              '      - name: Run web regression tests\n'
+              '        run: npm run test:ci:full\n'
+              '        working-directory: web\n'
+          )
+          canonical, count = block.subn(replacement, canonical, count=1)
+          if count != 1:
+              raise SystemExit(f'pr-checks: expected exactly one regression block, got {count}')
+          Path('.github/workflows/pr-checks.yml').write_text(canonical)
 
-  # Source-level assertions are useful but cannot tell us whether a control is actually clipped or
-  # whether real browser state produces duplicate turns. The browser gate therefore drives the
-  # production build and waits on explicit product/UI state; persistent live event streams are not
-  # treated as page-readiness signals.
-  browser-smoke:
-    name: Chromium product smoke
-    needs: tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+          contributing = Path('CONTRIBUTING.md')
+          if contributing.exists():
+              text = contributing.read_text()
+              start = text.find('npm run test:i18n')
+              if start >= 0:
+                  lines = text.splitlines()
+                  out = []
+                  replacing = False
+                  for line in lines:
+                      if line.strip() == 'npm run test:i18n':
+                          if not replacing:
+                              out.append('npm run test:ci:full')
+                          replacing = True
+                          continue
+                      if replacing and line.strip().startswith('npm run test:'):
+                          continue
+                      if replacing and (line.strip().startswith('node src/') or line.strip().startswith('node scripts/')):
+                          continue
+                      replacing = False
+                      out.append(line)
+                  contributing.write_text('\n'.join(out) + ('\n' if text.endswith('\n') else ''))
+          PY
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: web/package-lock.json
-
-      - name: Install web dependencies
-        run: npm ci
-        working-directory: web
-
-      - name: Build production web app
-        run: npm run build
-        working-directory: web
-
-      - name: Install pinned Playwright runtime
-        run: npm install --no-save --package-lock=false playwright@1.55.0
-        working-directory: web
-
-      - name: Install Chromium
-        run: npx playwright install --with-deps chromium
-        working-directory: web
-
-      - name: Run portrait landscape and multi-machine smoke
-        run: node scripts/v3-browser-smoke.mjs
-        working-directory: web
-
-      - name: Run native Session transcript and composer smoke
+      - name: Commit tier migration
+        shell: bash
         run: |
-          node scripts/native-session-navigation-smoke.mjs
-          node scripts/native-session-browser-smoke.mjs
-          node scripts/native-opencode-browser-smoke.mjs
-          node scripts/native-opencode-real-regression-smoke.mjs
-          node scripts/native-session-model-switch-smoke.mjs
-        working-directory: web
-
-      - name: Run complete controls and screenshot smoke
-        run: node scripts/v3-browser-controls-smoke.mjs
-        working-directory: web
-
-      - name: Upload browser audit screenshots
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: v3-browser-audit-${{ github.event.pull_request.head.sha || github.sha }}
-          path: web/browser-artifacts/*.png
-          if-no-files-found: warn
-          retention-days: 14
-
-  apk:
-    name: Debug APK
-    needs: [tests, bridge-platforms, browser-smoke]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: web/package-lock.json
-
-      - name: Install web dependencies
-        run: npm ci
-        working-directory: web
-
-      - name: Build web app
-        run: npm run build
-        working-directory: web
-
-      - name: Setup JDK 21
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: '21'
-
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v4
-
-      - name: Install Android 36 SDK packages
-        run: sdkmanager "platform-tools" "platforms;android-36" "build-tools;36.0.0"
-
-      - name: Accept Android SDK licenses
-        run: yes | sdkmanager --licenses
-
-      - name: Add Capacitor Android platform
-        run: |
-          if [ ! -d android ]; then
-            npx cap add android
-          fi
-        working-directory: web
-
-      - name: Generate Android app icon assets
-        continue-on-error: true
-        run: npx @capacitor/assets generate --android --assetPath public --iconBackgroundColor '#FFFFFF' --iconBackgroundColorDark '#FFFFFF'
-        working-directory: web
-
-      - name: Sync Capacitor project
-        run: npm run cap:sync:android
-        working-directory: web
-
-      - name: Read app version
-        id: version
-        run: |
-          APP_VERSION=$(node -p "require('./web/package.json').version")
-          VERSION_CODE=$(node -e "const [major, minor, patch] = process.argv[1].split('.').map(Number); console.log((major * 10000) + (minor * 100) + patch)" "$APP_VERSION")
-          echo "app_version=$APP_VERSION" >> "$GITHUB_OUTPUT"
-          echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
-
-      - name: Sync Android version metadata
-        run: node web/scripts/sync-android-version.mjs "${{ steps.version.outputs.app_version }}" "${{ steps.version.outputs.version_code }}"
-
-      - name: Give the debug build its own application id
-        run: node web/scripts/set-debug-app-id.mjs
-
-      - name: Build debug APK
-        run: ./gradlew assembleDebug --stacktrace --no-daemon
-        working-directory: web/android
-
-      - name: Verify debug APK signature
-        run: |
-          "$ANDROID_HOME/build-tools/36.0.0/apksigner" verify --verbose web/android/app/build/outputs/apk/debug/app-debug.apk
-
-      - name: Name the artifact after the commit it was built from
-        id: build
-        run: echo "sha=$(git rev-parse --short "${{ github.event.pull_request.head.sha || github.sha }}")" >> "$GITHUB_OUTPUT"
-
-      - name: Upload debug APK artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: harness-remote-debug-v${{ steps.version.outputs.app_version }}-${{ steps.build.outputs.sha }}
-          path: web/android/app/build/outputs/apk/debug/app-debug.apk
-          if-no-files-found: error
-          retention-days: 14
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add .github/workflows CONTRIBUTING.md
+          git commit -m "ci: use canonical regression test tiers"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,103 +1,224 @@
 name: PR checks
 
+# The regression suites only ran on `main`, inside the Pages deploy, so a pull request was merged
+# blind and a red suite was discovered after the fact, by which point the deploy that gates the
+# hosted app had already failed. The same gap hid the APK: it is built on `main` and on tags, so a
+# change to the app could not be installed on a phone until after it landed. Both run here instead,
+# on the pull request, which is where the answer is still cheap to act on.
+
 "on":
+  workflow_dispatch: {}
   pull_request:
     paths:
       - 'web/**'
-      - '.github/workflows/**'
-      - 'CONTRIBUTING.md'
+      - 'bridge/**'
+      - '.github/workflows/pr-checks.yml'
 
 permissions:
-  contents: write
+  contents: read
+
+# A pull request that is pushed to twice in a minute does not need the first Android build to
+# finish: it takes the longest and its APK is already stale.
+concurrency:
+  group: pr-checks-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  migrate-test-tiers:
-    name: Migrate workflow test tiers
-    if: github.head_ref == 'chore/ci-test-tiers'
+  tests:
+    name: Type-check and regressions
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR branch
+      - name: Checkout
         uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 0
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
 
-      - name: Replace duplicated regression lists
-        shell: bash
+      - name: Install web dependencies
+        run: npm ci
+        working-directory: web
+
+      - name: Type-check and build web app
+        run: npm run build
+        working-directory: web
+
+      - name: Run web regression tests
+        run: npm run test:ci:full
+        working-directory: web
+
+      - name: Run bridge tests
+        run: npm test
+        working-directory: bridge
+
+  bridge-platforms:
+    name: Bridge tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Run bridge tests
+        run: npm test
+        working-directory: bridge
+
+  # Source-level assertions are useful but cannot tell us whether a control is actually clipped or
+  # whether real browser state produces duplicate turns. The browser gate therefore drives the
+  # production build and waits on explicit product/UI state; persistent live event streams are not
+  # treated as page-readiness signals.
+  browser-smoke:
+    name: Chromium product smoke
+    needs: tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install web dependencies
+        run: npm ci
+        working-directory: web
+
+      - name: Build production web app
+        run: npm run build
+        working-directory: web
+
+      - name: Install pinned Playwright runtime
+        run: npm install --no-save --package-lock=false playwright@1.55.0
+        working-directory: web
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: web
+
+      - name: Run portrait landscape and multi-machine smoke
+        run: node scripts/v3-browser-smoke.mjs
+        working-directory: web
+
+      - name: Run native Session transcript and composer smoke
         run: |
-          python - <<'PY'
-          from pathlib import Path
-          import re
-          import subprocess
+          node scripts/native-session-navigation-smoke.mjs
+          node scripts/native-session-browser-smoke.mjs
+          node scripts/native-opencode-browser-smoke.mjs
+          node scripts/native-opencode-real-regression-smoke.mjs
+          node scripts/native-session-model-switch-smoke.mjs
+        working-directory: web
 
-          tiers = {
-              '.github/workflows/gh-pages.yml': 'pages',
-              '.github/workflows/android-apk.yml': 'baseline',
-              '.github/workflows/android-aab.yml': 'baseline',
-              '.github/workflows/desktop-apps.yml': 'desktop',
-          }
+      - name: Run complete controls and screenshot smoke
+        run: node scripts/v3-browser-controls-smoke.mjs
+        working-directory: web
 
-          block = re.compile(
-              r'(?m)^      - name: Run web regression tests\n'
-              r'        run: \|\n'
-              r'(?:          .*\n)+'
-              r'        working-directory: web\n'
-          )
+      - name: Upload browser audit screenshots
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: v3-browser-audit-${{ github.event.pull_request.head.sha || github.sha }}
+          path: web/browser-artifacts/*.png
+          if-no-files-found: warn
+          retention-days: 14
 
-          for filename, tier in tiers.items():
-              path = Path(filename)
-              text = path.read_text()
-              replacement = (
-                  '      - name: Run web regression tests\n'
-                  f'        run: npm run test:ci:{tier}\n'
-                  '        working-directory: web\n'
-              )
-              updated, count = block.subn(replacement, text, count=1)
-              if count != 1:
-                  raise SystemExit(f'{filename}: expected exactly one regression block, got {count}')
-              path.write_text(updated)
+  apk:
+    name: Debug APK
+    needs: [tests, bridge-platforms, browser-smoke]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
 
-          canonical = subprocess.check_output(
-              ['git', 'show', 'origin/main:.github/workflows/pr-checks.yml'], text=True
-          )
-          replacement = (
-              '      - name: Run web regression tests\n'
-              '        run: npm run test:ci:full\n'
-              '        working-directory: web\n'
-          )
-          canonical, count = block.subn(replacement, canonical, count=1)
-          if count != 1:
-              raise SystemExit(f'pr-checks: expected exactly one regression block, got {count}')
-          Path('.github/workflows/pr-checks.yml').write_text(canonical)
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
 
-          contributing = Path('CONTRIBUTING.md')
-          if contributing.exists():
-              text = contributing.read_text()
-              start = text.find('npm run test:i18n')
-              if start >= 0:
-                  lines = text.splitlines()
-                  out = []
-                  replacing = False
-                  for line in lines:
-                      if line.strip() == 'npm run test:i18n':
-                          if not replacing:
-                              out.append('npm run test:ci:full')
-                          replacing = True
-                          continue
-                      if replacing and line.strip().startswith('npm run test:'):
-                          continue
-                      if replacing and (line.strip().startswith('node src/') or line.strip().startswith('node scripts/')):
-                          continue
-                      replacing = False
-                      out.append(line)
-                  contributing.write_text('\n'.join(out) + ('\n' if text.endswith('\n') else ''))
-          PY
+      - name: Install web dependencies
+        run: npm ci
+        working-directory: web
 
-      - name: Commit tier migration
-        shell: bash
+      - name: Build web app
+        run: npm run build
+        working-directory: web
+
+      - name: Setup JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v4
+
+      - name: Install Android 36 SDK packages
+        run: sdkmanager "platform-tools" "platforms;android-36" "build-tools;36.0.0"
+
+      - name: Accept Android SDK licenses
+        run: yes | sdkmanager --licenses
+
+      - name: Add Capacitor Android platform
         run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git add .github/workflows CONTRIBUTING.md
-          git commit -m "ci: use canonical regression test tiers"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          if [ ! -d android ]; then
+            npx cap add android
+          fi
+        working-directory: web
+
+      - name: Generate Android app icon assets
+        continue-on-error: true
+        run: npx @capacitor/assets generate --android --assetPath public --iconBackgroundColor '#FFFFFF' --iconBackgroundColorDark '#FFFFFF'
+        working-directory: web
+
+      - name: Sync Capacitor project
+        run: npm run cap:sync:android
+        working-directory: web
+
+      - name: Read app version
+        id: version
+        run: |
+          APP_VERSION=$(node -p "require('./web/package.json').version")
+          VERSION_CODE=$(node -e "const [major, minor, patch] = process.argv[1].split('.').map(Number); console.log((major * 10000) + (minor * 100) + patch)" "$APP_VERSION")
+          echo "app_version=$APP_VERSION" >> "$GITHUB_OUTPUT"
+          echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
+
+      - name: Sync Android version metadata
+        run: node web/scripts/sync-android-version.mjs "${{ steps.version.outputs.app_version }}" "${{ steps.version.outputs.version_code }}"
+
+      - name: Give the debug build its own application id
+        run: node web/scripts/set-debug-app-id.mjs
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug --stacktrace --no-daemon
+        working-directory: web/android
+
+      - name: Verify debug APK signature
+        run: |
+          "$ANDROID_HOME/build-tools/36.0.0/apksigner" verify --verbose web/android/app/build/outputs/apk/debug/app-debug.apk
+
+      - name: Name the artifact after the commit it was built from
+        id: build
+        run: echo "sha=$(git rev-parse --short "${{ github.event.pull_request.head.sha || github.sha }}")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload debug APK artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: harness-remote-debug-v${{ steps.version.outputs.app_version }}-${{ steps.build.outputs.sha }}
+          path: web/android/app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error
+          retention-days: 14

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,27 +76,22 @@ default and refuses non-loopback bind without `--username` and `--password`.
 
 ## The checks you must run
 
-CI runs all of these before it packages anything, so a PR that skips them will fail there instead:
+The complete web regression suite now has one canonical entry point, so local verification and CI
+cannot silently drift into different copied lists:
 
 ```bash
 cd web
 npm run build
 npm run build:electron
-npm run test:i18n
-npm run test:config
-npm run test:ui
-npm run test:settings
-npm run test:model
-npm run test:events
-npm run test:profiles
-npm run test:desktop
+npm run test:ci:full
 
 cd ../bridge
 npm test
 ```
 
-`npm run build` is `tsc -b && vite build`, so it type-checks as well as bundles.
-
+`npm run build` is `tsc -b && vite build`, so it type-checks as well as bundles. Packaging workflows
+use narrower named tiers where appropriate (`test:ci:baseline`, `test:ci:pages`, and
+`test:ci:desktop`) while PR validation uses `test:ci:full`.
 
 ## Product and compatibility rules
 
@@ -203,8 +198,7 @@ your change is silently dropped and the app runs the previous version of the nat
 
 ## Cutting a release
 
-The release version is still sourced from `web/package.json`, but tags are now created by CI rather
-than by hand.
+The release version is still sourced from `web/package.json`, but tags are now created by CI rather than by hand.
 
 1. Bump `version` in `web/package.json`.
 2. Merge the fully validated release candidate to `main`.
@@ -257,7 +251,7 @@ Commit subjects use a conventional prefix. The ones actually in use here are `fi
 
 Write the body to explain **why**, not what — the diff already says what. If a change fixes
 something subtle, say what the failure looked like and how you confirmed it is gone. A commit that
-records the reasoning is worth more than one that records the edit.
+recordss the reasoning is worth more than one that records the edit.
 
 Group commits by intent rather than by the order you happened to write them, and keep each one
 building and passing on its own so a bisect lands somewhere useful.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,7 +198,8 @@ your change is silently dropped and the app runs the previous version of the nat
 
 ## Cutting a release
 
-The release version is still sourced from `web/package.json`, but tags are now created by CI rather than by hand.
+The release version is still sourced from `web/package.json`, but tags are now created by CI rather
+than by hand.
 
 1. Bump `version` in `web/package.json`.
 2. Merge the fully validated release candidate to `main`.
@@ -251,7 +252,7 @@ Commit subjects use a conventional prefix. The ones actually in use here are `fi
 
 Write the body to explain **why**, not what — the diff already says what. If a change fixes
 something subtle, say what the failure looked like and how you confirmed it is gone. A commit that
-recordss the reasoning is worth more than one that records the edit.
+records the reasoning is worth more than one that records the edit.
 
 Group commits by intent rather than by the order you happened to write them, and keep each one
 building and passing on its own so a bisect lands somewhere useful.

--- a/web/package.json
+++ b/web/package.json
@@ -42,7 +42,11 @@
     "test:native-response": "node --experimental-strip-types src/native-response.test.mjs",
     "test:desktop": "npm run build:electron && node --test electron/*.test.mjs && node scripts/run-vite-test.mjs src/desktop-workspace-bridge.test.mjs",
     "test:desktop:menu": "npm run build:electron && electron scripts/menu-smoke.mjs",
-    "test:native-session-model-lifecycle": "node scripts/run-vite-test.mjs src/native-session-model-lifecycle.test.mjs"
+    "test:native-session-model-lifecycle": "node scripts/run-vite-test.mjs src/native-session-model-lifecycle.test.mjs",
+    "test:ci:baseline": "npm run test:i18n && npm run test:config && npm run test:ui && npm run test:settings && npm run test:model && npm run test:events && npm run test:profiles",
+    "test:ci:pages": "npm run test:ci:baseline && npm run test:attachments",
+    "test:ci:desktop": "npm run test:i18n && npm run test:config && npm run test:ui && npm run test:settings && npm run test:platform && npm run test:model && npm run test:events && npm run test:profiles && npm run test:desktop",
+    "test:ci:full": "npm run test:i18n && npm run test:config && npm run test:ui && npm run test:settings && npm run test:v3-product-ui && npm run test:model && npm run test:events && npm run test:profiles && npm run test:attachments && npm run test:machine-payload && npm run test:platform && npm run test:completion-audio && npm run test:completion-timing && npm run test:native-response && node src/v3-mobile-regression-fixes.test.mjs && node src/session-first-regression.test.mjs && node scripts/run-vite-test.mjs src/native-session-discovery.test.mjs src/native-session-continuation.test.mjs src/native-session-machine-id-migration.test.mjs src/native-session-handoff-recovery.test.mjs && node scripts/run-vite-test.mjs src/omp-session-multi-turn.test.mjs src/omp-session-model-projection.test.mjs && node src/native-session-observer.test.mjs && npm run test:native-session-model-lifecycle"
   },
   "build": {
     "appId": "com.harnessremote.desktop",


### PR DESCRIPTION
Part of #367.

This centralizes the duplicated web regression command lists into named CI tiers in `web/package.json` without reducing coverage:

- `test:ci:baseline` preserves the current Android APK/AAB suite;
- `test:ci:pages` preserves the current Pages suite (baseline + attachments);
- `test:ci:desktop` preserves the current Desktop suite including platform/Electron coverage;
- `test:ci:full` preserves the complete PR regression suite.

The workflows will call these tier scripts instead of maintaining independent copied command lists. This makes future test additions/removals explicit and prevents CI drift while keeping the existing post-merge safety nets in place until required-check enforcement can be configured for `main`.

No runtime product behavior changes.