### PR TITLE
fix: preserve bounded native session pagination

### DIFF
--- a/bridge/src/acp-client.js
+++ b/bridge/src/acp-client.js
@@ -236,10 +236,17 @@ export class AcpClient extends EventEmitter {
     this.#child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`)
   }
 
-  async listSessions() {
+  async listSessionPage(cursor) {
     await this.start()
-    const result = await this.request("session/list", {})
-    return result.sessions ?? []
+    const result = await this.request("session/list", cursor ? { cursor } : {})
+    return {
+      sessions: result.sessions ?? [],
+      ...(typeof result.nextCursor === "string" && result.nextCursor ? { nextCursor: result.nextCursor } : {})
+    }
+  }
+
+  async listSessions() {
+    return (await this.listSessionPage()).sessions
   }
 
   close() {

--- a/bridge/src/acp-prompt-echo-filter.js
+++ b/bridge/src/acp-prompt-echo-filter.js
@@ -42,6 +42,7 @@ export class AcpPromptEchoFilter extends EventEmitter {
   get processID() { return this.#acp.processID }
 
   start(...args) { return this.#acp.start(...args) }
+  listSessionPage(...args) { return this.#acp.listSessionPage(...args) }
   listSessions(...args) { return this.#acp.listSessions(...args) }
   notify(...args) { return this.#acp.notify(...args) }
   close(...args) { return this.#acp.close?.(...args) }

--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -565,6 +565,25 @@ export class AcpService {
     })
   }
 
+  /**
+   * Seed lightweight ACP listing metadata without restoring a transcript snapshot.
+   *
+   * The paged Session index can reveal an older Session before any stable endpoint or mutation
+   * addresses it. Remembering that metadata lets a later open/claim resolve the native identity
+   * without turning every recurring index refresh into an eager walk of the full history.
+   */
+  rememberListedSessions(sessions) {
+    return sessions.map((session) => {
+      const known = this.#sessions.get(session.sessionId)
+      const updatedAt = this.#preserveListedTimestamps && known?.updatedAt
+        ? known.updatedAt
+        : session.updatedAt ?? known?.updatedAt ?? new Date().toISOString()
+      const normalized = { ...session, updatedAt }
+      this.#sessions.set(normalized.sessionId, normalized)
+      return normalized
+    })
+  }
+
   async createSession({ directory, title, model }) {
     await this.#acp.start()
     const result = await this.#acp.request("session/new", { cwd: directory, mcpServers: [] })
@@ -1746,17 +1765,8 @@ export class AcpService {
   async #refreshSessions() {
     if (!this.#sessionListing) {
       this.#sessionListing = this.#acp.listSessions().then((sessions) => {
-        const listed = new Set()
-        const refreshed = sessions.map((session) => {
-          listed.add(session.sessionId)
-          const known = this.#sessions.get(session.sessionId)
-          const updatedAt = this.#preserveListedTimestamps && known?.updatedAt
-            ? known.updatedAt
-            : session.updatedAt ?? known?.updatedAt ?? new Date().toISOString()
-          const normalized = { ...session, updatedAt }
-          this.#sessions.set(normalized.sessionId, normalized)
-          return normalized
-        })
+        const listed = new Set(sessions.map((session) => session.sessionId))
+        const refreshed = this.rememberListedSessions(sessions)
         for (const [sessionID, session] of this.#sessions) {
           if (this.#ownedSessions.has(sessionID) && !listed.has(sessionID)) refreshed.push(session)
         }

--- a/bridge/src/codex-session-history.js
+++ b/bridge/src/codex-session-history.js
@@ -198,7 +198,10 @@ export function createCodexHistoryLoader(sessionRoot = path.join(homedir(), ".co
 
   loadCodexHistory.page = async (sessionID, options = {}) => {
     const file = await locateSession(sessionID)
-    if (!file) return { messages: [], before: null, hasMore: false }
+    // Absence is not proof of an empty Session: a rollout may live outside this installation's
+    // local tree while ACP session/load can still replay it. Let AcpService distinguish that from a
+    // located, genuinely empty rollout and fall through to the protocol source.
+    if (!file) return undefined
     return readCodexPage(file, sessionID, options)
   }
 

--- a/bridge/src/server.js
+++ b/bridge/src/server.js
@@ -227,13 +227,18 @@ export function createBridgeServer({ config, acp, serviceOptions, machineRegistr
   // Live activity is tracked separately so an active Session still sorts to the top without reading
   // its transcript. Invalid or missing harness timestamps stay at zero instead of pretending to be
   // freshly updated on every poll.
-  const listVisibleSessionMetadata = async (directory) => {
-    const [sessions, deletedSessionIDs] = await Promise.all([
-      acp.listSessions(),
+  const listVisibleSessionMetadata = async (directory, cursor) => {
+    const [page, deletedSessionIDs] = await Promise.all([
+      typeof acp.listSessionPage === "function"
+        ? acp.listSessionPage(cursor)
+        : cursor
+          ? { sessions: [] }
+          : acp.listSessions().then((sessions) => ({ sessions })),
       service.deletedSessionIDs()
     ])
+    service.rememberListedSessions(page.sessions)
     const visible = new Map(
-      sessions
+      page.sessions
         .filter((session) => !directory || sameListedDirectory(session.cwd, directory))
         .filter((session) => !hiddenSessionIDs?.has(session.sessionId))
         .filter((session) => !deletedSessionIDs.has(session.sessionId))
@@ -250,24 +255,26 @@ export function createBridgeServer({ config, acp, serviceOptions, machineRegistr
         })
     )
 
-    // PI can create a valid writer Session before its lightweight ACP listing exposes it. Codex and
-    // other ACP adapters may also lack a native rename primitive even though Harness Remote can keep
-    // an explicit user title for the owned Session. Overlay only those already-owned identities:
-    // native discovery remains authoritative for every other Session and no transcript snapshot is
-    // restored merely to draw the rail.
+    // PI can create a valid writer Session before its lightweight ACP listing exposes it. Add that
+    // missing identity only to page one. A title override, however, must decorate whichever native
+    // page contains the Session; otherwise loading its older page would overwrite the title page
+    // one already supplied. No transcript snapshot is restored merely to draw either view.
     for (const { session, titleOverride } of service.ownedSessionIndex(directory)) {
       if (hiddenSessionIDs?.has(session.id) || deletedSessionIDs.has(session.id)) continue
       const listed = visible.get(session.id)
-      if (!listed) {
+      if (listed && titleOverride) {
+        visible.set(session.id, { ...listed, title: titleOverride })
+      } else if (!cursor && !listed) {
         visible.set(session.id, {
           ...session,
           status: publicSessionStatus(session.id, session.time?.updated)
         })
-      } else if (titleOverride) {
-        visible.set(session.id, { ...listed, title: titleOverride })
       }
     }
-    return [...visible.values()]
+    return {
+      sessions: [...visible.values()],
+      ...(page.nextCursor ? { nextCursor: page.nextCursor } : {})
+    }
   }
 
   const server = http.createServer(async (request, response) => {
@@ -350,7 +357,9 @@ export function createBridgeServer({ config, acp, serviceOptions, machineRegistr
         return
       }
       if (request.method === "GET" && url.pathname === "/experimental/session") {
-        writeJSON(response, 200, await listVisibleSessionMetadata(directory))
+        const page = await listVisibleSessionMetadata(directory, url.searchParams.get("cursor") || undefined)
+        if (page.nextCursor) response.setHeader("x-next-cursor", page.nextCursor)
+        writeJSON(response, 200, page.sessions)
         return
       }
       if (request.method === "GET" && (url.pathname === "/v1/sessions" || url.pathname === "/session")) {
@@ -358,7 +367,8 @@ export function createBridgeServer({ config, acp, serviceOptions, machineRegistr
         return
       }
       if (request.method === "GET" && url.pathname === "/session/status") {
-        const statuses = Object.fromEntries((await listVisibleSessionMetadata(directory)).map((session) => [session.id, session.status]))
+        const page = await listVisibleSessionMetadata(directory)
+        const statuses = Object.fromEntries(page.sessions.map((session) => [session.id, session.status]))
         writeJSON(response, 200, statuses)
         return
       }

--- a/bridge/test/acp-client.test.js
+++ b/bridge/test/acp-client.test.js
@@ -80,6 +80,36 @@ test("initializes, authenticates, and lists ACP sessions", async () => {
   assert.equal(client.processID, undefined)
 })
 
+test("preserves ACP Session pagination and sends an opaque cursor unchanged", async () => {
+  const listRequests = []
+  const client = new AcpClient({
+    spawnProcess: fakeSpawn((child, request) => {
+      respondToHandshake(child, request)
+      if (request.method === "session/list") {
+        listRequests.push(request.params)
+        child.respond({
+          jsonrpc: "2.0",
+          id: request.id,
+          result: {
+            sessions: [{ sessionId: request.params.cursor ? "session-2" : "session-1" }],
+            ...(request.params.cursor ? {} : { nextCursor: "opaque+/cursor==" })
+          }
+        })
+      }
+    })
+  })
+
+  assert.deepEqual(await client.listSessionPage(), {
+    sessions: [{ sessionId: "session-1" }],
+    nextCursor: "opaque+/cursor=="
+  })
+  assert.deepEqual(await client.listSessionPage("opaque+/cursor=="), {
+    sessions: [{ sessionId: "session-2" }]
+  })
+  assert.deepEqual(listRequests, [{}, { cursor: "opaque+/cursor==" }])
+  client.close()
+})
+
 test("launches an ACP adapter with the configured command and arguments", async () => {
   const calls = []
   const client = new AcpClient({

--- a/bridge/test/codex-session-history.test.js
+++ b/bridge/test/codex-session-history.test.js
@@ -197,7 +197,7 @@ test("reports no history rather than failing when a rollout is absent", async ()
   try {
     const loadHistory = createCodexHistoryLoader(root)
     assert.deepEqual(await loadHistory(sessionID), [])
-    assert.deepEqual(await loadHistory.page(sessionID, { limit: 10 }), { messages: [], before: null, hasMore: false })
+    assert.equal(await loadHistory.page(sessionID, { limit: 10 }), undefined)
     assert.deepEqual(await loadHistory("../escape"), [], "a session id must not be able to walk the filesystem")
     assert.deepEqual(await createCodexHistoryLoader(path.join(root, "missing"))(sessionID), [])
   } finally {

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -852,6 +852,27 @@ test("keeps an external OMP session observational when its journal is empty", as
   assert.equal(acp.loads, 0, "a read-only OMP open must not fall back to a blocking ACP replay")
 })
 
+test("falls back to ACP replay when a paged journal cannot locate the Session", async () => {
+  class MissingJournalReplayAcp extends ReplayAcp {
+    loads = 0
+
+    async request(method, params) {
+      if (method === "session/load") this.loads += 1
+      return super.request(method, params)
+    }
+  }
+
+  const acp = new MissingJournalReplayAcp()
+  const historyLoader = async () => []
+  historyLoader.page = async () => undefined
+  const service = new AcpService(acp, { historyLoader })
+
+  const page = await service.messagePage("session-1", { limit: 100 })
+  assert.ok(page.messages.some((message) => message.parts.some((part) => part.text === "Persist this prompt")))
+  assert.ok(page.messages.some((message) => message.parts.some((part) => part.text === "Persist this response")))
+  assert.equal(acp.loads, 1, "an absent journal file must not masquerade as a valid empty transcript")
+})
+
 test("renames and hides ACP sessions through OpenCode-compatible endpoints", async () => {
   const bridge = await startServer()
   try {

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -2082,6 +2082,13 @@ test("lightweight Session index keeps a bridge-created Session visible and prese
       }]
     }
 
+    async listSessionPage(cursor) {
+      if (cursor === "older" && this.exposeNative && this.created) {
+        return { sessions: [{ ...this.created, title: "Harness generated title" }] }
+      }
+      return { sessions: [], ...(this.exposeNative ? { nextCursor: "older" } : {}) }
+    }
+
     async request(method, params) {
       if (method === "session/new") {
         this.created = {
@@ -2126,6 +2133,57 @@ test("lightweight Session index keeps a bridge-created Session visible and prese
     assert.equal(renamed.status, 200)
     index = await readJSON(bridge.baseURL, `/experimental/session?directory=${directory}`)
     assert.equal(index[0].title, "Renamed from Harness Remote", "a bridge-local Codex rename must survive a Session-list refresh")
+
+    const older = await readJSON(bridge.baseURL, `/experimental/session?directory=${directory}&cursor=older`)
+    assert.equal(older[0].title, "Renamed from Harness Remote", "an older native page must retain the bridge-owned title override")
+  } finally {
+    await bridge.close()
+  }
+})
+
+test("lightweight Session index exposes one ACP page and forwards its opaque cursor", async () => {
+  class PagedNativeIndexAcp extends EventEmitter {
+    agentInfo = { version: "1.0.0" }
+    cursors = []
+
+    async start() {}
+
+    async listSessionPage(cursor) {
+      this.cursors.push(cursor)
+      return cursor
+        ? {
+            sessions: [{ sessionId: "older", title: "Older", cwd: process.cwd(), updatedAt: "2026-08-01T00:00:00.000Z" }]
+          }
+        : {
+            sessions: [{ sessionId: "recent", title: "Recent", cwd: process.cwd(), updatedAt: "2026-09-01T00:00:00.000Z" }],
+            nextCursor: "opaque+/cursor=="
+          }
+    }
+
+    async listSessions() {
+      throw new Error("the paged metadata route must not fall back to an eager listing")
+    }
+
+    async request() { return {} }
+    notify() {}
+  }
+
+  const acp = new PagedNativeIndexAcp()
+  const bridge = await startServer({ acp, backend: "codex" })
+  try {
+    const first = await fetch(`${bridge.baseURL}/experimental/session`, { headers: authHeaders() })
+    assert.equal(first.status, 200)
+    assert.equal(first.headers.get("x-next-cursor"), "opaque+/cursor==")
+    assert.deepEqual((await first.json()).map((session) => session.id), ["recent"])
+
+    const second = await fetch(`${bridge.baseURL}/experimental/session?cursor=${encodeURIComponent("opaque+/cursor==")}`, { headers: authHeaders() })
+    assert.equal(second.status, 200)
+    assert.equal(second.headers.get("x-next-cursor"), null)
+    assert.deepEqual((await second.json()).map((session) => session.id), ["older"])
+
+    const statuses = await readJSON(bridge.baseURL, "/session/status")
+    assert.deepEqual(Object.keys(statuses), ["recent"], "status polling must remain bounded to the first page")
+    assert.deepEqual(acp.cursors, [undefined, "opaque+/cursor==", undefined])
   } finally {
     await bridge.close()
   }

--- a/bridge/test/server.test.js
+++ b/bridge/test/server.test.js
@@ -2188,3 +2188,56 @@ test("lightweight Session index exposes one ACP page and forwards its opaque cur
     await bridge.close()
   }
 })
+
+test("lightweight Session index preserves non-paginated behavior across ACP backends", async () => {
+  class SinglePageAcp extends EventEmitter {
+    agentInfo = { version: "1.0.0" }
+    cursors = []
+
+    constructor(backend) {
+      super()
+      this.backend = backend
+    }
+
+    async start() {}
+
+    async listSessionPage(cursor) {
+      this.cursors.push(cursor)
+      return {
+        sessions: [{
+          sessionId: `${this.backend}-session`,
+          title: `${this.backend} Session`,
+          cwd: process.cwd(),
+          updatedAt: "2026-09-01T00:00:00.000Z"
+        }]
+      }
+    }
+
+    async listSessions() {
+      throw new Error("the lightweight index must use the shared single-page path")
+    }
+
+    async request() { return {} }
+    notify() {}
+  }
+
+  for (const backend of ["omp", "pi", "claude", "codex"]) {
+    const acp = new SinglePageAcp(backend)
+    const bridge = await startServer({ acp, backend })
+    try {
+      const response = await fetch(`${bridge.baseURL}/experimental/session`, { headers: authHeaders() })
+      assert.equal(response.status, 200, backend)
+      assert.equal(response.headers.get("x-next-cursor"), null, `${backend} must remain a one-page listing without a cursor`)
+      assert.deepEqual((await response.json()).map((session) => ({ id: session.id, title: session.title })), [{
+        id: `${backend}-session`,
+        title: `${backend} Session`
+      }])
+
+      const statuses = await readJSON(bridge.baseURL, "/session/status")
+      assert.deepEqual(Object.keys(statuses), [`${backend}-session`], `${backend} status discovery must keep using page one`)
+      assert.deepEqual(acp.cursors, [undefined, undefined], `${backend} must not invent or follow a cursor`)
+    } finally {
+      await bridge.close()
+    }
+  }
+})

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -188,7 +188,7 @@ read from a spec:**
 |---|---|
 | `session/list` enumerates every Codex thread on the machine | the session list empties |
 | Rollouts stay at `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<timestamp>-<sessionId>.jsonl` | `createCodexHistoryLoader` finds nothing and every session Codex holds open shows as empty |
-| A rollout records the turns the user saw as `event_msg` records — `user_message.message`, `agent_message.message`, `agent_reasoning.text` | the transcript of an externally-held session goes empty, or starts showing the instruction blocks Codex feeds the model, which `response_item` carries under the `user` role |
+| A rollout records the turns the user saw as `event_msg` records. Current rollouts use `item_completed` with `UserMessage.content[type=text]`, `AgentMessage.content[type=Text]`, and `Reasoning.summary_text`; legacy rollouts use `user_message.message`, `agent_message.message`, and `agent_reasoning.text` | the transcript of an externally-held session goes empty, or starts showing the instruction blocks Codex feeds the model, which `response_item` carries under the `user` role |
 | Model config option ids are bare (`gpt-5.2`), not `provider/model` | covered by the same bare-id handling the Claude Code backend proved; if ids gain a provider prefix they still parse, under that provider name |
 | `reasoning_effort` and `mode` config options are advertised but not exposed | they stay invisible in the app; no crash, just unused surface |
 | `plan` / `plan_update` notifications carry entries addressed as `{content, status, priority}` | todo updates stop rendering |

--- a/web/electron/desktop-transport.test.mjs
+++ b/web/electron/desktop-transport.test.mjs
@@ -27,6 +27,12 @@ server = createServer(async (request, response) => {
     response.end(JSON.stringify({ ok: true }))
     return
   }
+  if (request.url === '/cursor' && request.method === 'GET') {
+    response.setHeader('content-type', 'application/json')
+    response.setHeader('x-next-cursor', 'opaque+/cursor==')
+    response.end('[]')
+    return
+  }
   if (request.url === '/v1/agents/opencode/query?directory=%2Fwork%2Frepo' && request.method === 'GET') {
     response.setHeader('content-type', 'application/json')
     response.end(JSON.stringify({ url: request.url }))
@@ -149,6 +155,7 @@ test('window restore selects saved monitor and keeps title bar visible', async (
 
 test('request transport enforces approved profile target and HTTP contract', async () => {
   assert.deepEqual((await executeDesktopRequest(localProfile, { path: '/json' })).response.data, { ok: true })
+  assert.equal((await executeDesktopRequest(localProfile, { path: '/cursor' })).response.headers['x-next-cursor'], 'opaque+/cursor==')
   assert.deepEqual((await executeDesktopRequest(localProfile, { path: '/body', method: 'POST', body: { value: 2 } })).response.data, { method: 'POST', body: { value: 2 } })
   assert.equal((await executeDesktopRequest(localProfile, { path: '/empty' })).response.data, true)
   const httpError = await executeDesktopRequest(localProfile, { path: '/error' })

--- a/web/scripts/native-session-navigation-smoke.mjs
+++ b/web/scripts/native-session-navigation-smoke.mjs
@@ -8,16 +8,19 @@ const DAEMON_PORT = 4425
 const APP_ORIGIN = `http://127.0.0.1:${PREVIEW_PORT}`
 const STORAGE_KEY = "harness-remote.workspace.machines.v1"
 const DIRECTORY = "/work/native-navigation"
-const SESSION_A = "native-pi-navigation-a"
-const SESSION_B = "native-pi-navigation-b"
+const SESSION_A = "native-codex-navigation-a"
+const SESSION_B = "native-codex-navigation-b"
+const SESSION_BROKEN = "native-codex-navigation-broken"
 const TITLE_A = "Navigation Session A"
 const TITLE_B = "Navigation Session B"
+const TITLE_BROKEN = "Navigation Session With Failed History"
 const MARKER_A = "NAVIGATION-TRANSCRIPT-A"
 const MARKER_B = "NAVIGATION-TRANSCRIPT-B"
 
 const sessions = [
   { id: SESSION_A, title: TITLE_A, directory: DIRECTORY, external: true, time: { created: 1000, updated: 1001 } },
-  { id: SESSION_B, title: TITLE_B, directory: DIRECTORY, external: true, time: { created: 2000, updated: 2001 } }
+  { id: SESSION_B, title: TITLE_B, directory: DIRECTORY, external: true, time: { created: 2000, updated: 2001 } },
+  { id: SESSION_BROKEN, title: TITLE_BROKEN, directory: DIRECTORY, external: true, time: { created: 3000, updated: 3001 } }
 ]
 
 const transcripts = new Map([
@@ -31,7 +34,23 @@ const transcripts = new Map([
   }]]
 ])
 
-let modelReads = 0
+const CODEX_MODELS = [{
+  providerID: "codex",
+  providerName: "Codex",
+  modelID: "gpt-codex-navigation",
+  modelName: "Codex Navigation",
+  isDefault: true,
+  tools: true
+}]
+const OMP_MODELS = [{
+  providerID: "omp",
+  providerName: "Oh My Pi",
+  modelID: "omp-navigation",
+  modelName: "OMP Navigation",
+  isDefault: true,
+  tools: true
+}]
+const modelRoutes = []
 let sseResponses = new Set()
 
 function corsHeaders() {
@@ -60,16 +79,30 @@ function startFakeDaemon() {
     if (request.method === "GET" && url.pathname === "/v1/machine") {
       json(response, 200, {
         machine: { id: "machine-native-navigation", name: "Native Navigation Test", createdAt: new Date().toISOString() },
-        agents: [{
-          id: "pi",
-          label: "PI",
-          backend: "pi",
-          transport: "acp",
-          managed: true,
-          state: "available",
-          capabilities: { sessions: true, prompt: true, abort: true, streaming: true, models: true },
-          contract: { sessions: { stop: "owned-session-native-cancel" } }
-        }]
+        // OMP is deliberately the saved machine profile's primary harness. Opening the Codex row
+        // below must use the Codex URL identity and must never carry OMP as a routing override.
+        agents: [
+          {
+            id: "omp",
+            label: "OMP",
+            backend: "omp",
+            transport: "acp",
+            managed: true,
+            state: "available",
+            capabilities: { sessions: true, prompt: true, abort: true, streaming: true, models: true },
+            contract: { sessions: { stop: "owned-session-native-cancel" } }
+          },
+          {
+            id: "codex",
+            label: "Codex",
+            backend: "codex",
+            transport: "acp",
+            managed: true,
+            state: "available",
+            capabilities: { sessions: true, prompt: true, abort: true, streaming: true, models: true },
+            contract: { sessions: { stop: "owned-session-native-cancel" } }
+          }
+        ]
       })
       return
     }
@@ -81,37 +114,55 @@ function startFakeDaemon() {
       return
     }
 
-    if (request.method === "GET" && url.pathname === "/v1/agents/pi/experimental/session") {
+    if (request.method === "GET" && url.pathname === "/v1/agents/omp/experimental/session") {
+      json(response, 200, [])
+      return
+    }
+
+    if (request.method === "GET" && url.pathname === "/v1/agents/codex/experimental/session") {
       json(response, 200, sessions)
       return
     }
 
-    if (request.method === "GET" && url.pathname === "/v1/agents/pi/session/status") {
-      json(response, 200, { [SESSION_A]: { type: "idle" }, [SESSION_B]: { type: "idle" } })
+    if (request.method === "GET" && url.pathname === "/v1/agents/omp/session/status") {
+      json(response, 200, {})
       return
     }
 
-    if (request.method === "GET" && url.pathname === "/v1/agents/pi/models") {
-      modelReads += 1
+    if (request.method === "GET" && url.pathname === "/v1/agents/codex/session/status") {
       json(response, 200, {
-        models: [{
-          providerID: "pi",
-          providerName: "PI",
-          modelID: "pi-coding",
-          modelName: "PI Coding",
-          isDefault: true,
-          tools: true
-        }],
-        stale: false,
-        refreshedAt: new Date().toISOString(),
-        source: "native-navigation-smoke"
+        [SESSION_A]: { type: "idle" },
+        [SESSION_B]: { type: "idle" },
+        [SESSION_BROKEN]: { type: "idle" }
       })
       return
     }
 
-    const messageMatch = /^\/v1\/agents\/pi\/session\/([^/]+)\/message$/.exec(url.pathname)
+    const modelMatch = /^\/v1\/agents\/(codex|omp)\/models$/.exec(url.pathname)
+    if (request.method === "GET" && modelMatch) {
+      const pathAgent = modelMatch[1]
+      const routedBackend = String(request.headers["x-harness-backend"] || "")
+      modelRoutes.push({ pathAgent, routedBackend })
+      // Mirror the daemon rule relevant to the reverted #381 behavior: an explicit mismatched
+      // routing header wins, while a machine-scoped request with no header follows its agent path.
+      const routedAgent = routedBackend || pathAgent
+      const models = routedAgent === "omp" ? OMP_MODELS : CODEX_MODELS
+      json(response, 200, {
+        models,
+        stale: false,
+        refreshedAt: new Date().toISOString(),
+        source: `native-navigation-smoke:${routedBackend || pathAgent}`
+      })
+      return
+    }
+
+    const messageMatch = /^\/v1\/agents\/codex\/session\/([^/]+)\/message$/.exec(url.pathname)
     if (request.method === "GET" && messageMatch) {
       const sessionID = decodeURIComponent(messageMatch[1])
+      if (sessionID === SESSION_BROKEN) {
+        json(response, 500, { error: "Simulated persisted Codex history failure" })
+        return
+      }
       json(response, 200, transcripts.get(sessionID) || [], { "X-Has-More": "0" })
       return
     }
@@ -170,7 +221,7 @@ async function seed(page) {
     localStorage.setItem(key, JSON.stringify([{
       id: "machine-native-navigation",
       name: "Native Navigation Test",
-      config: { backend: "opencode", host: "127.0.0.1", port, username: "harness", password: "testpw" }
+      config: { backend: "omp", host: "127.0.0.1", port, username: "harness", password: "testpw" }
     }]))
   }, { key: STORAGE_KEY, port: DAEMON_PORT })
 }
@@ -197,12 +248,30 @@ async function openAndAssert(page, title, marker, absentMarker) {
   await page.locator(".tdw-work-thread-conversation").waitFor({ state: "visible", timeout: 12_000 })
   await page.getByText(marker, { exact: true }).waitFor({ state: "visible", timeout: 12_000 })
   await page.locator(".uw-composer-shell").waitFor({ state: "visible", timeout: 12_000 })
-  const composer = page.getByRole("textbox", { name: "Message PI" })
+  const composer = page.getByRole("textbox", { name: "Message Codex" })
   await composer.waitFor({ state: "visible", timeout: 12_000 })
   assert.equal(await composer.isDisabled(), false, `${title} composer stayed disabled`)
   assert.equal(await page.getByText("Loading Session into the v3 controller...", { exact: true }).count(), 0, `${title} stayed in native controller loading state`)
   assert.equal(await page.getByText(marker, { exact: true }).count(), 1, `${title} transcript duplicated its marker`)
   assert.equal(await page.getByText(absentMarker, { exact: true }).count(), 0, `${title} retained the previous Session transcript`)
+  const modelPicker = page.locator(".tdw-model-trigger")
+  await modelPicker.waitFor({ state: "visible", timeout: 12_000 })
+  await modelPicker.click()
+  const catalogText = await page.locator(".tdw-model-picker").innerText()
+  assert.match(catalogText, /Codex Navigation/, `${title} did not receive Codex's model catalog`)
+  assert.doesNotMatch(catalogText, /OMP Navigation/, `${title} received the machine primary harness's catalog`)
+  await page.keyboard.press("Escape")
+}
+
+async function openAndAssertHistoryFailure(page) {
+  await page.locator('.hr-native-workspace[aria-label="Sessions"]').waitFor({ state: "visible", timeout: 12_000 })
+  await page.getByRole("button", { name: new RegExp(TITLE_BROKEN) }).click()
+  await page.getByRole("heading", { name: TITLE_BROKEN }).waitFor({ state: "visible", timeout: 12_000 })
+  const failure = page.locator(".uw-transcript-error")
+  await failure.waitFor({ state: "visible", timeout: 12_000 })
+  assert.match(await failure.innerText(), /Session history could not be loaded/)
+  assert.match(await failure.innerText(), /Simulated persisted Codex history failure/)
+  assert.equal(await page.getByText(/Start the conversation/).count(), 0, "a failed history read masqueraded as a valid empty Session")
 }
 
 let daemon
@@ -224,12 +293,15 @@ try {
 
   await openAndAssert(page, TITLE_A, MARKER_A, MARKER_B)
   await openAndAssert(page, TITLE_B, MARKER_B, MARKER_A)
+  await openAndAssertHistoryFailure(page)
   await openAndAssert(page, TITLE_A, MARKER_A, MARKER_B)
   await openAndAssert(page, TITLE_B, MARKER_B, MARKER_A)
 
-  assert.ok(modelReads >= 1, "sequential Session navigation never reached the mature model catalog path")
+  const codexModelRoutes = modelRoutes.filter((route) => route.pathAgent === "codex")
+  assert.ok(codexModelRoutes.length >= 1, "sequential Codex navigation never reached the model catalog path")
+  assert.ok(codexModelRoutes.every((route) => !route.routedBackend || route.routedBackend === "codex"), `Codex catalog request carried mismatched routing: ${JSON.stringify(codexModelRoutes)}`)
   assert.deepEqual(pageErrors, [], `browser errors during A -> B -> A -> B navigation: ${pageErrors.join(" | ")}`)
-  console.log("native Session sequential navigation smoke: A -> B -> A -> B passed")
+  console.log("native Codex Session navigation, model routing, and failed-history smoke passed")
   await context.close()
 } finally {
   if (browser) await browser.close().catch(() => {})

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -64,6 +64,11 @@ export type MessagePage = {
   model?: ModelSelection
 }
 
+export type SessionPage = {
+  sessions: Session[]
+  nextCursor?: string
+}
+
 export type NativeSessionIdentityPayload = {
   machineID: string
   agentID: string
@@ -277,14 +282,27 @@ export const api = {
     return request<Session[]>(config, withDirectory("/session", directory))
   },
 
+  async listGlobalSessionPage(config: ServerConfig, cursor?: string): Promise<SessionPage> {
+    const path = cursor ? `/experimental/session?cursor=${encodeURIComponent(cursor)}` : "/experimental/session"
+    const response = await requestWithHeaders<Session[]>(config, path)
+    return {
+      sessions: response.data,
+      ...(response.headers["x-next-cursor"] ? { nextCursor: response.headers["x-next-cursor"] } : {})
+    }
+  },
+
   async listGlobalSessions(config: ServerConfig) {
     const sessions: Session[] = []
     let cursor: string | undefined
+    const seenCursors = new Set<string>()
     do {
-      const path = cursor ? `/experimental/session?cursor=${encodeURIComponent(cursor)}` : "/experimental/session"
-      const response = await requestWithHeaders<Session[]>(config, path)
-      sessions.push(...response.data)
-      cursor = response.headers["x-next-cursor"]
+      const page = await api.listGlobalSessionPage(config, cursor)
+      sessions.push(...page.sessions)
+      if (page.nextCursor && seenCursors.has(page.nextCursor)) {
+        throw new Error("Session listing returned the same pagination cursor twice.")
+      }
+      if (page.nextCursor) seenCursors.add(page.nextCursor)
+      cursor = page.nextCursor
     } while (cursor)
     return sessions
   },

--- a/web/src/components/native-session-home.tsx
+++ b/web/src/components/native-session-home.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { listMachineProjects, type MachineProject } from "../machineClient"
 import { canCreateNativeSession, createNativeSessionTarget } from "../native-session-create"
 import {
-  discoverMachineNativeSessions,
+  discoverAgentNativeSessionPage,
   nativeSessionSurfaceTarget,
   type NativeSessionRecord,
   type NativeSessionSurfaceTarget
@@ -56,6 +56,20 @@ type CreateProject = {
 type ActivityAnchor = {
   key: string
   updatedAt: number
+}
+
+export type CursorPageState<T> = {
+  records: T[]
+  firstPageCursor?: string
+  nextCursor?: string
+  loadedOlder: boolean
+}
+
+type AgentPageCache = CursorPageState<RecordWithMachine> & {
+  machine: WorkspaceMachine
+  machineID: string
+  agent: MachineAgentHost
+  projects: MachineProject[]
 }
 
 type SessionPresentationState = "working" | "attention" | "stopped" | "ready"
@@ -129,6 +143,54 @@ function harnessIconUrl(backend: string): string | undefined {
 
 function recordKey(item: RecordWithMachine): string {
   return `${item.machineID}:${item.record.key}`
+}
+
+function pageScopeKey(machineID: string, agentID: string): string {
+  return `${machineID}\u0000${agentID}`
+}
+
+function uniqueSessionRecords(records: RecordWithMachine[]): RecordWithMachine[] {
+  const unique = new Map<string, RecordWithMachine>()
+  for (const item of records) unique.set(recordKey(item), item)
+  return [...unique.values()].sort(sessionActivityCompare)
+}
+
+function uniquePageRecords<T>(records: T[], key: (record: T) => string): T[] {
+  const unique = new Map<string, T>()
+  for (const record of records) unique.set(key(record), record)
+  return [...unique.values()]
+}
+
+/** Overlay a fresh first page without losing rows that moved across its boundary after older pages
+ * were loaded. Before pagination begins, a refresh remains an exact replacement. */
+export function refreshCursorPage<T>(
+  current: CursorPageState<T> | undefined,
+  records: T[],
+  nextCursor: string | undefined,
+  key: (record: T) => string
+): CursorPageState<T> {
+  const loadedOlder = current?.loadedOlder === true
+  return {
+    records: uniquePageRecords([...(loadedOlder ? current.records : []), ...records], key),
+    firstPageCursor: nextCursor,
+    nextCursor: loadedOlder ? current?.nextCursor : nextCursor,
+    loadedOlder
+  }
+}
+
+/** Add one explicitly requested older page and advance only that cursor chain. */
+export function appendCursorPage<T>(
+  current: CursorPageState<T>,
+  records: T[],
+  nextCursor: string | undefined,
+  key: (record: T) => string
+): CursorPageState<T> {
+  return {
+    ...current,
+    records: uniquePageRecords([...current.records, ...records], key),
+    nextCursor,
+    loadedOlder: true
+  }
 }
 
 function activityTimestamp(item: RecordWithMachine, anchor?: ActivityAnchor | null): number {
@@ -295,6 +357,8 @@ export function NativeSessionHome({
   const [creating, setCreating] = useState(false)
   const [createError, setCreateError] = useState<string | null>(null)
   const [discoveryError, setDiscoveryError] = useState<string | null>(null)
+  const [loadingOlder, setLoadingOlder] = useState(false)
+  const [olderSessionError, setOlderSessionError] = useState<string | null>(null)
   const [query, setQuery] = useState("")
   const [filter, setFilter] = useState<SessionFilter>("all")
   const [machineFilter, setMachineFilter] = useState("")
@@ -304,6 +368,8 @@ export function NativeSessionHome({
   const selectedRowRef = useRef<HTMLButtonElement | null>(null)
   const previousSelectedState = useRef<{ key?: string; state?: SessionPresentationState }>({})
   const completionTimer = useRef<number | null>(null)
+  const pageCache = useRef<Map<string, AgentPageCache>>(new Map())
+  const pageCacheSignature = useRef<string | null>(null)
   // The selected Session receives live status before the 30s discovery list refreshes. Keep that
   // last observed state by Session key while the user navigates elsewhere, otherwise the row falls
   // back to its stale discovery snapshot and visibly flips Working <-> Ready. The next successful
@@ -317,7 +383,8 @@ export function NativeSessionHome({
       machine.config.host,
       machine.config.port,
       machine.config.agentId || "",
-      snapshot?.machine.id || state
+      snapshot?.machine.id || state,
+      snapshot?.agents.map((agent) => `${agent.id}:${agent.backend}:${agent.transport}:${agent.processID ?? ""}:${agent.state}`).join(",") || ""
     ].join(":")
   ).join("|")
   const loaded = discoveryReady && loadedSignature === machineSignature
@@ -376,9 +443,12 @@ export function NativeSessionHome({
 
   useEffect(() => {
     if (!sources.length) {
+      pageCache.current.clear()
+      pageCacheSignature.current = machineSignature
       setRecords([])
       setProjectsByMachine({})
       setPresentationOverrides({})
+      setOlderSessionError(null)
       setLoadedSignature(machineSignature)
       setLoading(false)
       return
@@ -395,29 +465,58 @@ export function NativeSessionHome({
     let cancelled = false
     setLoading(true)
     setDiscoveryError(null)
+    setOlderSessionError(null)
     void Promise.all(sources.map(async ({ machine, snapshot }) => {
-      if (!snapshot) return { machine, projects: [] as MachineProject[], records: [] as RecordWithMachine[] }
-      const [sessions, projects] = await Promise.all([
-        discoverMachineNativeSessions(machine.config, snapshot.agents),
+      if (!snapshot) return { machine, snapshot, projects: [] as MachineProject[], pages: [] }
+      const [pages, projects] = await Promise.all([
+        Promise.all(snapshot.agents.map(async (agent) => ({
+          agent,
+          page: await discoverAgentNativeSessionPage(machine.config, agent).catch(() => null)
+        }))),
         listMachineProjects(machine.config).catch(() => [] as MachineProject[])
       ])
-      return {
-        machine,
-        projects,
-        records: sessions.map((record) => ({
-          machine,
-          machineID: snapshot.machine.id,
-          record,
-          project: catalogProject(record, projects, snapshot.machine.id)
-        }))
-      }
+      return { machine, snapshot, projects, pages }
     })).then((results) => {
       if (cancelled) return
       setProjectsByMachine(Object.fromEntries(results.map((result) => [result.machine.id, result.projects])))
+      if (pageCacheSignature.current !== machineSignature) pageCache.current.clear()
+      pageCacheSignature.current = machineSignature
+      const activeScopes = new Set<string>()
+      for (const result of results) {
+        if (!result.snapshot) continue
+        for (const { agent, page } of result.pages) {
+          const scope = pageScopeKey(result.machine.id, agent.id)
+          activeScopes.add(scope)
+          const existing = pageCache.current.get(scope)
+          if (!page) continue
+          const firstRecords = page.records.map((record) => ({
+            machine: result.machine,
+            machineID: result.snapshot!.machine.id,
+            record,
+            project: catalogProject(record, result.projects, result.snapshot!.machine.id)
+          }))
+          const refreshed = refreshCursorPage(existing, firstRecords, page.nextCursor, recordKey)
+          const recordsForScope = uniqueSessionRecords(refreshed.records)
+            .filter((item) => !deletingKeys?.has(recordKey(item)))
+          pageCache.current.set(scope, {
+            machine: result.machine,
+            machineID: result.snapshot.machine.id,
+            agent,
+            projects: result.projects,
+            records: recordsForScope,
+            firstPageCursor: refreshed.firstPageCursor,
+            nextCursor: refreshed.nextCursor,
+            loadedOlder: refreshed.loadedOlder
+          })
+        }
+      }
+      for (const scope of pageCache.current.keys()) {
+        if (!activeScopes.has(scope)) pageCache.current.delete(scope)
+      }
       // This is a fresh status read from every harness, so it supersedes any presentation bridge
       // remembered only to span the gap between a detail event and this discovery cycle.
       setPresentationOverrides({})
-      setRecords(results.flatMap((result) => result.records).sort(sessionActivityCompare))
+      setRecords(uniqueSessionRecords([...pageCache.current.values()].flatMap((entry) => entry.records)))
       setLoadedSignature(machineSignature)
     }).catch((reason) => {
       // Preserve an already loaded list, but never present a failed refresh as a genuinely empty machine.
@@ -431,7 +530,7 @@ export function NativeSessionHome({
       if (!cancelled) setLoading(false)
     })
     return () => { cancelled = true }
-  }, [sources, revision, refreshToken, discoveryReady, machineSignature])
+  }, [sources, revision, refreshToken, discoveryReady, machineSignature, deletingKeys])
 
   useEffect(() => {
     if (!loaded || document.visibilityState !== "visible") return
@@ -588,6 +687,58 @@ export function NativeSessionHome({
     })
     .sort((left, right) => right.updatedAt - left.updatedAt || left.label.localeCompare(right.label)), [agentFilter, filter, filteredGroups, machineFilter, presentationForItem, query, sources])
 
+  const olderPageTargets = [...pageCache.current.entries()].filter(([, entry]) =>
+    entry.nextCursor
+    && (!machineFilter || entry.machine.id === machineFilter)
+    && (!agentFilter || entry.agent.id === agentFilter)
+  )
+
+  async function loadOlderSessions() {
+    if (loadingOlder || olderPageTargets.length === 0) return
+    setLoadingOlder(true)
+    setOlderSessionError(null)
+    const outcomes = await Promise.all(olderPageTargets.map(async ([scope, entry]) => {
+      const cursor = entry.nextCursor!
+      try {
+        const page = await discoverAgentNativeSessionPage(entry.machine.config, entry.agent, cursor)
+        if (page.nextCursor === cursor) throw new Error("Session listing returned the same pagination cursor twice.")
+        const records = page.records.map((record) => ({
+          machine: entry.machine,
+          machineID: entry.machineID,
+          record,
+          project: catalogProject(record, entry.projects, entry.machineID)
+        }))
+        return { ok: true as const, scope, cursor, page, records }
+      } catch (error) {
+        return { ok: false as const, scope, cursor, error: error instanceof Error ? error.message : String(error) }
+      }
+    }))
+
+    let firstError: string | null = null
+    for (const outcome of outcomes) {
+      const current = pageCache.current.get(outcome.scope)
+      if (!current || current.nextCursor !== outcome.cursor) continue
+      if (!outcome.ok) {
+        firstError ??= outcome.error
+        pageCache.current.set(outcome.scope, {
+          ...current,
+          nextCursor: current.firstPageCursor
+        })
+        continue
+      }
+      const appended = appendCursorPage(current, outcome.records, outcome.page.nextCursor, recordKey)
+      pageCache.current.set(outcome.scope, {
+        ...current,
+        ...appended,
+        records: uniqueSessionRecords(appended.records)
+          .filter((item) => !deletingKeys?.has(recordKey(item)))
+      })
+    }
+    setRecords(uniqueSessionRecords([...pageCache.current.values()].flatMap((entry) => entry.records)))
+    setOlderSessionError(firstError)
+    setLoadingOlder(false)
+  }
+
   const createMachines = useMemo<CreateMachine[]>(() => sources.flatMap(({ machine, snapshot, state, error }) =>
     snapshot && state === "online" && !error
       ? [{ machine, snapshot, label: snapshot.machine.name || machine.name }]
@@ -686,8 +837,22 @@ export function NativeSessionHome({
         directory: selectedCreateProject.project.path,
         title: createTitle
       })
+      const createdRecord = {
+        machine: selectedCreateMachine.machine,
+        machineID: selectedCreateMachine.snapshot.machine.id,
+        record,
+        project: selectedCreateProject.project
+      }
+      const scope = pageScopeKey(selectedCreateMachine.machine.id, selectedCreateAgent.id)
+      const cached = pageCache.current.get(scope)
+      if (cached) {
+        pageCache.current.set(scope, {
+          ...cached,
+          records: uniqueSessionRecords([...cached.records, createdRecord])
+        })
+      }
       setRecords((current) => [
-        { machine: selectedCreateMachine.machine, machineID: selectedCreateMachine.snapshot.machine.id, record, project: selectedCreateProject.project },
+        createdRecord,
         ...current.filter((item) => !(item.machine.id === selectedCreateMachine.machine.id && item.record.key === record.key))
       ].sort(sessionActivityCompare))
       setCreateTitle("")
@@ -832,6 +997,12 @@ export function NativeSessionHome({
         <div className="hr-native-home-notice" role="alert">
           <span><strong>{t("sf.refreshFailed")}</strong> {t("sf.refreshFailedDetail")}</span>
           <button type="button" className="tdw-button secondary" onClick={() => setRevision((value) => value + 1)} disabled={loading}>{t("sf.retry")}</button>
+        </div>
+      ) : null}
+      {olderSessionError ? (
+        <div className="hr-native-home-notice" role="alert">
+          <span><strong>{t("sf.olderSessionsFailed")}</strong> {olderSessionError}</span>
+          <button type="button" className="tdw-button secondary" onClick={() => olderPageTargets.length ? void loadOlderSessions() : setRevision((value) => value + 1)} disabled={loading || loadingOlder}>{t("sf.retry")}</button>
         </div>
       ) : null}
 
@@ -990,6 +1161,15 @@ export function NativeSessionHome({
           )
         })}
       </div>
+
+      {loaded && olderPageTargets.length > 0 ? (
+        <div className="hr-native-home-pagination">
+          <button type="button" className="tdw-button secondary" onClick={() => void loadOlderSessions()} disabled={loading || loadingOlder} aria-busy={loadingOlder}>
+            {loadingOlder ? <LoadingIcon size={14} /> : null}
+            {t(loadingOlder ? "sf.loadingOlderSessions" : "sf.loadOlderSessions")}
+          </button>
+        </div>
+      ) : null}
 
       {loaded && records.length > 0 && filteredGroups.length === 0 ? (
         <div className="hr-native-home-empty compact"><SearchIcon size={18} /><span>{t("sf.noMatch")}</span></div>

--- a/web/src/components/native-session-home.tsx
+++ b/web/src/components/native-session-home.tsx
@@ -86,8 +86,10 @@ type Props = {
   selectedState?: SessionPresentationState
   /** Fires when native Session discovery has settled at least once for the current machines. */
   onDiscoveredChange?: (discovered: boolean) => void
-  /** Session keys already deleted server-side but still present in the last discovered rail snapshot. */
+  /** Session keys whose delete transition is still visible, including the in-flight request. */
   deletingKeys?: ReadonlySet<string>
+  /** Successful deletes suppressed from cached pages even when an older page cannot be re-read. */
+  deletedKeys?: ReadonlySet<string>
   /** Called once a fresh discovery proves a deleting Session has disappeared from the native index. */
   onDeletionSettled?: (key: string) => void
 }
@@ -331,6 +333,7 @@ export function NativeSessionHome({
   selectedKey,
   selectedState,
   deletingKeys,
+  deletedKeys,
   onDeletionSettled
 }: Props) {
   const t = useTranslator()
@@ -497,7 +500,7 @@ export function NativeSessionHome({
           }))
           const refreshed = refreshCursorPage(existing, firstRecords, page.nextCursor, recordKey)
           const recordsForScope = uniqueSessionRecords(refreshed.records)
-            .filter((item) => !deletingKeys?.has(recordKey(item)))
+            .filter((item) => !deletedKeys?.has(recordKey(item)))
           pageCache.current.set(scope, {
             machine: result.machine,
             machineID: result.snapshot.machine.id,
@@ -530,7 +533,7 @@ export function NativeSessionHome({
       if (!cancelled) setLoading(false)
     })
     return () => { cancelled = true }
-  }, [sources, revision, refreshToken, discoveryReady, machineSignature, deletingKeys])
+  }, [sources, revision, refreshToken, discoveryReady, machineSignature, deletedKeys])
 
   useEffect(() => {
     if (!loaded || document.visibilityState !== "visible") return
@@ -731,7 +734,7 @@ export function NativeSessionHome({
         ...current,
         ...appended,
         records: uniqueSessionRecords(appended.records)
-          .filter((item) => !deletingKeys?.has(recordKey(item)))
+          .filter((item) => !deletedKeys?.has(recordKey(item)))
       })
     }
     setRecords(uniqueSessionRecords([...pageCache.current.values()].flatMap((entry) => entry.records)))

--- a/web/src/components/standalone-universal-workspace.tsx
+++ b/web/src/components/standalone-universal-workspace.tsx
@@ -343,6 +343,9 @@ function NativeSessionsWorkspace({
   // A successful DELETE is authoritative before the next Session-index read completes. Keep that
   // stale rail row as a disabled "Deleting..." tombstone instead of briefly presenting it as usable.
   const [deletingSessionKeys, setDeletingSessionKeys] = useState<Set<string>>(() => new Set())
+  // Paginated discovery cannot re-read every cached older page after DELETE. Once the server accepts
+  // the mutation, suppress that exact native identity from retained pages for this app lifetime.
+  const [deletedSessionKeys, setDeletedSessionKeys] = useState<Set<string>>(() => new Set())
   // Machines answering is only the first half of starting up; the Session list is the half the user
   // is actually waiting for. See the startup states below.
   const [sessionsDiscovered, setSessionsDiscovered] = useState(machines.length === 0)
@@ -691,6 +694,12 @@ function NativeSessionsWorkspace({
   function handleSessionDeleted(key: string) {
     // Session discovery is the only data that changed. Refreshing the whole machine here used to
     // light the global top-right spinner and could leave it spinning behind a perfectly valid DELETE.
+    setDeletedSessionKeys((current) => {
+      if (current.has(key)) return current
+      const next = new Set(current)
+      next.add(key)
+      return next
+    })
     setListRevision((value) => value + 1)
     if (selected?.key !== key) return
     setSelected(null)
@@ -779,6 +788,7 @@ function NativeSessionsWorkspace({
             selectedKey={selected?.key}
             selectedState={selectedState}
             deletingKeys={deletingSessionKeys}
+            deletedKeys={deletedSessionKeys}
             onDeletionSettled={handleSessionDeletionSettled}
           />
         </aside>

--- a/web/src/components/taskdesk-conversation.tsx
+++ b/web/src/components/taskdesk-conversation.tsx
@@ -1,7 +1,7 @@
 import { memo, useEffect, useMemo, useRef, useState, type KeyboardEvent, type ReactNode } from "react"
 import { ATTACHMENT_MAX_COUNT, fileToAttachment, type AttachmentPart } from "../attachments"
 import type { CommandInfo, MessageEnvelope } from "../types"
-import { ChatIcon, CloseIcon, JumpToBottomIcon, JumpToTopIcon, LoadingIcon, PaperclipIcon, StopCircleIcon } from "../Icons"
+import { AlertIcon, ChatIcon, CloseIcon, JumpToBottomIcon, JumpToTopIcon, LoadingIcon, PaperclipIcon, StopCircleIcon } from "../Icons"
 import "../taskdesk-conversation.css"
 import "../taskdesk-conversation-fixes.css"
 import "../taskdesk-history-loader.css"
@@ -54,6 +54,8 @@ type Props = {
   showWaitingIndicator?: boolean
   placeholder?: string
   emptyText?: string
+  /** A failed transcript read is not a valid empty conversation and must remain visible as such. */
+  transcriptError?: string
   directory?: string
   footerHint?: string
   renderMessage?: (message: MessageEnvelope) => ReactNode
@@ -61,7 +63,8 @@ type Props = {
 
 type TranscriptProps = Pick<Props,
   "messages" | "agentLabel" | "agentBackend" | "loading" | "waiting" | "ready" | "hasMore" |
-  "loadingOlder" | "onLoadOlder" | "sending" | "workingLabel" | "showWaitingIndicator" | "emptyText" | "renderMessage"
+  "loadingOlder" | "onLoadOlder" | "sending" | "workingLabel" | "showWaitingIndicator" | "emptyText" |
+  "transcriptError" | "renderMessage"
 >
 
 type JumpAffordances = { top: boolean; bottom: boolean }
@@ -147,6 +150,7 @@ function transcriptPropsEqual(previous: TranscriptProps, next: TranscriptProps):
     && previous.workingLabel === next.workingLabel
     && previous.showWaitingIndicator === next.showWaitingIndicator
     && previous.emptyText === next.emptyText
+    && previous.transcriptError === next.transcriptError
 }
 
 /**
@@ -170,6 +174,7 @@ const ConversationTranscript = memo(function ConversationTranscript({
   workingLabel,
   showWaitingIndicator = true,
   emptyText = "This conversation has no messages yet.",
+  transcriptError,
   renderMessage
 }: TranscriptProps) {
   const transcriptRef = useRef<HTMLDivElement>(null)
@@ -325,7 +330,14 @@ const ConversationTranscript = memo(function ConversationTranscript({
                 </button>
               </div>
             ) : null}
-            {messages.length === 0 && !waiting ? (
+            {transcriptError ? (
+              <div className="uw-empty-panel uw-transcript-error" role="alert">
+                <AlertIcon size={24} />
+                <strong>Session history could not be loaded.</strong>
+                <span>{transcriptError}</span>
+              </div>
+            ) : null}
+            {messages.length === 0 && !waiting && !transcriptError ? (
               <div className="uw-empty-panel"><ChatIcon size={24} /><strong>{emptyText}</strong></div>
             ) : renderMessage
               ? messages.map((message) => renderMessage(message))
@@ -387,6 +399,7 @@ export function TaskDeskConversation({
   showWaitingIndicator = true,
   placeholder,
   emptyText = "This conversation has no messages yet.",
+  transcriptError,
   directory,
   footerHint,
   renderMessage
@@ -480,6 +493,7 @@ export function TaskDeskConversation({
         workingLabel={workingLabel}
         showWaitingIndicator={showWaitingIndicator}
         emptyText={emptyText}
+        transcriptError={transcriptError}
         renderMessage={renderMessage}
       />
 

--- a/web/src/components/work-thread-conversation.tsx
+++ b/web/src/components/work-thread-conversation.tsx
@@ -349,6 +349,7 @@ export function WorkThreadConversation({
   const [awaitingReplyTurnID, setAwaitingReplyTurnID] = useState<string | null>(null)
   const [stopping, setStopping] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [transcriptError, setTranscriptError] = useState<string | null>(null)
   const [modelError, setModelError] = useState<string | null>(null)
   const [questions, setQuestions] = useState<QuestionRequest[]>([])
   const [permissions, setPermissions] = useState<PermissionRequest[]>([])
@@ -438,6 +439,7 @@ export function WorkThreadConversation({
     feedsRef.current = {}
     setLoading(true)
     setError(null)
+    setTranscriptError(null)
     setModelError(null)
     setQuestions([])
     setPermissions([])
@@ -495,7 +497,9 @@ export function WorkThreadConversation({
       if (Object.keys(feedsRef.current).length === 0) setLoading(true)
       return
     }
+    setTranscriptError(null)
     if (Object.keys(feedsRef.current).length === 0) setLoading(true)
+    let firstFailure: string | null = null
     void Promise.all(missing.map(async (target) => {
       try {
         const feed = await loadInitialTarget(target)
@@ -503,11 +507,15 @@ export function WorkThreadConversation({
         setFeeds((current) => current[target.sessionID] ? current : { ...current, [target.sessionID]: feed })
       } catch (reason) {
         if (isTransportFailure(reason)) onConnectionIssueRef.current?.()
+        firstFailure ??= reason instanceof Error ? reason.message : String(reason)
         // Durable Session history can outlive a live transport. Persisted turn outcome/error is the safe
         // fallback; do not invent a transcript association when the Session cannot be read.
       }
     })).finally(() => {
-      if (!cancelled && loadGeneration.current === generation) setLoading(false)
+      if (!cancelled && loadGeneration.current === generation) {
+        setTranscriptError(firstFailure)
+        setLoading(false)
+      }
     })
     return () => { cancelled = true }
   }, [targetSignature, loadInitialTarget, interactionEnabled])
@@ -1109,6 +1117,7 @@ export function WorkThreadConversation({
         stopping={stopping}
         placeholder={`Message ${agentLabel(destinationAgents, targetAgentID)}…`}
         emptyText="Start the conversation. You can continue with another coding agent at any time."
+        transcriptError={transcriptError || undefined}
         footerHint={hasAttention
           ? "Your input is required before the agent can continue"
           : modelBootstrapBlocked

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -332,6 +332,9 @@ type TranslationKey =
   | 'sf.groupSessions'
   | 'sf.showMore'
   | 'sf.showLess'
+  | 'sf.loadOlderSessions'
+  | 'sf.loadingOlderSessions'
+  | 'sf.olderSessionsFailed'
   | 'sf.noWorkingDirectory'
   | 'sf.findingSessions'
   | 'sf.refreshFailed'
@@ -799,6 +802,9 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'sf.groupSessions': '{name} Sessions',
     'sf.showMore': 'Show {count} more',
     'sf.showLess': 'Show less',
+    'sf.loadOlderSessions': 'Load older Sessions',
+    'sf.loadingOlderSessions': 'Loading older Sessions…',
+    'sf.olderSessionsFailed': 'Older Sessions could not be loaded.',
     'sf.noWorkingDirectory': 'No working directory',
     'sf.findingSessions': 'Finding Sessions from your coding agents…',
     'sf.refreshFailed': 'Session refresh failed.',
@@ -1266,6 +1272,9 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'sf.groupSessions': 'Sessioni di {name}',
     'sf.showMore': 'Mostra altre {count}',
     'sf.showLess': 'Mostra meno',
+    'sf.loadOlderSessions': 'Carica sessioni precedenti',
+    'sf.loadingOlderSessions': 'Caricamento sessioni precedenti…',
+    'sf.olderSessionsFailed': 'Impossibile caricare le sessioni precedenti.',
     'sf.noWorkingDirectory': 'Nessuna directory di lavoro',
     'sf.findingSessions': 'Ricerca delle sessioni nei tuoi coding agent…',
     'sf.refreshFailed': 'Aggiornamento delle sessioni non riuscito.',
@@ -1685,6 +1694,9 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'sf.groupSessions': '{name} 的工作階段',
     'sf.showMore': '再顯示 {count} 個',
     'sf.showLess': '顯示較少',
+    'sf.loadOlderSessions': '載入較舊的工作階段',
+    'sf.loadingOlderSessions': '正在載入較舊的工作階段…',
+    'sf.olderSessionsFailed': '無法載入較舊的工作階段。',
     'sf.noWorkingDirectory': '沒有工作目錄',
     'sf.findingSessions': '正在從編碼代理尋找工作階段…',
     'sf.refreshFailed': '工作階段重新整理失敗。',
@@ -2149,6 +2161,9 @@ const translations: Record<LanguageCode, Partial<Record<TranslationKey, string>>
     'sf.groupSessions': '{name} 的会话',
     'sf.showMore': '再显示 {count} 个',
     'sf.showLess': '收起',
+    'sf.loadOlderSessions': '加载较早的会话',
+    'sf.loadingOlderSessions': '正在加载较早的会话…',
+    'sf.olderSessionsFailed': '无法加载较早的会话。',
     'sf.noWorkingDirectory': '没有工作目录',
     'sf.findingSessions': '正在从编码代理查找会话…',
     'sf.refreshFailed': '会话刷新失败。',

--- a/web/src/native-session-discovery.test.mjs
+++ b/web/src/native-session-discovery.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import {
+  discoverAgentNativeSessionPage,
   discoverAgentNativeSessions,
   discoverMachineNativeSessions,
   nativeSessionConfig,
@@ -163,6 +164,59 @@ assert.deepEqual(await discoverAgentNativeSessions(base, disabled, {
   async listStatuses() { disabledReads += 1; return {} }
 }), [])
 assert.equal(disabledReads, 0)
+
+const pageCalls = []
+const page = await discoverAgentNativeSessionPage(base, codex, "opaque+/cursor==", {
+  async listGlobalSessionPage(config, cursor) {
+    pageCalls.push([config.agentId, cursor])
+    return {
+      sessions: [{
+        id: "older-codex",
+        title: "Older Codex",
+        directory: "/repo",
+        time: { created: 1, updated: 5 },
+        status: { type: "idle" }
+      }],
+      nextCursor: "tail"
+    }
+  },
+  async listSessions() {
+    throw new Error("a paged read must not fall back")
+  },
+  async listStatuses() {
+    throw new Error("inline page status must avoid a duplicate status read")
+  }
+})
+assert.deepEqual(pageCalls, [["codex", "opaque+/cursor=="]])
+assert.equal(page.records[0].key, "codex:older-codex")
+assert.deepEqual(page.records[0].status, { type: "idle" })
+assert.equal(page.nextCursor, "tail")
+
+let pagedFallbackReads = 0
+const initialFallback = await discoverAgentNativeSessionPage(base, pi, undefined, {
+  async listGlobalSessionPage() {
+    throw new Error("unsupported")
+  },
+  async listSessions() {
+    pagedFallbackReads += 1
+    return [{ id: "fallback-page", title: "Fallback", directory: "/repo", time: { created: 1, updated: 2 } }]
+  },
+  async listStatuses() {
+    return { "fallback-page": { type: "busy" } }
+  }
+})
+assert.equal(pagedFallbackReads, 1)
+assert.deepEqual(initialFallback.records.map((record) => record.key), ["pi:fallback-page"])
+assert.deepEqual(initialFallback.records[0].status, { type: "busy" })
+
+await assert.rejects(
+  discoverAgentNativeSessionPage(base, pi, "cursor-that-cannot-fall-back", {
+    async listGlobalSessionPage() { throw new Error("expired cursor") },
+    async listSessions() { throw new Error("must not be called") },
+    async listStatuses() { throw new Error("must not be called") }
+  }),
+  /expired cursor/
+)
 
 const machineClient = {
   async listGlobalSessions(config) {

--- a/web/src/native-session-discovery.test.mjs
+++ b/web/src/native-session-discovery.test.mjs
@@ -192,6 +192,58 @@ assert.equal(page.records[0].key, "codex:older-codex")
 assert.deepEqual(page.records[0].status, { type: "idle" })
 assert.equal(page.nextCursor, "tail")
 
+const nonPaginatedAgents = [
+  { id: "opencode", label: "OpenCode", backend: "opencode", transport: "http" },
+  { id: "omp", label: "Oh My Pi", backend: "omp", transport: "acp" },
+  { id: "pi", label: "PI", backend: "pi", transport: "acp" },
+  { id: "claude", label: "Claude Code", backend: "claude", transport: "acp" },
+  { id: "codex", label: "Codex", backend: "codex", transport: "acp" }
+].map((agent) => ({
+  ...agent,
+  managed: true,
+  state: "available",
+  capabilities: { sessions: true, abort: true, models: true },
+  contract: { sessions: { stop: "owned-session-native-cancel" } }
+}))
+const nonPaginatedCalls = []
+const nonPaginatedClient = {
+  async listGlobalSessionPage(config, cursor) {
+    nonPaginatedCalls.push([config.backend, config.agentId, cursor])
+    return {
+      sessions: [{
+        id: `${config.agentId}-existing`,
+        title: `${config.agentId} existing Session`,
+        directory: "/repo",
+        time: { created: 1, updated: 2 },
+        status: { type: "idle" }
+      }]
+    }
+  },
+  async listSessions() {
+    throw new Error("a successful single-page read must not use the stable fallback")
+  },
+  async listStatuses() {
+    throw new Error("inline page status must avoid a duplicate status read")
+  }
+}
+
+for (const agent of nonPaginatedAgents) {
+  const singlePage = await discoverAgentNativeSessionPage(base, agent, undefined, nonPaginatedClient)
+  assert.equal(singlePage.nextCursor, undefined, `${agent.id} must not expose a load-older cursor when none was returned`)
+  assert.deepEqual(singlePage.records.map((record) => ({
+    key: record.key,
+    backend: record.backend,
+    transport: record.transport,
+    status: record.status
+  })), [{
+    key: `${agent.id}:${agent.id}-existing`,
+    backend: agent.backend,
+    transport: agent.transport,
+    status: { type: "idle" }
+  }])
+}
+assert.deepEqual(nonPaginatedCalls, nonPaginatedAgents.map((agent) => [agent.backend, agent.id, undefined]))
+
 let pagedFallbackReads = 0
 const initialFallback = await discoverAgentNativeSessionPage(base, pi, undefined, {
   async listGlobalSessionPage() {

--- a/web/src/native-session-discovery.ts
+++ b/web/src/native-session-discovery.ts
@@ -186,6 +186,67 @@ export function nativeSessionSurfaceTarget(
 
 export type NativeSessionReadApi = Pick<typeof api, "listGlobalSessions" | "listSessions" | "listStatuses">
 
+export type NativeSessionPageReadApi = Pick<typeof api, "listGlobalSessionPage" | "listSessions" | "listStatuses">
+
+export type NativeSessionRecordPage = {
+  records: NativeSessionRecord[]
+  nextCursor?: string
+}
+
+function nativeSessionRecords(
+  agent: MachineAgentHost,
+  config: ServerConfig,
+  sessions: Session[],
+  statuses: Record<string, SessionStatus> = {}
+): NativeSessionRecord[] {
+  return sessions.map((session) => ({
+    key: `${agent.id}:${session.id}`,
+    agentId: agent.id,
+    agentLabel: agent.label || agent.id,
+    backend: config.backend,
+    transport: agent.transport,
+    stopCapability: agent.contract?.sessions?.stop,
+    abortSupported: agent.capabilities?.abort === true,
+    modelsSupported: agent.capabilities?.models === true,
+    commandsSupported: agent.capabilities?.commands === true,
+    renameSupported: agent.capabilities?.sessionRename === true,
+    deleteSupported: agent.capabilities?.sessionDelete === true,
+    session,
+    status: statuses[session.id] ?? session.status
+  }))
+}
+
+/**
+ * Read exactly one lightweight native Session page. A cursor belongs to the adapter connection and
+ * is forwarded untouched; only the initial page may fall back to the stable non-paged endpoint.
+ */
+export async function discoverAgentNativeSessionPage(
+  base: ServerConfig,
+  agent: MachineAgentHost,
+  cursor?: string,
+  client: NativeSessionPageReadApi = api
+): Promise<NativeSessionRecordPage> {
+  if (agent.capabilities?.sessions === false) return { records: [] }
+  const config = nativeSessionConfig(base, agent)
+  try {
+    const page = await client.listGlobalSessionPage(config, cursor)
+    const statuses = page.sessions.some((session) => !session.status)
+      ? await client.listStatuses(config).catch(() => ({} as Record<string, SessionStatus>))
+      : {}
+    return {
+      records: nativeSessionRecords(agent, config, page.sessions, statuses),
+      ...(page.nextCursor ? { nextCursor: page.nextCursor } : {})
+    }
+  } catch (error) {
+    if (cursor) throw error
+    const sessions = await client.listSessions(config)
+    const statuses = sessions.some((session) => !session.status)
+      ? await client.listStatuses(config).catch(() => ({} as Record<string, SessionStatus>))
+      : {}
+    return { records: nativeSessionRecords(agent, config, sessions, statuses) }
+  }
+}
+
 /**
  * Read-only discovery for one native harness. The experimental global listing is preferred because
  * it already provides pagination for large histories; harnesses that do not expose it fall back to
@@ -203,21 +264,7 @@ export async function discoverAgentNativeSessions(
   const config = nativeSessionConfig(base, agent)
   const sessions = await client.listGlobalSessions(config).catch(() => client.listSessions(config))
   const statuses = await client.listStatuses(config).catch(() => ({} as Record<string, SessionStatus>))
-  return sessions.map((session) => ({
-    key: `${agent.id}:${session.id}`,
-    agentId: agent.id,
-    agentLabel: agent.label || agent.id,
-    backend: config.backend,
-    transport: agent.transport,
-    stopCapability: agent.contract?.sessions?.stop,
-    abortSupported: agent.capabilities?.abort === true,
-    modelsSupported: agent.capabilities?.models === true,
-    commandsSupported: agent.capabilities?.commands === true,
-    renameSupported: agent.capabilities?.sessionRename === true,
-    deleteSupported: agent.capabilities?.sessionDelete === true,
-    session,
-    status: statuses[session.id]
-  }))
+  return nativeSessionRecords(agent, config, sessions, statuses)
 }
 
 /**

--- a/web/src/native-session-home.css
+++ b/web/src/native-session-home.css
@@ -291,6 +291,18 @@
   color: var(--tdw-text, #f5f6f8);
 }
 
+.hr-native-home-pagination {
+  display: flex;
+  justify-content: center;
+  padding: 12px 4px 2px;
+}
+
+.hr-native-home-pagination .tdw-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .hr-native-project-group + .hr-native-project-group {
   margin-top: 16px;
 }
@@ -542,6 +554,7 @@
   .hr-native-project-heading small { max-width: 62vw; }
   .hr-native-session-row { min-height: 56px; padding-block: 8px; }
   .hr-native-project-more { min-height: 44px; }
+  .hr-native-home-pagination .tdw-button { min-height: 44px; }
   .hr-native-create-panel { grid-template-columns: 1fr; }
   .hr-native-create-panel > label,
   .hr-native-create-actions { grid-column: 1; }

--- a/web/src/native-session-home.test.mjs
+++ b/web/src/native-session-home.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { readFileSync } from "node:fs"
-import { sessionTreeRows } from "./components/native-session-home.tsx"
+import { appendCursorPage, refreshCursorPage, sessionTreeRows } from "./components/native-session-home.tsx"
 import { canCreateNativeSession } from "./native-session-create.ts"
 
 function item(id, parentID) {
@@ -46,6 +46,46 @@ assert.deepEqual(rows.map(({ item: row, depth }) => [row.record.session.id, dept
 ])
 assert.equal(new Set(rows.map(({ item: row }) => row.record.session.id)).size, 7, "cycles or missing parents must never hide or duplicate a native Session")
 
+const byID = (record) => record.id
+let cursorPage = refreshCursorPage(undefined, [
+  { id: "recent-1", title: "Recent one" },
+  { id: "recent-2", title: "Recent two" }
+], "page-2", byID)
+assert.deepEqual(cursorPage, {
+  records: [
+    { id: "recent-1", title: "Recent one" },
+    { id: "recent-2", title: "Recent two" }
+  ],
+  firstPageCursor: "page-2",
+  nextCursor: "page-2",
+  loadedOlder: false
+})
+
+cursorPage = appendCursorPage(cursorPage, [
+  { id: "older-1", title: "Older" },
+  { id: "recent-2", title: "Updated at the page boundary" }
+], "page-3", byID)
+assert.equal(cursorPage.loadedOlder, true)
+assert.equal(cursorPage.nextCursor, "page-3")
+assert.equal(cursorPage.records.find((record) => record.id === "recent-2").title, "Updated at the page boundary")
+
+cursorPage = refreshCursorPage(cursorPage, [
+  { id: "newest", title: "Newest" },
+  { id: "recent-1", title: "Fresh status/title" }
+], "new-page-2", byID)
+assert.deepEqual(new Set(cursorPage.records.map(byID)), new Set(["newest", "recent-1", "recent-2", "older-1"]))
+assert.equal(cursorPage.records.find((record) => record.id === "recent-1").title, "Fresh status/title")
+assert.equal(cursorPage.firstPageCursor, "new-page-2", "a failed old tail can restart from the latest first-page cursor")
+assert.equal(cursorPage.nextCursor, "page-3", "a recurring refresh must not silently jump an in-progress older-page chain")
+
+const replacementPage = refreshCursorPage({
+  records: [{ id: "stale", title: "Stale" }],
+  firstPageCursor: "old",
+  nextCursor: "old",
+  loadedOlder: false
+}, [{ id: "current", title: "Current" }], undefined, byID)
+assert.deepEqual(replacementPage.records.map(byID), ["current"], "before manual pagination, page one remains an exact refresh")
+
 for (const [backend, transport] of [
   ["opencode", "http"],
   ["omp", "acp"],
@@ -77,7 +117,7 @@ assert.equal(canCreateNativeSession({
 const source = readFileSync(new URL("./components/native-session-home.tsx", import.meta.url), "utf8")
 assert.match(source, /presentationOverrides/, "live detail status must survive selecting another Session")
 assert.match(source, /\{ \.\.\.current, \[selectedKey\]: selectedState \}/, "the status bridge must be keyed by native Session identity")
-assert.match(source, /setPresentationOverrides\(\{\}\)[\s\S]*setRecords\(results\.flatMap/, "a successful native discovery must retire temporary presentation overrides")
+assert.match(source, /setPresentationOverrides\(\{\}\)[\s\S]*setRecords\(uniqueSessionRecords/, "a successful native discovery must retire temporary presentation overrides")
 assert.match(source, /presentationOverrides\[targetKey\]/, "non-selected rows must retain their last observed live state until discovery reconciles them")
 assert.match(source, /createMachineID/, "native Session creation must have an explicit machine selection independent of the list filter")
 assert.match(source, /createMachines\.map/, "the create panel must render the available machine choices")
@@ -92,5 +132,10 @@ assert.match(source, /if \(!loaded \|\| createMachines\.length === 0\) return/, 
 assert.match(source, /t\("sf\.loadingSessions"\)/, "the empty rail must say Sessions are loading instead of implying the machine is disconnected")
 assert.match(source, /const discoveryReady = sources\.every\(\(\{ state \}\) => state !== "loading"\)/, "Session discovery must not settle while machine probes are still in flight")
 assert.match(source, /if \(!discoveryReady\) \{[\s\S]*setLoading\(true\)[\s\S]*return/, "the rail must remain explicitly loading until machine discovery can produce real Session results")
+assert.match(source, /discoverAgentNativeSessionPage\(machine\.config, agent\)/, "recurring discovery must fetch exactly the first native Session page")
+assert.doesNotMatch(source, /discoverMachineNativeSessions/, "the recurring rail must not eagerly flatten every Session page")
+assert.match(source, /entry\.nextCursor[\s\S]*loadOlderSessions/, "older native Session pages must require an explicit user action")
+assert.match(source, /refreshCursorPage\(existing, firstRecords, page\.nextCursor/, "a recurring first-page refresh must preserve the manual pagination tail")
+assert.match(source, /agent\.processID/, "adapter restarts must invalidate connection-bound ACP cursors")
 
 console.log("native Session Home tree, create parity and stable-selection UX tests passed")

--- a/web/src/taskdesk-conversation-component.test.mjs
+++ b/web/src/taskdesk-conversation-component.test.mjs
@@ -43,6 +43,15 @@ test("shared conversation owns paging and scroll preservation", () => {
   assert.match(component, /nearBottomRef/)
 })
 
+test("a failed initial transcript read cannot masquerade as an empty conversation", () => {
+  assert.match(controller, /const \[transcriptError, setTranscriptError\] = useState/)
+  assert.match(controller, /catch \(reason\)[\s\S]*setTranscriptError\(firstFailure\)/)
+  assert.match(controller, /transcriptError=\{transcriptError \|\| undefined\}/)
+  assert.match(component, /className="uw-empty-panel uw-transcript-error" role="alert"/)
+  assert.match(component, />Session history could not be loaded\.</)
+  assert.match(component, /messages\.length === 0 && !waiting && !transcriptError/)
+})
+
 test("conversation mutations reconcile ambiguous outcomes instead of blindly resending", () => {
   assert.match(taskClient, /clientRequestId/)
   assert.match(taskClient, /PENDING_CONTINUE_STORAGE_PREFIX/)

--- a/web/src/taskdesk-performance.test.mjs
+++ b/web/src/taskdesk-performance.test.mjs
@@ -20,7 +20,9 @@ test("Session list never fans out transcript reads for card previews", () => {
   const home = read("./components/native-session-home.tsx")
   assert.doesNotMatch(home, /loadMessagePage/)
   assert.doesNotMatch(home, /loadLatestMessage/)
-  assert.match(home, /discoverMachineNativeSessions/)
+  assert.match(home, /discoverAgentNativeSessionPage\(machine\.config, agent\)/)
+  assert.match(home, /loadOlderSessions/)
+  assert.doesNotMatch(home, /discoverMachineNativeSessions/)
 })
 
 test("Session detail keeps bounded paging and memoized transcript rendering", () => {
@@ -40,6 +42,8 @@ test("ACP bridge retains lightweight Session indexing, cursor paging and diagnos
   const service = read("../../bridge/src/acp-service.js")
 
   assert.match(source, /const listVisibleSessionMetadata = async/)
+  assert.match(source, /acp\.listSessionPage\(cursor\)/)
+  assert.match(source, /setHeader\("x-next-cursor"/)
   assert.match(source, /const MAX_MESSAGE_PAGE = 500/)
   assert.match(source, /service\.messagePage\(sessionID/)
   assert.match(source, /X-Next-Cursor/)

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -171,6 +171,9 @@ export type Session = {
     pattern?: string
     action?: string
   }>
+  /** Lightweight native discovery includes status on each page so loading older Sessions does not
+   * require a second full-index status request. */
+  status?: SessionStatus
 }
 
 export type SessionStatus = {


### PR DESCRIPTION
## Summary

- preserve the opaque ACP `session/list` cursor through the bridge and web API
- keep the recurring Session rail refresh bounded to the first page
- add explicit incremental loading for older pages, with deduplication and cursor reset after adapter changes
- retain owned Session metadata and status enrichment without loading transcript snapshots
- keep an in-flight Session deletion visible until DELETE succeeds, then suppress that exact identity from cached pages

## Why

Codex ACP returns native Sessions in pages of 25. Harness Remote currently drops `nextCursor`, so older Sessions are invisible. Eagerly flattening the complete catalog fixes the data loss but makes the 30-second rail refresh expensive: the observed 794-Session response was about 317 KB and took about 10.5 seconds with a warm adapter.

This change keeps ordinary discovery cheap. Page one refreshes automatically; each `Load older Sessions` action advances one page for the applicable harnesses and keeps the accumulated rows in the client.

The Chromium gate also exposed browser fixtures that still served the machine-wide model endpoint after #381 switched existing Sessions to their Session-scoped catalog. Those fixtures now exercise the merged endpoint contract. The same gate caught premature cached-row suppression during an in-flight DELETE; pending and successful deletion states are now distinct.

## Verification

- `node --test test/acp-client.test.js test/server.test.js` — 70/70
- `npm run test:ci:full` — pass
- `npm run build` — pass
- `npm run build:desktop` — pass
- `npm run test:desktop` — 20/20
- all five native Session Chromium product scenarios — pass locally and in GitHub CI
- live Codex adapter smoke — 25 rows on page one, 25 non-overlapping rows on page two, next cursor retained (about 5.0s cold / 0.55s warm)
- GitHub CI — type/regressions, Bridge on Windows and macOS, Chromium product smoke, macOS application menu, and Debug APK all pass

The full bridge suite passes 474/475 on this Windows host. The unchanged `project-catalog` symlink fixture receives `EPERM` before reaching its assertion because this account cannot create symlinks.

No Android package or running Harness daemon was replaced for this test.
