### PR TITLE
P2: add idempotent cross-machine target-create boundary

### DIFF
--- a/bridge/src/cross-machine-handoff-server.js
+++ b/bridge/src/cross-machine-handoff-server.js
@@ -4,6 +4,7 @@ import { authenticateDaemonRequest, writeJSON } from "./http-policy.js"
 
 const TARGET_HANDOFF_ROUTE = "/v1/session-handoff-target"
 const MAX_BODY_BYTES = 1_000_000
+const TARGET_CREATION_LEDGER_NAMESPACE = "cross-machine-handoff"
 
 function requestError(message, code = "invalid_request") {
   const error = new Error(message)
@@ -82,14 +83,17 @@ function signature(input) {
 /**
  * SessionOperationLedger requires an agent/session tuple because its original consumers mutate one
  * local native Session. A cross-machine target does not have a target Session yet, so use a reserved
- * opaque scope derived from the complete source identity. The hash prevents collisions between two
+ * ledger namespace plus an opaque scope derived from the complete source identity. Target harness,
+ * Project/model/title/variant deliberately do not change this key: they live in the mutation
+ * signature, so reusing one source-scoped clientRequestId with changed target semantics conflicts
+ * instead of silently creating a second resource. The hash also prevents collisions between two
  * machines whose harnesses happen to use the same native Session id and never exposes a path in
- * diagnostics. It is a ledger key only; it is never presented as a native Session identity.
+ * diagnostics. Neither field is ever presented as a native Session identity.
  */
 export function targetCreationLedgerIdentity(input) {
   const sourceDigest = createHash("sha256").update(JSON.stringify(input.source)).digest("hex")
   return {
-    agentID: input.targetAgentID,
+    agentID: TARGET_CREATION_LEDGER_NAMESPACE,
     sessionID: `handoff-source:${sourceDigest}`,
     clientRequestId: input.clientRequestId
   }

--- a/bridge/src/cross-machine-handoff-server.js
+++ b/bridge/src/cross-machine-handoff-server.js
@@ -1,0 +1,209 @@
+import { createHash } from "node:crypto"
+import http from "node:http"
+import { authenticateDaemonRequest, writeJSON } from "./http-policy.js"
+
+const TARGET_HANDOFF_ROUTE = "/v1/session-handoff-target"
+const MAX_BODY_BYTES = 1_000_000
+
+function requestError(message, code = "invalid_request") {
+  const error = new Error(message)
+  error.code = code
+  return error
+}
+
+function statusForError(error) {
+  if (error?.code === "invalid_request") return 400
+  if (error?.code === "unknown_project" || error?.code === "unknown_agent") return 404
+  if (error?.code === "agent_unavailable") return 503
+  if (["unsupported_agent", "handoff_rejected", "idempotency_conflict", "model_variant_unavailable"].includes(error?.code)) return 409
+  return 500
+}
+
+async function readJSONBody(request) {
+  let body = ""
+  for await (const chunk of request) {
+    body += chunk
+    if (body.length > MAX_BODY_BYTES) throw requestError("Request body is too large")
+  }
+  if (!body) return {}
+  try { return JSON.parse(body) }
+  catch { throw requestError("Request body must be valid JSON") }
+}
+
+function nativeSessionIdentity(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw requestError("Source Session identity is required")
+  const machineID = typeof value.machineID === "string" ? value.machineID.trim() : ""
+  const agentID = typeof value.agentID === "string" ? value.agentID.trim() : ""
+  const sessionID = typeof value.sessionID === "string" ? value.sessionID.trim() : ""
+  const directory = typeof value.directory === "string" ? value.directory : ""
+  if (![machineID, agentID, sessionID, directory].every(Boolean)) throw requestError("Source Session identity is incomplete")
+  return { machineID, agentID, sessionID, directory }
+}
+
+function modelInput(value) {
+  if (value === undefined || value === null) return null
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw requestError("Target model must be an object")
+  const providerID = typeof value.providerID === "string" ? value.providerID.trim() : ""
+  const modelID = typeof value.modelID === "string" ? value.modelID.trim() : ""
+  if (!providerID || !modelID) throw requestError("Target model requires providerID and modelID")
+  return { providerID, modelID }
+}
+
+function targetInput(body) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) throw requestError("Request body must be a JSON object")
+  if (Object.hasOwn(body, "directory") || Object.hasOwn(body, "targetDirectory")) {
+    throw requestError("Target directory is derived from projectId and cannot be supplied by the client")
+  }
+  const clientRequestId = typeof body.clientRequestId === "string" ? body.clientRequestId.trim() : ""
+  const projectId = typeof body.projectId === "string" ? body.projectId.trim() : ""
+  const targetAgentID = typeof body.targetAgentID === "string" ? body.targetAgentID.trim() : ""
+  const source = nativeSessionIdentity(body.source)
+  const model = modelInput(body.model)
+  const variant = typeof body.variant === "string" && body.variant.trim() ? body.variant.trim() : undefined
+  const title = typeof body.title === "string" && body.title.trim() ? body.title.trim().slice(0, 200) : undefined
+  if (!clientRequestId || clientRequestId.length > 200) throw requestError("A valid clientRequestId is required")
+  if (!projectId || projectId.length > 500) throw requestError("A valid target projectId is required")
+  if (!targetAgentID || targetAgentID.length > 200) throw requestError("A valid targetAgentID is required")
+  return { clientRequestId, projectId, targetAgentID, source, model, variant, title }
+}
+
+function signature(input) {
+  return createHash("sha256").update(JSON.stringify({
+    operation: "cross-machine-target-create-v1",
+    source: input.source,
+    projectId: input.projectId,
+    targetAgentID: input.targetAgentID,
+    model: input.model,
+    variant: input.variant ?? null,
+    title: input.title ?? null
+  })).digest("hex")
+}
+
+/**
+ * SessionOperationLedger requires an agent/session tuple because its original consumers mutate one
+ * local native Session. A cross-machine target does not have a target Session yet, so use a reserved
+ * opaque scope derived from the complete source identity. The hash prevents collisions between two
+ * machines whose harnesses happen to use the same native Session id and never exposes a path in
+ * diagnostics. It is a ledger key only; it is never presented as a native Session identity.
+ */
+export function targetCreationLedgerIdentity(input) {
+  const sourceDigest = createHash("sha256").update(JSON.stringify(input.source)).digest("hex")
+  return {
+    agentID: input.targetAgentID,
+    sessionID: `handoff-source:${sourceDigest}`,
+    clientRequestId: input.clientRequestId
+  }
+}
+
+async function runIdempotentCreation({ operationLedger, identity, mutationSignature, dispatch, reconcile }) {
+  const started = await operationLedger.begin({ ...identity, signature: mutationSignature })
+  if (started.duplicate) {
+    if (started.state === "uncertain" && typeof reconcile === "function") {
+      try {
+        const recovered = await reconcile(started.entry.result)
+        if (recovered) {
+          await operationLedger.accept({ ...identity, result: recovered })
+          return { status: "accepted", duplicate: true, result: recovered }
+        }
+      } catch {
+        // Read-only reconciliation failure must never replay a resource-creating operation.
+      }
+    }
+    return { status: started.state, duplicate: true, result: started.entry.result }
+  }
+
+  let dispatched = false
+  let checkpointedResult
+  const checkpoint = async (result) => {
+    await operationLedger.accept({ ...identity, result })
+    checkpointedResult = result
+  }
+
+  try {
+    const result = await dispatch({ checkpoint })
+    dispatched = true
+    const acceptedResult = result === undefined ? checkpointedResult : result
+    if (result !== undefined || checkpointedResult === undefined) {
+      await operationLedger.accept({ ...identity, result })
+    }
+    return { status: "accepted", duplicate: false, result: acceptedResult }
+  } catch (error) {
+    if (checkpointedResult !== undefined) {
+      return { status: "accepted", duplicate: false, result: checkpointedResult }
+    }
+    // Once dispatch has returned, the native resource may exist even if persisting `accepted`
+    // failed. Keep that operation uncertain so a retry can only reconcile; never delete the ledger
+    // entry and accidentally permit a second target Session.
+    const ambiguous = dispatched || error?.ambiguous === true
+    await operationLedger.fail({
+      ...identity,
+      ambiguous,
+      ...(error?.recovery !== undefined ? { result: error.recovery } : {})
+    })
+    if (ambiguous) return { status: "uncertain", duplicate: false }
+    throw error
+  }
+}
+
+/**
+ * Authenticated target-daemon boundary for cross-machine continuation.
+ *
+ * This server deliberately does not deliver the first prompt. It only creates/checkpoints the target
+ * native Session. The target filesystem path is resolved from the daemon's Project catalog, never
+ * from client input. Writer ownership, approvals, tool state and transcript state are not accepted
+ * by this contract and therefore cannot cross the machine boundary accidentally.
+ */
+export function createCrossMachineHandoffServer({
+  innerServer,
+  config,
+  projectCatalog,
+  operationLedger,
+  createTargetSession,
+  reconcileTargetSession,
+  createServer = http.createServer
+}) {
+  return createServer(async (request, response) => {
+    const requestURL = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`)
+    if (requestURL.pathname !== TARGET_HANDOFF_ROUTE) {
+      innerServer.emit("request", request, response)
+      return
+    }
+    if (!authenticateDaemonRequest(request, response, config)) return
+    if (request.method !== "POST") {
+      response.writeHead(405, { Allow: "POST, OPTIONS" })
+      response.end()
+      return
+    }
+
+    try {
+      if (!operationLedger) throw new Error("Native Session operation ledger is not configured")
+      if (typeof projectCatalog !== "function") throw new Error("Project catalog is not configured")
+      if (typeof createTargetSession !== "function") throw new Error("Target Session creation is not configured")
+      const input = targetInput(await readJSONBody(request))
+      const projects = await projectCatalog()
+      const project = projects.find((candidate) => candidate.id === input.projectId)
+      if (!project) throw requestError(`Unknown project: ${input.projectId}`, "unknown_project")
+
+      const identity = targetCreationLedgerIdentity(input)
+      const result = await runIdempotentCreation({
+        operationLedger,
+        identity,
+        mutationSignature: signature(input),
+        reconcile: typeof reconcileTargetSession === "function"
+          ? (recovery) => reconcileTargetSession({ ...input, project }, recovery)
+          : undefined,
+        dispatch: ({ checkpoint }) => createTargetSession({ ...input, project }, { checkpoint })
+      })
+      writeJSON(response, result.status === "accepted" ? 200 : 202, {
+        status: result.status,
+        clientRequestId: input.clientRequestId,
+        ...(result.result ? { result: result.result } : {})
+      })
+    } catch (error) {
+      writeJSON(response, statusForError(error), {
+        error: error instanceof Error ? error.message : String(error),
+        ...(error?.code ? { code: error.code } : {})
+      })
+    }
+  })
+}

--- a/bridge/test/cross-machine-handoff-ledger-failure.test.js
+++ b/bridge/test/cross-machine-handoff-ledger-failure.test.js
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import test from "node:test"
+import { createCrossMachineHandoffServer } from "../src/cross-machine-handoff-server.js"
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  return server.address().port
+}
+
+async function close(server) {
+  await new Promise((resolve) => server.close(resolve))
+}
+
+test("ledger accept failure after target creation becomes uncertain and is never replayed", async () => {
+  let creates = 0
+  let entry
+  const operationLedger = {
+    async begin(input) {
+      if (entry) return { duplicate: true, state: entry.state, entry: structuredClone(entry) }
+      entry = { ...input, state: "pending" }
+      return { duplicate: false, state: "pending", entry: structuredClone(entry) }
+    },
+    async accept() {
+      throw new Error("disk full after session/new")
+    },
+    async fail(input) {
+      assert.equal(input.ambiguous, true)
+      entry = { ...entry, state: "uncertain" }
+    }
+  }
+  const project = { id: "machine-b:repo", machineId: "machine-b", path: "/target/repo", kind: "git" }
+  const server = createCrossMachineHandoffServer({
+    innerServer: new EventEmitter(),
+    config: { username: "", password: "", corsOrigins: [] },
+    projectCatalog: async () => [project],
+    operationLedger,
+    async createTargetSession(input) {
+      creates += 1
+      return {
+        target: {
+          machineID: "machine-b",
+          agentID: input.targetAgentID,
+          sessionID: "created-but-ledger-write-failed",
+          directory: project.path
+        }
+      }
+    }
+  })
+  const port = await listen(server)
+  const payload = {
+    clientRequestId: "ledger-failure-1",
+    source: { machineID: "machine-a", agentID: "codex", sessionID: "source-1", directory: "/source/repo" },
+    projectId: project.id,
+    targetAgentID: "pi"
+  }
+  const post = () => fetch(`http://127.0.0.1:${port}/v1/session-handoff-target`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  })
+  try {
+    const first = await post()
+    assert.equal(first.status, 202)
+    assert.equal((await first.json()).status, "uncertain")
+
+    const retry = await post()
+    assert.equal(retry.status, 202)
+    assert.equal((await retry.json()).status, "uncertain")
+    assert.equal(creates, 1, "a failed accepted-ledger write must never permit a second target creation")
+  } finally {
+    await close(server)
+  }
+})

--- a/bridge/test/cross-machine-handoff-ledger-scope.test.js
+++ b/bridge/test/cross-machine-handoff-ledger-scope.test.js
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { targetCreationLedgerIdentity } from "../src/cross-machine-handoff-server.js"
+
+const source = {
+  machineID: "machine-a",
+  agentID: "codex",
+  sessionID: "native-1",
+  directory: "/source/repo"
+}
+
+function input(overrides = {}) {
+  return {
+    clientRequestId: "request-1",
+    source,
+    projectId: "machine-b:repo",
+    targetAgentID: "pi",
+    model: { providerID: "openai", modelID: "gpt-5.6-codex" },
+    variant: "high",
+    title: "Continue work",
+    ...overrides
+  }
+}
+
+test("target semantics stay in the signature rather than changing the durable ledger key", () => {
+  const first = targetCreationLedgerIdentity(input())
+  const changedTarget = targetCreationLedgerIdentity(input({
+    targetAgentID: "omp",
+    projectId: "machine-b:other-repo",
+    model: { providerID: "other", modelID: "other-model" },
+    variant: "low",
+    title: "Different target"
+  }))
+
+  assert.deepEqual(changedTarget, first)
+  assert.equal(first.agentID, "cross-machine-handoff")
+  assert.match(first.sessionID, /^handoff-source:[a-f0-9]{64}$/)
+  assert.equal(first.sessionID.includes(source.directory), false)
+})
+
+test("source identity and client request id remain part of the durable ledger scope", () => {
+  const first = targetCreationLedgerIdentity(input())
+  const otherMachine = targetCreationLedgerIdentity(input({ source: { ...source, machineID: "machine-c" } }))
+  const otherRequest = targetCreationLedgerIdentity(input({ clientRequestId: "request-2" }))
+
+  assert.notEqual(otherMachine.sessionID, first.sessionID)
+  assert.equal(otherMachine.agentID, first.agentID)
+  assert.notEqual(otherRequest.clientRequestId, first.clientRequestId)
+})

--- a/bridge/test/cross-machine-handoff-server.test.js
+++ b/bridge/test/cross-machine-handoff-server.test.js
@@ -1,0 +1,228 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import test from "node:test"
+import { createCrossMachineHandoffServer, targetCreationLedgerIdentity } from "../src/cross-machine-handoff-server.js"
+import { SessionOperationLedger } from "../src/session-operation-ledger.js"
+
+const source = {
+  machineID: "machine-a",
+  agentID: "codex",
+  sessionID: "native-1",
+  directory: "/source/repo"
+}
+
+const project = {
+  id: "machine-b:repo",
+  machineId: "machine-b",
+  name: "repo",
+  path: "/target/repo",
+  kind: "git"
+}
+
+function body(overrides = {}) {
+  return {
+    clientRequestId: "cross-request-1",
+    source,
+    projectId: project.id,
+    targetAgentID: "pi",
+    model: { providerID: "openai", modelID: "gpt-5.6-codex" },
+    variant: "high",
+    title: "Continue native work",
+    ...overrides
+  }
+}
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  return server.address().port
+}
+
+async function close(server) {
+  await new Promise((resolve) => server.close(resolve))
+}
+
+async function withServer(options, run) {
+  const stateDirectory = await mkdtemp(path.join(tmpdir(), "harness-cross-machine-target-"))
+  const operationLedger = new SessionOperationLedger({ machineID: "machine-b", stateDirectory })
+  const server = createCrossMachineHandoffServer({
+    innerServer: new EventEmitter(),
+    config: { username: "", password: "", corsOrigins: [] },
+    projectCatalog: async () => [project],
+    operationLedger,
+    ...options
+  })
+  const port = await listen(server)
+  try { return await run(port, operationLedger) }
+  finally {
+    await close(server)
+    await rm(stateDirectory, { recursive: true, force: true })
+  }
+}
+
+function post(port, payload = body()) {
+  return fetch(`http://127.0.0.1:${port}/v1/session-handoff-target`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  })
+}
+
+test("target-create resolves the target path from projectId and accepted retry returns the exact same native Session", async () => {
+  let creates = 0
+  const expected = {
+    target: { machineID: "machine-b", agentID: "pi", sessionID: "pi-native-2", directory: project.path }
+  }
+  await withServer({
+    async createTargetSession(input) {
+      creates += 1
+      assert.deepEqual(input.source, source)
+      assert.equal(input.project.id, project.id)
+      assert.equal(input.project.path, project.path)
+      assert.equal(input.targetAgentID, "pi")
+      assert.deepEqual(input.model, { providerID: "openai", modelID: "gpt-5.6-codex" })
+      return expected
+    }
+  }, async (port) => {
+    const first = await post(port)
+    const retry = await post(port)
+    assert.equal(first.status, 200)
+    assert.equal(retry.status, 200)
+    assert.deepEqual((await first.json()).result, expected)
+    assert.deepEqual((await retry.json()).result, expected)
+    assert.equal(creates, 1)
+  })
+})
+
+test("client cannot smuggle a target directory and unknown Projects never dispatch creation", async () => {
+  let creates = 0
+  await withServer({ async createTargetSession() { creates += 1 } }, async (port) => {
+    const arbitraryPath = await post(port, body({ directory: "/etc" }))
+    assert.equal(arbitraryPath.status, 400)
+    assert.match((await arbitraryPath.json()).error, /derived from projectId/)
+
+    const unknown = await post(port, body({ clientRequestId: "unknown-project", projectId: "machine-b:missing" }))
+    assert.equal(unknown.status, 404)
+    assert.match((await unknown.json()).error, /Unknown project/)
+    assert.equal(creates, 0)
+  })
+})
+
+test("semantic changes conflict under the same source-scoped durable request id", async () => {
+  let creates = 0
+  await withServer({
+    async createTargetSession(input) {
+      creates += 1
+      return { target: { machineID: "machine-b", agentID: input.targetAgentID, sessionID: "native-2", directory: project.path } }
+    }
+  }, async (port) => {
+    assert.equal((await post(port)).status, 200)
+    const conflict = await post(port, body({ targetAgentID: "omp" }))
+    assert.equal(conflict.status, 409)
+    assert.match((await conflict.json()).error, /already used for a different native Session operation/)
+    assert.equal(creates, 1)
+  })
+})
+
+test("source identity is part of the ledger scope so identical native ids on different machines do not collide", async () => {
+  let creates = 0
+  await withServer({
+    async createTargetSession(input) {
+      creates += 1
+      return {
+        target: {
+          machineID: "machine-b",
+          agentID: input.targetAgentID,
+          sessionID: `target-${creates}`,
+          directory: project.path
+        }
+      }
+    }
+  }, async (port) => {
+    const first = await post(port)
+    const secondSource = { ...source, machineID: "machine-c" }
+    const second = await post(port, body({ source: secondSource }))
+    assert.equal(first.status, 200)
+    assert.equal(second.status, 200)
+    assert.notEqual((await first.json()).result.target.sessionID, (await second.json()).result.target.sessionID)
+    assert.equal(creates, 2)
+
+    const firstScope = targetCreationLedgerIdentity(body())
+    const secondScope = targetCreationLedgerIdentity(body({ source: secondSource }))
+    assert.notEqual(firstScope.sessionID, secondScope.sessionID)
+    assert.equal(firstScope.sessionID.includes(source.directory), false)
+  })
+})
+
+test("checkpointed target identity survives later enrichment failure and prevents duplicate creation", async () => {
+  let creates = 0
+  const expected = {
+    target: { machineID: "machine-b", agentID: "pi", sessionID: "checkpointed-target", directory: project.path }
+  }
+  await withServer({
+    async createTargetSession(_input, { checkpoint }) {
+      creates += 1
+      await checkpoint(expected)
+      throw new Error("lineage enrichment failed")
+    }
+  }, async (port) => {
+    const first = await post(port)
+    const retry = await post(port)
+    assert.equal(first.status, 200)
+    assert.equal(retry.status, 200)
+    assert.deepEqual((await first.json()).result, expected)
+    assert.deepEqual((await retry.json()).result, expected)
+    assert.equal(creates, 1)
+  })
+})
+
+test("ambiguous creation is never replayed and one unique read-only reconciliation can make it durable", async () => {
+  let creates = 0
+  let reconciles = 0
+  const recovery = {
+    kind: "cross-machine-target-create",
+    targetAgentID: "pi",
+    projectId: project.id,
+    beforeSessionIDs: ["old-target"]
+  }
+  const expected = {
+    target: { machineID: "machine-b", agentID: "pi", sessionID: "recovered-target", directory: project.path }
+  }
+  await withServer({
+    async createTargetSession() {
+      creates += 1
+      const error = new Error("session/new response lost")
+      error.ambiguous = true
+      error.recovery = recovery
+      throw error
+    },
+    async reconcileTargetSession(input, storedRecovery) {
+      reconciles += 1
+      assert.deepEqual(input.source, source)
+      assert.equal(input.project.path, project.path)
+      assert.deepEqual(storedRecovery, recovery)
+      return expected
+    }
+  }, async (port) => {
+    const first = await post(port)
+    assert.equal(first.status, 202)
+    assert.equal((await first.json()).status, "uncertain")
+
+    const retry = await post(port)
+    assert.equal(retry.status, 200)
+    assert.deepEqual((await retry.json()).result, expected)
+    assert.equal(creates, 1)
+    assert.equal(reconciles, 1)
+
+    const stable = await post(port)
+    assert.equal(stable.status, 200)
+    assert.deepEqual((await stable.json()).result, expected)
+    assert.equal(creates, 1)
+    assert.equal(reconciles, 1)
+  })
+})


