### PR TITLE
P2: add durable cross-machine target creation client

### DIFF
--- a/web/src/cross-machine-target-client.ts
+++ b/web/src/cross-machine-target-client.ts
@@ -1,0 +1,243 @@
+import { Capacitor, CapacitorHttp } from "@capacitor/core"
+import { desktopRequestResult, isDesktopPlatform } from "./desktopBridge"
+import type { NativeSessionRef, NativeSessionSurfaceTarget } from "./native-session-discovery"
+import { normalizeModel, sameModel } from "./native-session-model"
+import { authHeader, hasCredentials, machineBaseUrl } from "./serverConfig"
+import type { ModelSelection, ServerConfig } from "./types"
+
+export type CrossMachineTargetStatus = "accepted" | "pending" | "uncertain"
+
+export type CrossMachineTargetResult = {
+  target: NativeSessionRef
+  link?: unknown
+}
+
+type PendingCrossMachineTarget = {
+  clientRequestId: string
+  targetMachineID: string
+  projectId: string
+  targetAgentID: string
+  title?: string
+  model?: ModelSelection | null
+  createdAt: number
+}
+
+const STORAGE_PREFIX = "harness-remote.cross-machine-target.v1"
+const TARGET_ROUTE = "/v1/session-handoff-target"
+
+function storageKey(source: NativeSessionSurfaceTarget): string {
+  return `${STORAGE_PREFIX}:${encodeURIComponent(source.machineID)}:${encodeURIComponent(source.agentID)}:${encodeURIComponent(source.sessionID)}`
+}
+
+function requestID(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") return crypto.randomUUID()
+  return `cross-machine-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+}
+
+function machineConfig(config: ServerConfig): ServerConfig {
+  return { ...config, agentId: undefined }
+}
+
+function clearPending(source: NativeSessionSurfaceTarget) {
+  try { localStorage.removeItem(storageKey(source)) } catch {}
+}
+
+function loadPending(source: NativeSessionSurfaceTarget): PendingCrossMachineTarget | null {
+  try {
+    const raw = localStorage.getItem(storageKey(source))
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<PendingCrossMachineTarget>
+    if (typeof parsed.clientRequestId !== "string" || !parsed.clientRequestId) return null
+    if (typeof parsed.targetMachineID !== "string" || !parsed.targetMachineID.trim()) return null
+    if (typeof parsed.projectId !== "string" || !parsed.projectId.trim()) return null
+    if (typeof parsed.targetAgentID !== "string" || !parsed.targetAgentID.trim()) return null
+    return {
+      clientRequestId: parsed.clientRequestId,
+      targetMachineID: parsed.targetMachineID.trim(),
+      projectId: parsed.projectId.trim(),
+      targetAgentID: parsed.targetAgentID.trim(),
+      title: typeof parsed.title === "string" && parsed.title.trim() ? parsed.title.trim() : undefined,
+      model: normalizeModel(parsed.model),
+      createdAt: typeof parsed.createdAt === "number" ? parsed.createdAt : Date.now()
+    }
+  } catch {
+    return null
+  }
+}
+
+function persistPending(source: NativeSessionSurfaceTarget, pending: PendingCrossMachineTarget): boolean {
+  try {
+    localStorage.setItem(storageKey(source), JSON.stringify(pending))
+    return true
+  } catch {
+    return false
+  }
+}
+
+function errorDetail(body: unknown, status: number): string {
+  if (typeof body === "string") {
+    try { return errorDetail(JSON.parse(body), status) }
+    catch { return body || `HTTP ${status}` }
+  }
+  if (body && typeof body === "object" && typeof (body as { error?: unknown }).error === "string") {
+    return (body as { error: string }).error
+  }
+  return `HTTP ${status}`
+}
+
+function responseData(value: unknown): { status: CrossMachineTargetStatus; clientRequestId?: string; result?: CrossMachineTargetResult } {
+  if (!value || typeof value !== "object") return { status: "uncertain" }
+  const body = value as { status?: unknown; clientRequestId?: unknown; result?: unknown }
+  const status = body.status === "pending" || body.status === "uncertain" || body.status === "accepted"
+    ? body.status
+    : "uncertain"
+  const clientRequestId = typeof body.clientRequestId === "string" && body.clientRequestId ? body.clientRequestId : undefined
+  const candidate = body.result as CrossMachineTargetResult | undefined
+  if (!candidate?.target?.machineID || !candidate.target.agentID || !candidate.target.sessionID || !candidate.target.directory) {
+    return { status, clientRequestId }
+  }
+  return { status, clientRequestId, result: candidate }
+}
+
+/**
+ * The target daemon creates one real native Session; the first prompt remains a separate recovery
+ * domain. The creation id is persisted before network I/O and intentionally has no TTL. An accepted
+ * result is acknowledged only after the caller has durably stored the returned target identity.
+ *
+ * No source authority is sent across this boundary. The request carries source identity, target
+ * Project/harness/model metadata and nothing that can silently grant target-side writer permission.
+ */
+export async function createCrossMachineTargetSession({
+  source,
+  targetMachineID,
+  targetConfig,
+  projectId,
+  targetAgentID,
+  title,
+  model
+}: {
+  source: NativeSessionSurfaceTarget
+  targetMachineID: string
+  targetConfig: ServerConfig
+  projectId: string
+  targetAgentID: string
+  title?: string
+  model?: ModelSelection | null
+}): Promise<{ status: CrossMachineTargetStatus; clientRequestId: string; result?: CrossMachineTargetResult }> {
+  const machineID = targetMachineID.trim()
+  const project = projectId.trim()
+  const agentID = targetAgentID.trim()
+  if (!machineID || machineID === source.machineID) throw new Error("Choose a different target machine for this handoff.")
+  if (!project) throw new Error("A verified target Project is required for cross-machine continuation.")
+  if (!agentID) throw new Error("Choose a target coding agent for this handoff.")
+  if (!source.directory) throw new Error("This Session has no project directory, so it cannot be handed off safely.")
+
+  const normalizedTitle = title?.trim() || undefined
+  const normalizedModel = normalizeModel(model)
+  const existing = loadPending(source)
+  if (existing && (
+    existing.targetMachineID !== machineID
+    || existing.projectId !== project
+    || existing.targetAgentID !== agentID
+    || (existing.title || "") !== (normalizedTitle || "")
+    || !sameModel(existing.model, normalizedModel)
+  )) {
+    throw new Error("A previous cross-machine target creation is unresolved. Retry that exact machine, Project, harness and model before choosing another destination.")
+  }
+
+  const pending = existing ?? {
+    clientRequestId: requestID(),
+    targetMachineID: machineID,
+    projectId: project,
+    targetAgentID: agentID,
+    title: normalizedTitle,
+    model: normalizedModel,
+    createdAt: Date.now()
+  }
+  if (!persistPending(source, pending)) {
+    throw new Error("Cannot persist cross-machine handoff recovery state. No target Session was created.")
+  }
+
+  const config = machineConfig(targetConfig)
+  const body = {
+    clientRequestId: pending.clientRequestId,
+    projectId: pending.projectId,
+    targetAgentID: pending.targetAgentID,
+    source: source.ref,
+    title: pending.title,
+    model: pending.model ? { providerID: pending.model.providerID, modelID: pending.model.modelID } : undefined,
+    variant: pending.model?.variant || undefined
+  }
+
+  let parsed: { status: CrossMachineTargetStatus; clientRequestId?: string; result?: CrossMachineTargetResult }
+  if (isDesktopPlatform()) {
+    const result = await desktopRequestResult(config, { path: TARGET_ROUTE, method: "POST", body })
+    if (!result.ok) {
+      const status = Number(result.error.status)
+      if (result.error.code === "http" && status >= 400 && status < 500) clearPending(source)
+      throw new Error(result.error.message)
+    }
+    parsed = responseData(result.response.data)
+  } else {
+    const headers: Record<string, string> = { Accept: "application/json", "Content-Type": "application/json" }
+    if (hasCredentials(config)) headers.Authorization = authHeader(config)
+    const url = `${machineBaseUrl(config)}${TARGET_ROUTE}`
+
+    if (Capacitor.isNativePlatform()) {
+      let response
+      try {
+        response = await CapacitorHttp.request({
+          url,
+          method: "POST",
+          headers,
+          data: body,
+          connectTimeout: 12_000,
+          readTimeout: 30_000
+        })
+      } catch {
+        throw new Error(`Cannot reach ${config.host}:${config.port}. Target creation status is unknown; retry will use the same request id.`)
+      }
+      if (response.status >= 400) {
+        if (response.status < 500) clearPending(source)
+        throw new Error(errorDetail(response.data, response.status))
+      }
+      parsed = responseData(response.data)
+    } else {
+      let response: Response
+      try {
+        response = await fetch(url, { method: "POST", headers, body: JSON.stringify(body) })
+      } catch {
+        throw new Error(`Cannot reach ${config.host}:${config.port}. Target creation status is unknown; retry will use the same request id.`)
+      }
+      let data: unknown
+      try {
+        const raw = await response.text()
+        data = raw ? JSON.parse(raw) : undefined
+      } catch {}
+      if (!response.ok) {
+        if (response.status < 500) clearPending(source)
+        throw new Error(errorDetail(data, response.status))
+      }
+      parsed = responseData(data)
+    }
+  }
+
+  if (parsed.clientRequestId && parsed.clientRequestId !== pending.clientRequestId) {
+    throw new Error("The target daemon returned a different handoff request id. Retry the original target instead of creating another Session.")
+  }
+  if (parsed.status === "accepted") {
+    if (!parsed.result?.target) {
+      throw new Error("The target daemon accepted creation without a recoverable native Session identity. Retry will use the same request id.")
+    }
+    if (parsed.result.target.machineID !== pending.targetMachineID || parsed.result.target.agentID !== pending.targetAgentID) {
+      throw new Error("The target daemon returned a Session for a different machine or harness. Retry the original target instead of creating another Session.")
+    }
+  }
+
+  return { status: parsed.status, clientRequestId: pending.clientRequestId, result: parsed.result }
+}
+
+/** Clear the creation key only after the caller durably records the exact accepted target identity. */
+export function acknowledgeCrossMachineTargetSession(source: NativeSessionSurfaceTarget) {
+  clearPending(source)
+}

--- a/web/src/native-session-handoff-recovery.test.mjs
+++ b/web/src/native-session-handoff-recovery.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict"
+import { acknowledgeCrossMachineTargetSession, createCrossMachineTargetSession } from "./cross-machine-target-client.ts"
 import { acknowledgeNativeSessionHandoff, handoffNativeSession } from "./native-session-handoff.ts"
 
 class MemoryStorage {
@@ -136,6 +137,123 @@ try {
   }
   await handoffNativeSession(source, "omp", "Source", model)
   assert.notEqual(retryBody.clientRequestId, "definite-rejection", "after a proven rejection a new resource-creation attempt may use a new id")
+} finally {
+  globalThis.fetch = originalFetch
+  if (originalStorage === undefined) delete globalThis.localStorage
+  else globalThis.localStorage = originalStorage
+}
+
+// Cross-machine target creation has the same exactly-once resource rule, but its recovery identity
+// additionally binds the destination machine + Project + harness. The target path is never supplied
+// by the client; the daemon resolves it from projectId.
+try {
+  const storage = new MemoryStorage()
+  globalThis.localStorage = storage
+  const crossStorageKey = "harness-remote.cross-machine-target.v1:machine-1:pi:source-1"
+  const targetConfig = {
+    backend: "codex",
+    agentId: "stale-agent-routing-must-not-own-machine-route",
+    host: "target.example",
+    port: 5099,
+    username: "",
+    password: ""
+  }
+  const input = {
+    source,
+    targetMachineID: "machine-2",
+    targetConfig,
+    projectId: "machine-2:repo",
+    targetAgentID: "codex",
+    title: "Source",
+    model: { providerID: "openai", modelID: "gpt-5.6", variant: "high" }
+  }
+
+  const bodies = []
+  const urls = []
+  globalThis.fetch = async (url, options) => {
+    urls.push(String(url))
+    const body = JSON.parse(options.body)
+    bodies.push(body)
+    return new Response(JSON.stringify({
+      status: "accepted",
+      clientRequestId: body.clientRequestId,
+      result: {
+        target: { machineID: "machine-2", agentID: "codex", sessionID: "target-cross-1", directory: "/target/repo" }
+      }
+    }), { status: 200, headers: { "Content-Type": "application/json" } })
+  }
+
+  const first = await createCrossMachineTargetSession(input)
+  assert.equal(first.status, "accepted")
+  assert.match(urls[0], /target\.example:5099\/v1\/session-handoff-target$/)
+  assert.deepEqual(bodies[0].source, source.ref)
+  assert.equal(bodies[0].projectId, "machine-2:repo")
+  assert.equal(bodies[0].targetAgentID, "codex")
+  assert.deepEqual(bodies[0].model, { providerID: "openai", modelID: "gpt-5.6" })
+  assert.equal(bodies[0].variant, "high")
+  assert.equal(Object.hasOwn(bodies[0], "directory"), false, "target directory must be resolved only by the target daemon Project catalog")
+  const durableRequestId = JSON.parse(storage.getItem(crossStorageKey)).clientRequestId
+  assert.equal(first.clientRequestId, durableRequestId)
+
+  await createCrossMachineTargetSession(input)
+  assert.equal(bodies[1].clientRequestId, durableRequestId, "accepted creation must still reuse the same id until the caller persists and acknowledges the target")
+  await assert.rejects(
+    () => createCrossMachineTargetSession({ ...input, targetAgentID: "claude" }),
+    /previous cross-machine target creation is unresolved/,
+    "one unresolved source creation must not be redirected to another target"
+  )
+  assert.equal(bodies.length, 2, "conflicting target selection must fail before network I/O")
+
+  acknowledgeCrossMachineTargetSession(source)
+  assert.equal(storage.getItem(crossStorageKey), null)
+
+  globalThis.fetch = async () => { throw new Error("lost target response") }
+  await assert.rejects(
+    () => createCrossMachineTargetSession(input),
+    /Target creation status is unknown/,
+  )
+  const ambiguousId = JSON.parse(storage.getItem(crossStorageKey)).clientRequestId
+
+  let recoveredBody
+  globalThis.fetch = async (_url, options) => {
+    recoveredBody = JSON.parse(options.body)
+    return new Response(JSON.stringify({
+      status: "accepted",
+      clientRequestId: recoveredBody.clientRequestId,
+      result: {
+        target: { machineID: "machine-2", agentID: "codex", sessionID: "target-cross-recovered", directory: "/target/repo" }
+      }
+    }), { status: 200, headers: { "Content-Type": "application/json" } })
+  }
+  const recovered = await createCrossMachineTargetSession(input)
+  assert.equal(recovered.clientRequestId, ambiguousId)
+  assert.equal(recoveredBody.clientRequestId, ambiguousId, "lost responses must reconcile the original target creation instead of replaying with a new id")
+
+  globalThis.fetch = async () => new Response(JSON.stringify({ error: "Unknown project: machine-2:repo" }), {
+    status: 404,
+    headers: { "Content-Type": "application/json" }
+  })
+  await assert.rejects(() => createCrossMachineTargetSession(input), /Unknown project/)
+  assert.equal(storage.getItem(crossStorageKey), null, "a definite target-side 4xx may release the creation key")
+
+  let attemptedWithoutRecoveryStorage = false
+  globalThis.localStorage = {
+    get length() { return 0 },
+    key() { return null },
+    getItem() { return null },
+    setItem() { throw new Error("storage full") },
+    removeItem() {},
+    clear() {}
+  }
+  globalThis.fetch = async () => {
+    attemptedWithoutRecoveryStorage = true
+    throw new Error("network should not be reached")
+  }
+  await assert.rejects(
+    () => createCrossMachineTargetSession(input),
+    /Cannot persist cross-machine handoff recovery state/
+  )
+  assert.equal(attemptedWithoutRecoveryStorage, false, "cross-machine resource creation must not start without durable recovery state")
 } finally {
   globalThis.fetch = originalFetch
   if (originalStorage === undefined) delete globalThis.localStorage


### PR DESCRIPTION
Adds the next P2 source-side transport/recovery primitive after #424, without enabling any cross-machine UI yet.

- persists the target-creation request id before network I/O and gives resource creation no blind TTL
- binds one unresolved creation to exact target machine + Project + harness + model/title semantics
- addresses the target daemon at the machine level, never through a stale per-agent route
- sends only source identity plus target Project/harness/model metadata; no source approvals, writer ownership, transcript or tool state can cross this boundary
- never sends a target filesystem path: the daemon continues to derive it from `projectId`
- retains the creation key after an accepted result until the caller durably stores and explicitly acknowledges the returned target identity
- retains the same id across lost responses/5xx and releases it only after a definite 4xx rejection
- fails before network I/O if recovery state cannot be persisted
- extends the existing handoff recovery suite with exact-id retry, conflicting-target, machine-route, no-directory, definite-rejection and storage-failure coverage

Target: `codex/development-2026-09-11` only. No merge to `main` and no UI enablement.

Refs #371