### PR TITLE
P0: clarify startup summary and multi-harness availability

### DIFF
--- a/bridge/src/launcher.js
+++ b/bridge/src/launcher.js
@@ -221,8 +221,31 @@ export function lanAddresses(interfaces = networkInterfaces()) {
   return [...new Set((preferred.length ? preferred : candidates).map(({ address }) => address))]
 }
 
+export function formatStartupSummary({ plan, addresses, port, username, password }) {
+  const lines = ["Harness Remote", "", "Connect this machine:"]
+  const reachableAddresses = addresses.length ? addresses : ["<this machine's LAN address>"]
+  for (const address of reachableAddresses) lines.push(`  Address   http://${address}:${port}`)
+  lines.push(`  Username  ${username}`)
+  lines.push(`  Password  ${password}`)
+
+  if (plan.mode === "daemon") {
+    lines.push("", "Harnesses available through this machine:")
+    for (const agent of plan.detected) {
+      if (agent === plan.backend) lines.push(`  • ${agent} — primary`)
+      else if (agent === "opencode") lines.push("  • opencode — managed, starts on first use")
+      else lines.push(`  • ${agent} — available`)
+    }
+  } else {
+    lines.push("", `Harness: ${plan.backend}`)
+  }
+
+  lines.push("", "Next: open Harness Remote → Machines → Add machine, then enter the address and credentials above.")
+  lines.push("Keep this terminal running while you use Harness Remote.")
+  return `${lines.join("\n")}\n`
+}
+
 export function launcherUsage() {
-  return `Usage: harness-remote [options]\n\nQuick start options:\n  --backend <name>       Select omp, pi, claude, codex, or opencode (on multi-agent machines, selects the daemon primary)\n  --single               Force the legacy single-backend path instead of the machine daemon\n  --host <host>          Bind host (quick-start default: 0.0.0.0)\n  --port <port>          Preferred port (OpenCode single-host default: 4096; daemon/ACP default: 4097)\n  --username <username>  Override generated Basic Auth username\n  --password <password>  Override generated Basic Auth password\n  --help                 Show this help\n\nWith one detected agent, Harness starts the existing single-backend path. With multiple detected agents and at least one ACP backend, it starts the machine daemon automatically; OpenCode is included when installed and receives a free loopback port automatically.`
+  return `Usage: harness-remote [options]\n\nQuick start options:\n  --backend <name>       Select omp, pi, claude, codex, or opencode (on multi-agent machines, selects the daemon primary)\n  --single               Force the legacy single-backend path instead of the machine daemon\n  --host <host>          Bind host (quick-start default: 0.0.0.0)\n  --port <port>          Preferred port (OpenCode single-host default: 4096; daemon/ACP default: 4097)\n  --username <username>  Override generated Basic Auth username\n  --password <password>  Override generated Basic Auth password\n  --help                 Show this help\n\nWith one detected agent, Harness starts the existing single-backend path. With multiple detected agents and at least one ACP backend, it starts the machine daemon automatically and exposes every detected ACP harness through the machine endpoint; OpenCode is included when installed and receives a free loopback port automatically.`
 }
 
 export async function startManagedOpenCode({ host, port, username, password, command = "opencode", Host = ManagedOpenCodeHost } = {}) {
@@ -313,28 +336,7 @@ async function main() {
   if (!username) ({ username, password } = generateCredentials())
 
   const addresses = host === "0.0.0.0" ? lanAddresses() : [host]
-
-  process.stdout.write("Harness Remote\n\n")
-  process.stdout.write("Configure this server in Harness Remote:\n")
-  if (addresses.length) {
-    for (const address of addresses) process.stdout.write(`  Address   http://${address}:${port}\n`)
-  } else {
-    process.stdout.write(`  Address   http://<this machine's LAN address>:${port}\n`)
-  }
-  process.stdout.write(`  Username  ${username}\n`)
-  process.stdout.write(`  Password  ${password}\n`)
-
-  if (plan.mode === "daemon") {
-    process.stdout.write("\nHarnesses detected on this machine:\n")
-    for (const agent of plan.detected) {
-      if (agent === backend) process.stdout.write(`  • ${agent} — selected as primary\n`)
-      else if (agent === "opencode") process.stdout.write("  • opencode — will be started by the daemon\n")
-      else process.stdout.write(`  • ${agent} — detected, not started\n`)
-    }
-    process.stdout.write("\n")
-  } else {
-    process.stdout.write(`\nBackend: ${backend}\n`)
-  }
+  process.stdout.write(formatStartupSummary({ plan, addresses, port, username, password }))
 
   if (plan.mode === "daemon") {
     const daemonArgs = buildDaemonArgs(args, { backend, host, port, openCode: plan.openCode, openCodePort })

--- a/bridge/test/launcher.test.js
+++ b/bridge/test/launcher.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict"
 import path from "node:path"
 import test from "node:test"
-import { bridgeEnvironment, buildBridgeArgs, buildDaemonArgs, canListenForBind, createManagedShutdown, detectBackends, lanAddresses, resolveBackend, resolveLaunchPlan, startManagedOpenCode } from "../src/launcher.js"
+import { bridgeEnvironment, buildBridgeArgs, buildDaemonArgs, canListenForBind, createManagedShutdown, detectBackends, formatStartupSummary, lanAddresses, resolveBackend, resolveLaunchPlan, startManagedOpenCode } from "../src/launcher.js"
 
 test("detects executable agent files on PATH without running them", () => {
   const pathValue = ["/bin", "/tools"].join(path.delimiter)
@@ -79,6 +79,34 @@ test("keeps the legacy resolver strict for callers that still require one backen
 
 test("requires an installed or explicit backend when discovery finds none", () => {
   assert.throws(() => resolveLaunchPlan([], []), /No supported agent CLI was found on PATH/)
+})
+
+test("describes every daemon harness as available instead of claiming secondary ACP hosts are not started", () => {
+  const summary = formatStartupSummary({
+    plan: { mode: "daemon", backend: "codex", detected: ["codex", "claude", "opencode"], openCode: true },
+    addresses: ["192.168.1.42"],
+    port: 4097,
+    username: "harness",
+    password: "secret"
+  })
+  assert.match(summary, /codex — primary/)
+  assert.match(summary, /claude — available/)
+  assert.match(summary, /opencode — managed, starts on first use/)
+  assert.doesNotMatch(summary, /not started/)
+  assert.match(summary, /Machines → Add machine/)
+})
+
+test("keeps the single-backend startup summary simple", () => {
+  const summary = formatStartupSummary({
+    plan: { mode: "single", backend: "pi", detected: ["pi"] },
+    addresses: [],
+    port: 4097,
+    username: "harness",
+    password: "secret"
+  })
+  assert.match(summary, /Harness: pi/)
+  assert.match(summary, /<this machine's LAN address>/)
+  assert.doesNotMatch(summary, /Harnesses available through this machine/)
 })
 
 test("injects quick-start defaults but never places credentials or launcher-only flags on child argv", () => {

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -29,7 +29,8 @@ npx github:giuliastro/harness-remote \
 ```
 
 `--root` is the directory boundary used when choosing Projects. The launcher prints the machine
-address and credentials you will enter in the client.
+address and credentials you will enter in the client, the harnesses that will be available through
+that machine, and the next step to add it under **Machines → Add machine**.
 
 To use the web/PWA frontend from a checkout:
 
@@ -68,12 +69,13 @@ The launcher inspects `PATH` without executing discovered agent binaries and cho
 
 - with exactly one supported CLI, it preserves the existing single-backend startup path;
 - with multiple supported CLIs and at least one ACP-backed agent, it starts the machine daemon automatically;
-- the daemon selects one detected ACP backend as its primary host and includes managed OpenCode when OpenCode is installed;
+- the daemon exposes every detected ACP-backed agent through the same machine endpoint and selects one of them as the primary for legacy/unprefixed routing;
+- managed OpenCode is included when OpenCode is installed and starts lazily on first use;
 - `--backend <name>` selects the ACP primary on a multi-agent machine;
 - `--single --backend <name>` explicitly opts out of the daemon and forces the legacy single-backend path;
 - if managed OpenCode is included, the launcher chooses a free loopback port automatically instead of assuming 4096 is unused;
 - credentials are generated automatically and kept out of child-process argv;
-- the LAN address and credentials to enter in the client are printed before startup continues.
+- the LAN address, credentials, available harnesses and next client action are printed before startup continues.
 
 The supported CLI names are `omp`, `pi`, `claude`, `codex`, and `opencode`.
 
@@ -85,15 +87,16 @@ harness-remote
 
 starts one machine daemon instead of failing and asking you to choose a backend. The launcher reports the CLIs it detected, selects an ACP primary, finds a free loopback port for managed OpenCode, and exposes the machine through one authenticated daemon connection.
 
-The current automatic multi-host shape is deliberately precise:
+The current automatic multi-host shape is:
 
 ```text
 Harness daemon :4097
-  ├── one detected ACP primary (Codex / Claude / OMP / PI)
-  └── OpenCode, when installed, as a managed loopback HTTP host
+  ├── Codex / Claude / OMP / PI — every detected ACP harness
+  │   └── one selected as primary for legacy/unprefixed routing
+  └── OpenCode, when installed — managed loopback host, started on first use
 ```
 
-Other detected ACP CLIs are reported by discovery but are not all instantiated concurrently by this startup slice yet. The daemon API and client are already agent-scoped, so adding more ACP host instances does not require another client transport change.
+The daemon registers the detected ACP harnesses independently, so choosing one primary does not hide the others from agent-scoped machine APIs. Harness processes may still be started lazily by their adapters; “available” describes what the machine endpoint exposes, not a promise that every CLI process is already resident before first use.
 
 ## Choose the daemon primary or force one backend
 

--- a/web/src/native-session-observer.test.mjs
+++ b/web/src/native-session-observer.test.mjs
@@ -35,7 +35,11 @@ assert.ok(adapter.includes('candidates?.length !== 1'), 'PI identity stabilizati
 assert.ok(adapter.includes('nextKeyCounts.get(key) !== 1'), 'PI identity stabilization must preserve legitimate repeated identical journal answers')
 assert.ok(adapter.includes('entry.target.backend !== "pi" || before'), 'PI identity stabilization must stay scoped to current tail reads and never rewrite older-page history')
 assert.ok(adapter.includes('message.info.error'), 'PI identity stabilization must keep interrupted/error turns outside text-only aliasing')
-assert.ok(adapter.includes('if (entry && entry.listeners.size === 0) conversations.delete(id)'), 'leaving a Session must dispose its transient projection so another Session starts cleanly')
+// Assert the disposal invariant rather than one exact one-line spelling. Session teardown may need
+// additional cleanup before the transient projection is removed from the map.
+assert.ok(adapter.includes('entry?.listeners.delete(onConversationUpdate)'), 'leaving a Session must remove its projection listener')
+assert.ok(adapter.includes('if (entry && entry.listeners.size === 0) {'), 'the final listener must trigger projection disposal')
+assert.ok(adapter.includes('conversations.delete(id)'), 'leaving the final listener must dispose the transient projection so another Session starts cleanly')
 assert.equal(adapter.includes('MAX_CACHED_PROJECTIONS'), false, 'Session runtimes must not survive navigation in a global cache')
 assert.equal(adapter.includes('pruneInactiveProjections'), false, 'Session navigation must not retain inactive runtime state')
 assert.ok(adapter.includes('reconcileNativeSessionModel(entry, page, before)'), 'every current tail page must refresh delayed OpenCode and Codex model metadata')


### PR DESCRIPTION
## Summary

This is a P0 startup/onboarding slice for #368.

- makes launcher output tell users exactly how to connect and what to do next;
- fixes the stale/misleading `detected, not started` label for secondary ACP harnesses;
- reflects the current machine daemon behavior: every detected ACP harness is exposed, one remains primary for legacy/unprefixed routing, and managed OpenCode starts lazily;
- adds focused regression coverage for daemon and single-backend startup summaries;
- aligns `docs/QUICK_START.md` with the runtime that already ships;
- fixes one pre-existing brittle source-text guard in `native-session-observer.test.mjs`: the runtime already disposed zero-listener projections correctly, but the guard still required the old one-line spelling and made the full regression tier red.

## Risk boundary

No ACP protocol, adapter behavior, routing, Native Session behavior, reconciliation, model-selection, Stop/cancel, or daemon-registration behavior is changed. Runtime changes are limited to launcher text formatting; the web change is test-only.

## Validation

The PR targets `codex/development-2026-09-11`, not `main`.

The first CI run exposed the stale disposal source-text guard while bridge tests were already green on macOS and Windows. After changing the guard to assert the disposal invariant instead of exact formatting, the full web regression tier and Linux bridge tests pass. Cross-platform bridge and product gates are allowed to complete before merge.

Refs #368
Refs #330