### PR DESCRIPTION
#418 is integrated in `codex/development-2026-09-11`; this PR targets the integration branch directly.

This slice defines and tests the target-daemon creation contract but does **not** wire it into the machine daemon or enable the UI yet.

- adds authenticated `POST /v1/session-handoff-target` boundary as an isolated server component
- requires a complete source Native Session identity and a target `projectId`
- rejects caller-supplied target directories; target path is resolved only from the target daemon Project catalog
- scopes the durable ledger key to an opaque hash of the complete source identity + client request id; target Project/harness/model/title/variant stay in the mutation signature, so changing semantics under the same request id yields an idempotency conflict instead of a second resource
- prevents native Session id collisions across source machines
- checkpoints the exact target Session identity before optional enrichment can fail
- ambiguous creation is never replayed blindly; a duplicate may only perform read-only reconciliation
- if `session/new` succeeded but persisting the accepted ledger result fails, the operation stays uncertain rather than allowing a duplicate create
- accepts no approval/writer/tool/transcript state and does not deliver the first prompt
- adds regression coverage for retry, semantic conflict, project/path scoping, cross-machine ID collision, ledger scope, checkpoint, uncertain reconciliation, and post-dispatch ledger failure

Daemon runtime and wiring remain separate reviewed slices.

Target: `codex/development-2026-09-11` only. Never `main`.