### PR TITLE
P1: render one-time machine pairing QR in terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ See [REFERENCE.md](REFERENCE.md) for detailed security and backend notes.
 
 ## Quick start
 
-> **Upgrading from Harness Remote 2.x?** HR3 uses a **Machine daemon** as its normal connection contract, not the old per-harness server profile model. Old standalone ACP bridge commands still start and can expose native Sessions, but they are a legacy compatibility path and do not provide the complete HR3 Machine → Project → Session workflow. A direct 2.x-style `opencode serve` endpoint is **not** an HR3 Machine endpoint. Saved 2.x server profiles are also not automatically imported into the new Machines list, so add the machine again after upgrading. For HR3, prefer the launcher/daemon setup below and connect through **Machines → Add machine**.
+> **Upgrading from Harness Remote 2.x?** HR3 uses a **Machine daemon** as its normal connection contract, not the old per-harness server profile model. Old standalone ACP bridge commands still start and can expose native Sessions, but they are a legacy compatibility path and do not provide the complete HR3 Machine → Project → Session workflow. A direct 2.x-style `opencode serve` endpoint is **not** an HR3 Machine endpoint. Saved 2.x server profiles are also not automatically imported into the new Machines list, so add the machine again after upgrading. For HR3, prefer the launcher/daemon setup below; Android can pair from its short-lived QR, while **Machines → Add machine** remains the manual fallback.
 
 ### 1. Start Harness Remote on the machine with your code
 
@@ -208,11 +208,13 @@ npx github:giuliastro/harness-remote \
 
 `--root` defines the directory boundary Harness Remote may browse when you select Projects.
 
-The launcher detects supported CLIs on `PATH`, starts the compatible local runtime and prints the connection details.
+The launcher detects supported CLIs on `PATH`, starts the compatible local runtime and, for the HR3 machine daemon, prints a compact pairing QR. The QR contains a 256-bit one-time token valid for five minutes — not the long-lived daemon password. Plain pairing links and the normal connection details are printed as fallback.
 
-### 2. Connect from desktop or Android
+### 2. Pair Android or add the machine manually
 
-Open **Machines → Add machine** and enter the address, port, username and password printed by the launcher.
+On Android, scan/open the QR. Harness Remote claims the one-time token and imports the machine automatically. The token can be used only once.
+
+If the phone cannot reach the preferred LAN address, use one of the alternate pairing links printed by the launcher. Desktop, web and Android can always use **Machines → Add machine** with the address, port, username and password printed by the launcher.
 
 One machine endpoint exposes the harnesses managed by that machine — you do not need a separate public endpoint for every coding agent.
 

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -18,5 +18,8 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "dependencies": {
+    "qrcode-terminal": "0.12.0"
   }
 }

--- a/bridge/src/pairing-server.js
+++ b/bridge/src/pairing-server.js
@@ -1,5 +1,6 @@
 import http from "node:http"
 import { randomBytes, timingSafeEqual } from "node:crypto"
+import { createRequire } from "node:module"
 import { networkInterfaces } from "node:os"
 import { allowedOrigin, applyCorsHeaders, writeJSON } from "./http-policy.js"
 
@@ -8,6 +9,7 @@ export const PAIRING_TTL_MS = 5 * 60 * 1_000
 export const PAIRING_TOKEN_MAX_LENGTH = 256
 const MAX_PAIRING_BODY_BYTES = 4_096
 const VIRTUAL_INTERFACE = /^(docker|br-|veth|virbr|tun|tap|utun)/i
+const require = createRequire(import.meta.url)
 
 function sameToken(expected, candidate) {
   if (typeof expected !== "string" || typeof candidate !== "string") return false
@@ -98,15 +100,45 @@ export function machinePairingLinks(config, grant, interfaces = networkInterface
   })
 }
 
