### PR TITLE
P2: clarify Native Session identity and lineage

### DIFF
--- a/web/src/native-session-lineage-identity.test.mjs
+++ b/web/src/native-session-lineage-identity.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+
+const workspace = readFileSync(new URL("./components/standalone-universal-workspace.tsx", import.meta.url), "utf8")
+const lineageCss = readFileSync(new URL("./session-handoff-routing.css", import.meta.url), "utf8")
+
+test("open Native Session keeps machine Project harness and native id visible", () => {
+  assert.match(workspace, /selected\.agentLabel/, "the owning harness label must remain visible")
+  assert.match(workspace, /selected\.nativeAgent/, "native agent or mode stays visible when the harness reports it")
+  assert.match(workspace, /selectedMachine\?\.name/, "the selected machine identity must remain visible")
+  assert.match(workspace, /selectedProject/, "the Project identity must remain visible")
+  assert.match(
+    workspace,
+    /<code title=\{selected\.sessionID\}>\{selected\.sessionID\}<\/code>/,
+    "the harness-owned native Session id must remain directly inspectable"
+  )
+})
+
+test("lineage lookup and navigation use the full native identity tuple", () => {
+  assert.match(
+    workspace,
+    /api\.listNativeSessionLinks\(selectedRuntime\.machine\.config, selected\.ref\)/,
+    "lineage must be queried by the selected NativeSessionRef, not by a synthetic conversation id"
+  )
+  assert.match(workspace, /link\.target\.machineID === selected\.machineID/)
+  assert.match(workspace, /link\.target\.agentID === selected\.agentID/)
+  assert.match(workspace, /link\.target\.sessionID === selected\.sessionID/)
+  assert.match(workspace, /candidate\.snapshot\?\.machine\.id === ref\.machineID/)
+  assert.match(workspace, /candidate\.id === ref\.agentID/)
+  assert.match(workspace, /candidate\.session\.id === ref\.sessionID/)
+  assert.match(workspace, /selectedLinks\.map\(\(link\) =>/)
+  assert.match(workspace, /linkedDestination\(link\)/)
+})
+
+test("lineage remains optional read-only enrichment", () => {
+  assert.match(
+    workspace,
+    /Lineage is optional enrichment\./,
+    "a lineage read failure must not make the Native Session unusable"
+  )
+  assert.match(workspace, /setSelectedLinks\(\[\]\)/)
+  assert.doesNotMatch(
+    workspace,
+    /registerNativeSessionLink\([^)]*selectedLinks/,
+    "rendering lineage must never manufacture or rewrite links"
+  )
+})
+
+test("identity and previous next lineage remain legible on narrow mobile panes", () => {
+  assert.match(lineageCss, /\.hr-native-session-eyebrow\s*\{[\s\S]*flex-wrap:\s*wrap/)
+  assert.match(lineageCss, /\.hr-native-workspace-session-header code\s*\{[\s\S]*font-variant-numeric:\s*tabular-nums/)
+  assert.match(lineageCss, /\.hr-session-lineage-links\s*\{[\s\S]*grid-template-columns:\s*repeat\(auto-fit/)
+  assert.match(lineageCss, /\.hr-session-lineage-link\s*\{[\s\S]*border-left:\s*3px solid var\(--td3-blue-border\)/)
+  assert.match(lineageCss, /@media \(max-width: 780px\)[\s\S]*\.hr-session-lineage-links \{ grid-template-columns: 1fr; \}/)
+})

--- a/web/src/session-handoff-routing.css
+++ b/web/src/session-handoff-routing.css
@@ -16,23 +16,58 @@
 .hr-native-session-observer .tdw-route-preview > small { margin-left: auto; font-size: 10.5px; }
 .hr-native-session-observer .tdw-route-preview.active { animation: hrsf-working-pulse 1.9s ease-in-out infinite; }
 
+/* Native identity is control-plane information, not decoration. Keep harness / machine / Project and
+   the harness-owned Session id readable even when the title is long or the pane is narrow. */
+.hr-native-session-eyebrow {
+  flex-wrap: wrap;
+  overflow: visible;
+  row-gap: 3px;
+  white-space: normal;
+}
+.hr-native-session-eyebrow > span:first-child {
+  color: var(--td3-blue-text);
+  font-weight: 750;
+}
+.hr-native-session-eyebrow > span,
+.hr-native-session-eyebrow > strong {
+  max-width: min(280px, 36vw);
+  white-space: nowrap;
+}
+.hr-native-workspace-session-header code {
+  max-width: min(260px, 28vw);
+  padding: 3px 7px;
+  border: 1px solid var(--td3-border-soft);
+  border-radius: 7px;
+  background: var(--td3-field);
+  color: var(--td3-muted);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+}
+
 .hr-session-lineage {
   flex: none;
   display: grid;
-  gap: 7px;
-  padding: 7px 14px;
+  gap: 8px;
+  padding: 8px 14px;
   border-bottom: 1px solid var(--td3-border-soft);
-  background: var(--td3-chrome);
+  background: linear-gradient(180deg, var(--td3-chrome), color-mix(in srgb, var(--td3-blue-soft) 30%, var(--td3-chrome)));
 }
-.hr-session-lineage-links { display: flex; flex-wrap: wrap; gap: 6px; }
+.hr-session-lineage-links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 1fr));
+  gap: 7px;
+}
 .hr-session-lineage-link {
-  min-height: 34px;
+  position: relative;
+  min-width: 0;
+  min-height: 42px;
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: 7px;
-  padding: 5px 9px;
+  gap: 8px;
+  padding: 6px 10px 6px 11px;
   border: 1px solid var(--td3-border);
+  border-left: 3px solid var(--td3-blue-border);
   border-radius: 9px;
   background: var(--td3-control);
   color: var(--td3-text-2);
@@ -41,9 +76,31 @@
   cursor: pointer;
 }
 .hr-session-lineage-link:hover,
-.hr-session-lineage-link:focus-visible { border-color: var(--td3-blue-border); background: var(--td3-blue-soft); outline: 0; }
-.hr-session-lineage-link > span { color: var(--td3-muted); font-size: 10px; font-weight: 700; text-transform: uppercase; }
-.hr-session-lineage-link > strong { min-width: 0; overflow: hidden; color: var(--td3-text); font-size: 11.5px; text-overflow: ellipsis; white-space: nowrap; }
+.hr-session-lineage-link:focus-visible {
+  border-color: var(--td3-blue-border);
+  background: var(--td3-blue-soft);
+  outline: 2px solid transparent;
+}
+.hr-session-lineage-link > span {
+  padding: 2px 5px;
+  border: 1px solid var(--td3-blue-border);
+  border-radius: 999px;
+  color: var(--td3-blue-text);
+  background: var(--td3-blue-soft);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: .02em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.hr-session-lineage-link > strong {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--td3-text);
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .hr-session-lineage-link > strong i { padding: 0 3px; opacity: .42; font-style: normal; }
 .hr-session-lineage-link > small { color: var(--td3-blue-text); font-size: 10.5px; white-space: nowrap; }
 
@@ -68,10 +125,21 @@
   .hr-native-session-observer .tdw-route-preview { display: grid; grid-template-columns: 1fr auto; gap: 2px 8px; padding: 6px 8px; }
   .hr-native-session-observer .tdw-route-preview > strong { justify-self: end; }
   .hr-native-session-observer .tdw-route-preview > small { grid-column: 1 / -1; margin-left: 0; }
-  .hr-session-lineage { gap: 5px; padding: 5px 8px; }
-  .hr-session-lineage-links { display: grid; grid-template-columns: 1fr; }
-  .hr-session-lineage-link { min-height: 44px; grid-template-columns: auto minmax(0, 1fr); padding: 6px 8px; }
-  .hr-session-lineage-link > small { grid-column: 2; }
+  .hr-native-session-eyebrow { gap: 3px 5px; }
+  .hr-native-session-eyebrow > span,
+  .hr-native-session-eyebrow > strong { max-width: calc(100vw - 78px); }
+  .hr-native-workspace-session-header code { max-width: min(52vw, 220px); }
+  .hr-session-lineage { gap: 6px; padding: 6px 8px; }
+  .hr-session-lineage-links { grid-template-columns: 1fr; }
+  .hr-session-lineage-link {
+    min-height: 50px;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 3px 8px;
+    padding: 7px 9px;
+  }
+  .hr-session-lineage-link > span { width: max-content; max-width: 100%; grid-column: 1 / -1; }
+  .hr-session-lineage-link > strong { grid-column: 1; }
+  .hr-session-lineage-link > small { grid-column: 2; grid-row: 2; }
   .hr-session-transfer-context > summary { min-height: 40px; }
   .hr-session-transfer-context > summary span { display: none; }
   .hr-session-transfer-context > pre { max-height: 28dvh; font-size: 10.5px; }


### PR DESCRIPTION
Continues #371 after the federated Session index slices.

This is a deliberately read-only UX/guard slice:

- keeps machine, Project, harness/native-agent and harness-owned Session identity legible in the open Session header, including narrow/mobile panes
- makes previous/next handoff lineage read as an explicit navigable chain rather than low-contrast metadata
- preserves the existing exact NativeSessionRef tuple for lineage lookup/navigation (`machineID + agentID + sessionID + directory`)
- preserves lineage as optional enrichment: read failures never make an otherwise valid Native Session unusable
- adds regression guards that prevent future refactors from replacing native identity with a synthetic conversation identity or manufacturing lineage on read

No new network calls, transcript reads, daemon/API changes, ACP changes, writer operations, ownership changes, or authority transfer.

Target: `codex/development-2026-09-11` only. Do not merge to `main`.