### PR TITLE
P0: make real-harness validation a traceable release gate

### DIFF
--- a/bridge/package.json
+++ b/bridge/package.json
@@ -12,6 +12,8 @@
     "daemon": "node src/daemon-cli.js",
     "audit:probe": "node scripts/backend-audit-probe.mjs",
     "smoke:omp": "node scripts/omp-real-smoke.mjs",
+    "soak:session": "node scripts/session-first-soak.mjs",
+    "gate:real-harness": "node scripts/real-harness-release-gate.mjs",
     "test": "node --test"
   },
   "engines": {

--- a/bridge/scripts/real-harness-release-gate.mjs
+++ b/bridge/scripts/real-harness-release-gate.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+import { execFileSync, spawn } from "node:child_process"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+export const SUPPORTED_HARNESSES = ["opencode", "codex", "claude", "omp", "pi"]
+
+function optionValue(args, name) {
+  const index = args.indexOf(name)
+  return index >= 0 ? args[index + 1] : undefined
+}
+
+export function parseHarnessList(value = SUPPORTED_HARNESSES.join(",")) {
+  const requested = value.split(",").map((entry) => entry.trim().toLowerCase()).filter(Boolean)
+  const harnesses = [...new Set(requested)]
+  if (harnesses.length < 2) throw new Error("Real-harness release validation requires at least two harnesses so isolation can be exercised.")
+  const unsupported = harnesses.filter((harness) => !SUPPORTED_HARNESSES.includes(harness))
+  if (unsupported.length) throw new Error(`Unsupported harness(es): ${unsupported.join(", ")}. Supported: ${SUPPORTED_HARNESSES.join(", ")}.`)
+  return harnesses
+}
+
+export function buildHarnessPlan(harnesses) {
+  if (!Array.isArray(harnesses) || harnesses.length < 2) throw new Error("At least two harnesses are required.")
+  return harnesses.map((primary, index) => ({
+    primary,
+    secondary: harnesses[(index + 1) % harnesses.length]
+  }))
+}
+
+export function resolveGateMode(value = "release") {
+  if (value !== "release" && value !== "control-plane") {
+    throw new Error("--mode must be 'release' or 'control-plane'.")
+  }
+  return value
+}
+
+export function releaseEligibility({ mode, echoMarkers }) {
+  if (mode === "control-plane") {
+    return {
+      releaseEligible: false,
+      evidence: "control-plane-only",
+      note: "Native harness errors may count as delivered; this run cannot verify real inference."
+    }
+  }
+  return {
+    releaseEligible: true,
+    evidence: echoMarkers ? "echo-marker" : "turn-arrival",
+    note: echoMarkers
+      ? "Per-turn routing is proven with echoed markers."
+      : "Per-turn routing is judged by ordered turn arrival; report records the weaker evidence explicitly."
+  }
+}
+
+function safeURL(value) {
+  try {
+    const parsed = new URL(value)
+    parsed.username = ""
+    parsed.password = ""
+    return parsed.toString().replace(/\/$/, "")
+  } catch {
+    return "invalid-url"
+  }
+}
+
+function gitCommit() {
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim()
+  } catch {
+    return process.env.GITHUB_SHA ?? null
+  }
+}
+
+function stamp(date = new Date()) {
+  return date.toISOString().replace(/[:.]/g, "-")
+}
+
+export function defaultReportPath(cwd = process.cwd(), date = new Date()) {
+  return path.join(cwd, "artifacts", `real-harness-gate-${stamp(date)}.json`)
+}
+
+export function gateUsage() {
+  return `Usage: npm run gate:real-harness -- [options]\n\nOptions:\n  --harnesses <list>  Comma-separated harnesses to verify (default: ${SUPPORTED_HARNESSES.join(",")})\n  --mode <mode>       release (default) or control-plane\n  --report <path>     JSON evidence report path (default: artifacts/real-harness-gate-<timestamp>.json)\n  --help              Show this help\n\nShared soak settings still use HR_URL, HR_USER, HR_PASS, HR_DIR_A, HR_DIR_B, HR_CYCLES, HR_TURN_BUDGET_MS and HR_ECHO_MARKERS. Release mode always disables HR_ALLOW_TURN_ERRORS. Use --mode control-plane when inference is unavailable; that mode is recorded as not release-eligible.`
+}
+
+async function runSoak({ primary, secondary, mode, soakPath }) {
+  const startedAt = new Date()
+  const started = Date.now()
+  const env = {
+    ...process.env,
+    HR_PRIMARY: primary,
+    HR_SECONDARY: secondary,
+    HR_ALLOW_TURN_ERRORS: mode === "control-plane" ? "1" : "0"
+  }
+
+  const result = await new Promise((resolve) => {
+    const child = spawn(process.execPath, [soakPath], { env, stdio: "inherit" })
+    child.once("error", (error) => resolve({ exitCode: 1, signal: null, error: error.message }))
+    child.once("exit", (code, signal) => resolve({ exitCode: code ?? (signal ? 1 : 0), signal: signal ?? null, error: null }))
+  })
+
+  return {
+    primary,
+    secondary,
+    startedAt: startedAt.toISOString(),
+    durationMs: Date.now() - started,
+    ...result,
+    passed: result.exitCode === 0
+  }
+}
+
+export async function runGate({ harnesses, mode, reportPath, soakPath = fileURLToPath(new URL("./session-first-soak.mjs", import.meta.url)) }) {
+  const echoMarkers = process.env.HR_ECHO_MARKERS !== "0"
+  const eligibility = releaseEligibility({ mode, echoMarkers })
+  const plan = buildHarnessPlan(harnesses)
+  const runs = []
+
+  console.log(`Harness Remote real-harness gate: mode=${mode}`)
+  console.log(`Harnesses: ${harnesses.join(", ")}`)
+  console.log(`Evidence: ${eligibility.evidence}`)
+  console.log(eligibility.note)
+
+  for (const pair of plan) {
+    console.log(`\n========================================`)
+    console.log(`Primary ${pair.primary} / secondary ${pair.secondary}`)
+    console.log(`========================================`)
+    const result = await runSoak({ ...pair, mode, soakPath })
+    runs.push(result)
+    if (!result.passed) {
+      console.error(`Gate leg failed for ${pair.primary} (exit ${result.exitCode}${result.signal ? `, signal ${result.signal}` : ""}).`)
+    }
+  }
+
+  const allPassed = runs.every((run) => run.passed)
+  const verdict = !allPassed ? "failed" : eligibility.releaseEligible ? "verified" : "control-plane-only"
+  const report = {
+    schemaVersion: 1,
+    kind: "harness-remote-real-harness-gate",
+    generatedAt: new Date().toISOString(),
+    source: { commit: gitCommit() },
+    runtime: { platform: process.platform, arch: process.arch, node: process.version },
+    endpoint: safeURL(process.env.HR_URL ?? "http://127.0.0.1:4097"),
+    mode,
+    releaseEligible: eligibility.releaseEligible,
+    routingEvidence: eligibility.evidence,
+    harnesses,
+    settings: {
+      cycles: Number(process.env.HR_CYCLES ?? "5"),
+      turnBudgetMs: Number(process.env.HR_TURN_BUDGET_MS ?? "120000"),
+      echoMarkers,
+      allowTurnErrors: mode === "control-plane"
+    },
+    runs,
+    verdict
+  }
+
+  fs.mkdirSync(path.dirname(reportPath), { recursive: true })
+  fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8")
+  console.log(`\nEvidence report: ${reportPath}`)
+  console.log(`Verdict: ${verdict}`)
+  return report
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  if (args.includes("--help")) {
+    console.log(gateUsage())
+    return
+  }
+  const known = new Set(["--harnesses", "--mode", "--report"])
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (!known.has(arg)) throw new Error(`Unknown option '${arg}'. Use --help for usage.`)
+    if (!args[index + 1] || args[index + 1].startsWith("--")) throw new Error(`${arg} requires a value.`)
+    index += 1
+  }
+
+  const harnesses = parseHarnessList(optionValue(args, "--harnesses") ?? process.env.HR_GATE_HARNESSES)
+  const mode = resolveGateMode(optionValue(args, "--mode") ?? process.env.HR_GATE_MODE ?? "release")
+  const reportPath = path.resolve(optionValue(args, "--report") ?? process.env.HR_GATE_REPORT ?? defaultReportPath())
+  const report = await runGate({ harnesses, mode, reportPath })
+  if (report.verdict === "failed") process.exitCode = 1
+  else if (report.verdict === "control-plane-only") process.exitCode = 2
+}
+
+const direct = Boolean(process.argv[1]) && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (direct) {
+  main().catch((error) => {
+    console.error(error.message)
+    process.exitCode = 1
+  })
+}

