### PR TITLE
P2: add target-daemon cross-machine Session runtime

### DIFF
--- a/bridge/src/cross-machine-target-runtime.js
+++ b/bridge/src/cross-machine-target-runtime.js
@@ -1,0 +1,196 @@
+function runtimeError(code, message, options = {}) {
+  const error = new Error(message)
+  error.code = code
+  Object.assign(error, options)
+  return error
+}
+
+function internalAuthorization(host) {
+  if (!host.username && !host.password) return undefined
+  return `Basic ${Buffer.from(`${host.username ?? ""}:${host.password ?? ""}`, "utf8").toString("base64")}`
+}
+
+function validSource(source) {
+  return source
+    && typeof source === "object"
+    && [source.machineID, source.agentID, source.sessionID, source.directory].every((value) => typeof value === "string" && value)
+}
+
+/**
+ * Target-machine runtime for cross-machine Native Session continuation.
+ *
+ * It owns only creation/recovery of the new local Session and lineage metadata. It never loads or
+ * claims the remote source Session, never transfers writer/approval/tool state, and never sends the
+ * first prompt. The caller must provide a Project already resolved by the target daemon catalog.
+ */
+export function createCrossMachineTargetRuntime({ daemon, machineID, acpService, sessionLinkStore, fetchImpl = fetch }) {
+  const listSessions = async (targetAgentID, directory) => {
+    const targetEntry = daemon.hostEntry(targetAgentID)
+    if (!targetEntry) throw runtimeError("unknown_agent", `Unknown target agent: ${targetAgentID}`)
+
+    if (targetEntry.kind === "acp") {
+      const service = acpService(targetAgentID)
+      if (!service || typeof service.listSessions !== "function") {
+        throw runtimeError("agent_unavailable", `Agent ${targetAgentID} cannot list native Sessions for cross-machine recovery`)
+      }
+      const sessions = await service.listSessions(directory)
+      return sessions
+        .filter((session) => session?.id && (!directory || session.directory === directory))
+        .map((session) => ({ id: session.id, directory: session.directory || directory }))
+    }
+
+    const host = targetEntry.host
+    try { await host.start?.() }
+    catch (error) {
+      throw runtimeError("agent_unavailable", error instanceof Error ? error.message : `Agent ${targetAgentID} is unavailable`)
+    }
+    const query = directory ? `?directory=${encodeURIComponent(directory)}` : ""
+    const url = `http://${host.readinessHost ?? host.host ?? "127.0.0.1"}:${host.port}/session${query}`
+    const headers = { Accept: "application/json" }
+    const authorization = internalAuthorization(host)
+    if (authorization) headers.Authorization = authorization
+    let response
+    try { response = await fetchImpl(url, { method: "GET", headers }) }
+    catch { throw runtimeError("agent_unavailable", `Cannot list ${targetAgentID} Sessions for cross-machine recovery`) }
+    if (!response.ok) {
+      let detail = ""
+      try { detail = await response.text() } catch {}
+      throw runtimeError("agent_unavailable", detail || `Listing ${targetAgentID} Sessions returned HTTP ${response.status}`)
+    }
+    let payload
+    try { payload = await response.json() }
+    catch { throw runtimeError("agent_unavailable", `Listing ${targetAgentID} Sessions returned an unreadable response`) }
+    const sessions = Array.isArray(payload) ? payload : Array.isArray(payload?.sessions) ? payload.sessions : []
+    return sessions
+      .map((session) => ({ id: session?.id || session?.sessionId, directory: session?.directory || session?.cwd || directory }))
+      .filter((session) => session.id && (!directory || session.directory === directory))
+  }
+
+  const resultForTarget = async (source, targetAgentID, directory, targetSessionID) => {
+    const target = { machineID, agentID: targetAgentID, sessionID: targetSessionID, directory }
+    let link
+    try { link = await sessionLinkStore?.addHandoff({ source, target }) }
+    catch {
+      // The target identity is authoritative once session/new returned. Link persistence is optional
+      // enrichment and can be retried independently without creating another Session.
+    }
+    return { target, ...(link ? { link } : {}) }
+  }
+
+  const recoverySnapshot = async (input) => ({
+    kind: "cross-machine-target-create-v1",
+    targetAgentID: input.targetAgentID,
+    projectId: input.project.id,
+    directory: input.project.path,
+    beforeSessionIDs: (await listSessions(input.targetAgentID, input.project.path)).map((session) => session.id)
+  })
+
+  const reconcileTargetSession = async (input, recovery) => {
+    if (
+      !recovery
+      || recovery.kind !== "cross-machine-target-create-v1"
+      || recovery.targetAgentID !== input.targetAgentID
+      || recovery.projectId !== input.project.id
+      || recovery.directory !== input.project.path
+      || !Array.isArray(recovery.beforeSessionIDs)
+    ) return undefined
+    const before = new Set(recovery.beforeSessionIDs.filter((value) => typeof value === "string" && value))
+    const current = await listSessions(input.targetAgentID, input.project.path)
+    const candidates = current.filter((session) => !before.has(session.id))
+    if (candidates.length !== 1) return undefined
+    return resultForTarget(input.source, input.targetAgentID, input.project.path, candidates[0].id)
+  }
+
+  const createTargetSession = async (input, { checkpoint } = {}) => {
+    if (!validSource(input.source)) throw runtimeError("invalid_request", "Source Session identity is incomplete")
+    if (input.source.machineID === machineID) {
+      throw runtimeError("invalid_request", "Cross-machine target creation requires a source Session on another machine")
+    }
+    if (!input.project || input.project.machineId !== machineID || typeof input.project.path !== "string" || !input.project.path) {
+      throw runtimeError("invalid_request", "Target Project must belong to this machine")
+    }
+    const targetAgentID = input.targetAgentID
+    const directory = input.project.path
+    const targetEntry = daemon.hostEntry(targetAgentID)
+    if (!targetEntry) throw runtimeError("unknown_agent", `Unknown target agent: ${targetAgentID}`)
+    if (targetEntry.host?.capabilities?.sessions === false || daemon.registry.host(targetAgentID)?.capabilities?.sessions === false) {
+      throw runtimeError("unsupported_agent", `Agent ${targetAgentID} does not support native Sessions`)
+    }
+
+    const requestedModel = input.model ? { ...input.model, ...(input.variant ? { variant: input.variant } : {}) } : null
+    if (requestedModel) await daemon.resolveModel(targetAgentID, requestedModel, { directory })
+
+    // Recovery must be possible before creating a resource. If listing fails, fail closed before
+    // session/new instead of creating a target that a lost response could make impossible to find.
+    const recovery = await recoverySnapshot(input)
+    let targetSession
+
+    if (targetEntry.kind === "acp") {
+      const service = acpService(targetAgentID)
+      if (!service || typeof service.createSession !== "function") {
+        throw runtimeError("unsupported_agent", `Agent ${targetAgentID} cannot create native Sessions`)
+      }
+      try { targetSession = await service.createSession({ directory }) }
+      catch (error) {
+        if (error && typeof error === "object") {
+          error.ambiguous = true
+          error.recovery = recovery
+        }
+        throw error
+      }
+    } else {
+      const host = targetEntry.host
+      try { await host.start?.() }
+      catch (error) {
+        throw runtimeError("agent_unavailable", error instanceof Error ? error.message : `Agent ${targetAgentID} is unavailable`)
+      }
+      const url = `http://${host.readinessHost ?? host.host ?? "127.0.0.1"}:${host.port}/session?directory=${encodeURIComponent(directory)}`
+      const headers = { Accept: "application/json", "Content-Type": "application/json" }
+      const authorization = internalAuthorization(host)
+      if (authorization) headers.Authorization = authorization
+      let response
+      try { response = await fetchImpl(url, { method: "POST", headers, body: "{}" }) }
+      catch {
+        throw runtimeError("handoff_uncertain", `Creating ${targetAgentID} Session is uncertain`, { ambiguous: true, recovery })
+      }
+      if (!response.ok) {
+        let detail = ""
+        try { detail = await response.text() } catch {}
+        const message = detail || `Creating ${targetAgentID} Session returned HTTP ${response.status}`
+        if (response.status >= 500) throw runtimeError("handoff_uncertain", message, { ambiguous: true, recovery })
+        throw runtimeError("handoff_rejected", message)
+      }
+      try { targetSession = await response.json() }
+      catch {
+        throw runtimeError("handoff_uncertain", `Creating ${targetAgentID} Session returned an unreadable response`, { ambiguous: true, recovery })
+      }
+    }
+
+    if (!targetSession?.id) {
+      throw runtimeError("handoff_uncertain", `Agent ${targetAgentID} did not return a native Session id`, { ambiguous: true, recovery })
+    }
+
+    let result = { target: { machineID, agentID: targetAgentID, sessionID: targetSession.id, directory } }
+    if (typeof checkpoint === "function") {
+      try { await checkpoint(result) }
+      catch (error) {
+        if (error && typeof error === "object") {
+          error.ambiguous = true
+          error.recovery = recovery
+        }
+        throw error
+      }
+    }
+
+    if (input.title && targetEntry.kind === "acp") {
+      const service = acpService(targetAgentID)
+      try { await service?.renameSession?.(targetSession.id, input.title) } catch {}
+    }
+
+    result = await resultForTarget(input.source, targetAgentID, directory, targetSession.id)
+    if (typeof checkpoint === "function") await checkpoint(result)
+    return result
+  }
+
+  return { createTargetSession, reconcileTargetSession }
+}

