### PR TITLE
Preserve harness-provided model variant ordering

### DIFF
--- a/web/src/components/model-picker.tsx
+++ b/web/src/components/model-picker.tsx
@@ -28,6 +28,39 @@ type ModelGroup = {
 }
 const MAX_VISIBLE_MODEL_GROUPS = 100
 
+const REASONING_VARIANT_ORDER = new Map([
+  ["off", 0],
+  ["none", 0],
+  ["minimal", 1],
+  ["low", 2],
+  ["medium", 3],
+  ["high", 4],
+  ["xhigh", 5],
+  ["max", 6],
+  ["ultra", 7]
+])
+
+function normalizedVariant(value?: string): string {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/^extra[-_ ]?high$/, "xhigh")
+}
+
+function compareModelVariants(left: ModelOption, right: ModelOption): number {
+  const leftVariant = normalizedVariant(left.variant)
+  const rightVariant = normalizedVariant(right.variant)
+  const leftRank = REASONING_VARIANT_ORDER.get(leftVariant)
+  const rightRank = REASONING_VARIANT_ORDER.get(rightVariant)
+
+  if (leftRank !== undefined || rightRank !== undefined) {
+    if (leftRank === undefined) return 1
+    if (rightRank === undefined) return -1
+    if (leftRank !== rightRank) return leftRank - rightRank
+  }
+
+  return leftVariant.localeCompare(rightVariant)
+}
 
 export function modelOptionKey(model: Pick<ModelOption, "providerID" | "modelID" | "variant">): string {
   return `${model.providerID}|${model.modelID}|${model.variant || ""}`
@@ -61,7 +94,7 @@ function groupModels(models: ModelOption[]): ModelGroup[] {
     const base = options.find((option) => !option.variant) || options.find((option) => option.isDefault) || options[0]
     const variants = options
       .filter((option) => Boolean(option.variant))
-      .sort((left, right) => String(left.variant).localeCompare(String(right.variant)))
+      .sort(compareModelVariants)
     return {
       id,
       providerID: base.providerID,

--- a/web/src/components/model-picker.tsx
+++ b/web/src/components/model-picker.tsx
@@ -28,39 +28,6 @@ type ModelGroup = {
 }
 const MAX_VISIBLE_MODEL_GROUPS = 100
 
-const REASONING_VARIANT_ORDER = new Map([
-  ["off", 0],
-  ["none", 0],
-  ["minimal", 1],
-  ["low", 2],
-  ["medium", 3],
-  ["high", 4],
-  ["xhigh", 5],
-  ["max", 6],
-  ["ultra", 7]
-])
-
-function normalizedVariant(value?: string): string {
-  return String(value || "")
-    .trim()
-    .toLowerCase()
-    .replace(/^extra[-_ ]?high$/, "xhigh")
-}
-
-function compareModelVariants(left: ModelOption, right: ModelOption): number {
-  const leftVariant = normalizedVariant(left.variant)
-  const rightVariant = normalizedVariant(right.variant)
-  const leftRank = REASONING_VARIANT_ORDER.get(leftVariant)
-  const rightRank = REASONING_VARIANT_ORDER.get(rightVariant)
-
-  if (leftRank !== undefined || rightRank !== undefined) {
-    if (leftRank === undefined) return 1
-    if (rightRank === undefined) return -1
-    if (leftRank !== rightRank) return leftRank - rightRank
-  }
-
-  return leftVariant.localeCompare(rightVariant)
-}
 
 export function modelOptionKey(model: Pick<ModelOption, "providerID" | "modelID" | "variant">): string {
   return `${model.providerID}|${model.modelID}|${model.variant || ""}`
@@ -92,9 +59,9 @@ function groupModels(models: ModelOption[]): ModelGroup[] {
 
   return [...groups.entries()].map(([id, options]) => {
     const base = options.find((option) => !option.variant) || options.find((option) => option.isDefault) || options[0]
-    const variants = options
-      .filter((option) => Boolean(option.variant))
-      .sort(compareModelVariants)
+    // The harness/catalog already advertises variants in its intended order. Preserve that order
+    // instead of guessing semantics from variant labels in the UI.
+    const variants = options.filter((option) => Boolean(option.variant))
     return {
       id,
       providerID: base.providerID,

--- a/web/src/model-regression.test.mjs
+++ b/web/src/model-regression.test.mjs
@@ -26,14 +26,8 @@ assert.match(conversation, /<ModelPicker/, 'the Session controller must render t
 assert.match(picker, /Search model, provider, variant/, 'model catalog must remain searchable')
 assert.match(picker, /Harness default/, 'an unavailable catalog must fall back honestly to the harness default')
 assert.match(picker, /groupModels/, 'variants must stay grouped with their base model')
-assert.match(picker, /\.sort\(compareModelVariants\)/, 'reasoning variants must use semantic ordering instead of alphabetical ordering')
-const reasoningOrderStart = picker.indexOf('const REASONING_VARIANT_ORDER')
-const reasoningOrderEnd = picker.indexOf('function normalizedVariant', reasoningOrderStart)
-const reasoningOrderSource = picker.slice(reasoningOrderStart, reasoningOrderEnd)
-const expectedReasoningOrder = ['"low"', '"medium"', '"high"', '"xhigh"', '"max"', '"ultra"']
-const reasoningPositions = expectedReasoningOrder.map((variant) => reasoningOrderSource.indexOf(variant))
-assert.ok(reasoningPositions.every((position) => position >= 0), 'the reasoning scale must include the known effort levels')
-assert.deepEqual(reasoningPositions, [...reasoningPositions].sort((left, right) => left - right), 'known reasoning effort levels must remain ordered low → medium → high → xhigh → max → ultra')
+assert.match(picker, /const variants = options\.filter\(\(option\) => Boolean\(option\.variant\)\)/, 'variant grouping must preserve the catalog order advertised by the harness')
+assert.doesNotMatch(picker, /variant[^\n]*localeCompare|sort\(compareModelVariants\)|REASONING_VARIANT_ORDER/, 'the picker must not infer or alphabetically reorder variant semantics')
 assert.match(create, /api\.createSession\(config, title\?\.trim\(\) \|\| undefined, undefined, directory\)/, 'new native Sessions must not invent a stale explicit model')
 
 console.log('Session-first model regression tests passed')

--- a/web/src/model-regression.test.mjs
+++ b/web/src/model-regression.test.mjs
@@ -26,6 +26,14 @@ assert.match(conversation, /<ModelPicker/, 'the Session controller must render t
 assert.match(picker, /Search model, provider, variant/, 'model catalog must remain searchable')
 assert.match(picker, /Harness default/, 'an unavailable catalog must fall back honestly to the harness default')
 assert.match(picker, /groupModels/, 'variants must stay grouped with their base model')
+assert.match(picker, /\.sort\(compareModelVariants\)/, 'reasoning variants must use semantic ordering instead of alphabetical ordering')
+const reasoningOrderStart = picker.indexOf('const REASONING_VARIANT_ORDER')
+const reasoningOrderEnd = picker.indexOf('function normalizedVariant', reasoningOrderStart)
+const reasoningOrderSource = picker.slice(reasoningOrderStart, reasoningOrderEnd)
+const expectedReasoningOrder = ['"low"', '"medium"', '"high"', '"xhigh"', '"max"', '"ultra"']
+const reasoningPositions = expectedReasoningOrder.map((variant) => reasoningOrderSource.indexOf(variant))
+assert.ok(reasoningPositions.every((position) => position >= 0), 'the reasoning scale must include the known effort levels')
+assert.deepEqual(reasoningPositions, [...reasoningPositions].sort((left, right) => left - right), 'known reasoning effort levels must remain ordered low → medium → high → xhigh → max → ultra')
 assert.match(create, /api\.createSession\(config, title\?\.trim\(\) \|\| undefined, undefined, directory\)/, 'new native Sessions must not invent a stale explicit model')
 
 console.log('Session-first model regression tests passed')


### PR DESCRIPTION
## Summary

Fixes the model picker ordering for reasoning/model variants by preserving the order advertised by the harness/model catalog.

The daemon already emits variants in the order returned by the harness. The web picker was unnecessarily applying an alphabetical sort, which changed sequences such as the native reasoning-effort order into `high, low, max, medium, ultra, xhigh`.

This PR removes that frontend sort. No variant names or semantic ranking are hard-coded.

## Scope

- UI-only change in the shared model picker
- preserves the catalog/harness order exactly
- no ACP/session/harness protocol behavior changed
- adds a regression guard preventing future alphabetical or semantic reordering in the picker

## Validation

- branch is based directly on current `main`
- final diff only changes `web/src/components/model-picker.tsx` and `web/src/model-regression.test.mjs`
- backend catalog generation already preserves `variantOption.options` order and the client passes `catalog.models` through unchanged