--- a/bridge/test/real-harness-release-gate.test.js
+++ b/bridge/test/real-harness-release-gate.test.js
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict"
+import path from "node:path"
+import test from "node:test"
+import {
+  SUPPORTED_HARNESSES,
+  buildHarnessPlan,
+  defaultReportPath,
+  parseHarnessList,
+  releaseEligibility,
+  resolveGateMode
+} from "../scripts/real-harness-release-gate.mjs"
+
+test("defaults the release gate to every supported harness", () => {
+  assert.deepEqual(parseHarnessList(), SUPPORTED_HARNESSES)
+})
+
+test("normalizes and deduplicates an explicit harness list", () => {
+  assert.deepEqual(parseHarnessList(" codex,CLAUDE,codex,opencode "), ["codex", "claude", "opencode"])
+})
+
+test("rejects unknown harnesses and one-harness pseudo gates", () => {
+  assert.throws(() => parseHarnessList("codex,cursor"), /Unsupported harness/)
+  assert.throws(() => parseHarnessList("codex"), /at least two harnesses/i)
+})
+
+test("rotates each harness through primary responsibility", () => {
+  assert.deepEqual(buildHarnessPlan(["codex", "claude", "pi"]), [
+    { primary: "codex", secondary: "claude" },
+    { primary: "claude", secondary: "pi" },
+    { primary: "pi", secondary: "codex" }
+  ])
+})
+
+test("distinguishes release evidence from control-plane-only evidence", () => {
+  assert.deepEqual(releaseEligibility({ mode: "release", echoMarkers: true }), {
+    releaseEligible: true,
+    evidence: "echo-marker",
+    note: "Per-turn routing is proven with echoed markers."
+  })
+  assert.equal(releaseEligibility({ mode: "release", echoMarkers: false }).evidence, "turn-arrival")
+  assert.deepEqual(releaseEligibility({ mode: "control-plane", echoMarkers: true }), {
+    releaseEligible: false,
+    evidence: "control-plane-only",
+    note: "Native harness errors may count as delivered; this run cannot verify real inference."
+  })
+})
+
+test("only accepts the two explicit gate modes", () => {
+  assert.equal(resolveGateMode(), "release")
+  assert.equal(resolveGateMode("control-plane"), "control-plane")
+  assert.throws(() => resolveGateMode("quick"), /release.*control-plane/)
+})
+
+test("default report path stays outside source files and carries a timestamp", () => {
+  const report = defaultReportPath("/work", new Date("2026-09-11T03:45:12.345Z"))
+  assert.equal(report, path.join("/work", "artifacts", "real-harness-gate-2026-09-11T03-45-12-345Z.json"))
+})

