### PR TITLE
fix(ui): render live Session failures correctly

### DIFF
--- a/web/src/components/taskdesk-message-content.tsx
+++ b/web/src/components/taskdesk-message-content.tsx
@@ -445,17 +445,25 @@ function assistantTurnCompleted(message: MessageEnvelope): boolean {
  * body, while reasoning, tools and working narration remain inside Activity. Internal OpenCode
  * step/snapshot/patch markers stay protocol data and never leak into the chat. While a Run is live,
  * the whole assistant payload stays inside Activity so streamed chunks never jump between working
- * state and final dialogue.
+ * state and final dialogue. A provider error can arrive one live-refresh frame before the owning
+ * Conversation flips from running to failed; that terminal error wins over the stale active bit.
  */
 export function TaskDeskMessageContent({ message }: { message: MessageEnvelope }) {
-  const liveAssistant = message.info.role === "assistant" && Boolean((message as TaskDeskEnvelope).taskdesk?.active)
+  const hasFinalText = hasTerminalAssistantText(message.parts)
+  const reportedError = messageErrorText(message)
+  // Preserve recovery semantics: an old/intermediate error must not replace a later real answer.
+  // When there is no final answer, however, the native error is already authoritative even if the
+  // Conversation runtime still says running for one reconciliation frame.
+  const liveTurnFailed = Boolean(reportedError) && !hasFinalText
+  const liveAssistant = message.info.role === "assistant"
+    && Boolean((message as TaskDeskEnvelope).taskdesk?.active)
+    && !liveTurnFailed
   const visibleParts = message.parts.filter((part) => !isInternalProtocolPart(part))
   const groups = groupConversationParts(visibleParts, {
     forceActivity: liveAssistant,
     forceRunning: liveAssistant
   })
-  const hasFinalText = hasTerminalAssistantText(message.parts)
-  const turnError = liveAssistant || hasFinalText ? "" : messageErrorText(message)
+  const turnError = liveAssistant || hasFinalText ? "" : reportedError
   const hasActivity = visibleParts.some((part) => part.type === "reasoning" || part.type === "tool")
   const interruptedWithoutFinal = message.info.role === "assistant"
     && !liveAssistant

--- a/web/src/components/taskdesk-message-content.tsx
+++ b/web/src/components/taskdesk-message-content.tsx
@@ -78,12 +78,69 @@ const MARKDOWN_COMPONENTS: Components = {
   }
 }
 
-function hasTerminalAssistantText(parts: MessagePart[]): boolean {
+/** Provider failures sometimes arrive twice: once as `message.info.error` and once as a normal text
+ * part, with an HTTP status / `(type=...)` / `raw-http-request=...` suffix added by the transport.
+ * Compare the human message rather than those wrappers so that copy is never mistaken for a real
+ * final answer. */
+function normalizeErrorComparable(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/^\d{3}\s+/, "")
+    .replace(/\s+raw-http-request=\S+/gi, "")
+    .replace(/\s+\(type=[^)]+\)/gi, "")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+function textMirrorsReportedError(text: string | undefined, reportedError: string): boolean {
+  if (!text?.trim() || !reportedError.trim()) return false
+  const candidate = normalizeErrorComparable(text)
+  const expected = normalizeErrorComparable(reportedError)
+  if (!candidate || !expected) return false
+  if (candidate === expected) return true
+  const longer = candidate.length >= expected.length ? candidate : expected
+  const shorter = candidate.length >= expected.length ? expected : candidate
+  if (!longer.startsWith(shorter)) return false
+  // The field failure that motivated this guard repeats the provider sentence exactly twice. Keep
+  // the tolerance bounded so a genuine recovery answer that merely quotes the old error still wins.
+  return longer.length <= shorter.length * 2.35
+}
+
+function collapseRepeatedErrorBody(value: string): string {
+  const words = value.trim().split(/\s+/).filter(Boolean)
+  if (words.length < 4) return value.trim()
+  const midpoint = words.length / 2
+  for (let split = Math.max(1, Math.floor(midpoint) - 1); split <= Math.min(words.length - 1, Math.ceil(midpoint) + 1); split += 1) {
+    const left = words.slice(0, split).join(" ")
+    const right = words.slice(split).join(" ")
+    if (normalizeErrorComparable(left) && normalizeErrorComparable(left) === normalizeErrorComparable(right)) return left.trim()
+  }
+  return value.trim()
+}
+
+function cleanReportedErrorText(value: string): string {
+  const raw = value.trim()
+  if (!raw) return ""
+  const status = raw.match(/^(\d{3})\s+/)?.[1] || ""
+  const type = raw.match(/\(type=[^)]+\)/i)?.[0] || ""
+  let body = raw
+    .replace(/^\d{3}\s+/, "")
+    .replace(/\s+raw-http-request=\S+/gi, "")
+    .replace(/\s+\(type=[^)]+\)/gi, "")
+    .trim()
+  body = collapseRepeatedErrorBody(body)
+  return [status, body, type].filter(Boolean).join(" ")
+}
+
+function hasTerminalAssistantText(parts: MessagePart[], reportedError = ""): boolean {
   for (let index = parts.length - 1; index >= 0; index -= 1) {
     const part = parts[index]
     if (isInternalProtocolPart(part)) continue
     if (part.type === "text") {
-      if (typeof part.text === "string" && part.text.trim()) return true
+      if (typeof part.text === "string" && part.text.trim()) {
+        if (reportedError && textMirrorsReportedError(part.text, reportedError)) continue
+        return true
+      }
       continue
     }
     if (part.type === "reasoning" || part.type === "tool") return false
@@ -430,7 +487,19 @@ function readableErrorValue(value: unknown, depth = 0): string {
 function messageErrorText(message: MessageEnvelope): string {
   const error = message.info.error
   if (!error) return ""
-  return readableErrorValue(error.data?.message) || readableErrorValue(error.message) || error.name || "The coding agent failed to complete this turn."
+  const raw = readableErrorValue(error.data?.message)
+    || readableErrorValue(error.message)
+    || error.name
+    || "The coding agent failed to complete this turn."
+  const mirroredText = message.parts.find((part) =>
+    part.type === "text"
+    && typeof part.text === "string"
+    && textMirrorsReportedError(part.text, raw)
+  )?.text
+  // Prefer the transport copy only when it mirrors the structured error: it may carry the useful
+  // HTTP status / provider type that the structured payload omitted. Cleaning below removes only
+  // duplicate prose and the private raw-request path.
+  return cleanReportedErrorText(mirroredText || raw)
 }
 
 function assistantTurnCompleted(message: MessageEnvelope): boolean {
@@ -449,8 +518,8 @@ function assistantTurnCompleted(message: MessageEnvelope): boolean {
  * Conversation flips from running to failed; that terminal error wins over the stale active bit.
  */
 export function TaskDeskMessageContent({ message }: { message: MessageEnvelope }) {
-  const hasFinalText = hasTerminalAssistantText(message.parts)
   const reportedError = messageErrorText(message)
+  const hasFinalText = hasTerminalAssistantText(message.parts, reportedError)
   // Preserve recovery semantics: an old/intermediate error must not replace a later real answer.
   // When there is no final answer, however, the native error is already authoritative even if the
   // Conversation runtime still says running for one reconciliation frame.
@@ -458,7 +527,12 @@ export function TaskDeskMessageContent({ message }: { message: MessageEnvelope }
   const liveAssistant = message.info.role === "assistant"
     && Boolean((message as TaskDeskEnvelope).taskdesk?.active)
     && !liveTurnFailed
-  const visibleParts = message.parts.filter((part) => !isInternalProtocolPart(part))
+  const visibleParts = message.parts.filter((part) => {
+    if (isInternalProtocolPart(part)) return false
+    // Some native providers emit their terminal failure as both structured error metadata and a
+    // normal assistant text chunk. That chunk is transport duplication, not model prose.
+    return !(reportedError && part.type === "text" && textMirrorsReportedError(part.text, reportedError))
+  })
   const groups = groupConversationParts(visibleParts, {
     forceActivity: liveAssistant,
     forceRunning: liveAssistant

--- a/web/src/conversation-base.css
+++ b/web/src/conversation-base.css
@@ -1,9 +1,10 @@
 /*
  * Live conversation primitives that were accidentally removed with the retired
  * universal-workspace styles in PR 361. These selectors are still emitted by the
- * shared Session/Work Thread renderer. Keep this sheet structural: typography
- * and product-specific polish stay in the readable, Session and Beautiful UI
- * layers that load around it.
+ * shared Session/Work Thread renderer. Keep this sheet primarily structural:
+ * typography and product-specific polish stay in the readable, Session and
+ * Beautiful UI layers that load around it. Small resilient fallbacks and
+ * cross-group spacing live here when they are properties of the shared renderer.
  */
 
 .uw-message-body > header {
@@ -147,4 +148,37 @@
   overflow-wrap: anywhere;
   word-break: break-word;
   line-height: 1.5;
+}
+
+/* A new/unknown protocol part must degrade into a contained neutral chip, never
+ * raw unstyled text that can widen or visually break the conversation. */
+.uw-unsupported-part {
+  min-width: 0;
+  max-width: 100%;
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 7px;
+  border: 1px solid var(--td3-border-soft);
+  border-radius: 7px;
+  color: var(--td3-muted);
+  background: var(--td3-raise-1);
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  font-size: 10px;
+}
+
+/* The first final-answer paragraph intentionally has no top margin. That is good
+ * after the identity row, but too tight when it follows a collapsed/open Activity
+ * card. Give only this boundary a little breathing room. */
+.tdw-work-thread-conversation .uw-activity-group + .uw-message-content-group {
+  margin-top: 10px;
+}
+
+/* Provider errors can contain long model IDs, endpoints and URLs. Keep the red
+ * error treatment inside the same reading column on both desktop and mobile. */
+.tdw-work-thread-conversation .uw-message-turn-error {
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }

--- a/web/src/taskdesk-message-error.test.mjs
+++ b/web/src/taskdesk-message-error.test.mjs
@@ -25,6 +25,13 @@ test("a native turn failure wins over a stale live-active bit before reload", ()
   assert.match(source, /const turnError = liveAssistant \|\| hasFinalText \? "" : reportedError/)
 })
 
+test("assistant wording can never classify a message as an error", () => {
+  assert.match(source, /const error = message\.info\.error/)
+  assert.match(source, /if \(!error\) return ""/)
+  assert.doesNotMatch(source, /PROVIDER_FAILURE_TEXT/)
+  assert.doesNotMatch(source, /inferredProviderErrorText/)
+})
+
 test("provider error text duplication is not mistaken for a model final answer", () => {
   assert.match(source, /function textMirrorsReportedError/)
   assert.match(source, /function normalizeErrorComparable/)
@@ -32,10 +39,12 @@ test("provider error text duplication is not mistaken for a model final answer",
   assert.match(source, /return !\(reportedError && part\.type === "text" && textMirrorsReportedError\(part\.text, reportedError\)\)/)
 })
 
-test("provider diagnostics are compacted before they reach the red error card", () => {
+test("provider diagnostics are compacted only after a structured error exists", () => {
   assert.match(source, /function cleanReportedErrorText/)
   assert.match(source, /raw-http-request=\\S\+/)
   assert.match(source, /function collapseRepeatedErrorBody/)
+  assert.match(source, /const error = message\.info\.error/)
+  assert.match(source, /if \(!error\) return ""/)
   assert.match(source, /const mirroredText = message\.parts\.find/)
   assert.match(source, /return cleanReportedErrorText\(mirroredText \|\| raw\)/)
 })
@@ -52,7 +61,7 @@ test("a terminal assistant turn with only reasoning or tools is never silently p
   assert.match(source, /assistantTurnCompleted\(message\)/)
 })
 
-test("a later real final answer suppresses a stale transport or intermediate turn error", () => {
+test("a later real final answer suppresses a stale transport or intermediate structured turn error", () => {
   assert.match(source, /const hasFinalText = hasTerminalAssistantText\(message\.parts, reportedError\)/)
   assert.match(source, /if \(reportedError && textMirrorsReportedError\(part\.text, reportedError\)\) continue/)
   assert.match(source, /return true/)

--- a/web/src/taskdesk-message-error.test.mjs
+++ b/web/src/taskdesk-message-error.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test"
 
 const source = readFileSync(new URL("./components/taskdesk-message-content.tsx", import.meta.url), "utf8")
 const styles = readFileSync(new URL("./taskdesk-conversation.css", import.meta.url), "utf8")
+const baseStyles = readFileSync(new URL("./conversation-base.css", import.meta.url), "utf8")
 
 test("native provider and harness failures remain visible inside the persisted conversation", () => {
   assert.match(source, /function readableErrorValue/)
@@ -14,6 +15,13 @@ test("native provider and harness failures remain visible inside the persisted c
   assert.match(source, />Turn failed</)
   assert.match(styles, /\.uw-message-turn-error \{/)
   assert.match(styles, /var\(--td3-red-border\)/)
+})
+
+test("a native turn failure wins over a stale live-active bit before reload", () => {
+  assert.match(source, /const reportedError = messageErrorText\(message\)/)
+  assert.match(source, /const liveTurnFailed = Boolean\(reportedError\) && !hasFinalText/)
+  assert.match(source, /Boolean\(\(message as TaskDeskEnvelope\)\.taskdesk\?\.active\)[\s\S]*&& !liveTurnFailed/)
+  assert.match(source, /const turnError = liveAssistant \|\| hasFinalText \? "" : reportedError/)
 })
 
 test("OpenCode protocol bookkeeping never leaks into the visible chat", () => {
@@ -30,5 +38,12 @@ test("a terminal assistant turn with only reasoning or tools is never silently p
 
 test("a later final answer suppresses a stale transport or intermediate turn error", () => {
   assert.match(source, /const hasFinalText = hasTerminalAssistantText\(message\.parts\)/)
-  assert.match(source, /const turnError = liveAssistant \|\| hasFinalText \? "" : messageErrorText\(message\)/)
+  assert.match(source, /const liveTurnFailed = Boolean\(reportedError\) && !hasFinalText/)
+  assert.match(source, /const turnError = liveAssistant \|\| hasFinalText \? "" : reportedError/)
+})
+
+test("Activity-to-answer rhythm and fallback protocol parts stay visually contained", () => {
+  assert.match(baseStyles, /\.tdw-work-thread-conversation \.uw-activity-group \+ \.uw-message-content-group \{[\s\S]*?margin-top: 10px;/)
+  assert.match(baseStyles, /\.uw-unsupported-part \{[\s\S]*?max-width: 100%;[\s\S]*?overflow-wrap: anywhere;/)
+  assert.match(baseStyles, /\.tdw-work-thread-conversation \.uw-message-turn-error \{[\s\S]*?overflow-wrap: anywhere;/)
 })

--- a/web/src/taskdesk-message-error.test.mjs
+++ b/web/src/taskdesk-message-error.test.mjs
@@ -19,14 +19,30 @@ test("native provider and harness failures remain visible inside the persisted c
 
 test("a native turn failure wins over a stale live-active bit before reload", () => {
   assert.match(source, /const reportedError = messageErrorText\(message\)/)
+  assert.match(source, /const hasFinalText = hasTerminalAssistantText\(message\.parts, reportedError\)/)
   assert.match(source, /const liveTurnFailed = Boolean\(reportedError\) && !hasFinalText/)
   assert.match(source, /Boolean\(\(message as TaskDeskEnvelope\)\.taskdesk\?\.active\)[\s\S]*&& !liveTurnFailed/)
   assert.match(source, /const turnError = liveAssistant \|\| hasFinalText \? "" : reportedError/)
 })
 
+test("provider error text duplication is not mistaken for a model final answer", () => {
+  assert.match(source, /function textMirrorsReportedError/)
+  assert.match(source, /function normalizeErrorComparable/)
+  assert.match(source, /if \(reportedError && textMirrorsReportedError\(part\.text, reportedError\)\) continue/)
+  assert.match(source, /return !\(reportedError && part\.type === "text" && textMirrorsReportedError\(part\.text, reportedError\)\)/)
+})
+
+test("provider diagnostics are compacted before they reach the red error card", () => {
+  assert.match(source, /function cleanReportedErrorText/)
+  assert.match(source, /raw-http-request=\\S\+/)
+  assert.match(source, /function collapseRepeatedErrorBody/)
+  assert.match(source, /const mirroredText = message\.parts\.find/)
+  assert.match(source, /return cleanReportedErrorText\(mirroredText \|\| raw\)/)
+})
+
 test("OpenCode protocol bookkeeping never leaks into the visible chat", () => {
   assert.match(source, /INTERNAL_PROTOCOL_PARTS = new Set\(\["step-start", "step-finish", "snapshot", "patch"\]\)/)
-  assert.match(source, /visibleParts = message\.parts\.filter\(\(part\) => !isInternalProtocolPart\(part\)\)/)
+  assert.match(source, /if \(isInternalProtocolPart\(part\)\) return false/)
 })
 
 test("a terminal assistant turn with only reasoning or tools is never silently presented as complete", () => {
@@ -36,8 +52,10 @@ test("a terminal assistant turn with only reasoning or tools is never silently p
   assert.match(source, /assistantTurnCompleted\(message\)/)
 })
 
-test("a later final answer suppresses a stale transport or intermediate turn error", () => {
-  assert.match(source, /const hasFinalText = hasTerminalAssistantText\(message\.parts\)/)
+test("a later real final answer suppresses a stale transport or intermediate turn error", () => {
+  assert.match(source, /const hasFinalText = hasTerminalAssistantText\(message\.parts, reportedError\)/)
+  assert.match(source, /if \(reportedError && textMirrorsReportedError\(part\.text, reportedError\)\) continue/)
+  assert.match(source, /return true/)
   assert.match(source, /const liveTurnFailed = Boolean\(reportedError\) && !hasFinalText/)
   assert.match(source, /const turnError = liveAssistant \|\| hasFinalText \? "" : reportedError/)
 })


### PR DESCRIPTION
## What this fixes

- Provider/harness turn failures can arrive in the live native transcript one refresh frame before the Conversation runtime changes from `running` to `failed`. The renderer previously trusted the stale `active` bit first, so a real structured failure could be temporarily presented as normal/working assistant output.
- Structured failures (`message.info.error`) now override that stale live-active bit immediately and remain red after reopening the Session.
- Some providers duplicate the same already-structured failure into a normal assistant text part. That duplicate is suppressed only after the message has already been classified as an error by metadata; assistant wording is never used to decide whether something is an error.
- Error presentation is compacted after structured classification: duplicate error prose is collapsed and internal `raw-http-request` filesystem diagnostics are not shown in chat.
- Adds a small 10px rhythm gap only at the `Activity -> final answer` boundary.

## Error-classification rule

Harness Remote does **not** infer errors from assistant text. No `404`, `Error from provider`, model-name, endpoint, or other wording pattern can turn normal model output into an error.

- If the harness/bridge exposes an actual failure (`message.info.error`, e.g. ACP request rejection or OMP journal `errorMessage`), the UI renders `Turn failed`.
- If the harness emits only a normal assistant text part, Harness Remote renders it as normal text, even if that text looks like an HTTP/provider error.

The OMP journal reader already maps OMP's generic `errorMessage` field into `message.info.error`; the ACP live path records rejected `session/prompt` requests as `HarnessTurnError`. Those structured channels are the source of truth.

## UI hardening from the Session audit

- Unknown/new message-part types degrade into a contained neutral fallback instead of raw unstyled text.
- Long structured provider/model/endpoint errors are constrained to the conversation width and wrap safely.

## Scope

Frontend Session/shared conversation renderer + CSS + regression tests only. No ACP, harness adapters, routing, model execution, bridge or backend behavior changes.

## Validation

Regression coverage explicitly forbids text-based error classification while preserving structured live-error rendering, recovery semantics, diagnostic compaction and Session UI containment. PR remains open for manual browser/APK validation before merge.