### PR TITLE
revert: restore pre-#374 startup and routing behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ See [REFERENCE.md](REFERENCE.md) for detailed security and backend notes.
 
 ## Quick start
 
-> **Upgrading from Harness Remote 2.x?** HR3 uses a **Machine daemon** as its normal connection contract, not the old per-harness server profile model. The normal `harness-remote` launcher now exposes that Machine contract even when only one harness is installed, including OpenCode-only machines. Old standalone ACP bridges and direct OpenCode endpoints remain available only as explicit legacy compatibility paths such as `--single`; they do not provide the complete HR3 Machine → Project → Session workflow. Saved 2.x server profiles are also not automatically imported into the new Machines list, so add the machine again after upgrading.
+> **Upgrading from Harness Remote 2.x?** HR3 uses a **Machine daemon** as its normal connection contract, not the old per-harness server profile model. Old standalone ACP bridge commands still start and can expose native Sessions, but they are a legacy compatibility path and do not provide the complete HR3 Machine → Project → Session workflow. A direct 2.x-style `opencode serve` endpoint is **not** an HR3 Machine endpoint. Saved 2.x server profiles are also not automatically imported into the new Machines list, so add the machine again after upgrading. For HR3, prefer the launcher/daemon setup below and connect through **Machines → Add machine**.
 
 ### 1. Start Harness Remote on the machine with your code
 
@@ -290,7 +290,7 @@ The official `v3.0.0` release supports OpenCode, OMP, PI, Codex CLI and Claude C
 
 Post-release work intentionally prioritizes Session correctness and maintainability over broad orchestration. Cross-machine handoff is a separate follow-up, and architectural cleanup must start from current `main` rather than reviving pre-release checkpoint/draft branches.
 
-The launcher is machine-first: normal startup exposes the HR3 Machine endpoint for single- or multi-harness setups, and OpenCode can be the machine primary without requiring an ACP harness. The explicit `--single` path remains only for legacy per-harness compatibility.
+The automatic multi-agent launcher is still being expanded: the current release can expose one selected ACP-backed primary alongside managed OpenCode, while additional concurrent ACP host instances remain follow-up work.
 
 That focus is deliberate. A remote coding-agent UI is only useful if you can trust that the Session you see is the Session that actually exists.
 