-/** Startup output keeps long-lived credentials as a manual fallback, but the link itself contains
- * only a high-entropy one-time grant. It is intentionally plain text for now: the URI is QR-ready
- * without introducing a QR/package dependency into the bridge. */
-export function announceMachinePairing(config, grant, { write = (text) => process.stdout.write(text), interfaces } = {}) {
+/**
+ * Keep QR rendering outside the pairing authority contract. A source checkout that has not installed
+ * the optional presentation dependency still gets the exact same one-time URI as plain text; npx and
+ * normal installs render the compact terminal QR because qrcode-terminal is installed by package.json.
+ */
+export function renderPairingQRCode(uri, { load = () => require("qrcode-terminal") } = {}) {
+  try {
+    const qrcode = load()
+    if (!qrcode || typeof qrcode.generate !== "function") return null
+    let output = ""
+    qrcode.generate(uri, { small: true }, (rendered) => {
+      if (typeof rendered === "string") output = rendered
+    })
+    return output.trim() ? output : null
+  } catch {
+    return null
+  }
+}
+
+/** Startup output keeps long-lived credentials as a manual fallback, while the QR/link itself contains
+ * only a high-entropy one-time grant. Render one QR for the preferred LAN endpoint and keep every
+ * discovered endpoint as text so multi-interface machines remain recoverable without guessing. */
+export function announceMachinePairing(config, grant, {
+  write = (text) => process.stdout.write(text),
+  interfaces,
+  renderQR = renderPairingQRCode
+} = {}) {
   const links = machinePairingLinks(config, grant, interfaces)
   if (!links.length) return []
   write("\nPair a phone (one use, valid for 5 minutes):\n")
+  const qr = renderQR(links[0].uri)
+  if (qr) {
+    write(`${qr}\n`)
+    write(`Scan the QR above for ${links[0].endpoint}.\n`)
+  }
+  if (links.length > 1) write("If that network is not reachable from your phone, use another link below.\n")
+  write("Pairing links:\n")
   for (const { uri } of links) write(`  ${uri}\n`)
-  write("Open or scan one of these links in Harness Remote. The link does not contain the daemon password.\n")
+  write("The QR/link contains a one-time token, not the daemon password.\n")
   return links
 }
 

--- a/bridge/test/pairing-server.test.js
+++ b/bridge/test/pairing-server.test.js
@@ -4,9 +4,11 @@ import test from "node:test"
 import {
   OneTimePairingGrant,
   PAIRING_TTL_MS,
+  announceMachinePairing,
   createOneTimePairingGrant,
   createPairingServer,
-  machinePairingLinks
+  machinePairingLinks,
+  renderPairingQRCode
 } from "../src/pairing-server.js"
 
 async function listen(server) {
@@ -50,6 +52,53 @@ test("scan-ready pairing links contain the one-time grant but never Basic Auth c
   assert.match(links[0].uri, /^harnessremote:\/\/pair\?/)
   assert.match(links[0].uri, /token=one-time-token/)
   assert.doesNotMatch(links[0].uri, /secret-password|harness%3A|username|password/)
+})
+
+test("terminal QR renderer asks for compact output and returns the generated code", () => {
+  let received
+  const output = renderPairingQRCode("harnessremote://pair?token=abc", {
+    load: () => ({
+      generate(input, options, callback) {
+        received = { input, options }
+        callback("QR-CODE")
+      }
+    })
+  })
+  assert.equal(output, "QR-CODE")
+  assert.deepEqual(received, {
+    input: "harnessremote://pair?token=abc",
+    options: { small: true }
+  })
+})
+
+test("terminal QR renderer fails open to the plain pairing link when the presentation dependency is unavailable", () => {
+  const output = renderPairingQRCode("harnessremote://pair?token=abc", {
+    load: () => { throw new Error("module not installed") }
+  })
+  assert.equal(output, null)
+})
+
+test("startup pairing announcement renders one preferred QR and keeps alternate LAN links as text", () => {
+  let output = ""
+  let renderedURI
+  const links = announceMachinePairing(config(), grant(), {
+    interfaces: {
+      eth0: [{ family: "IPv4", internal: false, address: "192.168.1.44" }],
+      wlan0: [{ family: "IPv4", internal: false, address: "192.168.1.45" }]
+    },
+    write: (text) => { output += text },
+    renderQR: (uri) => {
+      renderedURI = uri
+      return "<QR>"
+    }
+  })
+  assert.equal(links.length, 2)
+  assert.equal(renderedURI, links[0].uri)
+  assert.match(output, /<QR>/)
+  assert.match(output, /Scan the QR above for http:\/\/192\.168\.1\.44:4097/)
+  assert.match(output, /192\.168\.1\.45%3A4097/)
+  assert.match(output, /one-time token, not the daemon password/i)
+  assert.doesNotMatch(output, /secret-password/)
 })
 
 test("pairing claim returns the existing daemon credentials without Basic Auth", async () => {

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -28,9 +28,15 @@ npx github:giuliastro/harness-remote \
   --cors http://localhost:5173
 ```
 
-`--root` is the directory boundary used when choosing Projects. The launcher prints the machine
-address and credentials you will enter in the client, the harnesses that will be available through
-that machine, and the next step to add it under **Machines → Add machine**.
+`--root` is the directory boundary used when choosing Projects. When the HR3 machine-daemon path is
+selected, startup prints a compact QR code plus a short-lived pairing link. On Android, scan/open that
+QR and Harness Remote imports the machine automatically; the QR contains a one-time token valid for
+five minutes, **not** the daemon password. The link can be used once.
+
+If QR rendering is unavailable in a source checkout, the same one-time pairing link is still printed
+as text. Host, port, username and password are also printed and remain the manual fallback. Pairing
+is currently a machine-daemon HR3 feature; legacy single-backend bridges keep their existing manual
+connection flow.
 
 To use the web/PWA frontend from a checkout:
 
@@ -44,8 +50,8 @@ Open the URL Vite prints, normally `http://localhost:5173`, then choose **Machin
 machine** and enter the address, port, username and password from the launcher. The `--cors` value
 above permits that browser origin; use the exact origin if you host the frontend elsewhere.
 
-Desktop and Android clients use the same machine address and credentials. Open the installed client
-and add the machine there; they do not need browser CORS configuration.
+Desktop and Android clients use the same machine address and credentials. Android can use the
+scan-first pairing flow above; manual **Machines → Add machine** remains available on every client.
 
 From a local repository checkout, the equivalent launcher command is:
 
@@ -58,6 +64,10 @@ npm start -- \
   --root "$HOME/Software" \
   --cors http://localhost:5173
 ```
+
+Run `npm install` once at the repository root if you want the checkout to render the terminal QR;
+without that presentation dependency the launcher deliberately falls back to the same one-time text
+link instead of making startup fail.
 
 When installed as a repository/package binary, the command is `harness-remote`. The root package
 remains private: the GitHub/repository launch path is intentional and does not imply that an npm
@@ -75,6 +85,8 @@ The launcher inspects `PATH` without executing discovered agent binaries and cho
 - `--single --backend <name>` explicitly opts out of the daemon and forces the legacy single-backend path;
 - if managed OpenCode is included, the launcher chooses a free loopback port automatically instead of assuming 4096 is unused;
 - credentials are generated automatically and kept out of child-process argv;
+- the HR3 machine daemon creates a 256-bit in-memory one-time pairing grant with a five-minute TTL;
+- startup renders a QR for the preferred LAN endpoint when the terminal QR renderer is installed, and always prints the one-time links as a fallback;
 - the LAN address, credentials, available harnesses and next client action are printed before startup continues.
 
 The supported CLI names are `omp`, `pi`, `claude`, `codex`, and `opencode`.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "engines": {
     "node": ">=20"
   },
+  "dependencies": {
+    "qrcode-terminal": "0.12.0"
+  },
   "description": "Local-first control plane for native AI coding-agent sessions across Codex CLI, Claude Code, OpenCode, Oh My Pi and PI.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

Build on #405 by making HR3 machine pairing scan-first at daemon startup.

- render a compact terminal QR for the preferred LAN pairing URI;
- keep every discovered LAN pairing URI as text so multi-interface machines remain recoverable;
- QR/link still contains only endpoint + 256-bit one-time token + expiry, never the daemon password;
- QR rendering is presentation-only: if the renderer is unavailable, startup deliberately falls back to the same text links instead of failing;
- declare `qrcode-terminal@0.12.0` for the root GitHub/npx launcher and direct bridge installs;
- add deterministic tests for compact QR generation, renderer failure fallback, preferred-endpoint selection, alternate links and credential non-leakage;
- update README and Quick Start so Android onboarding is scan-first while manual Machines → Add machine remains available.

## Risk boundary

No ACP adapter, Session writer, prompt/Stop path, model lifecycle, routing or pairing authority changes. The one-time claim contract from #405 is unchanged.

Legacy single-backend bridges keep their existing manual connection semantics; the QR is an HR3 machine-daemon onboarding surface.

Targets `codex/development-2026-09-11` only. `main` must remain untouched.

Refs #369