### PR TITLE
fix: restore current Codex session history

### DIFF
--- a/bridge/src/codex-session-history.js
+++ b/bridge/src/codex-session-history.js
@@ -18,16 +18,35 @@ function recordFromLine(line) {
   }
 }
 
+function textFromCompletedItem(item) {
+  if (item?.type === "Reasoning") {
+    return Array.isArray(item.summary_text)
+      ? item.summary_text.filter((text) => typeof text === "string" && text).join("\n\n")
+      : ""
+  }
+  if (item?.type !== "UserMessage" && item?.type !== "AgentMessage") return ""
+  return Array.isArray(item.content)
+    ? item.content
+      .filter((part) => typeof part?.text === "string" && part.text)
+      .map((part) => part.text)
+      .join("\n\n")
+    : ""
+}
+
 function messageFromRecord(sessionID, record, offset) {
   if (record?.type !== "event_msg") return undefined
   const payload = record.payload
-  const role = payload?.type === "user_message" ? "user"
-    : payload?.type === "agent_message" || payload?.type === "agent_reasoning" ? "assistant"
-    : undefined
+  const completedItem = payload?.type === "item_completed" ? payload.item : undefined
+  const role = payload?.type === "user_message" || completedItem?.type === "UserMessage" ? "user"
+    : payload?.type === "agent_message" || payload?.type === "agent_reasoning"
+      || completedItem?.type === "AgentMessage" || completedItem?.type === "Reasoning" ? "assistant"
+      : undefined
   if (!role) return undefined
 
-  const type = payload.type === "agent_reasoning" ? "reasoning" : "text"
-  const text = payload.type === "agent_reasoning" ? payload.text : payload.message
+  const type = payload.type === "agent_reasoning" || completedItem?.type === "Reasoning" ? "reasoning" : "text"
+  const text = completedItem ? textFromCompletedItem(completedItem)
+    : payload.type === "agent_reasoning" ? payload.text
+      : payload.message
   if (typeof text !== "string" || !text) return undefined
 
   // Rollouts are append-only. A byte offset is therefore both unique inside the file and stable as
@@ -138,9 +157,11 @@ async function readCodexPage(file, sessionID, { limit = 100, before } = {}) {
  * lock, so those sessions can be shown even while Codex itself owns them.
  *
  * The transcript comes from the `event_msg` records rather than the `response_item` ones: only the
- * former carry what the user actually saw. The latter also hold the instruction blocks Codex feeds
- * the model, AGENTS.md, the plugin list and desktop app context, under the `user` role, which would
- * surface as the user's own turns.
+ * former carry what the user actually saw. Current Codex versions wrap visible turns in
+ * `item_completed` (`UserMessage`, `AgentMessage`, and `Reasoning`), while older rollouts use the
+ * direct `user_message`, `agent_message`, and `agent_reasoning` event types. The `response_item`
+ * records also hold instruction blocks Codex feeds the model, AGENTS.md, the plugin list and desktop
+ * app context under the `user` role, which would surface as the user's own turns.
  */
 export function createCodexHistoryLoader(sessionRoot = path.join(homedir(), ".codex", "sessions")) {
   const sessionFiles = new Map()

--- a/bridge/test/codex-session-history.test.js
+++ b/bridge/test/codex-session-history.test.js
@@ -52,6 +52,37 @@ test("reads a Codex rollout as the conversation the user saw", async () => {
   }
 })
 
+test("reads current Codex item-completed rollout events without exposing model input", async () => {
+  const root = await writeRollout([
+    { timestamp: "2026-09-03T07:55:05.000Z", type: "response_item", payload: { type: "message", role: "developer", content: [{ type: "input_text", text: "<skills_instructions>private model input</skills_instructions>" }] } },
+    { timestamp: "2026-09-03T07:55:05.100Z", type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "# AGENTS.md instructions" }] } },
+    { timestamp: "2026-09-03T07:55:05.200Z", type: "event_msg", payload: { type: "item_completed", item: { type: "UserMessage", id: "user-1", content: [{ type: "text", text: "Clona e testa i branch", text_elements: [] }] } } },
+    { timestamp: "2026-09-03T07:55:06.000Z", type: "event_msg", payload: { type: "item_completed", item: { type: "Reasoning", id: "reasoning-1", summary_text: ["**Inspecting the branches**", "**Planning the tests**"], raw_content: [] } } },
+    { timestamp: "2026-09-03T07:55:07.000Z", type: "event_msg", payload: { type: "item_completed", item: { type: "CommandExecution", id: "command-1", command: ["git", "status"], status: "completed" } } },
+    { timestamp: "2026-09-03T07:55:08.000Z", type: "event_msg", payload: { type: "item_completed", item: { type: "AgentMessage", id: "assistant-1", content: [{ type: "text", text: "I test sono passati." }], phase: "final_answer" } } }
+  ])
+
+  try {
+    const loader = createCodexHistoryLoader(root)
+    const messages = await loader(sessionID)
+    assert.deepEqual(
+      messages.map((message) => [message.info.role, message.parts[0].type, message.parts[0].text]),
+      [
+        ["user", "text", "Clona e testa i branch"],
+        ["assistant", "reasoning", "**Inspecting the branches**\n\n**Planning the tests**"],
+        ["assistant", "text", "I test sono passati."]
+      ]
+    )
+
+    const page = await loader.page(sessionID, { limit: 2 })
+    assert.deepEqual(page.messages, messages.slice(-2))
+    assert.equal(page.hasMore, true)
+    assert.ok(page.before)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
 test("restores the current Codex model and reasoning effort from the newest native turn context", async () => {
   const root = await writeRollout([
     { timestamp: "2026-08-07T09:28:49.000Z", type: "turn_context", payload: { model: "gpt-5.6-codex", effort: "medium" } },


### PR DESCRIPTION
## Summary

- parse current Codex `event_msg/item_completed` records for user, assistant, and reasoning messages
- retain compatibility with older Codex rollout event types
- continue excluding `response_item` model input so instructions and app context do not appear as user turns
- add regression coverage for current-format history and paged reads

## Verification

- `PATH=/home/giulio/.nvm/versions/node/v24.13.0/bin:/usr/local/bin:/usr/bin:/bin npm --prefix bridge test`
- 474 tests passed
- local HTTP smoke confirmed current Codex rollouts return complete non-empty histories