--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -1414,7 +1414,11 @@ export class AcpService {
     try {
       const snapshot = JSON.parse(await readFile(this.#snapshotPath(sessionID), "utf8"))
       if (snapshot?.version !== 1) return
-      if (Array.isArray(snapshot.messages)) {
+      // A freshly created Session is already loaded in this process. Its first snapshot can still
+      // contain the empty pre-prompt transcript while a real prompt has since been recorded in
+      // memory; restoring that stale file here would erase the visible user turn. Snapshots only
+      // seed a Session that has not been loaded yet (restart or cache eviction).
+      if (!this.#loaded.has(sessionID) && Array.isArray(snapshot.messages)) {
         const fragmented = mergeFragmentedPiSnapshot(snapshot.messages)
         const restored = healPoisonedSnapshot(fragmented)
         if (restored.length !== fragmented.length) {

--- a/bridge/src/agent-router.js
+++ b/bridge/src/agent-router.js
@@ -320,13 +320,11 @@ export function createAgentRoutingServer({
     let route = agentScopedRequest(request)
     if (!route) {
       const matching = requestedBackend && daemon.snapshot().agents.find((agent) => agent.backend === requestedBackend)
-      if (matching) {
+      if (matching && matching.id !== primaryAgentID) {
         route = { agentID: matching.id, path: requestURL.pathname, search: requestURL.search }
-      } else if (bridgeServer) {
+      } else {
         bridgeServer.emit("request", request, response)
         return
-      } else {
-        route = { agentID: primaryAgentID, path: requestURL.pathname, search: requestURL.search }
       }
     }
     route = routedAgentForBackend(daemon, route, requestedBackend)
@@ -338,7 +336,7 @@ export function createAgentRoutingServer({
       return
     }
 
-    if (route.agentID === primaryAgentID && bridgeServer) {
+    if (route.agentID === primaryAgentID) {
       request.url = `${route.path}${route.search}`
       bridgeServer.emit("request", request, response)
       return

--- a/bridge/src/config.js
+++ b/bridge/src/config.js
@@ -32,8 +32,7 @@ function parseArgumentList(value, fallback) {
   return parsed
 }
 
-function parseBackend(value, { allowOpenCode = false } = {}) {
-  if (allowOpenCode && value === "opencode") return value
+function parseBackend(value) {
   return harnessProfile(value).id
 }
 
@@ -43,10 +42,10 @@ function environmentValue(environment, name) {
 }
 
 
-export function parseConfig(args, environment = process.env, { allowOpenCodeBackend = false } = {}) {
-  const backend = parseBackend(environmentValue(environment, "BACKEND") ?? "omp", { allowOpenCode: allowOpenCodeBackend })
-  const profile = backend === "opencode" && allowOpenCodeBackend ? null : harnessProfile(backend)
-  const launch = profile ? resolveAcpLaunch(profile) : { command: "", args: [] }
+export function parseConfig(args, environment = process.env) {
+  const backend = parseBackend(environmentValue(environment, "BACKEND") ?? "omp")
+  const profile = harnessProfile(backend)
+  const launch = resolveAcpLaunch(profile)
   const acpCommand = environmentValue(environment, "ACP_COMMAND")
   const acpArgs = environmentValue(environment, "ACP_ARGS")
   const root = environmentValue(environment, "ROOT")
@@ -71,18 +70,11 @@ export function parseConfig(args, environment = process.env, { allowOpenCodeBack
     const option = args[index]
     switch (option) {
       case "--backend":
-        config.backend = parseBackend(requireValue(args, index, option), { allowOpenCode: allowOpenCodeBackend })
+        config.backend = parseBackend(requireValue(args, index, option))
         {
-          const selected = config.backend === "opencode" && allowOpenCodeBackend
-            ? null
-            : resolveAcpLaunch(harnessProfile(config.backend))
-          if (selected) {
-            if (!acpCommandOverridden) config.acpCommand = selected.command
-            if (!acpArgsOverridden) config.acpArgs = [...selected.args]
-          } else {
-            if (!acpCommandOverridden) config.acpCommand = ""
-            if (!acpArgsOverridden) config.acpArgs = []
-          }
+          const selected = resolveAcpLaunch(harnessProfile(config.backend))
+          if (!acpCommandOverridden) config.acpCommand = selected.command
+          if (!acpArgsOverridden) config.acpArgs = [...selected.args]
         }
         index += 1
         break

--- a/bridge/src/daemon-cli.js
+++ b/bridge/src/daemon-cli.js
@@ -76,11 +76,7 @@ export function parseDaemonOptions(args, environment = process.env, detect = res
   const named = bridgeArgs.includes("--backend") || environment.HARNESS_REMOTE_BACKEND || environment.OMP_BRIDGE_BACKEND
   if (!named) bridgeArgs.push("--backend", detect(args).backend)
 
-  const config = parseConfig(bridgeArgs, environment, { allowOpenCodeBackend: true })
-  if (config.backend === "opencode" && !options.openCode) {
-    throw new Error("--no-opencode cannot be used when OpenCode is the machine primary")
-  }
-  return { config, ...options }
+  return { config: parseConfig(bridgeArgs, environment), ...options }
 }
 
 export function daemonUsage() {
@@ -116,11 +112,8 @@ async function main() {
   const identity = await loadMachineIdentity(config.stateDirectory)
   const daemon = new MachineDaemon(identity)
   const plan = resolveLaunchPlan(process.argv.slice(2))
-  const acpBackends = [...new Set([
-    ...plan.detected.filter((backend) => backend !== "opencode"),
-    ...(config.backend === "opencode" ? [] : [config.backend])
-  ])]
-  const primaryProfile = config.backend === "opencode" ? null : harnessProfile(config.backend)
+  const acpBackends = [...new Set([...plan.detected.filter((backend) => backend !== "opencode"), config.backend])]
+  const primaryProfile = harnessProfile(config.backend)
   const acpHosts = new Map()
   for (const backend of acpBackends) {
     const profile = harnessProfile(backend)
@@ -168,8 +161,8 @@ async function main() {
     acp.on("stderr", (line) => process.stderr.write(`[${profile.id}] ${line}\n`))
     acp.on("exit", (error) => process.stderr.write(`[${profile.id}] ${error.message}\n`))
   }
-  const acp = primaryProfile ? acpHosts.get(primaryProfile.id) : undefined
-  if (primaryProfile && !acp) throw new Error(`Primary harness ${primaryProfile.id} was not detected`)
+  const acp = acpHosts.get(primaryProfile.id)
+  if (!acp) throw new Error(`Primary harness ${primaryProfile.id} was not detected`)
 
   if (openCode) {
     const managedOpenCode = new ManagedOpenCodeHost({
@@ -214,15 +207,14 @@ async function main() {
     daemon,
     config,
     primaryAcp: acp,
-    primaryAgentID: config.backend,
-    serviceOptions: primaryProfile ? {
+    serviceOptions: {
       snapshotDirectory: path.join(config.stateDirectory, primaryProfile.id),
       historyLoader: primaryProfile.historyLoader,
       preserveListedTimestamps: primaryProfile.preserveListedTimestamps,
       hiddenSessionIDs: daemon.hostEntry(primaryProfile.id).modelCatalog.hiddenSessionIDs,
       reloadOnHistoryRefresh: primaryProfile.reloadOnHistoryRefresh,
       replaySettleMs: primaryProfile.replaySettleMs
-    } : undefined
+    }
   })
 
   await new Promise((resolve, reject) => {
@@ -239,7 +231,7 @@ async function main() {
   process.stdout.write(`Machine: ${identity.name} (${identity.id})\n`)
   process.stdout.write("Active agents:\n")
   for (const host of daemon.snapshot().agents) {
-    if (host.id === config.backend) {
+    if (host.id === primaryProfile.id) {
       process.stdout.write(`  • ${host.label} - primary (${host.transport.toUpperCase()})\n`)
       continue
     }

--- a/bridge/src/launcher.js
+++ b/bridge/src/launcher.js
@@ -80,41 +80,34 @@ export function resolveBackend(args, detected = detectBackends()) {
 export function resolveLaunchPlan(args, detected = detectBackends()) {
   const explicit = optionValue(args, "--backend")
   const forceSingle = hasOption(args, "--single")
-  const supported = new Set([...ACP_BACKENDS, "opencode"])
 
-  if (explicit && !supported.has(explicit)) {
-    throw new Error(`Unsupported backend '${explicit}' for Harness Remote startup.`)
+  if (detected.length === 0) {
+    if (explicit) return { mode: "single", backend: explicit, detected }
+    throw new Error("No supported agent CLI was found on PATH. Install/select omp, pi, claude, codex, or opencode, then re-run with --backend if needed.")
   }
 
   if (forceSingle) {
     const backend = explicit ?? (detected.length === 1 ? detected[0] : null)
     if (!backend) {
-      if (detected.length === 0) {
-        throw new Error("No supported agent CLI was found on PATH. Install/select omp, pi, claude, codex, or opencode, then re-run with --backend if needed.")
-      }
       throw new Error(`--single requires --backend when multiple supported agent CLIs are installed (${detected.join(", ")}).`)
     }
     return { mode: "single", backend, detected }
   }
 
-  if (detected.length === 0 && !explicit) {
-    throw new Error("No supported agent CLI was found on PATH. Install/select omp, pi, claude, codex, or opencode, then re-run with --backend if needed.")
+  if (detected.length === 1) return { mode: "single", backend: explicit ?? detected[0], detected }
+
+  if (explicit === "opencode") return { mode: "single", backend: explicit, detected }
+  if (explicit && !ACP_BACKENDS.includes(explicit)) {
+    throw new Error(`Unsupported ACP backend '${explicit}' for machine-daemon startup.`)
   }
 
-  const effectiveDetected = detected.length ? detected : [explicit]
-  const primary = explicit
-    ?? ACP_BACKENDS.find((backend) => effectiveDetected.includes(backend))
-    ?? (effectiveDetected.includes("opencode") ? "opencode" : null)
-
-  if (!primary) {
-    throw new Error("No supported agent CLI was found on PATH. Install/select omp, pi, claude, codex, or opencode, then re-run with --backend if needed.")
-  }
-
+  const primary = explicit ?? ACP_BACKENDS.find((backend) => detected.includes(backend))
+  if (!primary) return { mode: "single", backend: detected[0], detected }
   return {
     mode: "daemon",
     backend: primary,
-    detected: effectiveDetected,
-    openCode: effectiveDetected.includes("opencode") || primary === "opencode"
+    detected,
+    openCode: detected.includes("opencode")
   }
 }
 
@@ -200,7 +193,7 @@ export function lanAddresses(interfaces = networkInterfaces()) {
 }
 
 export function launcherUsage() {
-  return `Usage: harness-remote [options]\n\nQuick start options:\n  --backend <name>       Select omp, pi, claude, codex, or opencode as the machine primary\n  --single               Force the legacy single-backend path instead of the HR3 machine daemon\n  --host <host>          Bind host (quick-start default: 0.0.0.0)\n  --port <port>          Preferred public Machine port (default: 4097)\n  --username <username>  Override generated Basic Auth username\n  --password <password>  Override generated Basic Auth password\n  --help                 Show this help\n\nWithout --single, Harness always starts the HR3 machine daemon, including single-harness and OpenCode-only setups. OpenCode is managed behind a loopback port chosen automatically. Use --single only for the legacy per-harness compatibility endpoint.`
+  return `Usage: harness-remote [options]\n\nQuick start options:\n  --backend <name>       Select omp, pi, claude, codex, or opencode (on multi-agent machines, selects the daemon primary)\n  --single               Force the legacy single-backend path instead of the machine daemon\n  --host <host>          Bind host (quick-start default: 0.0.0.0)\n  --port <port>          Preferred port (OpenCode single-host default: 4096; daemon/ACP default: 4097)\n  --username <username>  Override generated Basic Auth username\n  --password <password>  Override generated Basic Auth password\n  --help                 Show this help\n\nWith one detected agent, Harness starts the existing single-backend path. With multiple detected agents and at least one ACP backend, it starts the machine daemon automatically; OpenCode is included when installed and receives a free loopback port automatically.`
 }
 
 export async function startManagedOpenCode({ host, port, username, password, command = "opencode", Host = ManagedOpenCodeHost } = {}) {

--- a/bridge/src/machine-daemon.js
+++ b/bridge/src/machine-daemon.js
@@ -205,10 +205,7 @@ export function createMachineDaemonServer({
   sessionOperationLedger,
   sessionLinkStore
 }) {
-  const primaryEntry = daemon.hostEntry(primaryAgentID)
-  const bridgeServer = primaryEntry?.kind === "acp" && primaryAcp
-    ? createServer({ config, acp: primaryAcp, machineRegistry: daemon.registry, serviceOptions })
-    : undefined
+  const bridgeServer = createServer({ config, acp: primaryAcp, machineRegistry: daemon.registry, serviceOptions })
   const scopedAcpServers = new Map()
   // Writer ownership belongs to one live adapter process. An adapter that exits takes every loaded
   // Session with it, so remembering a claim across a restart made Stop skip the reload it needs and
@@ -222,7 +219,7 @@ export function createMachineDaemonServer({
     })
   }
   const acpBridgeServer = (agentID) => {
-    if (agentID === primaryAgentID && bridgeServer) return bridgeServer
+    if (agentID === primaryAgentID) return bridgeServer
     const cached = scopedAcpServers.get(agentID)
     if (cached) return cached
     const entry = daemon.hostEntry(agentID)
@@ -245,7 +242,7 @@ export function createMachineDaemonServer({
   const operations = sessionOperationLedger ?? new SessionOperationLedger({ machineID, stateDirectory })
   const links = sessionLinkStore ?? new SessionLinkStore({ machineID, stateDirectory })
   const acpService = (agentID) => {
-    const server = agentID === primaryAgentID && bridgeServer ? bridgeServer : acpBridgeServer(agentID)
+    const server = agentID === primaryAgentID ? bridgeServer : acpBridgeServer(agentID)
     return server?.acpService
   }
   const claimedAgents = new Set()
@@ -637,7 +634,7 @@ export function createMachineDaemonServer({
     diagnostics: () => ({
       ...daemon.diagnostics(),
       services: Object.fromEntries([
-        ...(bridgeServer ? [[primaryAgentID, bridgeServer.acpService?.diagnostics?.()]] : []),
+        [primaryAgentID, bridgeServer.acpService?.diagnostics?.()],
         ...[...scopedAcpServers.entries()].map(([agentID, server]) => [agentID, server.acpService?.diagnostics?.()])
       ].filter(([, value]) => value)),
       // Session-first control-plane state. Writer claims are per live adapter process, so a count

--- a/bridge/test/agent-router.test.js
+++ b/bridge/test/agent-router.test.js
@@ -185,32 +185,6 @@ test("a non-primary ACP agent is dispatched to its own bridge instead of the pri
   }
 })
 
-test("an HTTP primary handles unprefixed compatibility routes without an ACP bridge", async () => {
-  let routed
-  const server = createAgentRoutingServer({
-    daemon: daemonWith(
-      { opencode: { id: "opencode", kind: "http", host: {} } },
-      { opencode: "available" }
-    ),
-    config: { username: "", password: "", corsOrigins: [] },
-    primaryAgentID: "opencode",
-    proxyRequest: async ({ route, response }) => {
-      routed = route
-      response.writeHead(200, { "Content-Type": "application/json" })
-      response.end(JSON.stringify({ ok: true }))
-    }
-  })
-  const port = await listen(server)
-  try {
-    const response = await fetch(`http://127.0.0.1:${port}/session?directory=%2Fwork`)
-    assert.equal(response.status, 200)
-    assert.deepEqual(await response.json(), { ok: true })
-    assert.deepEqual(routed, { agentID: "opencode", path: "/session", search: "?directory=%2Fwork" })
-  } finally {
-    await close(server)
-  }
-})
-
 test("managed HTTP routing replaces client credentials with host credentials", async () => {
   let upstreamRequest
   const upstream = http.createServer((request, response) => {

--- a/bridge/test/daemon-cli.test.js
+++ b/bridge/test/daemon-cli.test.js
@@ -17,21 +17,6 @@ test("daemon defaults to one ACP primary plus loopback managed OpenCode", () => 
   assert.equal(parsed.config.port, 4097)
 })
 
-test("daemon accepts OpenCode as the machine primary without inventing an ACP backend", () => {
-  const parsed = parseDaemonOptions(["--backend", "opencode"], { HARNESS_REMOTE_HOST: "127.0.0.1" })
-  assert.equal(parsed.config.backend, "opencode")
-  assert.equal(parsed.config.acpCommand, "")
-  assert.deepEqual(parsed.config.acpArgs, [])
-  assert.equal(parsed.openCode, true)
-})
-
-test("OpenCode primary cannot disable its own managed host", () => {
-  assert.throws(
-    () => parseDaemonOptions(["--backend", "opencode", "--no-opencode"], { HARNESS_REMOTE_HOST: "127.0.0.1" }),
-    /cannot be used when OpenCode is the machine primary/
-  )
-})
-
 test("daemon does not inherit a LAN daemon bind for managed OpenCode", () => {
   const parsed = parseDaemonOptions(["--host", "0.0.0.0"], {
     HARNESS_REMOTE_BACKEND: "codex",

--- a/bridge/test/launcher.test.js
+++ b/bridge/test/launcher.test.js
@@ -44,16 +44,12 @@ test("escalates a second shutdown signal from SIGTERM to SIGKILL", () => {
 
 test("uses an explicit backend on a fresh environment with no detected CLI", () => {
   assert.equal(resolveBackend(["--backend", "claude"], []), "claude")
-  assert.deepEqual(resolveLaunchPlan(["--backend", "claude"], []), { mode: "daemon", backend: "claude", detected: ["claude"], openCode: false })
+  assert.deepEqual(resolveLaunchPlan(["--backend", "claude"], []), { mode: "single", backend: "claude", detected: [] })
 })
 
-test("auto-selects exactly one detected backend into the HR3 machine daemon", () => {
+test("auto-selects exactly one detected backend", () => {
   assert.equal(resolveBackend([], ["omp"]), "omp")
-  assert.deepEqual(resolveLaunchPlan([], ["omp"]), { mode: "daemon", backend: "omp", detected: ["omp"], openCode: false })
-})
-
-test("OpenCode-only startup uses the HR3 machine daemon", () => {
-  assert.deepEqual(resolveLaunchPlan([], ["opencode"]), { mode: "daemon", backend: "opencode", detected: ["opencode"], openCode: true })
+  assert.deepEqual(resolveLaunchPlan([], ["omp"]), { mode: "single", backend: "omp", detected: ["omp"] })
 })
 
 test("starts the machine daemon automatically when multiple agents are detected", () => {
@@ -66,12 +62,11 @@ test("uses --backend to select the daemon primary", () => {
 
 test("uses --single as the daemon opt-out", () => {
   assert.deepEqual(resolveLaunchPlan(["--single", "--backend", "claude"], ["codex", "claude", "opencode"]), { mode: "single", backend: "claude", detected: ["codex", "claude", "opencode"] })
-  assert.deepEqual(resolveLaunchPlan(["--single"], ["opencode"]), { mode: "single", backend: "opencode", detected: ["opencode"] })
   assert.throws(() => resolveLaunchPlan(["--single"], ["codex", "claude"]), /--single requires --backend/)
 })
 
-test("explicit OpenCode selects the HTTP primary without leaving the machine daemon", () => {
-  assert.deepEqual(resolveLaunchPlan(["--backend", "opencode"], ["codex", "opencode"]), { mode: "daemon", backend: "opencode", detected: ["codex", "opencode"], openCode: true })
+test("keeps explicit OpenCode on the single-host path", () => {
+  assert.deepEqual(resolveLaunchPlan(["--backend", "opencode"], ["codex", "opencode"]), { mode: "single", backend: "opencode", detected: ["codex", "opencode"] })
 })
 
 test("starts a daemon without OpenCode when multiple ACP agents are detected", () => {

--- a/bridge/test/machine-daemon.test.js
+++ b/bridge/test/machine-daemon.test.js
@@ -199,37 +199,6 @@ test("machine server wires registry, routing, native Session operations, task li
   assert.deepEqual(bridgeOptions.machineRegistry.snapshot().agents.map((host) => host.id), ["pi", "opencode"])
 })
 
-test("OpenCode-only machine server does not construct a phantom ACP bridge", () => {
-  const daemon = new MachineDaemon({ id: "machine_http_only", name: "workstation" })
-  daemon.registerManagedHttpHost({
-    id: "opencode",
-    label: "OpenCode",
-    host: new FakeHttpHost(),
-    eager: false
-  })
-
-  let routerOptions
-  const value = createMachineDaemonServer({
-    daemon,
-    config: { backend: "opencode", port: 4097, stateDirectory: "/tmp/hr-http-only" },
-    primaryAgentID: "opencode",
-    sessionOperationLedger: { diagnostics() { return {} } },
-    sessionLinkStore: {},
-    createServer: () => { throw new Error("OpenCode-only startup must not create an ACP bridge") },
-    createRouter: (options) => { routerOptions = options; return { marker: "router" } },
-    createClaimServer: ({ innerServer }) => innerServer,
-    createLaunchServer: ({ innerServer }) => innerServer,
-    createModelServer: ({ innerServer }) => innerServer,
-    createFinishServer: ({ innerServer }) => innerServer,
-    createWorkThreadServerFactory: ({ innerServer }) => innerServer
-  })
-
-  assert.deepEqual(value, { marker: "router" })
-  assert.equal(routerOptions.primaryAgentID, "opencode")
-  assert.equal(routerOptions.bridgeServer, undefined)
-  assert.deepEqual(daemon.snapshot().agents.map((host) => host.id), ["opencode"])
-})
-
 test("machine handoff checkpoints a created target before link enrichment can fail", async () => {
   const daemon = new MachineDaemon({ id: "machine_test", name: "workstation" })
   const codex = new FakeAcp()

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -1306,6 +1306,47 @@ test("restores messages from disk when ACP replay is empty or partial after rest
   }
 })
 
+test("an empty initial snapshot cannot erase the first prompt of a loaded journal-backed Session", async () => {
+  class FreshSessionAcp extends EventEmitter {
+    async start() {}
+
+    async listSessions() {
+      return [{ sessionId: "fresh-session", cwd: process.cwd(), updatedAt: "2026-09-06T00:00:00.000Z" }]
+    }
+
+    async request(method) {
+      if (method === "session/new") {
+        return {
+          sessionId: "fresh-session",
+          configOptions: [{ id: "model", currentValue: "free", options: [{ value: "free" }] }]
+        }
+      }
+      return {}
+    }
+
+    notify() {}
+  }
+
+  const snapshotDirectory = await mkdtemp(path.join(tmpdir(), "harness-remote-fresh-snapshot-"))
+  try {
+    const service = new AcpService(new FreshSessionAcp(), {
+      snapshotDirectory,
+      historyLoader: async () => [],
+      journalPageWhileOwned: false
+    })
+    const created = await service.createSession({ directory: process.cwd() })
+    await service.flushSnapshots()
+    await service.prompt(created.id, "Keep the first prompt")
+    assert.deepEqual(
+      (await service.messages(created.id)).map((message) => [message.info.role, message.parts[0]?.text]),
+      [["user", "Keep the first prompt"]]
+    )
+    await service.flushSnapshots()
+  } finally {
+    await rm(snapshotDirectory, { recursive: true, force: true })
+  }
+})
+
 test("reads external history without loading and interrupting the ACP session", async () => {
   const message = (id, text) => ({
     info: { id, role: "assistant", sessionID: "session-1", time: { created: Date.now() } },

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -11,7 +11,7 @@ Harness Remote 3 changes the normal startup contract. HR2 commonly connected the
 - Existing standalone ACP bridge commands such as `npx --yes ./bridge --backend omp|pi|claude|codex ...` are still supported as compatibility paths. They can expose native Sessions, but they do not provide the complete HR3 Project catalog/new-Session workflow.
 - A direct `opencode serve` process from an HR2 setup is not a Harness Machine endpoint and cannot be added under **Machines** in HR3.
 - HR2 saved server profiles are kept in storage for legacy code paths, but they are not automatically converted into HR3 `workspaceMachines`. After upgrading, add the machine again in **Machines → Add machine**.
-- For the full HR3 experience, stop the old per-harness public endpoints and use the launcher or machine daemon described below. The launcher now uses the HR3 Machine endpoint even when only one harness is installed; `--single` is the explicit legacy compatibility opt-out.
+- For the full HR3 experience, stop the old per-harness public endpoints and use the launcher or machine daemon described below. Legacy single-backend startup is intended for compatibility, not as the preferred HR3 onboarding path.
 
 ## Start a machine and open the client
 
@@ -66,11 +66,11 @@ package has been published.
 
 The launcher inspects `PATH` without executing discovered agent binaries and chooses the least-friction compatible runtime:
 
-- without `--single`, it always starts the HR3 machine daemon, including single-harness setups;
-- OpenCode-only machines are exposed through the same Machine → Project → Session contract as ACP-backed machines;
-- the daemon selects a detected harness as its primary and includes the other detected harnesses it can manage;
-- `--backend <name>` selects the machine primary, including `opencode`;
-- `--single --backend <name>` explicitly opts out of the daemon and forces the legacy per-harness endpoint;
+- with exactly one supported CLI, it preserves the existing single-backend startup path;
+- with multiple supported CLIs and at least one ACP-backed agent, it starts the machine daemon automatically;
+- the daemon selects one detected ACP backend as its primary host and includes managed OpenCode when OpenCode is installed;
+- `--backend <name>` selects the ACP primary on a multi-agent machine;
+- `--single --backend <name>` explicitly opts out of the daemon and forces the legacy single-backend path;
 - if managed OpenCode is included, the launcher chooses a free loopback port automatically instead of assuming 4096 is unused;
 - credentials are generated automatically and kept out of child-process argv;
 - the LAN address and credentials to enter in the client are printed before startup continues.
@@ -83,21 +83,21 @@ For example, on a workstation with Codex, Claude Code and OpenCode installed, th
 harness-remote
 ```
 
-starts one machine daemon instead of failing and asking you to choose a backend. The launcher reports the CLIs it detected, selects the machine primary, finds a free loopback port when managed OpenCode is present, and exposes the machine through one authenticated daemon connection.
+starts one machine daemon instead of failing and asking you to choose a backend. The launcher reports the CLIs it detected, selects an ACP primary, finds a free loopback port for managed OpenCode, and exposes the machine through one authenticated daemon connection.
 
-The automatic shape is now consistent for one or many harnesses:
+The current automatic multi-host shape is deliberately precise:
 
 ```text
 Harness daemon :4097
-  ├── primary detected harness (ACP or OpenCode)
-  └── other detected managed harnesses, when present
+  ├── one detected ACP primary (Codex / Claude / OMP / PI)
+  └── OpenCode, when installed, as a managed loopback HTTP host
 ```
 
-A single ACP harness therefore still exposes `/v1/machine` and `/v1/projects`, and an OpenCode-only machine keeps its internal `opencode serve` listener private behind the daemon.
+Other detected ACP CLIs are reported by discovery but are not all instantiated concurrently by this startup slice yet. The daemon API and client are already agent-scoped, so adding more ACP host instances does not require another client transport change.
 
-## Choose the daemon primary or force one legacy backend
+## Choose the daemon primary or force one backend
 
-Choose the machine primary with:
+On a multi-agent machine, choose the daemon's ACP primary with:
 
 ```bash
 harness-remote --backend codex --root ~/dev
@@ -129,19 +129,13 @@ If OpenCode is present on a multi-agent machine, an existing process already usi
 
 ## OpenCode
 
-OpenCode uses the HR3 machine daemon by default, even when it is the only installed harness:
+When OpenCode is the only selected backend, Harness Remote starts `opencode serve` itself, passes credentials through `OPENCODE_SERVER_USERNAME` and `OPENCODE_SERVER_PASSWORD`, verifies the authenticated health endpoint, prints connection details, and supervises the child process until shutdown.
 
 ```bash
 harness-remote --backend opencode
 ```
 
-The daemon supervises an internal `opencode serve` listener on loopback and exposes it through the Machine endpoint and agent-scoped proxy. The phone/web/desktop client therefore never needs direct access to the internal OpenCode port.
-
-The old direct OpenCode endpoint is still available only when requested explicitly:
-
-```bash
-harness-remote --single --backend opencode
-```
+When the automatic machine daemon path is selected, OpenCode instead stays on its managed loopback listener and the client reaches it through the daemon's agent-scoped proxy. The phone/web/desktop client therefore does not need direct access to the internal OpenCode port.
 
 ## Machine daemon
 
@@ -168,7 +162,7 @@ Agent-scoped requests share the daemon connection:
 /v1/agents/opencode/global/event
 ```
 
-A primary ACP agent is routed through the normalized bridge API. When OpenCode is primary, legacy unprefixed routes are routed through the managed HTTP proxy instead. External credentials are authenticated at the daemon boundary and replaced with managed host credentials for internal OpenCode requests.
+The selected primary ACP agent is routed through the normalized bridge API. Managed OpenCode requests are streamed through the daemon to the loopback process; external credentials are authenticated at the daemon boundary and replaced with the managed host credentials for the internal request. Legacy unprefixed routes remain available during migration.
 
 Managed OpenCode binds to `127.0.0.1` by default even when the daemon binds to `0.0.0.0`. Wider exposure is explicit:
 


### PR DESCRIPTION
## Why

#374 was merged before the requested real-harness validation gate was completed. Although its automated CI was green, it changes shared Machine-daemon bootstrap/routing behavior for single-harness ACP and OpenCode-only setups, so it should not stay on `main` until that behavior is validated against the real installed harnesses.

## What this PR does

This is a strict revert of #374 only.

The branch starts from current `main` at `c797b027...` and its revert commit points to the exact tree from `91fb2a28...`, the commit immediately before #374. That means:

- #373 roadmap/documentation remains intact;
- #370 browser-smoke/live-stream test improvements remain intact;
- no unrelated later work is removed;
- all 11 files changed by #374 are restored byte-for-byte to their pre-#374 state.

## Files restored

- `README.md`
- `bridge/src/agent-router.js`
- `bridge/src/config.js`
- `bridge/src/daemon-cli.js`
- `bridge/src/launcher.js`
- `bridge/src/machine-daemon.js`
- `bridge/test/agent-router.test.js`
- `bridge/test/daemon-cli.test.js`
- `bridge/test/launcher.test.js`
- `bridge/test/machine-daemon.test.js`
- `docs/QUICK_START.md`

## Validation intent

Do not merge this PR automatically. Keep it open for maintainer review/approval.

After restoring the conservative baseline, the #374 behavior can be reconsidered on a separate branch only after real-harness validation covers Codex CLI, Claude Code, OMP, PI and OpenCode for startup, Machine discovery, Project discovery, existing/new Sessions, prompt/streaming, Stop, restart and resume.

Reverts #374.