### PR TITLE
P1: multiplex Android native live-event streams

### DIFF
--- a/bridge/test/android-live-events.test.js
+++ b/bridge/test/android-live-events.test.js
@@ -8,5 +8,5 @@ test("Android native SSE uses a finite read watchdog so sleep or Wi-Fi loss can 
   assert.match(source, /STALL_TIMEOUT_MS\s*=\s*30000/)
   assert.match(source, /setReadTimeout\(STALL_TIMEOUT_MS\)/)
   assert.doesNotMatch(source, /setReadTimeout\(0\)/)
-  assert.match(source, /publishStatus\("reconnecting"/)
+  assert.match(source, /publishStatus\(subscriptionID,\s*"reconnecting"/)
 })

--- a/web/native-android/LiveEventsPlugin.java
+++ b/web/native-android/LiveEventsPlugin.java
@@ -14,6 +14,8 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -23,62 +25,100 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class LiveEventsPlugin extends Plugin {
     private static final int CONNECT_TIMEOUT_MS = 10000;
     // The daemon writes an SSE heartbeat every 10 seconds. A 30 second period with no bytes means
-    // the socket is stale after sleep, backgrounding, Wi-Fi handoff or a brief network loss. The
-    // previous infinite read timeout could leave Android permanently blocked in readLine() while the
-    // native Session kept working. Let the existing reconnect loop own that failure instead.
+    // the socket is stale after sleep, backgrounding, Wi-Fi handoff or a brief network loss.
     private static final int STALL_TIMEOUT_MS = 30000;
+    private static final int MAX_SUBSCRIPTION_ID_LENGTH = 240;
 
-    private final ExecutorService executor = Executors.newSingleThreadExecutor();
-    private final AtomicBoolean stopped = new AtomicBoolean(true);
-    private volatile Future<?> task;
-    private volatile HttpURLConnection connection;
+    /**
+     * One Android plugin instance serves the whole WebView. Session detail, the global Attention
+     * Inbox and multiple machines may all subscribe concurrently, so stream ownership must be keyed
+     * instead of letting the most recent start() cancel every earlier socket.
+     */
+    private static final class StreamHandle {
+        final AtomicBoolean stopped = new AtomicBoolean(false);
+        volatile Future<?> task;
+        volatile HttpURLConnection connection;
+    }
+
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+    private final Map<String, StreamHandle> streams = new ConcurrentHashMap<>();
 
     @PluginMethod
     public void start(PluginCall call) {
+        String subscriptionID = call.getString("subscriptionID");
         String url = call.getString("url");
         String username = call.getString("username", "");
         String password = call.getString("password", "");
+        String backend = call.getString("backend", "");
+        if (!validSubscriptionID(subscriptionID)) {
+            call.reject("Missing or invalid subscription ID");
+            return;
+        }
         if (url == null || url.isEmpty()) {
             call.reject("Missing event stream URL");
             return;
         }
-        stopStream();
-        stopped.set(false);
-        task = executor.submit(() -> runStream(url, username, password));
+
+        // Replacing the same logical subscription is safe and does not disturb any sibling stream.
+        stopStream(subscriptionID, false);
+        StreamHandle handle = new StreamHandle();
+        streams.put(subscriptionID, handle);
+        handle.task = executor.submit(() -> runStream(subscriptionID, handle, url, username, password, backend));
         call.resolve();
     }
 
     @PluginMethod
     public void stop(PluginCall call) {
-        stopStream();
+        String subscriptionID = call.getString("subscriptionID");
+        if (!validSubscriptionID(subscriptionID)) {
+            call.reject("Missing or invalid subscription ID");
+            return;
+        }
+        stopStream(subscriptionID, true);
         call.resolve();
     }
 
     @Override
     protected void handleOnDestroy() {
-        stopStream();
+        for (String subscriptionID : streams.keySet()) stopStream(subscriptionID, false);
+        streams.clear();
         executor.shutdownNow();
     }
 
-    private void stopStream() {
-        stopped.set(true);
-        HttpURLConnection activeConnection = connection;
-        if (activeConnection != null) activeConnection.disconnect();
-        Future<?> activeTask = task;
-        if (activeTask != null) activeTask.cancel(true);
-        connection = null;
-        task = null;
-        publishStatus("closed", null, null);
+    private boolean validSubscriptionID(String value) {
+        return value != null && !value.isEmpty() && value.length() <= MAX_SUBSCRIPTION_ID_LENGTH;
     }
 
-    private void runStream(String endpoint, String username, String password) {
+    private void stopStream(String subscriptionID, boolean publishClosed) {
+        StreamHandle handle = streams.remove(subscriptionID);
+        if (handle == null) return;
+        handle.stopped.set(true);
+        HttpURLConnection activeConnection = handle.connection;
+        if (activeConnection != null) activeConnection.disconnect();
+        Future<?> activeTask = handle.task;
+        if (activeTask != null) activeTask.cancel(true);
+        handle.connection = null;
+        handle.task = null;
+        if (publishClosed) publishStatus(subscriptionID, "closed", null, null);
+    }
+
+    private void runStream(
+        String subscriptionID,
+        StreamHandle handle,
+        String endpoint,
+        String username,
+        String password,
+        String backend
+    ) {
         int delayMs = 1000;
-        while (!stopped.get()) {
+        while (!handle.stopped.get() && streams.get(subscriptionID) == handle) {
+            HttpURLConnection current = null;
             try {
-                HttpURLConnection current = (HttpURLConnection) new URL(endpoint).openConnection();
-                connection = current;
+                current = (HttpURLConnection) new URL(endpoint).openConnection();
+                handle.connection = current;
                 current.setRequestMethod("GET");
                 current.setRequestProperty("Accept", "text/event-stream");
+                if (backend != null && !backend.isEmpty()) current.setRequestProperty("X-Harness-Backend", backend);
                 if (!username.isEmpty() || !password.isEmpty()) {
                     String credentials = username + ":" + password;
                     String encoded = Base64.encodeToString(credentials.getBytes(StandardCharsets.UTF_8), Base64.NO_WRAP);
@@ -92,18 +132,17 @@ public class LiveEventsPlugin extends Plugin {
                     throw new IllegalStateException("HTTP " + status + "; expected text/event-stream");
                 }
                 delayMs = 1000;
-                publishStatus("connected", null, null);
-                readFrames(current.getInputStream());
+                publishStatus(subscriptionID, "connected", null, null);
+                readFrames(subscriptionID, handle, current.getInputStream());
             } catch (Exception error) {
-                if (stopped.get()) break;
-                publishStatus("connection-error", error.getMessage(), null);
+                if (handle.stopped.get() || streams.get(subscriptionID) != handle) break;
+                publishStatus(subscriptionID, "connection-error", error.getMessage(), null);
             } finally {
-                HttpURLConnection current = connection;
                 if (current != null) current.disconnect();
-                connection = null;
+                if (handle.connection == current) handle.connection = null;
             }
-            if (!stopped.get()) {
-                publishStatus("reconnecting", null, delayMs);
+            if (!handle.stopped.get() && streams.get(subscriptionID) == handle) {
+                publishStatus(subscriptionID, "reconnecting", null, delayMs);
                 try {
                     Thread.sleep(delayMs);
                 } catch (InterruptedException ignored) {
@@ -115,14 +154,14 @@ public class LiveEventsPlugin extends Plugin {
         }
     }
 
-    private void readFrames(InputStream inputStream) throws Exception {
+    private void readFrames(String subscriptionID, StreamHandle handle, InputStream inputStream) throws Exception {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
             StringBuilder data = new StringBuilder();
             String line;
-            while (!stopped.get() && (line = reader.readLine()) != null) {
+            while (!handle.stopped.get() && streams.get(subscriptionID) == handle && (line = reader.readLine()) != null) {
                 if (line.isEmpty()) {
                     if (data.length() > 0) {
-                        publishEvent(data.toString());
+                        publishEvent(subscriptionID, data.toString());
                         data.setLength(0);
                     }
                     continue;
@@ -136,14 +175,16 @@ public class LiveEventsPlugin extends Plugin {
         }
     }
 
-    private void publishEvent(String data) {
+    private void publishEvent(String subscriptionID, String data) {
         JSObject payload = new JSObject();
+        payload.put("subscriptionID", subscriptionID);
         payload.put("data", data);
         notifyListeners("event", payload);
     }
 
-    private void publishStatus(String type, String error, Integer delayMs) {
+    private void publishStatus(String subscriptionID, String type, String error, Integer delayMs) {
         JSObject payload = new JSObject();
+        payload.put("subscriptionID", subscriptionID);
         payload.put("type", type);
         if (error != null) payload.put("error", error);
         if (delayMs != null) payload.put("delayMs", delayMs);

--- a/web/package.json
+++ b/web/package.json
@@ -31,7 +31,7 @@
     "test:settings": "node src/settings-regression.test.mjs && node src/v3-ux-polish-regression.test.mjs",
     "test:v3-product-ui": "node --experimental-strip-types --test src/v3-conversation-input-performance.test.mjs src/workspace-runtime-merge.test.mjs src/workspace-machines.test.mjs src/v3-dialog-accessibility.test.mjs src/v3-workspace-navigation.test.mjs src/v3-composer-accessibility.test.mjs src/v3-offline-visibility.test.mjs src/v3-crash-recovery.test.mjs src/v3-terminology.test.mjs src/v3-topbar-layout.test.mjs src/v3-conversation-readability.test.mjs src/beautiful-ui-controls.test.mjs src/v3-mobile-keyboard-polish.test.mjs src/v3-v2-parity.test.mjs src/machine-live-refresh.test.mjs",
     "test:model": "node src/model-regression.test.mjs",
-    "test:events": "node --experimental-strip-types src/opencode-events.test.mjs",
+    "test:events": "node --experimental-strip-types src/opencode-events.test.mjs && node src/native-live-events-multiplex.test.mjs",
     "test:profiles": "node --experimental-strip-types src/server-profiles.test.mjs",
     "test:config": "node --experimental-strip-types src/server-config.test.mjs",
     "test:attachments": "node --experimental-strip-types src/attachments.test.mjs",

--- a/web/src/native-live-events-multiplex.test.mjs
+++ b/web/src/native-live-events-multiplex.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+
+const native = readFileSync(new URL("../native-android/LiveEventsPlugin.java", import.meta.url), "utf8")
+const transport = readFileSync(new URL("./opencode-events.ts", import.meta.url), "utf8")
+const taskdesk = readFileSync(new URL("./taskdesk-live-events.ts", import.meta.url), "utf8")
+
+assert.match(native, /Map<String, StreamHandle> streams = new ConcurrentHashMap<>\(\)/,
+  "Android must keep one independently owned stream per logical subscription")
+assert.match(native, /Executors\.newCachedThreadPool\(\)/,
+  "long-lived native streams cannot share a single-thread executor")
+assert.match(native, /call\.getString\("subscriptionID"\)/)
+assert.match(native, /stopStream\(subscriptionID, false\)/,
+  "starting one subscription may replace only itself, never sibling sockets")
+assert.match(native, /streams\.remove\(subscriptionID\)/,
+  "stop must be scoped to the requested subscription")
+assert.match(native, /payload\.put\("subscriptionID", subscriptionID\)/,
+  "native events and statuses must carry ownership back to the WebView")
+assert.match(native, /setRequestProperty\("X-Harness-Backend", backend\)/,
+  "Android SSE must preserve daemon backend routing")
+assert.doesNotMatch(native, /Executors\.newSingleThreadExecutor\(\)/)
+assert.doesNotMatch(native, /private volatile HttpURLConnection connection;/,
+  "socket state must live inside each StreamHandle, not on the plugin singleton")
+
+assert.match(transport, /const subscriptionID = nativeSubscriptionID\(\)/)
+assert.match(transport, /owner !== subscriptionID/,
+  "each JS listener must ignore native events owned by another subscription")
+assert.match(transport, /status\.subscriptionID !== subscriptionID/,
+  "status updates must be isolated exactly like event payloads")
+assert.match(transport, /NativeLiveEvents\.start\(\{[\s\S]*subscriptionID,[\s\S]*backend: options\.backend/)
+assert.match(transport, /NativeLiveEvents\.stop\(\{ subscriptionID \}\)/,
+  "closing Session detail or Attention must stop only its own native socket")
+assert.doesNotMatch(transport, /NativeLiveEvents\.stop\(\)/)
+
+assert.match(taskdesk, /backend: config\.backend/,
+  "selected harness routing must cross the Android native transport boundary")
+
+console.log("Android native live-event multiplexing regression tests passed")

--- a/web/src/opencode-events.ts
+++ b/web/src/opencode-events.ts
@@ -22,7 +22,6 @@ export type EventStreamStatus =
   | { type: "closed" }
 
 type EventSourceMessage = { data: string }
-
 type EventSourceLike = {
   onopen: ((event: Event) => unknown) | null
   onmessage: ((event: EventSourceMessage) => unknown) | null
@@ -36,7 +35,6 @@ type ReconnectConfig = {
 }
 
 type TimerID = ReturnType<typeof setTimeout>
-
 type EventSubscriptionOptions = {
   url: string
   reconnect?: ReconnectConfig
@@ -142,8 +140,6 @@ export function createFetchOpenCodeEventSubscription(options: FetchEventSubscrip
         stallTimer = setTimeout(() => {
           stallTimer = undefined
           logger(`OpenCode SSE stalled for ${stallTimeoutMs}ms, reconnecting`)
-          // Abort frees the socket; cancel guarantees the pending read settles even if the
-          // transport does not propagate the abort signal into the body stream.
           currentController.abort()
           reader.cancel().catch(() => undefined)
         }, stallTimeoutMs)
@@ -192,46 +188,68 @@ export function createFetchOpenCodeEventSubscription(options: FetchEventSubscrip
   }
 }
 
+type NativeEventEnvelope = { subscriptionID?: string, data?: string }
+type NativeStatusEnvelope = EventStreamStatus & { subscriptionID?: string }
 type NativeLiveEventsPlugin = {
-  start(options: { url: string; username: string; password: string }): Promise<void>
-  stop(): Promise<void>
-  addListener(eventName: "event", listenerFunc: (event: { data?: string }) => void): Promise<PluginListenerHandle>
-  addListener(eventName: "status", listenerFunc: (status: EventStreamStatus) => void): Promise<PluginListenerHandle>
+  start(options: { subscriptionID: string; url: string; username: string; password: string; backend: string }): Promise<void>
+  stop(options: { subscriptionID: string }): Promise<void>
+  addListener(eventName: "event", listenerFunc: (event: NativeEventEnvelope) => void): Promise<PluginListenerHandle>
+  addListener(eventName: "status", listenerFunc: (status: NativeStatusEnvelope) => void): Promise<PluginListenerHandle>
 }
 
 const NativeLiveEvents = registerPlugin<NativeLiveEventsPlugin>("LiveEvents")
+let nextNativeSubscription = 0
+
+function nativeSubscriptionID(): string {
+  nextNativeSubscription += 1
+  return `live-${Date.now().toString(36)}-${nextNativeSubscription.toString(36)}`
+}
 
 export function isNativeEventTransport(): boolean {
   return Capacitor.getPlatform() === "android"
 }
 
-/** Android WebView cannot reliably keep a fetch ReadableStream open; use a direct native HttpURLConnection SSE client. */
+/**
+ * Android WebView cannot reliably keep a fetch ReadableStream open, so each logical subscription
+ * owns one native socket. The subscription id is echoed by the plugin to prevent Session detail,
+ * Attention and multi-machine streams from consuming or cancelling one another.
+ */
 export function createNativeOpenCodeEventSubscription(options: {
   url: string
   username: string
   password: string
+  backend: string
   onEvent: (event: Extract<ParsedOpenCodeEvent, { ok: true }>) => void
   onStatus?: (status: EventStreamStatus) => void
 }): { close(): void } {
+  const subscriptionID = nativeSubscriptionID()
   let closed = false
   let handles: PluginListenerHandle[] = []
   void (async () => {
     try {
-      const eventHandle = await NativeLiveEvents.addListener("event", ({ data }) => {
-        if (closed || !data) return
+      const eventHandle = await NativeLiveEvents.addListener("event", ({ subscriptionID: owner, data }) => {
+        if (closed || owner !== subscriptionID || !data) return
         const event = parseOpenCodeEvent(data)
         if (event.ok) options.onEvent(event)
         else options.onStatus?.({ type: "parse-error", data })
       })
       const statusHandle = await NativeLiveEvents.addListener("status", (status) => {
-        if (!closed) options.onStatus?.(status)
+        if (closed || status.subscriptionID !== subscriptionID) return
+        const { subscriptionID: _owner, ...eventStatus } = status
+        options.onStatus?.(eventStatus as EventStreamStatus)
       })
       handles = [eventHandle, statusHandle]
       if (closed) {
         await Promise.all(handles.map((handle) => handle.remove()))
         return
       }
-      await NativeLiveEvents.start({ url: options.url, username: options.username, password: options.password })
+      await NativeLiveEvents.start({
+        subscriptionID,
+        url: options.url,
+        username: options.username,
+        password: options.password,
+        backend: options.backend
+      })
     } catch (error) {
       if (!closed) options.onStatus?.({ type: "connection-error", error: errorMessage(error) })
     }
@@ -240,7 +258,7 @@ export function createNativeOpenCodeEventSubscription(options: {
     close() {
       if (closed) return
       closed = true
-      void NativeLiveEvents.stop().catch(() => undefined)
+      void NativeLiveEvents.stop({ subscriptionID }).catch(() => undefined)
       void Promise.all(handles.map((handle) => handle.remove())).catch(() => undefined)
       options.onStatus?.({ type: "closed" })
     }
@@ -255,7 +273,7 @@ export function createOpenCodeEventSubscription(options: EventSubscriptionOption
   const initialDelayMs = validDelay(options.reconnect?.initialDelayMs, 1_000)
   const maxDelayMs = Math.max(initialDelayMs, validDelay(options.reconnect?.maxDelayMs, 30_000))
   const createEventSource: (url: string) => EventSourceLike = options.createEventSource
-    ?? ((url: string) => new EventSource(url) as EventSourceLike)
+    ?? ((url) => new EventSource(url) as EventSourceLike)
   const schedule = options.schedule ?? ((callback, delayMs) => setTimeout(callback, delayMs))
   const cancel = options.cancel ?? ((timerID) => clearTimeout(timerID))
   const logger = options.logger ?? ((message: string) => console.debug(message))
@@ -320,7 +338,6 @@ export function createOpenCodeEventSubscription(options: EventSubscriptionOption
   }
 
   connect()
-
   return {
     close() {
       if (closed) return

--- a/web/src/taskdesk-live-events.ts
+++ b/web/src/taskdesk-live-events.ts
@@ -84,6 +84,7 @@ export function subscribeTaskDeskLiveEvents({
       url: stream.url,
       username: config.username,
       password: config.password,
+      backend: config.backend,
       onEvent: (event) => emit(event.name, event.data),
       onStatus
     })


### PR DESCRIPTION
## Summary

Fix Android native live-event ownership before adding background notifications.

The Capacitor `LiveEvents` plugin previously held one global socket/task. Every new `start()` called `stopStream()`, so Session detail, Attention Inbox, or another machine/harness subscription could cancel the previously active stream.

This change:
- gives every logical native event subscription a unique `subscriptionID`;
- keeps independent socket/task/retry state per subscription in the Android plugin;
- uses a concurrent executor so long-lived streams can coexist;
- echoes `subscriptionID` on native event/status payloads and filters them in the renderer;
- makes `stop()` close only its own native stream;
- forwards the selected backend as `X-Harness-Backend` on Android SSE so daemon routing is preserved while the agent remains scoped by the existing `/v1/agents/{id}` path;
- adds regression guards that prevent a return to the singleton transport.

## Risk boundary

Android native live-event transport only. No daemon/router/ACP changes, no Session writer changes, no notification/background service yet, no new network endpoints.

Targets `codex/development-2026-09-11` only. `main` must remain untouched.

Refs #369