### PR TITLE
P1: add native Android Attention notifications

### DIFF
--- a/web/native-android/LiveEventsPlugin.java
+++ b/web/native-android/LiveEventsPlugin.java
@@ -1,5 +1,14 @@
 package ai.harness.remote;
 
+import android.Manifest;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.os.Build;
 import android.util.Base64;
 
 import com.getcapacitor.JSObject;
@@ -8,6 +17,9 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
+
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -15,6 +27,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -28,6 +41,35 @@ public class LiveEventsPlugin extends Plugin {
     // the socket is stale after sleep, backgrounding, Wi-Fi handoff or a brief network loss.
     private static final int STALL_TIMEOUT_MS = 30000;
     private static final int MAX_SUBSCRIPTION_ID_LENGTH = 240;
+    private static final int MAX_ATTENTION_ID_LENGTH = 512;
+    private static final int NOTIFICATION_PERMISSION_REQUEST = 7401;
+    private static final String ATTENTION_CHANNEL_ID = "harness_remote_attention";
+    private static final AtomicBoolean notificationPermissionRequested = new AtomicBoolean(false);
+
+    private static final class AttentionContext {
+        final String machineID;
+        final String machineName;
+        final String agentID;
+        final String agentLabel;
+        final boolean questions;
+        final boolean permissions;
+
+        AttentionContext(
+            String machineID,
+            String machineName,
+            String agentID,
+            String agentLabel,
+            boolean questions,
+            boolean permissions
+        ) {
+            this.machineID = machineID;
+            this.machineName = machineName;
+            this.agentID = agentID;
+            this.agentLabel = agentLabel;
+            this.questions = questions;
+            this.permissions = permissions;
+        }
+    }
 
     /**
      * One Android plugin instance serves the whole WebView. Session detail, the global Attention
@@ -36,8 +78,14 @@ public class LiveEventsPlugin extends Plugin {
      */
     private static final class StreamHandle {
         final AtomicBoolean stopped = new AtomicBoolean(false);
+        final Set<String> seenAttentionRequests = ConcurrentHashMap.newKeySet();
+        final AttentionContext attention;
         volatile Future<?> task;
         volatile HttpURLConnection connection;
+
+        StreamHandle(AttentionContext attention) {
+            this.attention = attention;
+        }
     }
 
     private final ExecutorService executor = Executors.newCachedThreadPool();
@@ -59,11 +107,18 @@ public class LiveEventsPlugin extends Plugin {
             return;
         }
 
+        AttentionContext attention = parseAttentionContext(url);
+        if (attention != null) {
+            ensureAttentionChannel();
+            requestNotificationPermissionIfNeeded();
+        }
+
         // Replacing the same logical subscription is safe and does not disturb any sibling stream.
         stopStream(subscriptionID, false);
-        StreamHandle handle = new StreamHandle();
+        StreamHandle handle = new StreamHandle(attention);
         streams.put(subscriptionID, handle);
-        handle.task = executor.submit(() -> runStream(subscriptionID, handle, url, username, password, backend));
+        String endpoint = stripFragment(url);
+        handle.task = executor.submit(() -> runStream(subscriptionID, handle, endpoint, username, password, backend));
         call.resolve();
     }
 