--- a/bridge/test/real-harness-release-gate.test.js
+++ b/bridge/test/real-harness-release-gate.test.js
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict"
+import fs from "node:fs"
+import os from "node:os"
 import path from "node:path"
 import test from "node:test"
 import {
@@ -7,7 +9,8 @@ import {
   defaultReportPath,
   parseHarnessList,
   releaseEligibility,
-  resolveGateMode
+  resolveGateMode,
+  runGate
 } from "../scripts/real-harness-release-gate.mjs"
 
 test("defaults the release gate to every supported harness", () => {
@@ -54,4 +57,32 @@ test("only accepts the two explicit gate modes", () => {
 test("default report path stays outside source files and carries a timestamp", () => {
   const report = defaultReportPath("/work", new Date("2026-09-11T03:45:12.345Z"))
   assert.equal(report, path.join("/work", "artifacts", "real-harness-gate-2026-09-11T03-45-12-345Z.json"))
+})
+
+test("orchestrates every primary and persists credential-free release evidence", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "hr-real-gate-"))
+  const soakPath = path.join(root, "fake-soak.mjs")
+  const reportPath = path.join(root, "report.json")
+  fs.writeFileSync(soakPath, "process.exit(0)\n", "utf8")
+  const previousURL = process.env.HR_URL
+  process.env.HR_URL = "http://user:secret@127.0.0.1:4097"
+
+  try {
+    const report = await runGate({ harnesses: ["codex", "claude"], mode: "release", reportPath, soakPath })
+    assert.equal(report.verdict, "verified")
+    assert.equal(report.releaseEligible, true)
+    assert.deepEqual(report.runs.map(({ primary, secondary, passed }) => ({ primary, secondary, passed })), [
+      { primary: "codex", secondary: "claude", passed: true },
+      { primary: "claude", secondary: "codex", passed: true }
+    ])
+
+    const persisted = JSON.parse(fs.readFileSync(reportPath, "utf8"))
+    assert.equal(persisted.endpoint, "http://127.0.0.1:4097")
+    assert.equal(JSON.stringify(persisted).includes("secret"), false)
+    assert.equal(JSON.stringify(persisted).includes("user:"), false)
+  } finally {
+    if (previousURL === undefined) delete process.env.HR_URL
+    else process.env.HR_URL = previousURL
+    fs.rmSync(root, { recursive: true, force: true })
+  }
 })

--- a/docs/REAL_HARNESS_RELEASE_GATE.md
+++ b/docs/REAL_HARNESS_RELEASE_GATE.md
@@ -1,0 +1,145 @@
+# Real-harness release gate
+
+Harness Remote treats installed coding harnesses as the authority for their Native Sessions. Unit tests and browser fixtures are necessary, but they cannot prove that the current OpenCode, Codex, Claude, OMP and PI integrations still behave correctly against real installed harnesses.
+
+This gate turns the existing Session-first soak into a repeatable release check and records what was actually verified on a machine.
+
+## What it verifies
+
+For every selected harness, the gate makes that harness the **primary** once and runs the existing Session-first soak against a second harness. A strict release run therefore exercises, for each primary:
+
+- live model-catalog discovery;
+- two real Native Sessions;
+- repeated model changes;
+- repeated prompt delivery and transcript convergence;
+- cross-harness navigation/isolation;
+- an advertised variant when one exists;
+- native Stop followed by a usable Session;
+- exactly-once user-turn checks;
+- bounded listeners/subscribers and no leftover ACP requests, queued prompts or unresolved mutations.
+
+The gate does not replace Android background/foreground or physical network-interruption testing. Those remain separate release checks because they require a real client/device boundary.
+
+## Start the daemon
+
+Run the development build you intend to validate and expose only the machine endpoint needed by the test. For example:
+
+```bash
+npm start -- \
+  --host 127.0.0.1 \
+  --port 4097 \
+  --username harness \
+  --password 'local-test-password' \
+  --root "$HOME/Software"
+```
+
+Use the same commit/build for every harness in one release evidence set.
+
+## Strict release run
+
+From `bridge/`:
+
+```bash
+HR_URL=http://127.0.0.1:4097 \
+HR_USER=harness \
+HR_PASS='local-test-password' \
+HR_DIR_A="$HOME/Software/project-a" \
+HR_DIR_B="$HOME/Software/project-b" \
+npm run gate:real-harness
+```
+
+By default the gate validates:
+
+```text
+opencode,codex,claude,omp,pi
+```
+
+Each harness becomes primary once. The secondary rotates so that switching/isolation is exercised as part of every leg.
+
+A successful strict run writes a report under `artifacts/real-harness-gate-<timestamp>.json` with verdict `verified`.
+
+The report deliberately contains no username, password, prompt body or model catalog. It records the commit when available, platform/architecture/Node version, endpoint without URL credentials, harness pairs, durations, exit status, evidence strength and final verdict.
+
+## Run a subset while developing
+
+A two-or-more harness subset is useful before the full release run:
+
+```bash
+npm run gate:real-harness -- --harnesses codex,claude,opencode
+```
+
+This can prove the selected integrations, but it is not evidence that the omitted harnesses were verified. For a release candidate, run all supported harnesses unless the release record explicitly marks an integration as unverified.
+
+## When a model does not echo markers reliably
+
+The soak normally asks the primary model to echo a unique marker. This is the strongest routing evidence because it ties a specific prompt to a specific assistant reply.
+
+For a harness/model that does not reliably obey that instruction:
+
+```bash
+HR_ECHO_MARKERS=0 npm run gate:real-harness
+```
+
+The run can still pass, but the JSON report records `routingEvidence: "turn-arrival"` instead of `echo-marker`. Do not describe the two evidence strengths as identical.
+
+## Control-plane-only mode
+
+If a provider cannot serve inference but you still want to exercise routing, catalogs, Session creation and lifecycle plumbing:
+
+```bash
+npm run gate:real-harness -- --mode control-plane
+```
+
+This mode sets the soak to allow native turn errors and records:
+
+```json
+{
+  "releaseEligible": false,
+  "verdict": "control-plane-only"
+}
+```
+
+It exits with code `2` even when every control-plane leg passes. This is intentional: a provider outage, missing subscription or invalid inference credential must never be silently promoted to a fully verified release.
+
+## Custom report location
+
+```bash
+npm run gate:real-harness -- --report /tmp/hr-release-evidence.json
+```
+
+or set `HR_GATE_REPORT`.
+
+## Existing soak command
+
+For focused diagnosis of one primary/secondary pair, the underlying probe is now exposed directly:
+
+```bash
+HR_PRIMARY=pi \
+HR_SECONDARY=opencode \
+HR_URL=http://127.0.0.1:4097 \
+HR_USER=harness \
+HR_PASS='local-test-password' \
+npm run soak:session
+```
+
+Useful environment controls include `HR_CYCLES`, `HR_TURN_BUDGET_MS`, `HR_DIR_A`, `HR_DIR_B`, `HR_ECHO_MARKERS` and `HR_ALLOW_TURN_ERRORS`.
+
+## Interpreting catalog checks
+
+Two different harnesses can legitimately advertise overlapping, or even identical, provider/model inventories. Catalog equality by itself is therefore not proof of cross-harness leakage. Release evidence should focus on agent-scoped requests, Native Session identity, prompt routing and stable per-agent diagnostics rather than assuming model names must differ.
+
+The legacy soak currently retains a conservative whole-catalog inequality assertion. If two selected harnesses intentionally expose the exact same normalized catalog, treat that specific failure as an **inconclusive tooling limitation**, not evidence that the runtime is broken, and do not mark the release `verified` until the probe has been rerun with an unambiguous isolation check.
+
+## Release record
+
+For each release candidate, preserve the JSON report and record the distinction required by the capability matrix:
+
+| Harness | Implemented | Advertised by installed harness | Verified on this real build | Evidence |
+| --- | --- | --- | --- | --- |
+| OpenCode | yes/no | yes/no | yes/no | report + notes |
+| Codex | yes/no | yes/no | yes/no | report + notes |
+| Claude | yes/no | yes/no | yes/no | report + notes |
+| OMP | yes/no | yes/no | yes/no | report + notes |
+| PI | yes/no | yes/no | yes/no | report + notes |
+
+A green GitHub Actions run proves the automated regression/product gates. It does **not** by itself fill the final “Verified on this real build” column.


### PR DESCRIPTION
## Summary

Second P0 reliability slice for #368.

- exposes the existing real Session soak as `npm run soak:session`;
- adds `npm run gate:real-harness`, which rotates every selected supported harness through primary responsibility;
- defaults the release gate to OpenCode, Codex, Claude, OMP and PI;
- writes a credential-free JSON evidence report with commit/runtime metadata, harness pairings, duration, exit status, evidence strength and verdict;
- separates strict `release` validation from `control-plane` validation so provider/inference failures cannot be mislabeled as a verified release;
- records weaker `HR_ECHO_MARKERS=0` evidence explicitly instead of silently treating it as marker-proven routing;
- documents the real-machine release workflow and the boundary between GitHub CI and real-harness verification;
- adds unit coverage for planning, evidence semantics, orchestration and credential hygiene.

## Runtime risk boundary

No adapter, ACP protocol, native Session implementation, router, daemon service, model catalog implementation, Stop/cancel behavior, or client runtime file is changed. This PR adds release-validation tooling only.

## Important existing soak limitation

Two harnesses can legitimately advertise identical normalized model inventories. The existing soak still has a conservative whole-catalog inequality assertion. The new documentation explicitly classifies an exact-identical-catalog failure as inconclusive tooling evidence, never as a verified pass. A future focused probe can replace that assertion with an unambiguous agent-scoped isolation proof without weakening runtime behavior.

## Validation

This PR targets `codex/development-2026-09-11`, never `main`. The full repository PR gate must pass before merge.

Refs #368