### PR TITLE
Fix silent OpenCode turns and stale PI activity

### DIFF
--- a/bridge/src/acp-service.js
+++ b/bridge/src/acp-service.js
@@ -459,6 +459,7 @@ export class AcpService {
   #preserveListedTimestamps
   #reloadOnHistoryRefresh
   #replaySettleMs
+  #promptSettleMs
   #preferListedTitles
   #nativeRenameCommand
   #journalPageWhileOwned
@@ -469,6 +470,11 @@ export class AcpService {
     preserveListedTimestamps = false,
     reloadOnHistoryRefresh = true,
     replaySettleMs = 0,
+    // Some ACP adapters (PI in particular) acknowledge session/prompt before their final stdout
+    // notifications have reached the bridge. Keep the turn live for this short drain window so a
+    // late reasoning chunk is settled with the rest of the completed turn rather than becoming a
+    // permanent Activity spinner.
+    promptSettleMs = 0,
     preferListedTitles = false,
     nativeRenameCommand,
     /**
@@ -497,6 +503,7 @@ export class AcpService {
     this.#preserveListedTimestamps = preserveListedTimestamps
     this.#reloadOnHistoryRefresh = reloadOnHistoryRefresh
     this.#replaySettleMs = replaySettleMs
+    this.#promptSettleMs = promptSettleMs
     this.#preferListedTitles = preferListedTitles
     this.#nativeRenameCommand = nativeRenameCommand
     this.#journalPageWhileOwned = journalPageWhileOwned
@@ -1269,9 +1276,20 @@ export class AcpService {
         this.#recordTurnFailure(sessionID, error.message)
         this.#emit("session.error", sessionID, { message: error.message })
       }
-    }).finally(() => {
+    }).finally(async () => {
+      if (this.#turnGenerations.get(sessionID) !== generation) return
+      // PI can write the JSON-RPC response before its final session/update notification. Do not
+      // clear #active until that tiny transport tail has drained: #handleNotification deliberately
+      // accepts those chunks, and otherwise they arrive after #settleActivity has already run.
+      if (this.#promptSettleMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, this.#promptSettleMs))
+      }
       if (this.#turnGenerations.get(sessionID) !== generation) return
       this.#active.delete(sessionID)
+      // Older adapters intentionally deliver assistant chunks after their RPC response, so their
+      // historical zero-drain behavior must stay permissive. PI opts into a real drain window above;
+      // once it closes, an even later chunk belongs to a subsequent native lifecycle, not this turn.
+      if (this.#promptSettleMs > 0) this.#promptedSessions.delete(sessionID)
       this.#chunkMessageIDs.delete(`${sessionID}:assistant`)
       // The turn is over, so no activity it started is still running, whatever the adapter said.
       this.#settleActivity(sessionID)

--- a/bridge/src/cli.js
+++ b/bridge/src/cli.js
@@ -46,7 +46,8 @@ if (config) {
       historyLoader: profile.historyLoader,
       preserveListedTimestamps: profile.preserveListedTimestamps,
       reloadOnHistoryRefresh: profile.reloadOnHistoryRefresh,
-      replaySettleMs: profile.replaySettleMs
+      replaySettleMs: profile.replaySettleMs,
+      promptSettleMs: profile.promptSettleMs
     }
   })
   let shuttingDown = false

--- a/bridge/src/daemon-cli.js
+++ b/bridge/src/daemon-cli.js
@@ -160,7 +160,8 @@ async function main() {
         preserveListedTimestamps: profile.preserveListedTimestamps,
         hiddenSessionIDs: modelCatalog.hiddenSessionIDs,
         reloadOnHistoryRefresh: profile.reloadOnHistoryRefresh,
-        replaySettleMs: profile.replaySettleMs
+        replaySettleMs: profile.replaySettleMs,
+        promptSettleMs: profile.promptSettleMs
       }
     })
     acpHosts.set(profile.id, acp)
@@ -219,7 +220,8 @@ async function main() {
       preserveListedTimestamps: primaryProfile.preserveListedTimestamps,
       hiddenSessionIDs: daemon.hostEntry(primaryProfile.id).modelCatalog.hiddenSessionIDs,
       reloadOnHistoryRefresh: primaryProfile.reloadOnHistoryRefresh,
-      replaySettleMs: primaryProfile.replaySettleMs
+      replaySettleMs: primaryProfile.replaySettleMs,
+      promptSettleMs: primaryProfile.promptSettleMs
     }
   })
 

--- a/bridge/src/harness-profiles.js
+++ b/bridge/src/harness-profiles.js
@@ -77,6 +77,9 @@ export const HARNESS_PROFILES = {
     preferListedTitles: true,
     // Keep the replay tail for the one real session/load used when the bridge takes ownership to prompt.
     replaySettleMs: 250,
+    // PI can acknowledge session/prompt before its final session/update notifications arrive. Keep
+    // that same short drain window around a completed prompt so late reasoning closes as Done.
+    promptSettleMs: 250,
     // Current PI ACP calls this `thinkingLevel`. The aliases are harmless compatibility hints for
     // adapter versions that rename the wire id; a variant is emitted only when that option exists.
     modelVariantConfigIDs: ["thinkingLevel", "thinking_level", "thinking"],

--- a/bridge/test/pi-prompt-settle.test.js
+++ b/bridge/test/pi-prompt-settle.test.js
@@ -1,0 +1,50 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import { AcpService } from "../src/acp-service.js"
+
+const SESSION = "pi-prompt-settle"
+
+class PiPromptTailAcp extends EventEmitter {
+  async start() {}
+
+  async listSessions() {
+    return [{ sessionId: SESSION, cwd: process.cwd(), title: "PI prompt tail", updatedAt: new Date().toISOString() }]
+  }
+
+  async request(method, params) {
+    if (method === "session/load") return { configOptions: [] }
+    if (method !== "session/prompt") throw new Error(`Unexpected request: ${method}`)
+
+    // PI can resolve the RPC before its final notifications have crossed stdout.
+    setTimeout(() => {
+      this.emit("notification", {
+        method: "session/update",
+        params: {
+          sessionId: params.sessionId,
+          update: { sessionUpdate: "agent_thought_chunk", messageId: "pi-answer", content: { type: "text", text: "Thinking" } }
+        }
+      })
+      this.emit("notification", {
+        method: "session/update",
+        params: {
+          sessionId: params.sessionId,
+          update: { sessionUpdate: "agent_message_chunk", messageId: "pi-answer", content: { type: "text", text: "Done" } }
+        }
+      })
+    }, 10)
+    return {}
+  }
+}
+
+test("PI prompt drain closes late reasoning after session/prompt resolves", async () => {
+  const service = new AcpService(new PiPromptTailAcp(), { promptSettleMs: 40 })
+  await service.prompt(SESSION, "answer")
+  await new Promise((resolve) => setTimeout(resolve, 80))
+
+  const assistant = (await service.messages(SESSION)).find((message) => message.info.role === "assistant")
+  const reasoning = assistant?.parts.find((part) => part.type === "reasoning")
+  assert.ok(reasoning?.time?.start, "late PI reasoning was retained")
+  assert.ok(reasoning?.time?.end, "late PI reasoning was closed after the prompt drain")
+  assert.deepEqual(service.status(SESSION), { type: "idle" })
+})

--- a/web/src/native-session-v3-adapter.ts
+++ b/web/src/native-session-v3-adapter.ts
@@ -26,6 +26,10 @@ const OPENCODE_IDLE_CONFIRM_MS = 750
 // the terminal-looking interruption. This watch is event-driven in the normal case; it does not add
 // fast polling and expires so an old failed turn cannot be resurrected indefinitely.
 const OPENCODE_RECOVERY_WATCH_MS = 2 * 60 * 1000
+// A rejected provider can make OpenCode accept prompt_async, then produce neither an assistant
+// envelope nor a session.status entry. Leave enough room for a real slow first token, then turn
+// that orphaned optimistic turn into a visible failure instead of spinning until navigation.
+const OPENCODE_SILENT_TURN_GRACE_MS = 15_000
 
 type NativeTurnRecord = {
   id: string
@@ -46,7 +50,9 @@ type NativeConversationEntry = {
   // legacy status endpoint omits the Session it can instead be the newest assistant error envelope.
   openCodeIdleObservedAt: number | null
   openCodeRecoveryWatchUntil: number
+  openCodeSilentTurn: { id: string; timer: ReturnType<typeof setTimeout> } | null
   currentModel: ModelSelection | null
+  error: { message: string } | null
   initialPageCaptured: boolean
   piTailMessages: MessageEnvelope[]
   writerReady: boolean
@@ -294,32 +300,9 @@ function reconcileOpenCodeTranscriptStatus(entry: NativeConversationEntry, page:
   const recoveryWatchActive = entry.openCodeRecoveryWatchUntil > Date.now()
   if (entry.forcedStatus !== "running" && !recoveryWatchActive) return
 
-  const orderedTurns = [...entry.turns.values()].sort((left, right) => left.created - right.created || left.id.localeCompare(right.id))
-  const current = orderedTurns[orderedTurns.length - 1]
-  const prompt = canonicalText(current?.prompt || "")
-  if (!current || !prompt) return
-
-  const occurrence = orderedTurns.slice(0, -1).filter((turn) => canonicalText(turn.prompt) === prompt).length
-  let seen = 0
-  let userIndex = -1
-  for (let index = 0; index < page.messages.length; index += 1) {
-    const message = page.messages[index]
-    if (message.info.role !== "user" || visiblePrompt(message) !== prompt) continue
-    if (seen === occurrence) {
-      userIndex = index
-      break
-    }
-    seen += 1
-  }
-  if (userIndex < 0) return
-
-  let latestAssistant: MessageEnvelope | null = null
-  for (let index = userIndex + 1; index < page.messages.length; index += 1) {
-    const message = page.messages[index]
-    if (message.info.role === "user") break
-    if (message.info.role === "assistant") latestAssistant = message
-  }
+  const latestAssistant = latestOpenCodeAssistantForCurrentTurn(entry, page)
   if (!latestAssistant) return
+  clearOpenCodeSilentTurn(entry)
 
   const now = Date.now()
   const completedByTranscript = openCodeAssistantProvesTurnCompleted(latestAssistant)
@@ -341,11 +324,96 @@ function reconcileOpenCodeTranscriptStatus(entry: NativeConversationEntry, page:
   const priorStatus = conversationStatus(entry)
   entry.statusType = "idle"
   entry.forcedStatus = null
+  entry.error = null
   entry.openCodeIdleObservedAt = null
   entry.openCodeRecoveryWatchUntil = terminalError ? now + OPENCODE_RECOVERY_WATCH_MS : 0
   const completedAt = Number(latestAssistant.info.time?.completed) || Number(latestAssistant.info.time?.created) || 0
   if (completedAt) entry.updatedAt = Math.max(entry.updatedAt, completedAt)
   if (conversationStatus(entry) !== priorStatus) notify(entry)
+}
+
+/** Locate the assistant envelope belonging to the latest logical turn, including repeated prompts. */
+function latestOpenCodeAssistantForCurrentTurn(entry: NativeConversationEntry, page: MessagePage): MessageEnvelope | null {
+  const orderedTurns = [...entry.turns.values()].sort((left, right) => left.created - right.created || left.id.localeCompare(right.id))
+  const current = orderedTurns[orderedTurns.length - 1]
+  const prompt = canonicalText(current?.prompt || "")
+  if (!current || !prompt) return null
+
+  const occurrence = orderedTurns.slice(0, -1).filter((turn) => canonicalText(turn.prompt) === prompt).length
+  let seen = 0
+  let userIndex = -1
+  for (let index = 0; index < page.messages.length; index += 1) {
+    const message = page.messages[index]
+    if (message.info.role !== "user" || visiblePrompt(message) !== prompt) continue
+    if (seen === occurrence) {
+      userIndex = index
+      break
+    }
+    seen += 1
+  }
+  if (userIndex < 0) return null
+
+  let latestAssistant: MessageEnvelope | null = null
+  for (let index = userIndex + 1; index < page.messages.length; index += 1) {
+    const message = page.messages[index]
+    if (message.info.role === "user") break
+    if (message.info.role === "assistant") latestAssistant = message
+  }
+  return latestAssistant
+}
+
+function clearOpenCodeSilentTurn(entry: NativeConversationEntry): void {
+  if (!entry.openCodeSilentTurn) return
+  clearTimeout(entry.openCodeSilentTurn.timer)
+  entry.openCodeSilentTurn = null
+}
+
+function armOpenCodeSilentTurnRecovery(entry: NativeConversationEntry, turnID: string): void {
+  if (entry.target.backend !== "opencode") return
+  clearOpenCodeSilentTurn(entry)
+  const timer = setTimeout(() => {
+    void settleOpenCodeSilentTurn(entry, turnID)
+  }, OPENCODE_SILENT_TURN_GRACE_MS)
+  entry.openCodeSilentTurn = { id: turnID, timer }
+}
+
+async function settleOpenCodeSilentTurn(entry: NativeConversationEntry, turnID: string): Promise<void> {
+  if (entry.openCodeSilentTurn?.id !== turnID) return
+  entry.openCodeSilentTurn = null
+  const orderedTurns = [...entry.turns.values()].sort((left, right) => left.created - right.created || left.id.localeCompare(right.id))
+  const newestTurn = orderedTurns[orderedTurns.length - 1]
+  if (entry.target.backend !== "opencode" || newestTurn?.id !== turnID) return
+
+  try {
+    const [statuses, page] = await Promise.all([
+      api.listStatuses(entry.target.config, entry.target.directory),
+      api.loadMessagePage(entry.target.config, entry.target.sessionID, entry.target.directory, undefined, 200, true)
+    ])
+    captureUserTurns(entry, page)
+    reconcileOpenCodeTranscriptStatus(entry, page)
+    // Any assistant envelope is a real response lifecycle. It may still be streaming, but it is no
+    // longer the silent provider failure this recovery is for.
+    if (latestOpenCodeAssistantForCurrentTurn(entry, page)) return
+
+    const reported = statuses[entry.target.sessionID]?.type
+    if (nativeSessionIsWorking(reported)) {
+      armOpenCodeSilentTurnRecovery(entry, turnID)
+      return
+    }
+  } catch {
+    // A transport read cannot prove that the native prompt failed. Keep its ordinary live state.
+    return
+  }
+
+  // prompt_async was accepted, but OpenCode has produced neither a response nor a status record.
+  // Preserve a recovery watch: a delayed retry can still make the turn running again on a later edge.
+  entry.statusType = "idle"
+  entry.forcedStatus = null
+  entry.error = { message: "OpenCode ended this request without a response. Check the selected model/provider credentials and try again." }
+  entry.openCodeIdleObservedAt = null
+  entry.openCodeRecoveryWatchUntil = Date.now() + OPENCODE_RECOVERY_WATCH_MS
+  entry.updatedAt = Date.now()
+  notify(entry)
 }
 
 function iso(timestamp: number): string {
@@ -370,6 +438,7 @@ function entryForRead(config: ServerConfig, sessionID: string, directory?: strin
 }
 
 function conversationStatus(entry: NativeConversationEntry): string {
+  if (entry.error) return "failed"
   if (entry.forcedStatus) return entry.forcedStatus
   return nativeSessionIsWorking(entry.statusType) ? "running" : "completed"
 }
@@ -406,6 +475,7 @@ function sortedTurns(entry: NativeConversationEntry): ConversationTurn[] {
     directory: entry.target.directory,
     prompt: turn.prompt,
     startedAt: iso(turn.created),
+    ...(index === ordered.length - 1 && entry.error ? { error: entry.error } : {}),
     ...(index === ordered.length - 1 && status === "running" ? {} : { finishedAt: iso(Math.max(turn.created, entry.updatedAt)) })
   }))
 }