@@ -87,6 +142,43 @@ public class LiveEventsPlugin extends Plugin {
 
     private boolean validSubscriptionID(String value) {
         return value != null && !value.isEmpty() && value.length() <= MAX_SUBSCRIPTION_ID_LENGTH;
+    }
+
+    private String cleanAttentionValue(String value) {
+        if (value == null) return null;
+        String normalized = value.trim();
+        if (normalized.isEmpty() || normalized.length() > MAX_ATTENTION_ID_LENGTH) return null;
+        for (int index = 0; index < normalized.length(); index++) {
+            char character = normalized.charAt(index);
+            if (character < 0x20 || character == 0x7f) return null;
+        }
+        return normalized;
+    }
+
+    private AttentionContext parseAttentionContext(String endpoint) {
+        try {
+            String fragment = new URL(endpoint).getRef();
+            if (fragment == null || fragment.isEmpty()) return null;
+            Uri metadata = Uri.parse("https://harness.remote/?" + fragment);
+            if (!"1".equals(metadata.getQueryParameter("hrAttention"))) return null;
+            String machineID = cleanAttentionValue(metadata.getQueryParameter("machineID"));
+            String machineName = cleanAttentionValue(metadata.getQueryParameter("machineName"));
+            String agentID = cleanAttentionValue(metadata.getQueryParameter("agentID"));
+            String agentLabel = cleanAttentionValue(metadata.getQueryParameter("agentLabel"));
+            boolean questions = "1".equals(metadata.getQueryParameter("questions"));
+            boolean permissions = "1".equals(metadata.getQueryParameter("permissions"));
+            if (machineID == null || machineName == null || agentID == null || agentLabel == null || (!questions && !permissions)) {
+                return null;
+            }
+            return new AttentionContext(machineID, machineName, agentID, agentLabel, questions, permissions);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private String stripFragment(String endpoint) {
+        int index = endpoint.indexOf('#');
+        return index >= 0 ? endpoint.substring(0, index) : endpoint;
     }
 
     private void stopStream(String subscriptionID, boolean publishClosed) {
@@ -161,7 +253,9 @@ public class LiveEventsPlugin extends Plugin {
             while (!handle.stopped.get() && streams.get(subscriptionID) == handle && (line = reader.readLine()) != null) {
                 if (line.isEmpty()) {
                     if (data.length() > 0) {
-                        publishEvent(subscriptionID, data.toString());
+                        String frame = data.toString();
+                        maybeNotifyAttention(handle, frame);
+                        publishEvent(subscriptionID, frame);
                         data.setLength(0);
                     }
                     continue;
@@ -172,6 +266,169 @@ public class LiveEventsPlugin extends Plugin {
                     data.append(value.startsWith(" ") ? value.substring(1) : value);
                 }
             }
+        }
+    }
+
+    private JSONObject eventPayload(String data) {
+        try {
+            JSONObject envelope = new JSONObject(data);
+            JSONObject payload = envelope.optJSONObject("payload");
+            return payload != null ? payload : envelope;
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private String firstText(JSONObject object, String... names) {
+        if (object == null) return null;
+        for (String name : names) {
+            String value = object.optString(name, "").trim();
+            if (!value.isEmpty()) return value;
+        }
+        return null;
+    }
+
+    private String requestKey(String family, JSONObject properties, String raw) {
+        String requestID = firstText(properties, "id", "requestID", "permissionID");
+        return family + ":" + (requestID != null ? requestID : Integer.toHexString(raw.hashCode()));
+    }
+
+    private void maybeNotifyAttention(StreamHandle handle, String raw) {
+        AttentionContext context = handle.attention;
+        if (context == null) return;
+        JSONObject payload = eventPayload(raw);
+        if (payload == null) return;
+        String type = payload.optString("type", "");
+        JSONObject properties = payload.optJSONObject("properties");
+        if (properties == null) return;
+
+        boolean questionAsked = context.questions && ("question.asked".equals(type) || "question.v2.asked".equals(type));
+        boolean permissionAsked = context.permissions && ("permission.asked".equals(type) || "permission.v2.asked".equals(type));
+        if (!questionAsked && !permissionAsked) {
+            if (type.startsWith("question.") && (type.endsWith(".replied") || type.endsWith(".rejected"))) {
+                handle.seenAttentionRequests.remove(requestKey("question", properties, raw));
+            } else if (type.startsWith("permission.") && (type.endsWith(".replied") || type.endsWith(".rejected"))) {
+                handle.seenAttentionRequests.remove(requestKey("permission", properties, raw));
+            }
+            return;
+        }
+
+        String sessionID = firstText(properties, "sessionID", "sessionId");
+        if (sessionID == null) return;
+        String family = questionAsked ? "question" : "permission";
+        String key = requestKey(family, properties, raw);
+        if (!handle.seenAttentionRequests.add(key)) return;
+
+        String title;
+        String body;
+        if (permissionAsked) {
+            title = "Authorization required";
+            String action = firstText(properties, "permission", "title", "name");
+            JSONObject metadata = properties.optJSONObject("metadata");
+            String explanation = firstText(metadata, "reason", "description", "message");
+            JSONArray patterns = properties.optJSONArray("patterns");
+            String boundary = patterns != null && patterns.length() > 0 ? patterns.optString(0, "").trim() : "";
+            body = compactBody(
+                action != null ? action : "Permission requested",
+                explanation,
+                !boundary.isEmpty() ? "Boundary: " + boundary : null,
+                "If you do nothing, this request stays blocked.",
+                context.machineName + " · " + context.agentLabel
+            );
+        } else {
+            title = "Input required";
+            String question = null;
+            JSONArray questions = properties.optJSONArray("questions");
+            if (questions != null && questions.length() > 0) {
+                JSONObject first = questions.optJSONObject(0);
+                question = firstText(first, "question", "header");
+            }
+            body = compactBody(
+                question != null ? question : "The coding agent is waiting for your input.",
+                context.machineName + " · " + context.agentLabel
+            );
+        }
+        showAttentionNotification(context, sessionID, key, title, body);
+    }
+
+    private String compactBody(String... parts) {
+        StringBuilder body = new StringBuilder();
+        for (String part : parts) {
+            if (part == null) continue;
+            String value = part.trim();
+            if (value.isEmpty()) continue;
+            if (body.length() > 0) body.append('\n');
+            body.append(value);
+            if (body.length() >= 1000) break;
+        }
+        return body.length() > 1000 ? body.substring(0, 1000) : body.toString();
+    }
+
+    private void ensureAttentionChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
+        NotificationManager manager = getContext().getSystemService(NotificationManager.class);
+        if (manager == null || manager.getNotificationChannel(ATTENTION_CHANNEL_ID) != null) return;
+        NotificationChannel channel = new NotificationChannel(
+            ATTENTION_CHANNEL_ID,
+            "Harness Remote attention",
+            NotificationManager.IMPORTANCE_DEFAULT
+        );
+        channel.setDescription("Coding-agent permissions and questions that require your attention");
+        manager.createNotificationChannel(channel);
+    }
+
+    private void requestNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT < 33 || getActivity() == null) return;
+        if (getContext().checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) return;
+        if (!notificationPermissionRequested.compareAndSet(false, true)) return;
+        getActivity().runOnUiThread(() -> getActivity().requestPermissions(
+            new String[] { Manifest.permission.POST_NOTIFICATIONS },
+            NOTIFICATION_PERMISSION_REQUEST
+        ));
+    }
+
+    private void showAttentionNotification(
+        AttentionContext context,
+        String sessionID,
+        String requestKey,
+        String title,
+        String body
+    ) {
+        NotificationManager manager = (NotificationManager) getContext().getSystemService(android.content.Context.NOTIFICATION_SERVICE);
+        if (manager == null) return;
+
+        Uri target = new Uri.Builder()
+            .scheme("harnessremote")
+            .authority("attention")
+            .appendQueryParameter("machineID", context.machineID)
+            .appendQueryParameter("agentID", context.agentID)
+            .appendQueryParameter("sessionID", sessionID)
+            .build();
+        Intent intent = new Intent(getContext(), MainActivity.class)
+            .setAction("ai.harness.remote.ATTENTION." + Integer.toHexString((requestKey + sessionID).hashCode()))
+            .setData(target)
+            .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        int pendingFlags = PendingIntent.FLAG_UPDATE_CURRENT;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) pendingFlags |= PendingIntent.FLAG_IMMUTABLE;
+        int notificationID = (context.machineID + context.agentID + sessionID + requestKey).hashCode() & 0x7fffffff;
+        PendingIntent contentIntent = PendingIntent.getActivity(getContext(), notificationID, intent, pendingFlags);
+
+        int smallIcon = getContext().getApplicationInfo().icon;
+        if (smallIcon == 0) smallIcon = android.R.drawable.ic_dialog_info;
+        Notification.Builder builder = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+            ? new Notification.Builder(getContext(), ATTENTION_CHANNEL_ID)
+            : new Notification.Builder(getContext());
+        builder
+            .setSmallIcon(smallIcon)
+            .setContentTitle(title)
+            .setContentText(body.replace('\n', ' '))
+            .setStyle(new Notification.BigTextStyle().bigText(body))
+            .setContentIntent(contentIntent)
+            .setAutoCancel(true);
+        try {
+            manager.notify(notificationID, builder.build());
+        } catch (SecurityException ignored) {
+            // Android 13+ may deny notification permission. The in-app Inbox remains authoritative.
         }
     }
 

--- a/web/scripts/sync-native-live-events.mjs
+++ b/web/scripts/sync-native-live-events.mjs
@@ -1,12 +1,25 @@
-import { cpSync, existsSync } from "node:fs"
-import { dirname, resolve } from "node:path"
+import { cpSync, existsSync, readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
 
 const root = resolve(import.meta.dirname, "..")
 const source = resolve(root, "native-android")
 const target = resolve(root, "android/app/src/main/java/ai/harness/remote")
+const manifest = resolve(root, "android/app/src/main/AndroidManifest.xml")
 
 if (!existsSync(target)) throw new Error("Android project not found; run npx cap sync android first")
 for (const file of ["MainActivity.java", "LiveEventsPlugin.java"]) {
   cpSync(resolve(source, file), resolve(target, file))
 }
-console.log("Synced Harness Remote live-events plugin")
+
+if (!existsSync(manifest)) throw new Error("Android manifest not found after Capacitor sync")
+let manifestText = readFileSync(manifest, "utf8")
+const notificationPermission = "android.permission.POST_NOTIFICATIONS"
+if (!manifestText.includes(notificationPermission)) {
+  manifestText = manifestText.replace(
+    /(<manifest\b[^>]*>)/,
+    `$1\n    <uses-permission android:name="${notificationPermission}" />`
+  )
+  writeFileSync(manifest, manifestText)
+}
+
+console.log("Synced Harness Remote live-events plugin and Attention notification permission")

--- a/web/src/components/native-session-home-attention.tsx
+++ b/web/src/components/native-session-home-attention.tsx
@@ -24,6 +24,12 @@ type AttentionTarget = NativeSessionAttentionLiveTarget & {
   machineName: string
 }
 
+type AttentionActivation = {
+  machineID: string
+  agentID: string
+  sessionID: string
+}
+
 type AttentionScope = {
   target: AttentionTarget
   index: NativeSessionAttentionIndex
@@ -138,6 +144,7 @@ export function NativeSessionHome(props: Props) {
   const [openError, setOpenError] = useState<string | null>(null)
   const [baseAttentionCount, setBaseAttentionCount] = useState(0)
   const generationRef = useRef(0)
+  const pendingActivationRef = useRef<AttentionActivation | null>(null)
   const notificationStateRef = useRef<NativeSessionAttentionNotificationState>({
     scopes: { ...EMPTY_NATIVE_SESSION_ATTENTION_NOTIFICATION_STATE.scopes }
   })
@@ -203,14 +210,17 @@ export function NativeSessionHome(props: Props) {
     }
   }, [openingKey, props.selectedKey, rememberAndOpen])
 
-  const activateAttention = useCallback((activation: { machineID: string; agentID: string; sessionID: string }) => {
+  const activateAttention = useCallback((activation: AttentionActivation) => {
     const target = [...targetsRef.current.values()].find((candidate) =>
       candidate.machineID === activation.machineID && candidate.agent.id === activation.agentID
     )
     if (!target) {
-      setOpenError("The machine or harness for this notification is not currently available.")
+      // A cold Android launch can deliver the PendingIntent before machine discovery has completed.
+      // Keep the exact identity and retry when the matching capability-scoped target appears.
+      pendingActivationRef.current = activation
       return
     }
+    pendingActivationRef.current = null
     void openAttentionSession(target, activation.sessionID)
   }, [openAttentionSession])
 
@@ -247,6 +257,17 @@ export function NativeSessionHome(props: Props) {
 
   useEffect(() => subscribeDesktopAttentionActivation(activateAttention), [activateAttention])
   useEffect(() => subscribeAndroidAttentionActivation(activateAttention), [activateAttention])
+
+  useEffect(() => {
+    const pending = pendingActivationRef.current
+    if (!pending) return
+    const target = attentionTargets.find((candidate) =>
+      candidate.machineID === pending.machineID && candidate.agent.id === pending.agentID
+    )
+    if (!target) return
+    pendingActivationRef.current = null
+    void openAttentionSession(target, pending.sessionID)
+  }, [openAttentionSession, targetSignature])
 
   useEffect(() => {
     const generation = ++generationRef.current

--- a/web/src/components/native-session-home-attention.tsx
+++ b/web/src/components/native-session-home-attention.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ComponentProps } from "react"
 import { notifyDesktopAttention, subscribeDesktopAttentionActivation } from "../desktopBridge"
+import { subscribeAndroidAttentionActivation } from "../native-session-attention-android"
 import { discoverAgentNativeSessionPage, nativeSessionSurfaceTarget, type NativeSessionSurfaceTarget } from "../native-session-discovery"
 import { loadNativeSessionAttentionIndex, type NativeSessionAttentionIndex, type NativeSessionAttentionIndexItem } from "../native-session-attention-index"
 import { startNativeSessionAttentionLiveRefresh, type NativeSessionAttentionLiveTarget } from "../native-session-attention-live"
@@ -202,6 +203,17 @@ export function NativeSessionHome(props: Props) {
     }
   }, [openingKey, props.selectedKey, rememberAndOpen])
 
+  const activateAttention = useCallback((activation: { machineID: string; agentID: string; sessionID: string }) => {
+    const target = [...targetsRef.current.values()].find((candidate) =>
+      candidate.machineID === activation.machineID && candidate.agent.id === activation.agentID
+    )
+    if (!target) {
+      setOpenError("The machine or harness for this notification is not currently available.")
+      return
+    }
+    void openAttentionSession(target, activation.sessionID)
+  }, [openAttentionSession])
+
   const refreshAttentionTarget = useCallback(async (candidate: NativeSessionAttentionLiveTarget, generation: number) => {
     const target = targetsRef.current.get(candidate.key)
     if (!target) return
@@ -233,16 +245,8 @@ export function NativeSessionHome(props: Props) {
     })
   }, [])
 
-  useEffect(() => subscribeDesktopAttentionActivation((activation) => {
-    const target = [...targetsRef.current.values()].find((candidate) =>
-      candidate.machineID === activation.machineID && candidate.agent.id === activation.agentID
-    )
-    if (!target) {
-      setOpenError("The machine or harness for this notification is not currently available.")
-      return
-    }
-    void openAttentionSession(target, activation.sessionID)
-  }), [openAttentionSession])
+  useEffect(() => subscribeDesktopAttentionActivation(activateAttention), [activateAttention])
+  useEffect(() => subscribeAndroidAttentionActivation(activateAttention), [activateAttention])
 
   useEffect(() => {
     const generation = ++generationRef.current

--- a/web/src/native-session-attention-android.test.mjs
+++ b/web/src/native-session-attention-android.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+import { parseAndroidAttentionActivation } from "./native-session-attention-android.ts"
+
+const native = readFileSync(new URL("../native-android/LiveEventsPlugin.java", import.meta.url), "utf8")
+const live = readFileSync(new URL("./native-session-attention-live.ts", import.meta.url), "utf8")
+const transport = readFileSync(new URL("./taskdesk-live-events.ts", import.meta.url), "utf8")
+const home = readFileSync(new URL("./components/native-session-home-attention.tsx", import.meta.url), "utf8")
+const sync = readFileSync(new URL("../scripts/sync-native-live-events.mjs", import.meta.url), "utf8")
+
+test("Android Attention activation accepts only the private exact-Session deep link", () => {
+  assert.deepEqual(
+    parseAndroidAttentionActivation("harnessremote://attention?machineID=machine-1&agentID=opencode&sessionID=session-123"),
+    { machineID: "machine-1", agentID: "opencode", sessionID: "session-123" }
+  )
+  assert.equal(parseAndroidAttentionActivation("https://example.com/?machineID=x&agentID=y&sessionID=z"), null)
+  assert.equal(parseAndroidAttentionActivation("harnessremote://attention?machineID=machine-1&agentID=opencode"), null)
+  assert.equal(parseAndroidAttentionActivation("not a url"), null)
+})
+
+test("only the capability-scoped Attention stream carries native notification identity", () => {
+  assert.match(live, /nativeAttention:[\s\S]*machineID: target\.machineID[\s\S]*questions: target\.agent\.capabilities\.questions === true[\s\S]*permissions: target\.agent\.capabilities\.permissions === true/)
+  assert.match(transport, /parsed\.hash = new URLSearchParams/)
+  assert.match(transport, /hrAttention: "1"/)
+  assert.match(native, /String endpoint = stripFragment\(url\)/,
+    "notification metadata must never be forwarded to the daemon request URL")
+  assert.match(native, /context\.questions && \("question\.asked"\.equals\(type\) \|\| "question\.v2\.asked"\.equals\(type\)\)/)
+  assert.match(native, /context\.permissions && \("permission\.asked"\.equals\(type\) \|\| "permission\.v2\.asked"\.equals\(type\)\)/)
+})
+
+test("native Attention notifications are fail-closed display only and deep-link to exact identity", () => {
+  assert.match(native, /ATTENTION_CHANNEL_ID/)
+  assert.match(native, /Manifest\.permission\.POST_NOTIFICATIONS/)
+  assert.match(sync, /android\.permission\.POST_NOTIFICATIONS/)
+  assert.match(native, /scheme\("harnessremote"\)/)
+  assert.match(native, /authority\("attention"\)/)
+  assert.match(native, /appendQueryParameter\("machineID", context\.machineID\)/)
+  assert.match(native, /appendQueryParameter\("agentID", context\.agentID\)/)
+  assert.match(native, /appendQueryParameter\("sessionID", sessionID\)/)
+  assert.match(native, /If you do nothing, this request stays blocked\./)
+  assert.doesNotMatch(native, /\/session\/.*\/message|loadMessages|promptAsync|permission.*reply/i)
+})
+
+test("Android notification activation reuses the existing explicit Inbox Session opener", () => {
+  assert.match(home, /subscribeAndroidAttentionActivation\(activateAttention\)/)
+  assert.match(home, /candidate\.machineID === activation\.machineID && candidate\.agent\.id === activation\.agentID/)
+  assert.match(home, /openAttentionSession\(target, activation\.sessionID\)/)
+  assert.doesNotMatch(home, /subscribeAndroidAttentionActivation[\s\S]*loadMessages/)
+})

--- a/web/src/native-session-attention-android.test.mjs
+++ b/web/src/native-session-attention-android.test.mjs
@@ -45,6 +45,9 @@ test("native Attention notifications are fail-closed display only and deep-link 
 test("Android notification activation reuses the existing explicit Inbox Session opener", () => {
   assert.match(home, /subscribeAndroidAttentionActivation\(activateAttention\)/)
   assert.match(home, /candidate\.machineID === activation\.machineID && candidate\.agent\.id === activation\.agentID/)
+  assert.match(home, /pendingActivationRef\.current = activation/,
+    "cold-start activation must survive until machine discovery catches up")
+  assert.match(home, /pendingActivationRef\.current = null[\s\S]*openAttentionSession\(target, pending\.sessionID\)/)
   assert.match(home, /openAttentionSession\(target, activation\.sessionID\)/)
   assert.doesNotMatch(home, /subscribeAndroidAttentionActivation[\s\S]*loadMessages/)
 })

--- a/web/src/native-session-attention-android.test.mjs
+++ b/web/src/native-session-attention-android.test.mjs
@@ -39,7 +39,7 @@ test("native Attention notifications are fail-closed display only and deep-link 
   assert.match(native, /appendQueryParameter\("agentID", context\.agentID\)/)
   assert.match(native, /appendQueryParameter\("sessionID", sessionID\)/)
   assert.match(native, /If you do nothing, this request stays blocked\./)
-  assert.doesNotMatch(native, /\/session\/.*\/message|loadMessages|promptAsync|permission.*reply/i)
+  assert.doesNotMatch(native, /\/session\/.*\/message|loadMessages|promptAsync|\/permission\/.*\/reply|\/question\/.*\/reply/i)
 })
 
 test("Android notification activation reuses the existing explicit Inbox Session opener", () => {

--- a/web/src/native-session-attention-android.ts
+++ b/web/src/native-session-attention-android.ts
@@ -1,0 +1,65 @@
+import { App } from "@capacitor/app"
+import { Capacitor, type PluginListenerHandle } from "@capacitor/core"
+
+export type AndroidAttentionActivation = {
+  machineID: string
+  agentID: string
+  sessionID: string
+}
+
+const MAX_ID_LENGTH = 512
+
+function cleanID(value: string | null): string | null {
+  const normalized = value?.trim() ?? ""
+  if (!normalized || normalized.length > MAX_ID_LENGTH || /[\u0000-\u001f\u007f]/.test(normalized)) return null
+  return normalized
+}
+
+/** Parse only the explicit URI shape emitted by the native Android notification PendingIntent. */
+export function parseAndroidAttentionActivation(url: string): AndroidAttentionActivation | null {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return null
+  }
+  if (parsed.protocol !== "harnessremote:" || parsed.hostname !== "attention") return null
+  const machineID = cleanID(parsed.searchParams.get("machineID"))
+  const agentID = cleanID(parsed.searchParams.get("agentID"))
+  const sessionID = cleanID(parsed.searchParams.get("sessionID"))
+  return machineID && agentID && sessionID ? { machineID, agentID, sessionID } : null
+}
+
+/**
+ * Android local notifications reopen MainActivity with a private explicit deep link. Capacitor's App
+ * bridge covers both a warm `appUrlOpen` and a cold `getLaunchUrl`, so notification activation never
+ * needs transcript data or a second native Session identity.
+ */
+export function subscribeAndroidAttentionActivation(
+  onActivation: (activation: AndroidAttentionActivation) => void
+): () => void {
+  if (Capacitor.getPlatform() !== "android") return () => undefined
+
+  let closed = false
+  let handle: PluginListenerHandle | undefined
+  const seen = new Set<string>()
+  const emit = (url: string | undefined) => {
+    if (closed || !url || seen.has(url)) return
+    const activation = parseAndroidAttentionActivation(url)
+    if (!activation) return
+    seen.add(url)
+    onActivation(activation)
+  }
+
+  void App.addListener("appUrlOpen", ({ url }) => emit(url)).then((created) => {
+    if (closed) void created.remove()
+    else handle = created
+  })
+  void App.getLaunchUrl().then((launch) => emit(launch?.url)).catch(() => undefined)
+
+  return () => {
+    if (closed) return
+    closed = true
+    if (handle) void handle.remove()
+  }
+}

--- a/web/src/native-session-attention-desktop.test.mjs
+++ b/web/src/native-session-attention-desktop.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict"
 import { readFileSync } from "node:fs"
 import test from "node:test"
 import { desktopAttentionNotification } from "./native-session-attention-notification-presentation.ts"
+import "./native-session-attention-android.test.mjs"
 
 function event(overrides = {}) {
   return {

--- a/web/src/native-session-attention-live.ts
+++ b/web/src/native-session-attention-live.ts
@@ -6,6 +6,10 @@ export type NativeSessionAttentionLiveTarget = {
   key: string
   baseConfig: ServerConfig
   agent: MachineAgentHost
+  /** Present for the global Session rail. Kept optional so isolated controller tests and older callers
+   * can still use the live-refresh primitive without enabling native Android notifications. */
+  machineID?: string
+  machineName?: string
 }
 
 type Subscribe = typeof subscribeTaskDeskLiveEvents
@@ -52,6 +56,16 @@ export function startNativeSessionAttentionLiveRefresh({
     .filter(({ agent }) => supportsAttention(agent))
     .map((target) => subscribe({
       config: nativeSessionConfig(target.baseConfig, target.agent),
+      ...(target.machineID && target.machineName ? {
+        nativeAttention: {
+          machineID: target.machineID,
+          machineName: target.machineName,
+          agentID: target.agent.id,
+          agentLabel: target.agent.label,
+          questions: target.agent.capabilities.questions === true,
+          permissions: target.agent.capabilities.permissions === true
+        }
+      } : {}),
       onEvent: (event) => {
         if (isAttentionEvent(event.type)) schedule(target)
       },

--- a/web/src/taskdesk-live-events.ts
+++ b/web/src/taskdesk-live-events.ts
@@ -15,6 +15,15 @@ export type TaskDeskLiveEvent = {
   sessionID?: string
 }
 
+export type NativeAttentionStreamContext = {
+  machineID: string
+  machineName: string
+  agentID: string
+  agentLabel: string
+  questions: boolean
+  permissions: boolean
+}
+
 type Subscription = { close(): void }
 
 function text(value: unknown): string | undefined {
@@ -52,17 +61,40 @@ export function taskDeskLiveEvent(name: string | undefined, data: unknown): Task
 }
 
 /**
+ * The native Android plugin owns the socket after WebView timers are paused. Carry only routing and
+ * display identity in the URL fragment: fragments are stripped before the HTTP request and contain
+ * no credentials. Generic Session streams do not receive this metadata and therefore cannot emit
+ * Attention notifications.
+ */
+export function nativeAttentionEventStreamURL(url: string, context?: NativeAttentionStreamContext): string {
+  if (!context) return url
+  const parsed = new URL(url)
+  parsed.hash = new URLSearchParams({
+    hrAttention: "1",
+    machineID: context.machineID,
+    machineName: context.machineName,
+    agentID: context.agentID,
+    agentLabel: context.agentLabel,
+    questions: context.questions ? "1" : "0",
+    permissions: context.permissions ? "1" : "0"
+  }).toString()
+  return parsed.toString()
+}
+
+/**
  * Use the transport already proven by Classic on each platform. Browser and Electron fetch streams
  * can carry auth headers, Android uses the native SSE plugin, and Electron main owns desktop sockets.
  */
 export function subscribeTaskDeskLiveEvents({
   config,
   onEvent,
-  onStatus
+  onStatus,
+  nativeAttention
 }: {
   config: ServerConfig
   onEvent: (event: TaskDeskLiveEvent) => void
   onStatus?: (status: EventStreamStatus) => void
+  nativeAttention?: NativeAttentionStreamContext
 }): Subscription {
   const emit = (name: string | undefined, data: unknown) => {
     const normalized = taskDeskLiveEvent(name, data)
@@ -81,7 +113,7 @@ export function subscribeTaskDeskLiveEvents({
   const stream = api.eventStream(config)
   if (isNativeEventTransport()) {
     return createNativeOpenCodeEventSubscription({
-      url: stream.url,
+      url: nativeAttentionEventStreamURL(stream.url, nativeAttention),
       username: config.username,
       password: config.password,
       backend: config.backend,


### PR DESCRIPTION
## Summary

Add the first native Android Attention notification path on top of the multiplexed event transport from #403.

- only the capability-scoped global Attention stream carries native notification metadata;
- the metadata lives in the URL fragment, contains no credentials, and is stripped before the HTTP request;
- the Android plugin recognizes `permission.asked` / `permission.v2.asked` and `question.asked` / `question.v2.asked` directly on the already-open native SSE socket;
- permission notifications explain the requested action, available reason/boundary and that no response leaves the request blocked;
- request-id dedup prevents replayed SSE edges from producing duplicate local notifications;
- Android 13+ notification permission and a dedicated notification channel are configured during Capacitor sync;
- tapping a notification opens Harness Remote through a private `harnessremote://attention` URI and reuses the existing explicit Inbox resolver to locate the exact machine + harness + native Session;
- the in-app pending endpoints remain authoritative and continue to reconcile on connect/reconnect; this native path does not reply to permissions/questions and never reads transcript history.

## Scope / limitation

This deliberately does **not** add a foreground service or claim killed-process/Doze reliability. It covers native delivery while the app process/live native stream remains alive; physical-device background/network/process-death validation remains a separate P1/P0 gate.

## Risk boundary

Android native client + Session rail composition only. No daemon/router/ACP changes, no writer/prompt/Stop changes, no permission auto-approval, and no new network endpoint.

Targets `codex/development-2026-09-11` only. `main` must remain untouched.

Refs #369