### PR TITLE
P1: add one-time machine pairing contract

### DIFF
--- a/bridge/src/agent-model-server.js
+++ b/bridge/src/agent-model-server.js
@@ -1,5 +1,6 @@
 import http from "node:http"
 import { allowedOrigin, applyCorsHeaders, matchesCredentials, writeJSON } from "./http-policy.js"
+import { announceMachinePairing, createOneTimePairingGrant, createPairingServer } from "./pairing-server.js"
 
 const MODEL_ROUTE = /^\/v1\/agents\/([^/]+)\/models$/
 const TASK_LAUNCH_ROUTE = /^\/v1\/tasks\/([^/]+)\/launch$/
@@ -47,7 +48,7 @@ async function settleWithin(promise, waitMs) {
 }
 
 export function createAgentModelServer({ innerServer, config, daemon, taskStore, createServer = http.createServer }) {
-  return createServer(async (request, response) => {
+  const authenticatedServer = createServer(async (request, response) => {
     const url = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`)
     const modelMatch = MODEL_ROUTE.exec(url.pathname)
     if (modelMatch) {
@@ -111,4 +112,13 @@ export function createAgentModelServer({ innerServer, config, daemon, taskStore,
 
     innerServer.emit("request", request, response)
   })
+
+  // This wrapper exists only in the multi-host machine daemon composition. Legacy standalone ACP /
+  // OpenCode bridge servers never construct createAgentModelServer, so their auth and startup
+  // contracts remain byte-for-byte outside the pairing path.
+  const machine = daemon.snapshot?.().machine
+  if (!machine) return authenticatedServer
+  const grant = createOneTimePairingGrant()
+  if (process.argv[1]?.endsWith("daemon-cli.js")) announceMachinePairing(config, grant)
+  return createPairingServer({ innerServer: authenticatedServer, config, machine, grant, createServer })
 }

--- a/bridge/src/pairing-server.js
+++ b/bridge/src/pairing-server.js
@@ -1,0 +1,96 @@
+import http from "node:http"
+import { timingSafeEqual } from "node:crypto"
+import { allowedOrigin, applyCorsHeaders, writeJSON } from "./http-policy.js"
+
+export const PAIRING_CLAIM_PATH = "/v1/pairing/claim"
+export const PAIRING_TOKEN_MAX_LENGTH = 256
+const MAX_PAIRING_BODY_BYTES = 4_096
+
+function sameToken(expected, candidate) {
+  if (typeof expected !== "string" || typeof candidate !== "string") return false
+  const left = Buffer.from(expected, "utf8")
+  const right = Buffer.from(candidate, "utf8")
+  return left.length === right.length && timingSafeEqual(left, right)
+}
+
+async function readPairingBody(request) {
+  let body = ""
+  for await (const chunk of request) {
+    body += chunk
+    if (Buffer.byteLength(body, "utf8") > MAX_PAIRING_BODY_BYTES) throw new Error("Pairing request is too large")
+  }
+  return body ? JSON.parse(body) : {}
+}
+
+/**
+ * In-memory, process-local claim. A daemon restart invalidates it by design: pairing is a short-lived
+ * bootstrap path, never durable authority. Consumption is synchronous so two concurrent valid claims
+ * cannot both win after their request bodies have been read.
+ */
+export class OneTimePairingGrant {
+  constructor({ token, expiresAt, now = () => Date.now() }) {
+    if (typeof token !== "string" || !token || token.length > PAIRING_TOKEN_MAX_LENGTH) {
+      throw new Error("Pairing token is invalid")
+    }
+    if (!Number.isFinite(expiresAt)) throw new Error("Pairing expiry is invalid")
+    this.token = token
+    this.expiresAt = Number(expiresAt)
+    this.now = now
+    this.consumed = false
+  }
+
+  consume(candidate) {
+    if (this.consumed) return { ok: false, status: 409, error: "This pairing link has already been used." }
+    if (this.now() >= this.expiresAt) return { ok: false, status: 410, error: "This pairing link has expired." }
+    if (!sameToken(this.token, candidate)) return { ok: false, status: 401, error: "Pairing token is invalid." }
+    this.consumed = true
+    return { ok: true }
+  }
+}
+
+/**
+ * The pairing claim is the daemon's only unauthenticated bootstrap route. Everything else is passed
+ * byte-for-byte to the existing authenticated server stack. The response returns the daemon's
+ * existing Basic Auth credentials; it does not create a second authority model.
+ */
+export function createPairingServer({ innerServer, config, machine, grant, createServer = http.createServer }) {
+  return createServer(async (request, response) => {
+    const url = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`)
+    if (url.pathname !== PAIRING_CLAIM_PATH) {
+      innerServer.emit("request", request, response)
+      return
+    }
+
+    applyCorsHeaders(request, response, config)
+    if (request.method === "OPTIONS") {
+      response.writeHead(allowedOrigin(request, config) ? 204 : 403)
+      response.end()
+      return
+    }
+    if (request.method !== "POST") {
+      response.writeHead(405, { Allow: "POST, OPTIONS", "Cache-Control": "no-store" })
+      response.end()
+      return
+    }
+
+    let body
+    try {
+      body = await readPairingBody(request)
+    } catch {
+      writeJSON(response, 400, { error: "Pairing request is invalid." })
+      return
+    }
+
+    const result = grant.consume(body?.token)
+    if (!result.ok) {
+      writeJSON(response, result.status, { error: result.error })
+      return
+    }
+
+    writeJSON(response, 200, {
+      version: 1,
+      machine: { id: machine.id, name: machine.name },
+      credentials: { username: config.username ?? "", password: config.password ?? "" }
+    })
+  })
+}

--- a/bridge/src/pairing-server.js
+++ b/bridge/src/pairing-server.js
@@ -1,10 +1,13 @@
 import http from "node:http"
-import { timingSafeEqual } from "node:crypto"
+import { randomBytes, timingSafeEqual } from "node:crypto"
+import { networkInterfaces } from "node:os"
 import { allowedOrigin, applyCorsHeaders, writeJSON } from "./http-policy.js"
 
 export const PAIRING_CLAIM_PATH = "/v1/pairing/claim"
+export const PAIRING_TTL_MS = 5 * 60 * 1_000
 export const PAIRING_TOKEN_MAX_LENGTH = 256
 const MAX_PAIRING_BODY_BYTES = 4_096
+const VIRTUAL_INTERFACE = /^(docker|br-|veth|virbr|tun|tap|utun)/i
 
 function sameToken(expected, candidate) {
   if (typeof expected !== "string" || typeof candidate !== "string") return false
@@ -46,6 +49,65 @@ export class OneTimePairingGrant {
     this.consumed = true
     return { ok: true }
   }
+}
+
+export function createOneTimePairingGrant({
+  now = () => Date.now(),
+  randomBytesImpl = randomBytes,
+  ttlMs = PAIRING_TTL_MS
+} = {}) {
+  const issuedAt = now()
+  return new OneTimePairingGrant({
+    token: randomBytesImpl(32).toString("base64url"),
+    expiresAt: issuedAt + ttlMs,
+    now
+  })
+}
+
+function pairingAddresses(host, interfaces = networkInterfaces()) {
+  const normalized = String(host ?? "").trim()
+  if (normalized !== "0.0.0.0" && normalized !== "::") return normalized ? [normalized] : []
+
+  const candidates = []
+  for (const [name, addresses] of Object.entries(interfaces)) {
+    for (const address of addresses ?? []) {
+      if (address.family === "IPv4" && !address.internal) candidates.push({ name, address: address.address })
+    }
+  }
+  const preferred = candidates.filter(({ name }) => !VIRTUAL_INTERFACE.test(name))
+  return [...new Set((preferred.length ? preferred : candidates).map(({ address }) => address))]
+}
+
+function endpointHost(host) {
+  return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host
+}
+
+export function pairingURI(endpoint, grant) {
+  const params = new URLSearchParams({
+    endpoint,
+    token: grant.token,
+    expires: String(grant.expiresAt)
+  })
+  return `harnessremote://pair?${params.toString()}`
+}
+
+export function machinePairingLinks(config, grant, interfaces = networkInterfaces()) {
+  return pairingAddresses(config.host, interfaces).map((host) => {
+    const endpoint = `http://${endpointHost(host)}:${config.port}`
+    return { endpoint, uri: pairingURI(endpoint, grant) }
+  })
+}
+
+/** Startup output keeps long-lived credentials as a manual fallback, but the link itself contains
+ * only a high-entropy one-time grant. It is intentionally plain text for now: the URI is QR-ready
+ * without introducing a QR/package dependency into the bridge. */
+export function announceMachinePairing(config, grant, { write = (text) => process.stdout.write(text), interfaces } = {}) {
+  const links = machinePairingLinks(config, grant, interfaces)
+  if (!links.length) return []
+  write("\nPair a phone (one use, valid for 5 minutes):\n")
+  for (const { uri } of links) write(`  ${uri}\n`)
+  write("Open or scan one of these links in Harness Remote. The link does not contain the daemon password.\n")
+  return links
 }
 
 /**

--- a/bridge/test/pairing-server.test.js
+++ b/bridge/test/pairing-server.test.js
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict"
+import http from "node:http"
+import test from "node:test"
+import { OneTimePairingGrant, createPairingServer } from "../src/pairing-server.js"
+
+async function listen(server) {
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
+  const address = server.address()
+  return `http://127.0.0.1:${address.port}`
+}
+function close(server) { return new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve())) }
+function config() { return { username: "harness", password: "secret-password", corsOrigins: [] } }
+function machine() { return { id: "machine-1", name: "Dev workstation" } }
+function grant(overrides = {}) {
+  return new OneTimePairingGrant({ token: "one-time-token", expiresAt: 2_000, now: () => 1_000, ...overrides })
+}
+
+async function claim(base, token = "one-time-token") {
+  return fetch(`${base}/v1/pairing/claim`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token })
+  })
+}
+
+test("pairing claim returns the existing daemon credentials without Basic Auth", async () => {
+  const innerServer = http.createServer((_request, response) => { response.writeHead(401); response.end() })
+  const server = createPairingServer({ innerServer, config: config(), machine: machine(), grant: grant() })
+  const base = await listen(server)
+  try {
+    const response = await claim(base)
+    assert.equal(response.status, 200)
+    assert.equal(response.headers.get("cache-control"), "no-store")
+    assert.deepEqual(await response.json(), {
+      version: 1,
+      machine: { id: "machine-1", name: "Dev workstation" },
+      credentials: { username: "harness", password: "secret-password" }
+    })
+  } finally { await close(server) }
+})
+
+test("a pairing grant can be consumed exactly once", async () => {
+  const innerServer = http.createServer((_request, response) => { response.writeHead(500); response.end() })
+  const server = createPairingServer({ innerServer, config: config(), machine: machine(), grant: grant() })
+  const base = await listen(server)
+  try {
+    assert.equal((await claim(base)).status, 200)
+    const second = await claim(base)
+    assert.equal(second.status, 409)
+    assert.match((await second.json()).error, /already been used/i)
+  } finally { await close(server) }
+})
+
+test("invalid token does not consume the valid grant", async () => {
+  const innerServer = http.createServer((_request, response) => { response.writeHead(500); response.end() })
+  const server = createPairingServer({ innerServer, config: config(), machine: machine(), grant: grant() })
+  const base = await listen(server)
+  try {
+    assert.equal((await claim(base, "wrong-token")).status, 401)
+    assert.equal((await claim(base)).status, 200)
+  } finally { await close(server) }
+})
+
+test("expired pairing grant fails closed", async () => {
+  const innerServer = http.createServer((_request, response) => { response.writeHead(500); response.end() })
+  const server = createPairingServer({
+    innerServer,
+    config: config(),
+    machine: machine(),
+    grant: grant({ expiresAt: 999 })
+  })
+  const base = await listen(server)
+  try {
+    const response = await claim(base)
+    assert.equal(response.status, 410)
+    assert.match((await response.json()).error, /expired/i)
+  } finally { await close(server) }
+})
+
+test("pairing wrapper delegates every unrelated route to the existing authenticated stack", async () => {
+  let delegated = 0
+  const innerServer = http.createServer((request, response) => {
+    delegated += 1
+    assert.equal(request.url, "/v1/machine")
+    response.writeHead(401, { "WWW-Authenticate": "Basic" })
+    response.end()
+  })
+  const server = createPairingServer({ innerServer, config: config(), machine: machine(), grant: grant() })
+  const base = await listen(server)
+  try {
+    const response = await fetch(`${base}/v1/machine`)
+    assert.equal(response.status, 401)
+    assert.equal(delegated, 1)
+  } finally { await close(server) }
+})

--- a/bridge/test/pairing-server.test.js
+++ b/bridge/test/pairing-server.test.js
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict"
 import http from "node:http"
 import test from "node:test"
-import { OneTimePairingGrant, createPairingServer } from "../src/pairing-server.js"
+import {
+  OneTimePairingGrant,
+  PAIRING_TTL_MS,
+  createOneTimePairingGrant,
+  createPairingServer,
+  machinePairingLinks
+} from "../src/pairing-server.js"
 
 async function listen(server) {
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
@@ -9,7 +15,7 @@ async function listen(server) {
   return `http://127.0.0.1:${address.port}`
 }
 function close(server) { return new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve())) }
-function config() { return { username: "harness", password: "secret-password", corsOrigins: [] } }
+function config() { return { host: "0.0.0.0", port: 4097, username: "harness", password: "secret-password", corsOrigins: [] } }
 function machine() { return { id: "machine-1", name: "Dev workstation" } }
 function grant(overrides = {}) {
   return new OneTimePairingGrant({ token: "one-time-token", expiresAt: 2_000, now: () => 1_000, ...overrides })
@@ -22,6 +28,29 @@ async function claim(base, token = "one-time-token") {
     body: JSON.stringify({ token })
   })
 }
+
+test("generated pairing grant is high entropy and expires after the short bootstrap window", () => {
+  const generated = createOneTimePairingGrant({
+    now: () => 10_000,
+    randomBytesImpl: (size) => {
+      assert.equal(size, 32)
+      return Buffer.alloc(size, 0xab)
+    }
+  })
+  assert.match(generated.token, /^[A-Za-z0-9_-]{40,}$/)
+  assert.equal(generated.expiresAt, 10_000 + PAIRING_TTL_MS)
+})
+
+test("scan-ready pairing links contain the one-time grant but never Basic Auth credentials", () => {
+  const links = machinePairingLinks(config(), grant(), {
+    eth0: [{ family: "IPv4", internal: false, address: "192.168.1.44" }]
+  })
+  assert.equal(links.length, 1)
+  assert.equal(links[0].endpoint, "http://192.168.1.44:4097")
+  assert.match(links[0].uri, /^harnessremote:\/\/pair\?/)
+  assert.match(links[0].uri, /token=one-time-token/)
+  assert.doesNotMatch(links[0].uri, /secret-password|harness%3A|username|password/)
+})
 
 test("pairing claim returns the existing daemon credentials without Basic Auth", async () => {
   const innerServer = http.createServer((_request, response) => { response.writeHead(401); response.end() })

--- a/web/scripts/sync-native-live-events.mjs
+++ b/web/scripts/sync-native-live-events.mjs
@@ -13,13 +13,32 @@ for (const file of ["MainActivity.java", "LiveEventsPlugin.java"]) {
 
 if (!existsSync(manifest)) throw new Error("Android manifest not found after Capacitor sync")
 let manifestText = readFileSync(manifest, "utf8")
+let changed = false
 const notificationPermission = "android.permission.POST_NOTIFICATIONS"
 if (!manifestText.includes(notificationPermission)) {
   manifestText = manifestText.replace(
     /(<manifest\b[^>]*>)/,
     `$1\n    <uses-permission android:name="${notificationPermission}" />`
   )
-  writeFileSync(manifest, manifestText)
+  changed = true
 }
 
-console.log("Synced Harness Remote live-events plugin and Attention notification permission")
+// A phone camera / QR scanner opens this custom URI through MainActivity. The token itself remains
+// short-lived and one-use; this filter merely lets Android deliver the URI to Capacitor App.
+const pairingMarker = 'android:host="pair"'
+if (!manifestText.includes(pairingMarker)) {
+  const activityPattern = /(<activity\b[^>]*android:name="\.MainActivity"[^>]*>)([\s\S]*?)(<\/activity>)/
+  if (!activityPattern.test(manifestText)) throw new Error("MainActivity not found in Android manifest after Capacitor sync")
+  const pairingFilter = `
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="harnessremote" android:host="pair" />
+            </intent-filter>`
+  manifestText = manifestText.replace(activityPattern, `$1$2${pairingFilter}\n        $3`)
+  changed = true
+}
+
+if (changed) writeFileSync(manifest, manifestText)
+console.log("Synced Harness Remote live-events plugin, Attention permission and machine-pairing deep link")

--- a/web/src/controls-preview.ts
+++ b/web/src/controls-preview.ts
@@ -44,6 +44,7 @@ import "./session-first-workbench.css"
 import "./conversation-base.css"
 import "./session-first-centering-fix.css"
 import "./session-handoff-routing.css"
+import "./machine-pairing.css"
 import "./beautiful-ui-controls.css"
 
 /** Same list, same order as `main.tsx` - `beautiful-ui-controls.test.mjs` asserts the two match, so

--- a/web/src/machine-pairing.css
+++ b/web/src/machine-pairing.css
@@ -1,0 +1,55 @@
+.hr-machine-pairing-notice {
+  position: fixed;
+  right: max(16px, env(safe-area-inset-right));
+  bottom: max(76px, calc(env(safe-area-inset-bottom) + 68px));
+  z-index: 1200;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  max-width: min(420px, calc(100vw - 32px));
+  padding: 12px 12px 12px 14px;
+  border: 1px solid var(--tdw-border, rgba(127, 127, 127, .28));
+  border-radius: 12px;
+  background: var(--tdw-surface, Canvas);
+  box-shadow: 0 12px 36px rgba(0, 0, 0, .18);
+}
+
+.hr-machine-pairing-notice > span {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+  line-height: 1.35;
+}
+
+.hr-machine-pairing-notice > span strong {
+  font-size: 12px;
+  letter-spacing: .02em;
+}
+
+.hr-machine-pairing-notice > button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  padding: 0 3px;
+  opacity: .7;
+}
+
+.hr-machine-pairing-notice.success {
+  border-inline-start-width: 4px;
+}
+
+.hr-machine-pairing-notice.error {
+  border-inline-start-width: 4px;
+}
+
+@media (max-width: 640px) {
+  .hr-machine-pairing-notice {
+    left: 12px;
+    right: 12px;
+    bottom: max(76px, calc(env(safe-area-inset-bottom) + 68px));
+    max-width: none;
+  }
+}

--- a/web/src/machine-pairing.test.mjs
+++ b/web/src/machine-pairing.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+import {
+  claimMachinePairing,
+  parseMachinePairingActivation,
+  upsertPairedMachine
+} from "./machine-pairing.ts"
+
+const future = () => Date.now() + 60_000
+const pairingURL = (endpoint = "http://192.168.1.20:4097") =>
+  `harnessremote://pair?endpoint=${encodeURIComponent(endpoint)}&token=${"a".repeat(43)}&expires=${future()}`
+
+test("pairing activation accepts only the private explicit daemon endpoint shape", () => {
+  assert.deepEqual(parseMachinePairingActivation(pairingURL()), {
+    endpoint: "http://192.168.1.20:4097",
+    token: "a".repeat(43),
+    expiresAt: Number(new URL(pairingURL()).searchParams.get("expires"))
+  })
+  assert.equal(parseMachinePairingActivation("https://example.com"), null)
+  assert.equal(parseMachinePairingActivation(pairingURL("http://user:secret@192.168.1.20:4097")), null)
+  assert.equal(parseMachinePairingActivation(pairingURL("http://192.168.1.20")), null)
+  assert.equal(parseMachinePairingActivation(pairingURL("http://192.168.1.20:4097/path")), null)
+})
+
+test("native pairing claim exchanges the one-time token for the existing daemon credentials", async () => {
+  const activation = parseMachinePairingActivation(pairingURL())
+  assert.ok(activation)
+  let requestOptions
+  const paired = await claimMachinePairing(activation, {
+    native: true,
+    nativeRequest: async (options) => {
+      requestOptions = options
+      return {
+        status: 200,
+        data: {
+          version: 1,
+          machine: { id: "physical-machine-1", name: "Studio PC" },
+          credentials: { username: "harness", password: "generated-secret" }
+        },
+        headers: {},
+        url: options.url
+      }
+    }
+  })
+
+  assert.equal(requestOptions.url, "http://192.168.1.20:4097/v1/pairing/claim")
+  assert.equal(requestOptions.method, "POST")
+  assert.deepEqual(requestOptions.data, { token: "a".repeat(43) })
+  assert.deepEqual(paired, {
+    id: "physical-machine-1",
+    name: "Studio PC",
+    config: {
+      backend: "opencode",
+      host: "192.168.1.20",
+      port: 4097,
+      username: "harness",
+      password: "generated-secret",
+      agentId: undefined
+    }
+  })
+})
+
+test("re-pairing updates an existing endpoint in place instead of duplicating it", () => {
+  const existing = {
+    id: "local-stable-id",
+    name: "Old name",
+    config: {
+      backend: "opencode",
+      host: "192.168.1.20",
+      port: 4097,
+      username: "harness",
+      password: "old-secret"
+    }
+  }
+  const paired = {
+    id: "physical-machine-1",
+    name: "Studio PC",
+    config: {
+      backend: "opencode",
+      host: "192.168.1.20",
+      port: 4097,
+      username: "harness",
+      password: "new-secret"
+    }
+  }
+  const result = upsertPairedMachine([existing], paired)
+  assert.equal(result.length, 1)
+  assert.equal(result[0].id, "local-stable-id")
+  assert.equal(result[0].name, "Studio PC")
+  assert.equal(result[0].config.password, "new-secret")
+})
+
+test("Android packaging exposes only the pairing deep-link host and the app imports it at the storage boundary", () => {
+  const sync = readFileSync(new URL("../scripts/sync-native-live-events.mjs", import.meta.url), "utf8")
+  const main = readFileSync(new URL("./main.tsx", import.meta.url), "utf8")
+  assert.match(sync, /android:scheme="harnessremote" android:host="pair"/)
+  assert.match(sync, /android\.intent\.category\.BROWSABLE/)
+  assert.match(main, /subscribeAndroidMachinePairing/)
+  assert.match(main, /claimMachinePairing\(activation\)/)
+  assert.match(main, /upsertPairedMachine\(machinesRef\.current, paired\)/)
+  assert.match(main, /persistMachines\(nextMachines\)/)
+})

--- a/web/src/machine-pairing.test.mjs
+++ b/web/src/machine-pairing.test.mjs
@@ -8,14 +8,16 @@ import {
 } from "./machine-pairing.ts"
 
 const future = () => Date.now() + 60_000
-const pairingURL = (endpoint = "http://192.168.1.20:4097") =>
-  `harnessremote://pair?endpoint=${encodeURIComponent(endpoint)}&token=${"a".repeat(43)}&expires=${future()}`
+const pairingURL = (endpoint = "http://192.168.1.20:4097", expiresAt = future()) =>
+  `harnessremote://pair?endpoint=${encodeURIComponent(endpoint)}&token=${"a".repeat(43)}&expires=${expiresAt}`
 
 test("pairing activation accepts only the private explicit daemon endpoint shape", () => {
-  assert.deepEqual(parseMachinePairingActivation(pairingURL()), {
+  const expiresAt = future()
+  const url = pairingURL("http://192.168.1.20:4097", expiresAt)
+  assert.deepEqual(parseMachinePairingActivation(url), {
     endpoint: "http://192.168.1.20:4097",
     token: "a".repeat(43),
-    expiresAt: Number(new URL(pairingURL()).searchParams.get("expires"))
+    expiresAt
   })
   assert.equal(parseMachinePairingActivation("https://example.com"), null)
   assert.equal(parseMachinePairingActivation(pairingURL("http://user:secret@192.168.1.20:4097")), null)

--- a/web/src/machine-pairing.ts
+++ b/web/src/machine-pairing.ts
@@ -170,20 +170,19 @@ export function upsertPairedMachine(machines: WorkspaceMachine[], paired: Worksp
   return next
 }
 
-/** Capacitor receives both warm appUrlOpen activations and cold launch URLs. */
+/** Capacitor receives both warm appUrlOpen activations and cold launch URLs. Duplicate delivery is
+ * intentionally left to the claim coordinator: a failed network attempt must remain retryable with
+ * the same still-valid one-time token. */
 export function subscribeAndroidMachinePairing(
   onActivation: (activation: MachinePairingActivation) => void
 ): () => void {
   if (Capacitor.getPlatform() !== "android") return () => undefined
   let closed = false
   let handle: PluginListenerHandle | undefined
-  const seen = new Set<string>()
   const emit = (url: string | undefined) => {
-    if (closed || !url || seen.has(url)) return
+    if (closed || !url) return
     const activation = parseMachinePairingActivation(url)
-    if (!activation) return
-    seen.add(url)
-    onActivation(activation)
+    if (activation) onActivation(activation)
   }
 
   void App.addListener("appUrlOpen", ({ url }) => emit(url)).then((created) => {

--- a/web/src/machine-pairing.ts
+++ b/web/src/machine-pairing.ts
@@ -37,8 +37,9 @@ function normalizedPairingEndpoint(value: string): string | null {
   return `${endpoint.protocol}//${endpoint.hostname}:${port}`
 }
 
-/** Accept only the private URI emitted by the HR3 machine daemon startup pairing grant. */
-export function parseMachinePairingActivation(url: string, now = Date.now()): MachinePairingActivation | null {
+/** Accept only the private URI emitted by the HR3 machine daemon startup pairing grant. Expiry is
+ * checked during claim so opening an old QR produces an explicit user-visible error rather than a no-op. */
+export function parseMachinePairingActivation(url: string): MachinePairingActivation | null {
   let parsed: URL
   try { parsed = new URL(url) } catch { return null }
   if (parsed.protocol !== "harnessremote:" || parsed.hostname !== "pair") return null
@@ -48,7 +49,7 @@ export function parseMachinePairingActivation(url: string, now = Date.now()): Ma
   const expiresAt = Number(parsed.searchParams.get("expires"))
   const endpoint = endpointRaw ? normalizedPairingEndpoint(endpointRaw) : null
   if (!endpoint || !token || !TOKEN_PATTERN.test(token)) return null
-  if (!Number.isFinite(expiresAt) || expiresAt <= now) return null
+  if (!Number.isFinite(expiresAt) || expiresAt <= 0) return null
   return { endpoint, token, expiresAt }
 }
 

--- a/web/src/machine-pairing.ts
+++ b/web/src/machine-pairing.ts
@@ -1,7 +1,7 @@
 import { App } from "@capacitor/app"
 import { Capacitor, CapacitorHttp, type PluginListenerHandle } from "@capacitor/core"
-import { machineBaseUrl, normalizeServerConfig } from "./serverConfig"
-import type { WorkspaceMachine } from "./workspaceMachines"
+import { machineBaseUrl, normalizeServerConfig } from "./serverConfig.ts"
+import type { WorkspaceMachine } from "./workspaceMachines.ts"
 
 export type MachinePairingActivation = {
   endpoint: string

--- a/web/src/machine-pairing.ts
+++ b/web/src/machine-pairing.ts
@@ -1,0 +1,199 @@
+import { App } from "@capacitor/app"
+import { Capacitor, CapacitorHttp, type PluginListenerHandle } from "@capacitor/core"
+import { machineBaseUrl, normalizeServerConfig } from "./serverConfig"
+import type { WorkspaceMachine } from "./workspaceMachines"
+
+export type MachinePairingActivation = {
+  endpoint: string
+  token: string
+  expiresAt: number
+}
+
+type PairingClaimResponse = {
+  version: 1
+  machine: { id: string; name: string }
+  credentials: { username: string; password: string }
+}
+
+const MAX_TOKEN_LENGTH = 256
+const TOKEN_PATTERN = /^[A-Za-z0-9_-]+$/
+
+function cleanText(value: unknown, max = 512): string | null {
+  if (typeof value !== "string") return null
+  const normalized = value.trim()
+  if (!normalized || normalized.length > max || /[\u0000-\u001f\u007f]/.test(normalized)) return null
+  return normalized
+}
+
+function normalizedPairingEndpoint(value: string): string | null {
+  let endpoint: URL
+  try { endpoint = new URL(value) } catch { return null }
+  if (endpoint.protocol !== "http:" && endpoint.protocol !== "https:") return null
+  if (endpoint.username || endpoint.password || endpoint.search || endpoint.hash) return null
+  if (endpoint.pathname !== "/" && endpoint.pathname !== "") return null
+  if (!endpoint.hostname || !endpoint.port) return null
+  const port = Number(endpoint.port)
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) return null
+  return `${endpoint.protocol}//${endpoint.hostname}:${port}`
+}
+
+/** Accept only the private URI emitted by the HR3 machine daemon startup pairing grant. */
+export function parseMachinePairingActivation(url: string, now = Date.now()): MachinePairingActivation | null {
+  let parsed: URL
+  try { parsed = new URL(url) } catch { return null }
+  if (parsed.protocol !== "harnessremote:" || parsed.hostname !== "pair") return null
+
+  const endpointRaw = parsed.searchParams.get("endpoint")
+  const token = cleanText(parsed.searchParams.get("token"), MAX_TOKEN_LENGTH)
+  const expiresAt = Number(parsed.searchParams.get("expires"))
+  const endpoint = endpointRaw ? normalizedPairingEndpoint(endpointRaw) : null
+  if (!endpoint || !token || !TOKEN_PATTERN.test(token)) return null
+  if (!Number.isFinite(expiresAt) || expiresAt <= now) return null
+  return { endpoint, token, expiresAt }
+}
+
+function bodyObject(value: unknown): Record<string, unknown> | null {
+  if (value && typeof value === "object" && !Array.isArray(value)) return value as Record<string, unknown>
+  if (typeof value !== "string") return null
+  try {
+    const parsed = JSON.parse(value)
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : null
+  } catch {
+    return null
+  }
+}
+
+function claimPayload(value: unknown): PairingClaimResponse | null {
+  const body = bodyObject(value)
+  const machine = bodyObject(body?.machine)
+  const credentials = bodyObject(body?.credentials)
+  const id = cleanText(machine?.id)
+  const name = cleanText(machine?.name)
+  const username = typeof credentials?.username === "string" ? credentials.username : null
+  const password = typeof credentials?.password === "string" ? credentials.password : null
+  if (body?.version !== 1 || !id || !name || username === null || password === null) return null
+  return { version: 1, machine: { id, name }, credentials: { username, password } }
+}
+
+function errorDetail(value: unknown, fallback: string): string {
+  const body = bodyObject(value)
+  const detail = cleanText(body?.error, 1_000)
+  return detail || fallback
+}
+
+function workspaceMachine(endpoint: string, payload: PairingClaimResponse): WorkspaceMachine {
+  const url = new URL(endpoint)
+  const port = Number(url.port)
+  // Preserve explicit https; plain HTTP host spelling matches the existing manual Add Machine flow.
+  const host = url.protocol === "https:" ? `https://${url.hostname}` : url.hostname
+  const config = normalizeServerConfig({
+    backend: "opencode",
+    host,
+    port,
+    username: payload.credentials.username,
+    password: payload.credentials.password
+  })
+  if (!config) throw new Error("The paired machine returned an invalid endpoint.")
+  return {
+    id: payload.machine.id,
+    name: payload.machine.name,
+    config: { ...config, backend: "opencode", agentId: undefined }
+  }
+}
+
+type NativePairingRequest = typeof CapacitorHttp.request
+
+export async function claimMachinePairing(
+  activation: MachinePairingActivation,
+  options: { nativeRequest?: NativePairingRequest; fetchImpl?: typeof fetch; native?: boolean } = {}
+): Promise<WorkspaceMachine> {
+  if (Date.now() >= activation.expiresAt) throw new Error("This pairing link has expired.")
+  const target = `${activation.endpoint}/v1/pairing/claim`
+  const native = options.native ?? Capacitor.isNativePlatform()
+
+  if (native) {
+    const request = options.nativeRequest ?? CapacitorHttp.request.bind(CapacitorHttp)
+    let response
+    try {
+      response = await request({
+        url: target,
+        method: "POST",
+        headers: { Accept: "application/json", "Content-Type": "application/json" },
+        data: { token: activation.token },
+        connectTimeout: 10_000,
+        readTimeout: 10_000
+      })
+    } catch (error) {
+      throw new Error(error instanceof Error ? error.message : "Could not reach the machine pairing endpoint.")
+    }
+    if (response.status < 200 || response.status >= 300) {
+      throw new Error(errorDetail(response.data, `Pairing failed with HTTP ${response.status}.`))
+    }
+    const payload = claimPayload(response.data)
+    if (!payload) throw new Error("The machine returned an invalid pairing response.")
+    return workspaceMachine(activation.endpoint, payload)
+  }
+
+  const fetchImpl = options.fetchImpl ?? fetch
+  let response: Response
+  try {
+    response = await fetchImpl(target, {
+      method: "POST",
+      headers: { Accept: "application/json", "Content-Type": "application/json" },
+      body: JSON.stringify({ token: activation.token })
+    })
+  } catch (error) {
+    throw new Error(error instanceof Error ? error.message : "Could not reach the machine pairing endpoint.")
+  }
+  let body: unknown = null
+  try { body = await response.json() } catch { /* handled below */ }
+  if (!response.ok) throw new Error(errorDetail(body, `Pairing failed with HTTP ${response.status}.`))
+  const payload = claimPayload(body)
+  if (!payload) throw new Error("The machine returned an invalid pairing response.")
+  return workspaceMachine(activation.endpoint, payload)
+}
+
+function endpointIdentity(machine: WorkspaceMachine): string {
+  return machineBaseUrl(machine.config).toLowerCase()
+}
+
+/** Pairing may be repeated after the old grant expires. Re-pairing the same physical machine or
+ * endpoint updates credentials in place instead of duplicating the machine and breaking local keys. */
+export function upsertPairedMachine(machines: WorkspaceMachine[], paired: WorkspaceMachine): WorkspaceMachine[] {
+  const endpoint = endpointIdentity(paired)
+  const index = machines.findIndex((machine) => machine.id === paired.id || endpointIdentity(machine) === endpoint)
+  if (index < 0) return [...machines, paired]
+  const current = machines[index]
+  const next = [...machines]
+  next[index] = { ...paired, id: current.id }
+  return next
+}
+
+/** Capacitor receives both warm appUrlOpen activations and cold launch URLs. */
+export function subscribeAndroidMachinePairing(
+  onActivation: (activation: MachinePairingActivation) => void
+): () => void {
+  if (Capacitor.getPlatform() !== "android") return () => undefined
+  let closed = false
+  let handle: PluginListenerHandle | undefined
+  const seen = new Set<string>()
+  const emit = (url: string | undefined) => {
+    if (closed || !url || seen.has(url)) return
+    const activation = parseMachinePairingActivation(url)
+    if (!activation) return
+    seen.add(url)
+    onActivation(activation)
+  }
+
+  void App.addListener("appUrlOpen", ({ url }) => emit(url)).then((created) => {
+    if (closed) void created.remove()
+    else handle = created
+  })
+  void App.getLaunchUrl().then((launch) => emit(launch?.url)).catch(() => undefined)
+
+  return () => {
+    if (closed) return
+    closed = true
+    if (handle) void handle.remove()
+  }
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -47,6 +47,8 @@ function HarnessRemoteBoundary() {
   const machines = useMemo(loadWorkspaceMachines, [revision])
   const machinesRef = useRef(machines)
   machinesRef.current = machines
+  const pairingInFlightRef = useRef(new Set<string>())
+  const pairedGrantRef = useRef(new Set<string>())
   const [desktopReady, setDesktopReady] = useState(() => !isDesktopPlatform())
   const [desktopSyncError, setDesktopSyncError] = useState<Error | null>(null)
   const [pairingNotice, setPairingNotice] = useState<PairingNotice | null>(null)
@@ -81,15 +83,23 @@ function HarnessRemoteBoundary() {
   }
 
   useEffect(() => subscribeAndroidMachinePairing((activation) => {
+    const grantKey = `${activation.endpoint}\u0000${activation.token}`
+    if (pairedGrantRef.current.has(grantKey) || pairingInFlightRef.current.has(grantKey)) return
+    pairingInFlightRef.current.add(grantKey)
     setPairingNotice({ kind: "working", text: "Connecting to this machine…" })
     void claimMachinePairing(activation).then(
       (paired) => {
+        pairingInFlightRef.current.delete(grantKey)
+        pairedGrantRef.current.add(grantKey)
         const nextMachines = upsertPairedMachine(machinesRef.current, paired)
         machinesRef.current = nextMachines
         persistMachines(nextMachines)
         setPairingNotice({ kind: "success", text: `${paired.name} is connected.` })
       },
       (error: unknown) => {
+        // A transport failure does not imply the daemon consumed the grant. A re-scan therefore gets
+        // another chance until the server itself reports used/expired.
+        pairingInFlightRef.current.delete(grantKey)
         setPairingNotice({
           kind: "error",
           text: error instanceof Error ? error.message : "Machine pairing failed."

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react"
+import React, { useEffect, useMemo, useRef, useState } from "react"
 import ReactDOM from "react-dom/client"
 import { Capacitor } from "@capacitor/core"
 import { installAppPreferences } from "./appPreferences"
@@ -6,6 +6,7 @@ import { installCompletionAudioGuard } from "./completion-audio"
 import { StandaloneUniversalWorkspace } from "./components/standalone-universal-workspace"
 import { syncDesktopProfiles, isDesktopPlatform } from "./desktopBridge"
 import { ErrorBoundary } from "./ErrorBoundary"
+import { claimMachinePairing, subscribeAndroidMachinePairing, upsertPairedMachine } from "./machine-pairing"
 import { SERVER_STORAGE_KEYS } from "./storageKeys"
 import {
   loadWorkspaceMachines,
@@ -28,6 +29,7 @@ import "./session-first-workbench.css"
 import "./conversation-base.css"
 import "./session-first-centering-fix.css"
 import "./session-handoff-routing.css"
+import "./machine-pairing.css"
 // Loaded last: the ported controls refine rules the sheets above already set, and settling those
 // ties by load order is what keeps the port free of `!important`.
 import "./beautiful-ui-controls.css"
@@ -35,12 +37,19 @@ import "./beautiful-ui-controls.css"
 installAppPreferences()
 installCompletionAudioGuard()
 
+type PairingNotice = {
+  kind: "working" | "success" | "error"
+  text: string
+}
 
 function HarnessRemoteBoundary() {
   const [revision, setRevision] = useState(0)
   const machines = useMemo(loadWorkspaceMachines, [revision])
+  const machinesRef = useRef(machines)
+  machinesRef.current = machines
   const [desktopReady, setDesktopReady] = useState(() => !isDesktopPlatform())
   const [desktopSyncError, setDesktopSyncError] = useState<Error | null>(null)
+  const [pairingNotice, setPairingNotice] = useState<PairingNotice | null>(null)
 
   // The Session-first workspace talks to the daemon immediately on mount. Electron must therefore
   // acknowledge the stable WorkspaceMachine allowlist before the workspace is allowed to discover
@@ -71,6 +80,24 @@ function HarnessRemoteBoundary() {
     )
   }
 
+  useEffect(() => subscribeAndroidMachinePairing((activation) => {
+    setPairingNotice({ kind: "working", text: "Connecting to this machine…" })
+    void claimMachinePairing(activation).then(
+      (paired) => {
+        const nextMachines = upsertPairedMachine(machinesRef.current, paired)
+        machinesRef.current = nextMachines
+        persistMachines(nextMachines)
+        setPairingNotice({ kind: "success", text: `${paired.name} is connected.` })
+      },
+      (error: unknown) => {
+        setPairingNotice({
+          kind: "error",
+          text: error instanceof Error ? error.message : "Machine pairing failed."
+        })
+      }
+    )
+  }), [])
+
   if (desktopSyncError) throw desktopSyncError
   if (!desktopReady) {
     return (
@@ -83,10 +110,22 @@ function HarnessRemoteBoundary() {
   }
 
   return (
-    <StandaloneUniversalWorkspace
-      machines={machines}
-      onPersistMachines={persistMachines}
-    />
+    <>
+      <StandaloneUniversalWorkspace
+        machines={machines}
+        onPersistMachines={persistMachines}
+      />
+      {pairingNotice ? (
+        <div
+          className={`hr-machine-pairing-notice ${pairingNotice.kind}`}
+          role={pairingNotice.kind === "error" ? "alert" : "status"}
+          aria-live="polite"
+        >
+          <span><strong>Machine pairing</strong>{pairingNotice.text}</span>
+          <button type="button" onClick={() => setPairingNotice(null)} aria-label="Dismiss machine pairing status">×</button>
+        </div>
+      ) : null}
+    </>
   )
 }
 

--- a/web/src/workspace-machines.test.mjs
+++ b/web/src/workspace-machines.test.mjs
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 import { sameMachineConnection } from "./machineConnection.ts"
-import "./machine-pairing.test.mjs"
 
 const connection = (overrides = {}) => ({
   backend: "opencode",

--- a/web/src/workspace-machines.test.mjs
+++ b/web/src/workspace-machines.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 import { sameMachineConnection } from "./machineConnection.ts"
+import "./machine-pairing.test.mjs"
 
 const connection = (overrides = {}) => ({
   backend: "opencode",


### PR DESCRIPTION
## Summary

Add the first HR3 machine-pairing path without putting long-lived Basic Auth credentials in a QR/deep-link payload.

- machine daemon generates a 256-bit in-memory pairing grant with a 5 minute TTL;
- exposes one bootstrap exception, `POST /v1/pairing/claim`, while every unrelated route remains delegated to the existing authenticated stack;
- a valid grant is consumed exactly once and returns the daemon's existing Basic Auth credentials + machine identity;
- startup emits `harnessremote://pair` scan-ready links containing only endpoint + one-time token + expiry, never username/password;
- Android registers the `harnessremote://pair` BROWSABLE deep link during Capacitor sync;
- Android claims through native HTTP, imports the resulting machine into the existing WorkspaceMachine store and updates an existing physical machine/endpoint in place instead of duplicating it;
- duplicate warm/cold activation is coalesced while a claim is in flight, while a transport failure remains retryable with the same still-valid token;
- pairing status is surfaced as a compact in-app notice.

## Scope / limitation

This first slice is deliberately **machine-daemon HR3 only**. Legacy single-backend bridge startup remains unchanged. The emitted URI is QR-ready plain text; this PR does not add a QR rendering/package dependency. A graphical terminal/UI QR can follow separately.

Pairing uses the same LAN HTTP transport as the existing daemon Basic Auth connection. The one-time grant avoids embedding the long-lived password in the scan payload; it does not claim to add TLS or LAN confidentiality.

## Risk boundary

No ACP adapter, Session writer, prompt/Stop path, model lifecycle or harness routing changes. Pairing is an outer bootstrap wrapper around the machine daemon only.

Targets `codex/development-2026-09-11` only. `main` must remain untouched.

Refs #369