### PR TITLE
fix(ui): balance native Session conversation column

### DIFF
--- a/web/src/controls-preview.ts
+++ b/web/src/controls-preview.ts
@@ -40,6 +40,7 @@ import "./v3-mobile-a11y-fix.css"
 import "./v3-mobile-product-parity.css"
 import "./session-first-navigation.css"
 import "./session-first-workbench.css"
+import "./session-first-centering-fix.css"
 import "./session-handoff-routing.css"
 import "./beautiful-ui-controls.css"
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -25,6 +25,7 @@ import "./v3-mobile-a11y-fix.css"
 import "./v3-mobile-product-parity.css"
 import "./session-first-navigation.css"
 import "./session-first-workbench.css"
+import "./session-first-centering-fix.css"
 import "./session-handoff-routing.css"
 // Loaded last: the ported controls refine rules the sheets above already set, and settling those
 // ties by load order is what keeps the port free of `!important`.

--- a/web/src/session-first-centering-fix.css
+++ b/web/src/session-first-centering-fix.css
@@ -1,0 +1,25 @@
+/* Session pane centering
+   Keep the reading column centered inside the detail pane. PR #309 intentionally shifted the
+   transcript left by half the Session rail to center it against the whole browser window; in the
+   current Session-first layout that makes the transcript, empty state and composer all read as
+   left-shifted inside the pane. The rail is navigation chrome, not part of the conversation's
+   containing block, so the conversation should center within the detail surface itself. */
+.hr-native-workspace {
+  --hrsf-optical-shift: 0px;
+}
+
+/* Empty/loading states are not message rows. Keep their icon and copy together as a centered state
+   so the Chat icon cannot be mistaken for an avatar or for the corner activity indicator. */
+.hr-native-session-observer .uw-empty-panel {
+  min-height: clamp(140px, 28vh, 280px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  text-align: center;
+}
+
+.hr-native-session-observer .uw-empty-panel > strong {
+  max-width: 560px;
+}

--- a/web/src/session-first-centering-fix.css
+++ b/web/src/session-first-centering-fix.css
@@ -1,15 +1,31 @@
-/* Session pane centering
-   Keep the reading column centered inside the detail pane. PR #309 intentionally shifted the
-   transcript left by half the Session rail to center it against the whole browser window; in the
-   current Session-first layout that makes the transcript, empty state and composer all read as
-   left-shifted inside the pane. The rail is navigation chrome, not part of the conversation's
-   containing block, so the conversation should center within the detail surface itself. */
+/* Balanced Session reading column
+   A persistent navigation rail changes the visual weight of the window, so perfectly centering the
+   conversation inside the detail pane can read a little too far right. The opposite extreme from
+   PR #309 was more disruptive: shifting by half the rail mathematically centered the conversation
+   on the whole window, but on common desktop widths it consumed almost all of the inner left gutter
+   and made transcript, empty state and composer look attached to the rail.
+
+   Follow the desktop coding-client pattern instead: the rail remains its own navigation surface,
+   the chat keeps a stable bounded reading column, and only a modest optical correction compensates
+   for the rail's visual weight. One fifth of the rail, capped at 64px, is intentionally much smaller
+   than the old 150-178px half-rail shift. The existing max() in the workbench alignment formulas
+   automatically reduces the effective shift when the detail pane has little spare width. */
 .hr-native-workspace {
-  --hrsf-optical-shift: 0px;
+  --hrsf-optical-shift: min(calc(var(--hrsf-rail-width) / 5), 64px);
 }
 
-/* Empty/loading states are not message rows. Keep their icon and copy together as a centered state
-   so the Chat icon cannot be mistaken for an avatar or for the corner activity indicator. */
+/* On phone/compact layouts the Session rail becomes a separate full-screen sheet. There is no
+   persistent left-hand visual weight to compensate for, so the conversation returns to true pane
+   centering. Keep this override here because this stylesheet loads after session-first-workbench.css. */
+@media (max-width: 780px), (pointer: coarse) and (min-width: 600px) and (max-height: 640px) {
+  .hr-native-workspace {
+    --hrsf-optical-shift: 0px;
+  }
+}
+
+/* Empty/loading states are states, not message rows. Keep their icon and copy together on the same
+   reading column and center the group so the Chat icon cannot be mistaken for an avatar or for the
+   corner activity indicator. The composer remains the primary action below. */
 .hr-native-session-observer .uw-empty-panel {
   min-height: clamp(140px, 28vh, 280px);
   display: flex;

--- a/web/src/v3-topbar-layout.test.mjs
+++ b/web/src/v3-topbar-layout.test.mjs
@@ -37,11 +37,12 @@ test("the native Session rail disappears when the mobile detail takes over", () 
   assert.equal(existsSync(new URL("./components/conversation-workspace.tsx", import.meta.url)), false)
 })
 
-test("the native Session conversation centers inside the detail pane", () => {
-  assert.match(centering, /--hrsf-optical-shift: 0px;/)
+test("the native Session conversation uses a bounded optical offset", () => {
+  assert.match(centering, /--hrsf-optical-shift: min\(calc\(var\(--hrsf-rail-width\) \/ 5\), 64px\);/)
+  assert.match(centering, /@media \(max-width: 780px\)[\s\S]*?--hrsf-optical-shift: 0px;/)
   assert.match(centering, /\.hr-native-session-observer \.uw-empty-panel \{[\s\S]*?align-items: center;[\s\S]*?text-align: center;/)
   assert.ok(
     main.indexOf('session-first-centering-fix.css') > main.indexOf('session-first-workbench.css'),
-    "the centering correction must load after the workbench rules it corrects"
+    "the optical correction must load after the workbench rules it refines"
   )
 })

--- a/web/src/v3-topbar-layout.test.mjs
+++ b/web/src/v3-topbar-layout.test.mjs
@@ -5,6 +5,8 @@ import test from "node:test"
 const css = readFileSync(new URL("./taskdesk-workthreads.css", import.meta.url), "utf8")
 const workspace = readFileSync(new URL("./components/standalone-universal-workspace.tsx", import.meta.url), "utf8")
 const workbench = readFileSync(new URL("./session-first-workbench.css", import.meta.url), "utf8")
+const centering = readFileSync(new URL("./session-first-centering-fix.css", import.meta.url), "utf8")
+const main = readFileSync(new URL("./main.tsx", import.meta.url), "utf8")
 const topbar = css.match(/\.tdw-topbar \{[\s\S]*?\n\}/)?.[0] || ""
 
 test("the top bar action group is content-sized", () => {
@@ -33,4 +35,13 @@ test("the native Session rail disappears when the mobile detail takes over", () 
   assert.match(workbench, /\.hr-native-workspace-body \{[\s\S]*?grid-template-columns: 1fr/)
   assert.match(workbench, /\.hr-rail-resizer \{[\s\S]*?display: none/)
   assert.equal(existsSync(new URL("./components/conversation-workspace.tsx", import.meta.url)), false)
+})
+
+test("the native Session conversation centers inside the detail pane", () => {
+  assert.match(centering, /--hrsf-optical-shift: 0px;/)
+  assert.match(centering, /\.hr-native-session-observer \.uw-empty-panel \{[\s\S]*?align-items: center;[\s\S]*?text-align: center;/)
+  assert.ok(
+    main.indexOf('session-first-centering-fix.css') > main.indexOf('session-first-workbench.css'),
+    "the centering correction must load after the workbench rules it corrects"
+  )
 })


### PR DESCRIPTION
Refines the Session-first desktop conversation geometry introduced by #309 without reverting the rest of that UI work.

The previous #309 rule shifted the transcript left by half the Session rail width. That mathematically centers the reading column on the whole window, but on common desktop widths it consumes almost all of the detail pane's inner left gutter, so the transcript, empty state and composer look attached to the rail. The first revision of this PR over-corrected in the opposite direction by removing the shift entirely.

This revision follows the desktop coding-client pattern more closely: a persistent session/navigation rail remains a separate surface, while the conversation keeps a stable bounded reading column with only modest optical compensation for the rail's visual weight.

- replace the half-rail shift with a bounded `min(rail / 5, 64px)` optical correction;
- rely on the existing `max()` alignment formulas to naturally reduce the effective shift when the detail pane has little spare width;
- force the shift to zero on phone/compact layouts where the rail is no longer persistent;
- keep transcript, empty/loading state and composer on the same reading geometry;
- render the empty/loading state as a centered state with its icon above the copy, so it cannot read like a misplaced message row or activity indicator;
- keep the controls preview import order synchronized;
- add regression coverage to the existing v3 product UI suite.

Reference behavior: Codex Desktop keeps a dedicated left thread rail and a stable, generously inset conversation/composer column; Claude Code Desktop likewise treats the session sidebar as navigation beside independently laid-out/resizable workspace panes. This PR adopts that principle rather than copying either product's pixel values.

No ACP, daemon, harness adapter, model, Session loading, routing or backend behavior is changed. UI/CSS only.