--- a/bridge/test/cross-machine-target-runtime.test.js
+++ b/bridge/test/cross-machine-target-runtime.test.js
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { createCrossMachineTargetRuntime } from "../src/cross-machine-target-runtime.js"
+
+const source = {
+  machineID: "machine-a",
+  agentID: "codex",
+  sessionID: "source-native-1",
+  directory: "/source/repo"
+}
+const project = {
+  id: "machine-b:repo",
+  machineId: "machine-b",
+  name: "repo",
+  path: "/target/repo",
+  kind: "git"
+}
+
+function daemonFor(entry, { resolveModel } = {}) {
+  return {
+    hostEntry(id) { return id === "pi" ? entry : undefined },
+    registry: { host(id) { return id === "pi" ? { capabilities: { sessions: true } } : undefined } },
+    async resolveModel(...args) { return resolveModel ? resolveModel(...args) : args[1] }
+  }
+}
+
+function input(overrides = {}) {
+  return {
+    source,
+    project,
+    targetAgentID: "pi",
+    model: { providerID: "openai", modelID: "gpt-5.6-codex" },
+    variant: "high",
+    title: "Continue here",
+    ...overrides
+  }
+}
+
+test("ACP target creation uses only the target Project path and checkpoints before lineage enrichment", async () => {
+  const calls = []
+  const service = {
+    async listSessions(directory) { calls.push(["list", directory]); return [] },
+    async createSession(options) { calls.push(["create", options]); return { id: "pi-native-2" } },
+    async renameSession(id, title) { calls.push(["rename", id, title]) }
+  }
+  const links = {
+    async addHandoff(link) {
+      calls.push(["link", link])
+      return { type: "handoff", ...link, createdAt: "2026-09-11T18:00:00.000Z" }
+    }
+  }
+  const checkpoints = []
+  const runtime = createCrossMachineTargetRuntime({
+    daemon: daemonFor({ kind: "acp", host: { capabilities: { sessions: true } } }, {
+      resolveModel: async (agentID, model, options) => {
+        calls.push(["model", agentID, model, options])
+        return model
+      }
+    }),
+    machineID: "machine-b",
+    acpService: () => service,
+    sessionLinkStore: links
+  })
+
+  const result = await runtime.createTargetSession(input(), {
+    async checkpoint(value) { checkpoints.push(structuredClone(value)) }
+  })
+
+  assert.deepEqual(calls[0], ["model", "pi", { providerID: "openai", modelID: "gpt-5.6-codex", variant: "high" }, { directory: project.path }])
+  assert.deepEqual(calls[1], ["list", project.path])
+  assert.deepEqual(calls[2], ["create", { directory: project.path }])
+  assert.deepEqual(checkpoints[0], {
+    target: { machineID: "machine-b", agentID: "pi", sessionID: "pi-native-2", directory: project.path }
+  })
+  assert.deepEqual(calls[3], ["rename", "pi-native-2", "Continue here"])
+  assert.equal(calls[4][0], "link")
+  assert.deepEqual(calls[4][1].source, source)
+  assert.deepEqual(calls[4][1].target, result.target)
+  assert.equal(result.link.type, "handoff")
+  assert.deepEqual(checkpoints[1], result)
+  assert.equal(calls.some((call) => call[0] === "prompt"), false)
+})
+
+test("HTTP target creation lists before creating and uses the catalog path rather than the source path", async () => {
+  const requests = []
+  const host = {
+    readinessHost: "127.0.0.1",
+    port: 5555,
+    username: "daemon",
+    password: "secret",
+    capabilities: { sessions: true },
+    async start() {}
+  }
+  const fetchImpl = async (url, options) => {
+    requests.push([url, options])
+    if (options.method === "GET") {
+      return { ok: true, status: 200, async json() { return [] } }
+    }
+    return { ok: true, status: 200, async json() { return { id: "http-target-1" } } }
+  }
+  const links = { async addHandoff(link) { return { type: "handoff", ...link, createdAt: "now" } } }
+  const runtime = createCrossMachineTargetRuntime({
+    daemon: daemonFor({ kind: "http", host }),
+    machineID: "machine-b",
+    acpService: () => undefined,
+    sessionLinkStore: links,
+    fetchImpl
+  })
+  const result = await runtime.createTargetSession(input({ model: null, variant: undefined, title: undefined }))
+  assert.equal(requests.length, 2)
+  assert.equal(requests[0][0], `http://127.0.0.1:5555/session?directory=${encodeURIComponent(project.path)}`)
+  assert.equal(requests[0][1].method, "GET")
+  assert.equal(requests[1][0], `http://127.0.0.1:5555/session?directory=${encodeURIComponent(project.path)}`)
+  assert.equal(requests[1][1].method, "POST")
+  assert.match(requests[1][1].headers.Authorization, /^Basic /)
+  assert.equal(requests.some(([url]) => url.includes(encodeURIComponent(source.directory))), false)
+  assert.equal(result.target.directory, project.path)
+})
+
+test("runtime rejects a local source and a target Project owned by another machine before session/new", async () => {
+  let creates = 0
+  const service = {
+    async listSessions() { return [] },
+    async createSession() { creates += 1; return { id: "should-not-exist" } }
+  }
+  const runtime = createCrossMachineTargetRuntime({
+    daemon: daemonFor({ kind: "acp", host: { capabilities: { sessions: true } } }),
+    machineID: "machine-b",
+    acpService: () => service,
+    sessionLinkStore: { async addHandoff() {} }
+  })
+  await assert.rejects(
+    () => runtime.createTargetSession(input({ source: { ...source, machineID: "machine-b" } })),
+    /source Session on another machine/
+  )
+  await assert.rejects(
+    () => runtime.createTargetSession(input({ project: { ...project, machineId: "machine-c" } })),
+    /Target Project must belong to this machine/
+  )
+  assert.equal(creates, 0)
+})
+
+test("ambiguous ACP create carries a before-list recovery snapshot and unique reconciliation returns one target", async () => {
+  let sessions = [{ id: "old", directory: project.path }]
+  const service = {
+    async listSessions() { return sessions },
+    async createSession() {
+      sessions = [...sessions, { id: "new-target", directory: project.path }]
+      throw new Error("response lost")
+    }
+  }
+  const links = { async addHandoff(link) { return { type: "handoff", ...link, createdAt: "now" } } }
+  const runtime = createCrossMachineTargetRuntime({
+    daemon: daemonFor({ kind: "acp", host: { capabilities: { sessions: true } } }),
+    machineID: "machine-b",
+    acpService: () => service,
+    sessionLinkStore: links
+  })
+  let recovery
+  try {
+    await runtime.createTargetSession(input({ model: null }))
+    assert.fail("expected ambiguous creation")
+  } catch (error) {
+    assert.equal(error.ambiguous, true)
+    recovery = error.recovery
+  }
+  assert.deepEqual(recovery, {
+    kind: "cross-machine-target-create-v1",
+    targetAgentID: "pi",
+    projectId: project.id,
+    directory: project.path,
+    beforeSessionIDs: ["old"]
+  })
+  const result = await runtime.reconcileTargetSession(input({ model: null }), recovery)
+  assert.equal(result.target.sessionID, "new-target")
+  assert.deepEqual(result.link.source, source)
+})
+
+test("reconciliation refuses zero or multiple new candidates", async () => {
+  let sessions = [{ id: "old", directory: project.path }]
+  const service = { async listSessions() { return sessions } }
+  const runtime = createCrossMachineTargetRuntime({
+    daemon: daemonFor({ kind: "acp", host: { capabilities: { sessions: true } } }),
+    machineID: "machine-b",
+    acpService: () => service,
+    sessionLinkStore: { async addHandoff(link) { return { type: "handoff", ...link } } }
+  })
+  const recovery = {
+    kind: "cross-machine-target-create-v1",
+    targetAgentID: "pi",
+    projectId: project.id,
+    directory: project.path,
+    beforeSessionIDs: ["old"]
+  }
+  assert.equal(await runtime.reconcileTargetSession(input({ model: null }), recovery), undefined)
+  sessions = [
+    { id: "old", directory: project.path },
+    { id: "new-1", directory: project.path },
+    { id: "new-2", directory: project.path }
+  ]
+  assert.equal(await runtime.reconcileTargetSession(input({ model: null }), recovery), undefined)
+})


### PR DESCRIPTION
#419 is now integrated in `codex/development-2026-09-11`; this PR is retargeted directly to the integration branch.

This slice implements the target-machine Native Session creation/recovery runtime behind the still-unwired boundary.

- creates only a new local harness-owned target Session; it never loads or claims the remote source Session
- requires the target Project to belong to the local machine and always uses its catalog path
- supports both ACP and managed HTTP harnesses without changing their existing prompt/claim paths
- validates an explicit model before resource creation but defers model application to the future first prompt
- captures a before-session baseline before `session/new`, then checkpoints the returned target identity immediately
- persists cross-machine lineage only after target identity is durable; lineage failure cannot make the target unknown
- ambiguous create carries a read-only recovery snapshot and reconciliation accepts only exactly one new candidate
- source and target directories remain distinct in lineage metadata
- no first prompt, approvals, writer ownership, tool state or transcript state crosses machines
- adds ACP and HTTP regression tests plus fail-closed recovery cases

The next slice will only wire this runtime + #419 boundary into `createMachineDaemonServer`; UI remains disabled.

Target: `codex/development-2026-09-11` only. Never `main`.