### PR TITLE
P0: preflight real-harness validation and remove catalog false negatives

### DIFF
--- a/bridge/scripts/real-harness-release-gate.mjs
+++ b/bridge/scripts/real-harness-release-gate.mjs
@@ -63,6 +63,79 @@ function safeURL(value) {
   }
 }
 
+function authorization(user = process.env.HR_USER ?? "", pass = process.env.HR_PASS ?? "") {
+  return `Basic ${Buffer.from(`${user}:${pass}`, "utf8").toString("base64")}`
+}
+
+function preflightAgent(agentID, agents) {
+  const agent = agents.find((candidate) => candidate?.id === agentID)
+  return {
+    id: agentID,
+    registered: Boolean(agent),
+    backend: agent?.backend ?? null,
+    transport: agent?.transport ?? null,
+    state: agent?.state ?? null,
+    modelCatalog: agent?.modelCatalog
+      ? {
+          configured: true,
+          source: agent.modelCatalog.source ?? null,
+          cachedModels: agent.modelCatalog.cachedModels ?? 0,
+          phase: agent.modelCatalog.phase ?? null
+        }
+      : { configured: false, source: null, cachedModels: 0, phase: null }
+  }
+}
+
+export async function preflightDaemon({
+  harnesses,
+  urlRoot = process.env.HR_URL ?? "http://127.0.0.1:4097",
+  user = process.env.HR_USER ?? "",
+  pass = process.env.HR_PASS ?? "",
+  fetchImpl = globalThis.fetch,
+  timeoutMs = 10_000
+}) {
+  const root = urlRoot.replace(/\/$/, "")
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await fetchImpl(`${root}/v1/diagnostics`, {
+      headers: { Accept: "application/json", Authorization: authorization(user, pass) },
+      signal: controller.signal
+    })
+    const text = await response.text()
+    let data
+    try { data = text ? JSON.parse(text) : {} } catch { data = {} }
+
+    if (!response.ok) {
+      const detail = response.status === 401
+        ? "Daemon rejected the supplied credentials."
+        : `Diagnostics endpoint returned HTTP ${response.status}.`
+      return { passed: false, status: response.status, error: detail, machineID: null, agents: [], missingHarnesses: [...harnesses], missingModelCatalogs: [] }
+    }
+
+    const agents = Array.isArray(data?.agents) ? data.agents : []
+    const selected = harnesses.map((agentID) => preflightAgent(agentID, agents))
+    const missingHarnesses = selected.filter((agent) => !agent.registered).map((agent) => agent.id)
+    const missingModelCatalogs = selected.filter((agent) => agent.registered && !agent.modelCatalog.configured).map((agent) => agent.id)
+    return {
+      passed: missingHarnesses.length === 0 && missingModelCatalogs.length === 0,
+      status: response.status,
+      error: null,
+      machineID: data?.machine?.id ?? null,
+      agents: selected,
+      missingHarnesses,
+      missingModelCatalogs
+    }
+  } catch (error) {
+    const message = error?.name === "AbortError"
+      ? `Diagnostics preflight timed out after ${timeoutMs}ms.`
+      : `Could not reach daemon diagnostics: ${error instanceof Error ? error.message : String(error)}`
+    return { passed: false, status: 0, error: message, machineID: null, agents: [], missingHarnesses: [...harnesses], missingModelCatalogs: [] }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
 function gitCommit() {
   try {
     return execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim()
@@ -80,7 +153,7 @@ export function defaultReportPath(cwd = process.cwd(), date = new Date()) {
 }
 
 export function gateUsage() {
-  return `Usage: npm run gate:real-harness -- [options]\n\nOptions:\n  --harnesses <list>  Comma-separated harnesses to verify (default: ${SUPPORTED_HARNESSES.join(",")})\n  --mode <mode>       release (default) or control-plane\n  --report <path>     JSON evidence report path (default: artifacts/real-harness-gate-<timestamp>.json)\n  --help              Show this help\n\nShared soak settings still use HR_URL, HR_USER, HR_PASS, HR_DIR_A, HR_DIR_B, HR_CYCLES, HR_TURN_BUDGET_MS and HR_ECHO_MARKERS. Release mode always disables HR_ALLOW_TURN_ERRORS. Use --mode control-plane when inference is unavailable; that mode is recorded as not release-eligible.`
+  return `Usage: npm run gate:real-harness -- [options]\n\nOptions:\n  --harnesses <list>  Comma-separated harnesses to verify (default: ${SUPPORTED_HARNESSES.join(",")})\n  --mode <mode>       release (default) or control-plane\n  --report <path>     JSON evidence report path (default: artifacts/real-harness-gate-<timestamp>.json)\n  --help              Show this help\n\nThe gate first checks /v1/diagnostics and stops early if the daemon is unreachable, credentials are rejected, a requested harness is not registered, or model discovery is not configured. Shared soak settings use HR_URL, HR_USER, HR_PASS, HR_DIR_A, HR_DIR_B, HR_CYCLES, HR_TURN_BUDGET_MS and HR_ECHO_MARKERS. Release mode always disables HR_ALLOW_TURN_ERRORS. Use --mode control-plane when inference is unavailable; that mode is recorded as not release-eligible.`
 }
 
 async function runSoak({ primary, secondary, mode, soakPath }) {
@@ -109,7 +182,20 @@ async function runSoak({ primary, secondary, mode, soakPath }) {
   }
 }
 
-export async function runGate({ harnesses, mode, reportPath, soakPath = fileURLToPath(new URL("./session-first-soak.mjs", import.meta.url)) }) {
+function persistReport(reportPath, report) {
+  fs.mkdirSync(path.dirname(reportPath), { recursive: true })
+  fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8")
+  console.log(`\nEvidence report: ${reportPath}`)
+  console.log(`Verdict: ${report.verdict}`)
+}
+
+export async function runGate({
+  harnesses,
+  mode,
+  reportPath,
+  soakPath = fileURLToPath(new URL("./session-first-soak.mjs", import.meta.url)),
+  preflight = preflightDaemon
+}) {
   const echoMarkers = process.env.HR_ECHO_MARKERS !== "0"
   const eligibility = releaseEligibility({ mode, echoMarkers })
   const plan = buildHarnessPlan(harnesses)
@@ -120,21 +206,35 @@ export async function runGate({ harnesses, mode, reportPath, soakPath = fileURLT
   console.log(`Evidence: ${eligibility.evidence}`)
   console.log(eligibility.note)
 
-  for (const pair of plan) {
-    console.log(`\n========================================`)
-    console.log(`Primary ${pair.primary} / secondary ${pair.secondary}`)
-    console.log(`========================================`)
-    const result = await runSoak({ ...pair, mode, soakPath })
-    runs.push(result)
-    if (!result.passed) {
-      console.error(`Gate leg failed for ${pair.primary} (exit ${result.exitCode}${result.signal ? `, signal ${result.signal}` : ""}).`)
+  console.log("\n== daemon preflight ==")
+  const preflightResult = await preflight({ harnesses })
+  if (preflightResult.passed) {
+    for (const agent of preflightResult.agents) {
+      console.log(`  ok   ${agent.id}: registered, model discovery=${agent.modelCatalog.source ?? "configured"}`)
+    }
+  } else {
+    console.error(`  FAIL ${preflightResult.error ?? "Daemon preflight failed."}`)
+    if (preflightResult.missingHarnesses?.length) console.error(`       missing harnesses: ${preflightResult.missingHarnesses.join(", ")}`)
+    if (preflightResult.missingModelCatalogs?.length) console.error(`       model discovery unavailable: ${preflightResult.missingModelCatalogs.join(", ")}`)
+  }
+
+  if (preflightResult.passed) {
+    for (const pair of plan) {
+      console.log(`\n========================================`)
+      console.log(`Primary ${pair.primary} / secondary ${pair.secondary}`)
+      console.log(`========================================`)
+      const result = await runSoak({ ...pair, mode, soakPath })
+      runs.push(result)
+      if (!result.passed) {
+        console.error(`Gate leg failed for ${pair.primary} (exit ${result.exitCode}${result.signal ? `, signal ${result.signal}` : ""}).`)
+      }
     }
   }
 
-  const allPassed = runs.every((run) => run.passed)
+  const allPassed = preflightResult.passed && runs.length === plan.length && runs.every((run) => run.passed)
   const verdict = !allPassed ? "failed" : eligibility.releaseEligible ? "verified" : "control-plane-only"
   const report = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     kind: "harness-remote-real-harness-gate",
     generatedAt: new Date().toISOString(),
     source: { commit: gitCommit() },
@@ -150,14 +250,12 @@ export async function runGate({ harnesses, mode, reportPath, soakPath = fileURLT
       echoMarkers,
       allowTurnErrors: mode === "control-plane"
     },
+    preflight: preflightResult,
     runs,
     verdict
   }
 
-  fs.mkdirSync(path.dirname(reportPath), { recursive: true })
-  fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8")
-  console.log(`\nEvidence report: ${reportPath}`)
-  console.log(`Verdict: ${verdict}`)
+  persistReport(reportPath, report)
   return report
 }
 

--- a/bridge/scripts/session-first-soak-evidence.mjs
+++ b/bridge/scripts/session-first-soak-evidence.mjs
@@ -1,0 +1,41 @@
+export function catalogFingerprint(models = []) {
+  return models
+    .map((model) => `${model.providerID ?? ""}/${model.modelID ?? ""}/${model.variantConfigId ?? ""}/${model.variant ?? ""}`)
+    .sort()
+    .join("|")
+}
+
+export function catalogOwnershipEvidence({ primary, secondary, primaryModels = [], secondaryModels = [], state = {} }) {
+  const primaryState = state.agents?.[primary]
+  const secondaryState = state.agents?.[secondary]
+  const primaryFingerprint = catalogFingerprint(primaryModels)
+  const secondaryFingerprint = catalogFingerprint(secondaryModels)
+
+  return {
+    primaryFingerprint,
+    secondaryFingerprint,
+    catalogsIdentical: primaryFingerprint === secondaryFingerprint,
+    checks: [
+      { ok: primaryModels.length > 0, message: `${primary} advertises a model catalog` },
+      { ok: secondaryModels.length > 0, message: `${secondary} advertises a model catalog` },
+      { ok: Boolean(primaryState), message: `${primary}: diagnostics expose its registered agent entry` },
+      { ok: Boolean(secondaryState), message: `${secondary}: diagnostics expose its registered agent entry` },
+      {
+        ok: (primaryState?.catalogModels ?? 0) > 0,
+        message: `${primary}: diagnostics own a populated model catalog (${primaryState?.catalogModels ?? 0})`
+      },
+      {
+        ok: (secondaryState?.catalogModels ?? 0) > 0,
+        message: `${secondary}: diagnostics own a populated model catalog (${secondaryState?.catalogModels ?? 0})`
+      },
+      {
+        ok: Boolean(primaryState?.catalogSource),
+        message: `${primary}: diagnostics identify the catalog source (${primaryState?.catalogSource ?? "missing"})`
+      },
+      {
+        ok: Boolean(secondaryState?.catalogSource),
+        message: `${secondary}: diagnostics identify the catalog source (${secondaryState?.catalogSource ?? "missing"})`
+      }
+    ]
+  }
+}

--- a/bridge/scripts/session-first-soak.mjs
+++ b/bridge/scripts/session-first-soak.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { catalogFingerprint, catalogOwnershipEvidence } from "./session-first-soak-evidence.mjs"
+
 /*
  * Session-first model-lifecycle soak probe.
  *
@@ -205,16 +207,17 @@ const primaryCatalog = await catalog(PRIMARY)
 const secondaryCatalog = await catalog(SECONDARY)
 log(`  ${PRIMARY}: ${primaryCatalog.models.length} models in ${primaryCatalog.ms}ms (${primaryCatalog.attempts} request(s))${primaryCatalog.error ? ` error=${primaryCatalog.error}` : ""}`)
 log(`  ${SECONDARY}: ${secondaryCatalog.models.length} models in ${secondaryCatalog.ms}ms (${secondaryCatalog.attempts} request(s))${secondaryCatalog.error ? ` error=${secondaryCatalog.error}` : ""}`)
-check(primaryCatalog.models.length > 0, `${PRIMARY} advertises a model catalog`)
-// Two harnesses may legitimately be configured against the same provider, so overlapping model ids
-// are expected. What must not happen is one harness answering with the other's catalog, so compare
-// the catalogs as a whole rather than requiring them to be disjoint.
-const primaryKeys = primaryCatalog.models.map((model) => `${model.providerID}/${model.modelID}/${model.variant ?? ""}`).sort()
-const secondaryKeys = secondaryCatalog.models.map((model) => `${model.providerID}/${model.modelID}/${model.variant ?? ""}`).sort()
-check(
-  primaryKeys.join("|") !== secondaryKeys.join("|"),
-  `each harness answers with its own catalog, not the other's (${PRIMARY}=${primaryKeys.length}, ${SECONDARY}=${secondaryKeys.length})`
-)
+const ownership = catalogOwnershipEvidence({
+  primary: PRIMARY,
+  secondary: SECONDARY,
+  primaryModels: primaryCatalog.models,
+  secondaryModels: secondaryCatalog.models,
+  state: stableState(await diagnostics())
+})
+for (const evidence of ownership.checks) check(evidence.ok, evidence.message)
+if (ownership.catalogsIdentical) {
+  log("  note identical normalized catalogs are valid; isolation is proven by agent-scoped diagnostics and Session routing")
+}
 
 const models = distinctModels(primaryCatalog.models, 3)
 check(models.length >= 2, `${PRIMARY} offers at least two distinct models to switch between (${models.length})`)
@@ -270,7 +273,8 @@ for (let cycle = 1; cycle <= CYCLES; cycle += 1) {
   expected[name].push(marker)
   userTurns[name] += 1
   log(`  cycle ${cycle}: ${SECONDARY}=${away.models.length} ${PRIMARY}=${back.models.length} session=${secondarySession.status} prompt(${model.modelID})=${result.data?.status}`)
-  check(back.models.length === primaryCatalog.models.length, `cycle ${cycle}: ${PRIMARY} catalog unchanged after visiting ${SECONDARY}`)
+  check(catalogFingerprint(away.models) === ownership.secondaryFingerprint, `cycle ${cycle}: ${SECONDARY} catalog unchanged while switching away and back`)
+  check(catalogFingerprint(back.models) === ownership.primaryFingerprint, `cycle ${cycle}: ${PRIMARY} catalog unchanged after visiting ${SECONDARY}`)
   check(result.data?.status === "accepted", `cycle ${cycle}: ${PRIMARY} prompt accepted after harness switch and model change`)
   const answered = await waitForTurn(PRIMARY, sessionID, directory, marker, expected[name].length)
   check(answered.found, `cycle ${cycle}: ${name} completed ${marker} in ${answered.ms}ms`)

--- a/bridge/test/real-harness-release-gate.test.js
+++ b/bridge/test/real-harness-release-gate.test.js
@@ -8,6 +8,7 @@ import {
   buildHarnessPlan,
   defaultReportPath,
   parseHarnessList,
+  preflightDaemon,
   releaseEligibility,
   resolveGateMode,
   runGate
@@ -59,6 +60,60 @@ test("default report path stays outside source files and carries a timestamp", (
   assert.equal(report, path.join("/work", "artifacts", "real-harness-gate-2026-09-11T03-45-12-345Z.json"))
 })
 
+test("preflight accepts registered harnesses even when their model inventories may be identical", async () => {
+  let authorization
+  const fetchImpl = async (_url, options) => {
+    authorization = options.headers.Authorization
+    return new Response(JSON.stringify({
+      machine: { id: "machine-1" },
+      agents: [
+        { id: "codex", backend: "codex", transport: "acp", state: "configured", modelCatalog: { source: "acp-config-options", cachedModels: 4, phase: "ready" } },
+        { id: "claude", backend: "claude", transport: "acp", state: "configured", modelCatalog: { source: "acp-config-options", cachedModels: 4, phase: "ready" } }
+      ]
+    }), { status: 200, headers: { "Content-Type": "application/json" } })
+  }
+
+  const result = await preflightDaemon({
+    harnesses: ["codex", "claude"],
+    user: "harness",
+    pass: "secret",
+    fetchImpl
+  })
+
+  assert.equal(result.passed, true)
+  assert.equal(result.machineID, "machine-1")
+  assert.deepEqual(result.missingHarnesses, [])
+  assert.deepEqual(result.missingModelCatalogs, [])
+  assert.equal(result.agents[0].modelCatalog.cachedModels, 4)
+  assert.equal(result.agents[1].modelCatalog.cachedModels, 4)
+  assert.match(authorization, /^Basic /)
+  assert.equal(JSON.stringify(result).includes("secret"), false)
+})
+
+test("preflight reports missing harnesses and missing model discovery before the soak starts", async () => {
+  const fetchImpl = async () => new Response(JSON.stringify({
+    machine: { id: "machine-2" },
+    agents: [
+      { id: "codex", backend: "codex", transport: "acp", state: "configured", modelCatalog: null }
+    ]
+  }), { status: 200, headers: { "Content-Type": "application/json" } })
+
+  const result = await preflightDaemon({ harnesses: ["codex", "claude"], fetchImpl })
+  assert.equal(result.passed, false)
+  assert.deepEqual(result.missingHarnesses, ["claude"])
+  assert.deepEqual(result.missingModelCatalogs, ["codex"])
+})
+
+test("preflight turns authentication failures into a concise gate failure", async () => {
+  const result = await preflightDaemon({
+    harnesses: ["codex", "claude"],
+    fetchImpl: async () => new Response("nope", { status: 401 })
+  })
+  assert.equal(result.passed, false)
+  assert.equal(result.status, 401)
+  assert.match(result.error, /rejected.*credentials/i)
+})
+
 test("orchestrates every primary and persists credential-free release evidence", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "hr-real-gate-"))
   const soakPath = path.join(root, "fake-soak.mjs")
@@ -68,9 +123,25 @@ test("orchestrates every primary and persists credential-free release evidence",
   process.env.HR_URL = "http://user:secret@127.0.0.1:4097"
 
   try {
-    const report = await runGate({ harnesses: ["codex", "claude"], mode: "release", reportPath, soakPath })
+    const report = await runGate({
+      harnesses: ["codex", "claude"],
+      mode: "release",
+      reportPath,
+      soakPath,
+      preflight: async ({ harnesses }) => ({
+        passed: true,
+        status: 200,
+        error: null,
+        machineID: "machine-1",
+        agents: harnesses.map((id) => ({ id, registered: true, modelCatalog: { configured: true, source: "test", cachedModels: 2, phase: "ready" } })),
+        missingHarnesses: [],
+        missingModelCatalogs: []
+      })
+    })
     assert.equal(report.verdict, "verified")
     assert.equal(report.releaseEligible, true)
+    assert.equal(report.schemaVersion, 2)
+    assert.equal(report.preflight.passed, true)
     assert.deepEqual(report.runs.map(({ primary, secondary, passed }) => ({ primary, secondary, passed })), [
       { primary: "codex", secondary: "claude", passed: true },
       { primary: "claude", secondary: "codex", passed: true }
@@ -83,6 +154,38 @@ test("orchestrates every primary and persists credential-free release evidence",
   } finally {
     if (previousURL === undefined) delete process.env.HR_URL
     else process.env.HR_URL = previousURL
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test("does not launch any soak leg when daemon preflight fails", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "hr-real-gate-preflight-"))
+  const soakPath = path.join(root, "must-not-run.mjs")
+  const markerPath = path.join(root, "ran")
+  const reportPath = path.join(root, "report.json")
+  fs.writeFileSync(soakPath, `require('node:fs').writeFileSync(${JSON.stringify(markerPath)}, 'ran')\n`, "utf8")
+
+  try {
+    const report = await runGate({
+      harnesses: ["codex", "claude"],
+      mode: "release",
+      reportPath,
+      soakPath,
+      preflight: async () => ({
+        passed: false,
+        status: 200,
+        error: null,
+        machineID: "machine-1",
+        agents: [],
+        missingHarnesses: ["claude"],
+        missingModelCatalogs: []
+      })
+    })
+    assert.equal(report.verdict, "failed")
+    assert.deepEqual(report.runs, [])
+    assert.equal(fs.existsSync(markerPath), false)
+    assert.equal(JSON.parse(fs.readFileSync(reportPath, "utf8")).preflight.missingHarnesses[0], "claude")
+  } finally {
     fs.rmSync(root, { recursive: true, force: true })
   }
 })

--- a/bridge/test/session-first-soak-evidence.test.js
+++ b/bridge/test/session-first-soak-evidence.test.js
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { catalogFingerprint, catalogOwnershipEvidence } from "../scripts/session-first-soak-evidence.mjs"
+
+const sharedModels = [
+  { providerID: "shared", modelID: "model-a" },
+  { providerID: "shared", modelID: "model-b", variantConfigId: "thinking", variant: "high" }
+]
+
+test("catalog fingerprint is order independent and includes variant identity", () => {
+  assert.equal(catalogFingerprint(sharedModels), catalogFingerprint([...sharedModels].reverse()))
+  assert.notEqual(
+    catalogFingerprint(sharedModels),
+    catalogFingerprint([{ providerID: "shared", modelID: "model-a" }, { providerID: "shared", modelID: "model-b", variantConfigId: "thinking", variant: "low" }])
+  )
+})
+
+test("identical provider inventories are valid when diagnostics own separate agent catalogs", () => {
+  const evidence = catalogOwnershipEvidence({
+    primary: "codex",
+    secondary: "claude",
+    primaryModels: sharedModels,
+    secondaryModels: [...sharedModels],
+    state: {
+      agents: {
+        codex: { catalogModels: 2, catalogSource: "acp-config-options" },
+        claude: { catalogModels: 2, catalogSource: "acp-config-options" }
+      }
+    }
+  })
+
+  assert.equal(evidence.catalogsIdentical, true)
+  assert.equal(evidence.checks.every((entry) => entry.ok), true)
+})
+
+test("missing agent-scoped catalog diagnostics remain a real failure", () => {
+  const evidence = catalogOwnershipEvidence({
+    primary: "codex",
+    secondary: "claude",
+    primaryModels: sharedModels,
+    secondaryModels: sharedModels,
+    state: {
+      agents: {
+        codex: { catalogModels: 2, catalogSource: "acp-config-options" }
+      }
+    }
+  })
+
+  const failed = evidence.checks.filter((entry) => !entry.ok).map((entry) => entry.message)
+  assert.ok(failed.some((message) => message.includes("claude: diagnostics expose")))
+  assert.ok(failed.some((message) => message.includes("claude: diagnostics own")))
+  assert.ok(failed.some((message) => message.includes("claude: diagnostics identify")))
+})

--- a/docs/REAL_HARNESS_RELEASE_GATE.md
+++ b/docs/REAL_HARNESS_RELEASE_GATE.md
@@ -60,6 +60,18 @@ A successful strict run writes a report under `artifacts/real-harness-gate-<time
 
 The report deliberately contains no username, password, prompt body or model catalog. It records the commit when available, platform/architecture/Node version, endpoint without URL credentials, harness pairs, durations, exit status, evidence strength and final verdict.
 
+## Preflight
+
+Before any long-running soak starts, the gate calls the daemon diagnostics endpoint once and verifies the requested release surface:
+
+- the daemon is reachable and accepts the supplied credentials;
+- every selected harness is registered on that daemon;
+- every selected harness has model discovery configured.
+
+If any of those checks fail, no soak process is launched. The JSON report still gets written with `verdict: "failed"` and a concise `preflight` section showing the missing harnesses or model-discovery configuration. This makes startup/configuration failures distinct from Session/inference failures and avoids spending several minutes on legs that cannot succeed.
+
+The preflight report contains only non-sensitive harness metadata such as id, backend, transport, state, model-catalog source and cached-model count. It does not persist credentials or full model inventories.
+
 ## Run a subset while developing
 
 A two-or-more harness subset is useful before the full release run:
@@ -111,7 +123,7 @@ or set `HR_GATE_REPORT`.
 
 ## Existing soak command
 
-For focused diagnosis of one primary/secondary pair, the underlying probe is now exposed directly:
+For focused diagnosis of one primary/secondary pair, the underlying probe is exposed directly:
 
 ```bash
 HR_PRIMARY=pi \
@@ -126,9 +138,17 @@ Useful environment controls include `HR_CYCLES`, `HR_TURN_BUDGET_MS`, `HR_DIR_A`
 
 ## Interpreting catalog checks
 
-Two different harnesses can legitimately advertise overlapping, or even identical, provider/model inventories. Catalog equality by itself is therefore not proof of cross-harness leakage. Release evidence should focus on agent-scoped requests, Native Session identity, prompt routing and stable per-agent diagnostics rather than assuming model names must differ.
+Two different harnesses can legitimately advertise overlapping, or even identical, provider/model inventories. Catalog equality by itself is therefore not proof of cross-harness leakage and is no longer treated as a failure.
 
-The legacy soak currently retains a conservative whole-catalog inequality assertion. If two selected harnesses intentionally expose the exact same normalized catalog, treat that specific failure as an **inconclusive tooling limitation**, not evidence that the runtime is broken, and do not mark the release `verified` until the probe has been rerun with an unambiguous isolation check.
+The soak now proves the relevant ownership invariants instead:
+
+- both agent-scoped model endpoints return usable catalogs;
+- diagnostics expose separate registered entries for the primary and secondary harness;
+- each entry owns a populated model-catalog diagnostic with an explicit source;
+- the primary and secondary catalog fingerprints remain individually stable while the test repeatedly switches between harnesses;
+- Native Session creation and prompt routing continue to target the requested harness and Session.
+
+If two harnesses intentionally expose exactly the same normalized model inventory, the soak prints that fact as a note and continues. This avoids a false negative without weakening the isolation checks that actually matter.
 
 ## Release record
 


### PR DESCRIPTION
## Summary

Third P0 reliability slice for #368.

- adds a read-only `/v1/diagnostics` preflight before any real-harness soak leg starts;
- fails fast when the daemon is unreachable, credentials are rejected, a requested harness is not registered, or model discovery is not configured;
- persists concise preflight evidence in the JSON release report without credentials, prompt bodies or full model inventories;
- replaces the invalid assumption that two harnesses must advertise different model inventories;
- proves catalog ownership through separate agent diagnostics entries, populated catalog diagnostics and stable per-harness fingerprints while switching between harnesses;
- keeps identical normalized catalogs valid and explicitly noted rather than treated as cross-harness leakage;
- adds focused unit coverage for preflight, credential hygiene, fail-fast behavior, catalog fingerprints and identical-catalog ownership evidence;
- updates the real-harness release-gate documentation.

## Risk boundary

No ACP adapter, AcpService, machine-daemon runtime, router, Session implementation, model-discovery implementation, prompt path, Stop/cancel path, web runtime or Android runtime is changed. This PR modifies release-validation tooling and tests only.

## Validation target

This PR targets `codex/development-2026-09-11` only. It must pass the complete repository PR gate before merge. `main` must remain untouched.

Refs #368