@@ -426,7 +496,7 @@ function conversationSnapshot(entry: NativeConversationEntry): ConversationRunti
     directory: entry.target.directory,
     currentTurn: current,
     turns,
-    error: null,
+    error: entry.error,
     createdAt: iso(entry.createdAt),
     updatedAt: iso(entry.updatedAt),
     ...(status === "running" ? {} : { finishedAt: iso(entry.updatedAt) })
@@ -596,7 +666,10 @@ function appendAcceptedTurn(entry: NativeConversationEntry, prompt: string, mode
   entry.statusType = "running"
   entry.openCodeIdleObservedAt = null
   entry.openCodeRecoveryWatchUntil = 0
-  return notify(entry)
+  entry.error = null
+  const conversation = notify(entry)
+  armOpenCodeSilentTurnRecovery(entry, id)
+  return conversation
 }
 
 async function refreshStatus(entry: NativeConversationEntry): Promise<void> {
@@ -622,6 +695,7 @@ async function refreshStatus(entry: NativeConversationEntry): Promise<void> {
     if (entry.target.backend === "opencode") {
       if (nativeSessionIsWorking(next)) {
         entry.statusType = next
+        entry.error = null
         entry.openCodeIdleObservedAt = null
         if (openCodeRecoveryWatchActive && entry.forcedStatus !== "running") {
           entry.forcedStatus = "running"
@@ -748,6 +822,8 @@ function nativeConversationController(entry: NativeConversationEntry): Conversat
         throw new Error(`Stop delivery is ${result.status}. The existing native cancel request will be reconciled instead of repeated.`)
       }
       entry.forcedStatus = "cancelled"
+      entry.error = null
+      clearOpenCodeSilentTurn(entry)
       entry.statusType = "idle"
       entry.openCodeIdleObservedAt = null
       entry.openCodeRecoveryWatchUntil = 0
@@ -773,7 +849,9 @@ export function registerNativeSessionV3Adapter(
       forcedStatus: null,
       openCodeIdleObservedAt: null,
       openCodeRecoveryWatchUntil: 0,
+      openCodeSilentTurn: null,
       currentModel: target.model,
+      error: null,
       initialPageCaptured: false,
       piTailMessages: [],
       writerReady: !target.requiresExplicitClaim,
@@ -794,7 +872,10 @@ export function registerNativeSessionV3Adapter(
     controller: nativeConversationController(entry),
     dispose: () => {
       entry?.listeners.delete(onConversationUpdate)
-      if (entry && entry.listeners.size === 0) conversations.delete(id)
+      if (entry && entry.listeners.size === 0) {
+        clearOpenCodeSilentTurn(entry)
+        conversations.delete(id)
+      }
     }
   }
 }

--- a/web/src/session-first-regression.test.mjs
+++ b/web/src/session-first-regression.test.mjs
@@ -117,6 +117,8 @@ assert.ok(adapter.includes('OPENCODE_IDLE_CONFIRM_MS = 750') && adapter.includes
 assert.ok(adapter.includes('const terminalError = Boolean(latestAssistant.info.error)') && adapter.includes('if (!terminalError || entry.forcedStatus !== "running") return'), 'OpenCode terminal provider/model errors must have a transcript fallback when the legacy status endpoint omits the Session')
 assert.ok(adapter.includes('terminalError ? now + OPENCODE_RECOVERY_WATCH_MS : 0'), 'OpenCode transcript-confirmed errors must retain the bounded late-retry recovery window')
 assert.ok(adapter.includes('OPENCODE_RECOVERY_WATCH_MS') && adapter.includes('openCodeRecoveryWatchUntil'), 'OpenCode must retract a terminal-looking interruption when a bounded late retry becomes busy again')
+assert.ok(adapter.includes('OPENCODE_SILENT_TURN_GRACE_MS = 15_000') && adapter.includes('armOpenCodeSilentTurnRecovery(entry, id)'), 'an accepted OpenCode prompt with no response must schedule a bounded orphan-turn recovery')
+assert.ok(adapter.includes('api.listStatuses(entry.target.config, entry.target.directory)') && adapter.includes('OpenCode ended this request without a response'), 'OpenCode must surface a terminal no-response error only after an authoritative status/transcript check')
 assert.ok(adapter.includes('const statuses = await api.listStatuses(entry.target.config)'), 'non-OpenCode projections must retain native status enrichment')
 assert.equal(adapter.includes('WORKING_STATUS_GRACE_MS'), false, 'web adapter must not invent a generic stale-working timeout across harnesses')
 assert.equal(adapter.includes('TaskDeskConversation'), false, 'adapter must not render chat')


### PR DESCRIPTION
## Summary
- surface a failed OpenCode turn when prompt_async produces neither a response nor a session status
- retain PI's short post-prompt notification drain so late reasoning Activity settles to Done
- add regression coverage for late PI prompt notifications and the OpenCode orphan-turn recovery

## Verification
- npm test (bridge): 485 passing
- npm run build (web)
- node --experimental-strip-types web/src/session-first-regression.test.mjs