### PR TITLE
P2: add cross-machine Project identity preflight

### DIFF
--- a/bridge/src/agent-router.js
+++ b/bridge/src/agent-router.js
@@ -1,11 +1,12 @@
 import http from "node:http"
 import { allowedOrigin, applyCorsHeaders, matchesCredentials, writeJSON } from "./http-policy.js"
 import { ManagedEventFanout } from "./managed-event-fanout.js"
+import { inspectGitProjectIdentity } from "./project-identity.js"
 import { normalizeTaskModel } from "./task-model.js"
 
 const AGENT_ROUTE = /^\/v1\/agents\/([^/]+)(\/.*)?$/
 const TASK_WORKTREE_ROUTE = /^\/v1\/tasks\/([^/]+)\/worktree$/
-const MACHINE_ROUTES = new Set(["/v1/machine", "/global/machine", "/v1/projects", "/v1/tasks", "/v1/diagnostics"])
+const MACHINE_ROUTES = new Set(["/v1/machine", "/global/machine", "/v1/projects", "/v1/project-identity", "/v1/tasks", "/v1/diagnostics"])
 const HOP_BY_HOP = new Set([
   "connection",
   "keep-alive",
@@ -201,6 +202,7 @@ export function createAgentRoutingServer({
   acpBridgeServer,
   taskStore,
   projectCatalog,
+  projectIdentity = inspectGitProjectIdentity,
   worktreeManager,
   diagnostics,
   createServer = http.createServer,
@@ -260,6 +262,24 @@ export function createAgentRoutingServer({
         if (request.method === "GET" && requestURL.pathname === "/v1/projects") {
           const projects = await projectCatalog()
           writeJSON(response, 200, { projects })
+          return
+        }
+        if (request.method === "GET" && requestURL.pathname === "/v1/project-identity") {
+          const projectId = requestURL.searchParams.get("projectId")?.trim() || ""
+          if (!projectId) {
+            writeJSON(response, 400, { error: "A projectId is required" })
+            return
+          }
+          const projects = await projectCatalog()
+          const project = projects.find((candidate) => candidate.id === projectId)
+          if (!project) {
+            writeJSON(response, 404, { error: `Unknown project: ${projectId}` })
+            return
+          }
+          // Never accept a caller-supplied path here. Identity inspection is limited to a path that
+          // the daemon itself already admitted into the canonical Project catalog.
+          const identity = project.kind === "git" ? await projectIdentity(project.path) : null
+          writeJSON(response, 200, { projectId: project.id, identity })
           return
         }
         if (request.method === "GET" && requestURL.pathname === "/v1/tasks") {

--- a/bridge/src/project-identity.js
+++ b/bridge/src/project-identity.js
@@ -31,9 +31,10 @@ export function canonicalGitRemote(value) {
   const remote = String(value ?? "").trim()
   if (!remote) return ""
 
-  // Common SCP-style SSH syntax: git@github.com:owner/repo.git
+  // Common SCP-style SSH syntax: git@github.com:owner/repo.git. URL schemes contain a colon too,
+  // but must be parsed as URLs first so credentials never become part of the repository path.
   const scp = /^(?:[^@/]+@)?([^:/]+):(.+)$/.exec(remote)
-  if (scp && !/^[A-Za-z]:[\\/]/.test(remote)) {
+  if (!remote.includes("://") && scp && !/^[A-Za-z]:[\\/]/.test(remote)) {
     return `${scp[1].toLowerCase()}/${stripGitSuffix(scp[2].replace(/^\/+/, ""))}`
   }
 

--- a/bridge/src/project-identity.js
+++ b/bridge/src/project-identity.js
@@ -1,0 +1,110 @@
+import { createHash } from "node:crypto"
+import { execFile } from "node:child_process"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const GIT_TIMEOUT_MS = 8_000
+const MAX_GIT_OUTPUT = 1024 * 1024
+
+async function defaultRunGit(args) {
+  return execFileAsync("git", args, {
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: GIT_TIMEOUT_MS,
+    maxBuffer: MAX_GIT_OUTPUT
+  })
+}
+
+function fingerprint(namespace, value) {
+  return createHash("sha256").update(`${namespace}\0${value}`).digest("hex")
+}
+
+function stripGitSuffix(value) {
+  return value.replace(/\/+$/, "").replace(/\.git$/i, "")
+}
+
+/**
+ * Canonicalise only for hashing. The canonical remote is deliberately never returned by the API:
+ * an HTTPS remote may contain a username/token and an SSH remote may contain a local username.
+ */
+export function canonicalGitRemote(value) {
+  const remote = String(value ?? "").trim()
+  if (!remote) return ""
+
+  // Common SCP-style SSH syntax: git@github.com:owner/repo.git
+  const scp = /^(?:[^@/]+@)?([^:/]+):(.+)$/.exec(remote)
+  if (scp && !/^[A-Za-z]:[\\/]/.test(remote)) {
+    return `${scp[1].toLowerCase()}/${stripGitSuffix(scp[2].replace(/^\/+/, ""))}`
+  }
+
+  try {
+    const parsed = new URL(remote)
+    if (parsed.hostname) {
+      return `${parsed.hostname.toLowerCase()}/${stripGitSuffix(parsed.pathname.replace(/^\/+/, ""))}`
+    }
+  } catch {
+    // A local-path remote has no portable identity across machines, but hashing the normalized
+    // value is still useful evidence without exposing that path to the client.
+  }
+
+  return stripGitSuffix(remote.replace(/\\/g, "/"))
+}
+
+export function gitRemoteFingerprint(value) {
+  const canonical = canonicalGitRemote(value)
+  return canonical ? fingerprint("git-remote-v1", canonical) : undefined
+}
+
+function historyFingerprint(value) {
+  const roots = String(value ?? "")
+    .split(/\r?\n/)
+    .map((root) => root.trim())
+    .filter(Boolean)
+    .sort()
+  return roots.length ? fingerprint("git-roots-v1", roots.join("\n")) : undefined
+}
+
+async function readGit(runGit, args) {
+  try {
+    const result = await runGit(args)
+    return { ok: true, value: String(result?.stdout ?? "").trim() }
+  } catch {
+    return { ok: false, value: "" }
+  }
+}
+
+/**
+ * Read a bounded, privacy-preserving Git identity for cross-machine continuity preflight.
+ *
+ * This function never mutates the repository. Remote URLs are reduced to an opaque fingerprint;
+ * credentials and repository URLs never cross the daemon boundary. Missing Git metadata produces a
+ * partial identity rather than an invented match. A later handoff must treat missing proof as
+ * unverified/fail-closed, not as equivalence.
+ */
+export async function inspectGitProjectIdentity(projectPath, { runGit = defaultRunGit } = {}) {
+  if (typeof projectPath !== "string" || !projectPath.trim()) return null
+
+  const root = await readGit(runGit, ["-C", projectPath, "rev-parse", "--show-toplevel"])
+  if (!root.ok || !root.value) return null
+
+  const [remote, roots, head, branch, status] = await Promise.all([
+    readGit(runGit, ["-C", root.value, "config", "--get", "remote.origin.url"]),
+    readGit(runGit, ["-C", root.value, "rev-list", "--max-parents=0", "HEAD"]),
+    readGit(runGit, ["-C", root.value, "rev-parse", "HEAD"]),
+    readGit(runGit, ["-C", root.value, "branch", "--show-current"]),
+    readGit(runGit, ["-C", root.value, "status", "--porcelain=v1", "--untracked-files=all"])
+  ])
+
+  const repositoryFingerprint = remote.ok ? gitRemoteFingerprint(remote.value) : undefined
+  const rootsFingerprint = roots.ok ? historyFingerprint(roots.value) : undefined
+
+  return {
+    version: 1,
+    vcs: "git",
+    ...(repositoryFingerprint ? { repositoryFingerprint } : {}),
+    ...(rootsFingerprint ? { historyFingerprint: rootsFingerprint } : {}),
+    ...(head.ok && head.value ? { head: head.value } : {}),
+    ...(branch.ok && branch.value ? { branch: branch.value } : {}),
+    ...(status.ok ? { dirty: Boolean(status.value) } : {})
+  }
+}

--- a/bridge/test/project-identity-route.test.js
+++ b/bridge/test/project-identity-route.test.js
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import test from "node:test"
+import { createAgentRoutingServer } from "../src/agent-router.js"
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  return server.address().port
+}
+
+async function close(server) {
+  await new Promise((resolve) => server.close(resolve))
+}
+
+class BridgeServer extends EventEmitter {}
+
+function daemon() {
+  return {
+    registry: { host: () => ({ state: "available" }) },
+    hostEntry: () => undefined,
+    snapshot: () => ({ machine: { id: "machine-1" }, agents: [] })
+  }
+}
+
+function serverWith({ projects, projectIdentity }) {
+  return createAgentRoutingServer({
+    daemon: daemon(),
+    config: { username: "", password: "", corsOrigins: [] },
+    primaryAgentID: "codex",
+    bridgeServer: new BridgeServer(),
+    taskStore: { async list() { return [] } },
+    projectCatalog: async () => projects,
+    projectIdentity,
+    worktreeManager: {}
+  })
+}
+
+test("project identity is read only and scoped to an exact catalog project id", async () => {
+  const calls = []
+  const server = serverWith({
+    projects: [{ id: "machine-1:repo", machineId: "machine-1", name: "repo", path: "/repo", kind: "git" }],
+    projectIdentity: async (projectPath) => {
+      calls.push(projectPath)
+      return { version: 1, vcs: "git", repositoryFingerprint: "a".repeat(64), head: "abc", dirty: false }
+    }
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/project-identity?projectId=${encodeURIComponent("machine-1:repo")}`)
+    assert.equal(response.status, 200)
+    assert.deepEqual(await response.json(), {
+      projectId: "machine-1:repo",
+      identity: { version: 1, vcs: "git", repositoryFingerprint: "a".repeat(64), head: "abc", dirty: false }
+    })
+    assert.deepEqual(calls, ["/repo"])
+  } finally {
+    await close(server)
+  }
+})
+
+test("unknown project ids cannot be turned into arbitrary filesystem probes", async () => {
+  let inspected = false
+  const server = serverWith({
+    projects: [{ id: "machine-1:repo", machineId: "machine-1", name: "repo", path: "/repo", kind: "git" }],
+    projectIdentity: async () => { inspected = true; return null }
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/project-identity?projectId=${encodeURIComponent("/etc")}`)
+    assert.equal(response.status, 404)
+    assert.equal(inspected, false)
+  } finally {
+    await close(server)
+  }
+})
+
+test("non Git catalog projects are explicitly unverified and do not invoke Git", async () => {
+  let inspected = false
+  const server = serverWith({
+    projects: [{ id: "machine-1:notes", machineId: "machine-1", name: "notes", path: "/notes", kind: "directory" }],
+    projectIdentity: async () => { inspected = true; return { version: 1, vcs: "git" } }
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/project-identity?projectId=${encodeURIComponent("machine-1:notes")}`)
+    assert.equal(response.status, 200)
+    assert.deepEqual(await response.json(), { projectId: "machine-1:notes", identity: null })
+    assert.equal(inspected, false)
+  } finally {
+    await close(server)
+  }
+})

--- a/bridge/test/project-identity.test.js
+++ b/bridge/test/project-identity.test.js
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import {
+  canonicalGitRemote,
+  gitRemoteFingerprint,
+  inspectGitProjectIdentity
+} from "../src/project-identity.js"
+
+function gitFixture(remote) {
+  return async (args) => {
+    const command = args.slice(2).join(" ")
+    if (command === "rev-parse --show-toplevel") return { stdout: "/repo\n" }
+    if (command === "config --get remote.origin.url") return { stdout: `${remote}\n` }
+    if (command === "rev-list --max-parents=0 HEAD") return { stdout: "root-b\nroot-a\n" }
+    if (command === "rev-parse HEAD") return { stdout: "deadbeef\n" }
+    if (command === "branch --show-current") return { stdout: "feature/continuity\n" }
+    if (command === "status --porcelain=v1 --untracked-files=all") return { stdout: " M src/app.js\n" }
+    throw new Error(`Unexpected git command: ${command}`)
+  }
+}
+
+test("HTTPS and SCP remotes produce the same opaque repository fingerprint without credentials", async () => {
+  const httpsRemote = "https://secret-token@github.com/OpenAI/Harness-Remote.git"
+  const sshRemote = "git@github.com:OpenAI/Harness-Remote.git"
+
+  assert.equal(canonicalGitRemote(httpsRemote), "github.com/OpenAI/Harness-Remote")
+  assert.equal(canonicalGitRemote(sshRemote), "github.com/OpenAI/Harness-Remote")
+  assert.equal(gitRemoteFingerprint(httpsRemote), gitRemoteFingerprint(sshRemote))
+
+  const identity = await inspectGitProjectIdentity("/repo", { runGit: gitFixture(httpsRemote) })
+  assert.equal(identity.vcs, "git")
+  assert.equal(identity.version, 1)
+  assert.match(identity.repositoryFingerprint, /^[a-f0-9]{64}$/)
+  assert.match(identity.historyFingerprint, /^[a-f0-9]{64}$/)
+  assert.equal(identity.head, "deadbeef")
+  assert.equal(identity.branch, "feature/continuity")
+  assert.equal(identity.dirty, true)
+  assert.equal(JSON.stringify(identity).includes("secret-token"), false)
+  assert.equal(JSON.stringify(identity).includes("github.com"), false)
+})
+
+test("root commit ordering does not change the history fingerprint", async () => {
+  const first = await inspectGitProjectIdentity("/repo", { runGit: gitFixture("git@github.com:owner/repo.git") })
+  const second = await inspectGitProjectIdentity("/repo", {
+    runGit: async (args) => {
+      const command = args.slice(2).join(" ")
+      if (command === "rev-list --max-parents=0 HEAD") return { stdout: "root-a\nroot-b\n" }
+      return gitFixture("git@github.com:owner/repo.git")(args)
+    }
+  })
+  assert.equal(first.historyFingerprint, second.historyFingerprint)
+})
+
+test("missing optional metadata stays unverified instead of inventing equivalence", async () => {
+  const identity = await inspectGitProjectIdentity("/repo", {
+    runGit: async (args) => {
+      const command = args.slice(2).join(" ")
+      if (command === "rev-parse --show-toplevel") return { stdout: "/repo\n" }
+      if (command === "status --porcelain=v1 --untracked-files=all") return { stdout: "" }
+      throw new Error("metadata unavailable")
+    }
+  })
+  assert.deepEqual(identity, { version: 1, vcs: "git", dirty: false })
+})
+
+test("a path that is no longer a Git worktree has no identity", async () => {
+  const identity = await inspectGitProjectIdentity("/gone", {
+    runGit: async () => { throw new Error("not a git repository") }
+  })
+  assert.equal(identity, null)
+})


### PR DESCRIPTION
Prerequisite slice for #371 cross-machine continuation. This does **not** enable cross-machine Session creation yet.

- adds authenticated, read-only `/v1/project-identity?projectId=...`
- only inspects an exact Project already admitted by the daemon Project catalog; caller-supplied filesystem paths are never accepted
- derives privacy-preserving Git evidence on demand: opaque repository fingerprint, opaque history-root fingerprint, HEAD, branch and dirty state
- canonicalizes HTTPS/SSH remotes before hashing while never returning remote URLs, usernames or credentials
- returns `identity: null` for non-Git Projects so missing proof remains explicit rather than becoming an invented match
- uses bounded Git reads only when the preflight endpoint is requested; normal `/v1/projects` refresh remains unchanged
- adds route-boundary and identity/privacy regression tests

This establishes evidence needed to classify source/target Projects as matching, different or unverified before future cross-machine continuation. It does not transfer authorization, writer ownership, approval decisions, transcript state or tool state.

Target: `codex/development-2026-09-11` only. Do not merge to `main`.