### PR TITLE
P2: replicate cross-machine Session lineage safely

### DIFF
--- a/bridge/src/session-link-store.js
+++ b/bridge/src/session-link-store.js
@@ -18,6 +18,12 @@ function validIdentity(value) {
     && [value.machineID, value.agentID, value.sessionID, value.directory].every((entry) => typeof entry === "string" && entry)
 }
 
+function invalidLink(message) {
+  const error = new Error(message)
+  error.code = "invalid_request"
+  return error
+}
+
 function normalizedTransferredContext(value) {
   if (value === undefined || value === null || value === "") return undefined
   if (typeof value !== "string") throw new Error("Transferred Session context must be text")
@@ -97,7 +103,7 @@ export class SessionLinkStore {
   async addHandoff({ source, target, createdAt = new Date().toISOString(), transferredContext }) {
     if (!validIdentity(source) || !validIdentity(target)) throw new Error("Native Session link requires complete source and target identities")
     if (!this.#isLocalLink(source, target)) {
-      throw new Error("Native Session link must include a Session owned by this machine")
+      throw invalidLink("Native Session link must include a Session owned by this machine")
     }
     const context = normalizedTransferredContext(transferredContext)
     return this.#serial(async () => {

--- a/bridge/src/session-link-store.js
+++ b/bridge/src/session-link-store.js
@@ -31,6 +31,10 @@ function normalizedTransferredContext(value) {
  * A link does not own either Session or create a second conversation identity. It records that
  * Harness Remote deliberately handed work from one native Session to another and may retain the
  * exact bounded context string used for that handoff so the UI can explain it after reopening.
+ *
+ * Cross-machine links are replicated metadata, not shared authority: a daemon stores an edge only
+ * when at least one endpoint belongs to that daemon. The same A -> B edge may therefore be present
+ * on machine A and machine B, while an unrelated machine C must reject it.
  */
 export class SessionLinkStore {
   #machineID
@@ -46,6 +50,10 @@ export class SessionLinkStore {
     this.#path = path.join(stateDirectory, "session-links.json")
   }
 
+  #isLocalLink(source, target) {
+    return source.machineID === this.#machineID || target.machineID === this.#machineID
+  }
+
   async #load() {
     if (this.#loaded) return
     this.#loaded = true
@@ -55,7 +63,7 @@ export class SessionLinkStore {
       for (const link of parsed.links) {
         if (!link || typeof link !== "object" || link.type !== "handoff") continue
         if (!validIdentity(link.source) || !validIdentity(link.target)) continue
-        if (link.source.machineID !== this.#machineID || link.target.machineID !== this.#machineID) continue
+        if (!this.#isLocalLink(link.source, link.target)) continue
         this.#links.set(linkKey(link.source, link.target), link)
       }
     } catch (error) {
@@ -88,8 +96,8 @@ export class SessionLinkStore {
 
   async addHandoff({ source, target, createdAt = new Date().toISOString(), transferredContext }) {
     if (!validIdentity(source) || !validIdentity(target)) throw new Error("Native Session link requires complete source and target identities")
-    if (source.machineID !== this.#machineID || target.machineID !== this.#machineID) {
-      throw new Error("Native Session links must stay inside their machine scope")
+    if (!this.#isLocalLink(source, target)) {
+      throw new Error("Native Session link must include a Session owned by this machine")
     }
     const context = normalizedTransferredContext(transferredContext)
     return this.#serial(async () => {

--- a/bridge/test/session-link-server.test.js
+++ b/bridge/test/session-link-server.test.js
@@ -15,19 +15,19 @@ async function listen(server) {
   return server.address().port
 }
 
-test("machine Session-link endpoint mirrors and reads lineage", async () => {
-  const stateDirectory = await mkdtemp(path.join(tmpdir(), "harness-link-route-"))
-  const sessionLinkStore = new SessionLinkStore({ machineID: "machine-1", stateDirectory })
-  const server = createSessionClaimServer({
+function createLinkServer(machineID, stateDirectory) {
+  const sessionLinkStore = new SessionLinkStore({ machineID, stateDirectory })
+  return createSessionClaimServer({
     innerServer: new EventEmitter(),
     config: { username: "", password: "", corsOrigins: [] },
     sessionLinkStore
   })
-  await new Promise((resolve, reject) => {
-    server.once("error", reject)
-    server.listen(0, "127.0.0.1", resolve)
-  })
-  const port = server.address().port
+}
+
+test("machine Session-link endpoint mirrors and reads lineage", async () => {
+  const stateDirectory = await mkdtemp(path.join(tmpdir(), "harness-link-route-"))
+  const server = createLinkServer("machine-1", stateDirectory)
+  const port = await listen(server)
   const link = {
     type: "handoff",
     source: { machineID: "machine-1", agentID: "codex", sessionID: "source-1", directory: "/repo" },
@@ -58,5 +58,45 @@ test("machine Session-link endpoint mirrors and reads lineage", async () => {
   } finally {
     await new Promise((resolve) => server.close(resolve))
     await rm(stateDirectory, { recursive: true, force: true })
+  }
+})
+
+test("cross-machine Session-link endpoint accepts the same edge on both participating daemons", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-link-route-cross-machine-"))
+  const sourceServer = createLinkServer("machine-1", path.join(root, "source"))
+  const targetServer = createLinkServer("machine-2", path.join(root, "target"))
+  const unrelatedServer = createLinkServer("machine-3", path.join(root, "unrelated"))
+  const sourcePort = await listen(sourceServer)
+  const targetPort = await listen(targetServer)
+  const unrelatedPort = await listen(unrelatedServer)
+  const link = {
+    type: "handoff",
+    source: { machineID: "machine-1", agentID: "codex", sessionID: "source-1", directory: "/repo-a" },
+    target: { machineID: "machine-2", agentID: "pi", sessionID: "target-2", directory: "/repo-b" },
+    createdAt: "2026-09-11T17:20:00.000Z"
+  }
+  const register = (port) => fetch(`http://127.0.0.1:${port}/v1/session-links`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ link })
+  })
+  try {
+    assert.equal((await register(sourcePort)).status, 200)
+    assert.equal((await register(targetPort)).status, 200)
+    assert.equal((await register(unrelatedPort)).status, 500)
+
+    const sourceQuery = new URLSearchParams(link.source)
+    const targetQuery = new URLSearchParams(link.target)
+    const sourceList = await fetch(`http://127.0.0.1:${sourcePort}/v1/session-links?${sourceQuery}`)
+    const targetList = await fetch(`http://127.0.0.1:${targetPort}/v1/session-links?${targetQuery}`)
+    assert.deepEqual((await sourceList.json()).links, [link])
+    assert.deepEqual((await targetList.json()).links, [link])
+  } finally {
+    await Promise.all([
+      new Promise((resolve) => sourceServer.close(resolve)),
+      new Promise((resolve) => targetServer.close(resolve)),
+      new Promise((resolve) => unrelatedServer.close(resolve))
+    ])
+    await rm(root, { recursive: true, force: true })
   }
 })

--- a/bridge/test/session-link-server.test.js
+++ b/bridge/test/session-link-server.test.js
@@ -83,7 +83,7 @@ test("cross-machine Session-link endpoint accepts the same edge on both particip
   try {
     assert.equal((await register(sourcePort)).status, 200)
     assert.equal((await register(targetPort)).status, 200)
-    assert.equal((await register(unrelatedPort)).status, 500)
+    assert.equal((await register(unrelatedPort)).status, 400)
 
     const sourceQuery = new URLSearchParams(link.source)
     const targetQuery = new URLSearchParams(link.target)

--- a/bridge/test/session-link-store.test.js
+++ b/bridge/test/session-link-store.test.js
@@ -42,16 +42,27 @@ test("handoff link survives restart and remains only metadata between real nativ
   }
 })
 
-test("Session links stay machine-local", async () => {
-  const stateDirectory = await mkdtemp(path.join(tmpdir(), "harness-session-links-scope-"))
+test("cross-machine lineage is replicated only by participating machines", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-session-links-cross-machine-"))
+  const crossTarget = { ...target, machineID: "machine-2", directory: "/other/repo" }
+  const createdAt = "2026-09-11T17:20:00.000Z"
+  const expected = { type: "handoff", source, target: crossTarget, createdAt }
   try {
-    const store = new SessionLinkStore({ machineID: "machine-1", stateDirectory })
+    const sourceStore = new SessionLinkStore({ machineID: "machine-1", stateDirectory: path.join(root, "source") })
+    const targetStore = new SessionLinkStore({ machineID: "machine-2", stateDirectory: path.join(root, "target") })
+    const unrelatedStore = new SessionLinkStore({ machineID: "machine-3", stateDirectory: path.join(root, "unrelated") })
+
+    assert.deepEqual(await sourceStore.addHandoff({ source, target: crossTarget, createdAt }), expected)
+    assert.deepEqual(await targetStore.addHandoff({ source, target: crossTarget, createdAt }), expected)
+    assert.deepEqual(await sourceStore.listFor(source), [expected])
+    assert.deepEqual(await targetStore.listFor(crossTarget), [expected])
+
     await assert.rejects(
-      () => store.addHandoff({ source, target: { ...target, machineID: "machine-2" } }),
-      /stay inside their machine scope/
+      () => unrelatedStore.addHandoff({ source, target: crossTarget, createdAt }),
+      /must include a Session owned by this machine/
     )
   } finally {
-    await rm(stateDirectory, { recursive: true, force: true })
+    await rm(root, { recursive: true, force: true })
   }
 })
 


### PR DESCRIPTION
Prerequisite slice for cross-machine Native Session continuation. This remains lineage metadata only and does **not** create target Sessions or transfer authority.

- allows one handoff edge to be durably stored by both participating machine daemons
- a daemon accepts the edge only when either source or target belongs to that machine
- unrelated third machines reject the edge as an invalid request (HTTP 400)
- keeps lineage metadata-only: no writer ownership, authorization, approval state, transcript state, tool state or harness state moves with the edge
- preserves existing same-machine deduplication and transferred-context enrichment
- adds storage and HTTP regression coverage for source-local, target-local and unrelated-machine behavior

Target: `codex/development-2026-09-11` only. Never `main`.