### PR TITLE
P2: add conservative cross-machine Project preflight

### DIFF
--- a/web/src/cross-machine-project-preflight.ts
+++ b/web/src/cross-machine-project-preflight.ts
@@ -1,0 +1,105 @@
+import {
+  assessProjectContinuity,
+  loadProjectIdentity,
+  type ProjectContinuityAssessment
+} from "./project-continuity"
+import type { ServerConfig } from "./types"
+
+export type CrossMachineProjectDecision = "automatic" | "review" | "blocked"
+export type CrossMachineProjectReason = "exact_workspace" | "workspace_diverged" | "project_unverified" | "project_mismatch"
+
+export type CrossMachineProjectPreflight = {
+  sourceMachineID: string
+  targetMachineID: string
+  sourceProjectId: string
+  targetProjectId: string
+  sourceIdentityVerified: boolean
+  targetIdentityVerified: boolean
+  decision: CrossMachineProjectDecision
+  reason: CrossMachineProjectReason
+  assessment: ProjectContinuityAssessment
+}
+
+function machineConfig(config: ServerConfig): ServerConfig {
+  return { ...config, agentId: undefined }
+}
+
+export function classifyCrossMachineProjectContinuity(
+  assessment: ProjectContinuityAssessment
+): Pick<CrossMachineProjectPreflight, "decision" | "reason"> {
+  if (assessment.project === "different") {
+    return { decision: "blocked", reason: "project_mismatch" }
+  }
+  if (assessment.exactWorkspace) {
+    return { decision: "automatic", reason: "exact_workspace" }
+  }
+  if (assessment.project === "unverified") {
+    return { decision: "review", reason: "project_unverified" }
+  }
+  return { decision: "review", reason: "workspace_diverged" }
+}
+
+/**
+ * Read-only cross-machine preflight. It deliberately runs before target Session creation and sends
+ * only machine-local Project ids to the corresponding daemons. Filesystem paths are never compared
+ * across machines and a name/branch coincidence can never promote an unverified Project to a match.
+ */
+export async function preflightCrossMachineProject({
+  sourceMachineID,
+  targetMachineID,
+  sourceConfig,
+  sourceProjectId,
+  targetConfig,
+  targetProjectId
+}: {
+  sourceMachineID: string
+  targetMachineID: string
+  sourceConfig: ServerConfig
+  sourceProjectId: string
+  targetConfig: ServerConfig
+  targetProjectId: string
+}): Promise<CrossMachineProjectPreflight> {
+  const sourceMachine = sourceMachineID.trim()
+  const targetMachine = targetMachineID.trim()
+  const sourceProject = sourceProjectId.trim()
+  const targetProject = targetProjectId.trim()
+
+  if (!sourceMachine || !targetMachine) throw new Error("Both source and target machine identities are required.")
+  if (sourceMachine === targetMachine) throw new Error("Cross-machine Project preflight requires two different machines.")
+  if (!sourceProject || !targetProject) throw new Error("Both source and target Project identities are required.")
+
+  const [sourceIdentity, targetIdentity] = await Promise.all([
+    loadProjectIdentity(machineConfig(sourceConfig), sourceProject),
+    loadProjectIdentity(machineConfig(targetConfig), targetProject)
+  ])
+  const assessment = assessProjectContinuity(sourceIdentity, targetIdentity)
+  const classification = classifyCrossMachineProjectContinuity(assessment)
+
+  return {
+    sourceMachineID: sourceMachine,
+    targetMachineID: targetMachine,
+    sourceProjectId: sourceProject,
+    targetProjectId: targetProject,
+    sourceIdentityVerified: sourceIdentity !== null,
+    targetIdentityVerified: targetIdentity !== null,
+    ...classification,
+    assessment
+  }
+}
+
+/**
+ * Mutation gate used by later orchestration. Exact clean workspace continuity may proceed directly;
+ * any incomplete or diverged-but-same Project evidence requires an explicit caller confirmation.
+ * A contradictory Project identity is never overridable here.
+ */
+export function requireCrossMachineProjectApproval(
+  preflight: CrossMachineProjectPreflight,
+  { confirmed = false }: { confirmed?: boolean } = {}
+): void {
+  if (preflight.decision === "blocked") {
+    throw new Error("The target Project does not match the source Project. Cross-machine continuation is blocked.")
+  }
+  if (preflight.decision === "review" && !confirmed) {
+    throw new Error("Cross-machine Project continuity needs confirmation before creating a target Session.")
+  }
+}

--- a/web/src/project-continuity.test.mjs
+++ b/web/src/project-continuity.test.mjs
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 import {
+  classifyCrossMachineProjectContinuity,
+  requireCrossMachineProjectApproval
+} from "./cross-machine-project-preflight.ts"
+import {
   assessProjectContinuity,
   parseGitProjectIdentity
 } from "./project-continuity.ts"
@@ -18,8 +22,22 @@ function identity(overrides = {}) {
   }
 }
 
+function preflight(assessment, classification = classifyCrossMachineProjectContinuity(assessment)) {
+  return {
+    sourceMachineID: "machine-a",
+    targetMachineID: "machine-b",
+    sourceProjectId: "machine-a:repo",
+    targetProjectId: "machine-b:repo",
+    sourceIdentityVerified: true,
+    targetIdentityVerified: true,
+    ...classification,
+    assessment
+  }
+}
+
 test("exact clean clones are the only seamless workspace match", () => {
-  assert.deepEqual(assessProjectContinuity(identity(), identity()), {
+  const assessment = assessProjectContinuity(identity(), identity())
+  assert.deepEqual(assessment, {
     project: "match",
     repository: "match",
     history: "match",
@@ -29,6 +47,11 @@ test("exact clean clones are the only seamless workspace match", () => {
     targetDirty: false,
     exactWorkspace: true
   })
+  assert.deepEqual(classifyCrossMachineProjectContinuity(assessment), {
+    decision: "automatic",
+    reason: "exact_workspace"
+  })
+  assert.doesNotThrow(() => requireCrossMachineProjectApproval(preflight(assessment)))
 })
 
 test("fork-like shared history does not prove Project identity", () => {
@@ -40,41 +63,69 @@ test("fork-like shared history does not prove Project identity", () => {
   assert.equal(result.repository, "unverified")
   assert.equal(result.project, "unverified")
   assert.equal(result.exactWorkspace, false)
+  assert.deepEqual(classifyCrossMachineProjectContinuity(result), {
+    decision: "review",
+    reason: "project_unverified"
+  })
+  assert.throws(() => requireCrossMachineProjectApproval(preflight(result)), /needs confirmation/)
+  assert.doesNotThrow(() => requireCrossMachineProjectApproval(preflight(result), { confirmed: true }))
 })
 
 test("repository or history contradictions fail closed as different", () => {
-  assert.equal(
-    assessProjectContinuity(identity(), identity({ repositoryFingerprint: "c".repeat(64) })).project,
-    "different"
-  )
-  assert.equal(
-    assessProjectContinuity(identity(), identity({ historyFingerprint: "d".repeat(64) })).project,
-    "different"
+  const repositoryMismatch = assessProjectContinuity(identity(), identity({ repositoryFingerprint: "c".repeat(64) }))
+  const historyMismatch = assessProjectContinuity(identity(), identity({ historyFingerprint: "d".repeat(64) }))
+  assert.equal(repositoryMismatch.project, "different")
+  assert.equal(historyMismatch.project, "different")
+  assert.deepEqual(classifyCrossMachineProjectContinuity(repositoryMismatch), {
+    decision: "blocked",
+    reason: "project_mismatch"
+  })
+  assert.throws(
+    () => requireCrossMachineProjectApproval(preflight(repositoryMismatch), { confirmed: true }),
+    /does not match/,
+    "explicit confirmation must never override contradictory Project identity"
   )
 })
 
-test("branch, HEAD and dirty differences are visible instead of being called seamless", () => {
+test("branch, HEAD and dirty differences require review instead of being called seamless", () => {
   const branch = assessProjectContinuity(identity(), identity({ branch: "feature" }))
   assert.equal(branch.project, "match")
   assert.equal(branch.branch, "different")
   assert.equal(branch.exactWorkspace, false)
+  assert.deepEqual(classifyCrossMachineProjectContinuity(branch), {
+    decision: "review",
+    reason: "workspace_diverged"
+  })
 
   const head = assessProjectContinuity(identity(), identity({ head: "cafebabe" }))
   assert.equal(head.head, "different")
   assert.equal(head.exactWorkspace, false)
+  assert.deepEqual(classifyCrossMachineProjectContinuity(head), {
+    decision: "review",
+    reason: "workspace_diverged"
+  })
 
   const dirty = assessProjectContinuity(identity(), identity({ dirty: true }))
   assert.equal(dirty.project, "match")
   assert.equal(dirty.targetDirty, true)
   assert.equal(dirty.exactWorkspace, false)
+  assert.deepEqual(classifyCrossMachineProjectContinuity(dirty), {
+    decision: "review",
+    reason: "workspace_diverged"
+  })
 })
 
-test("missing daemon evidence remains unverified", () => {
+test("missing daemon evidence remains unverified and cannot auto-create", () => {
   const result = assessProjectContinuity(null, identity())
   assert.equal(result.project, "unverified")
   assert.equal(result.repository, "unverified")
   assert.equal(result.history, "unverified")
   assert.equal(result.exactWorkspace, false)
+  assert.deepEqual(classifyCrossMachineProjectContinuity(result), {
+    decision: "review",
+    reason: "project_unverified"
+  })
+  assert.throws(() => requireCrossMachineProjectApproval(preflight(result)), /needs confirmation/)
 })
 
 test("identity parser accepts only bounded v1 Git evidence", () => {


### PR DESCRIPTION
Stacked on #426. Adds the read-only Project continuity gate that must run before any cross-machine target Session creation; still no UI enablement.

- loads source and target Project identities from their own machine daemons using Project ids, never cross-machine filesystem paths
- classifies exact clean repository+branch+HEAD matches as `automatic`
- classifies same/unverified Project with branch/HEAD/dirty or missing evidence as `review`, requiring explicit caller confirmation before mutation
- classifies contradictory repository/history identity as `blocked`; confirmation cannot override it
- strips per-agent routing when querying machine-level Project identity
- keeps this layer read-only: no Session creation, prompt, approvals, writer ownership, tool state or transcript state are transferred
- extends the existing Project continuity suite with automatic/review/blocked mutation-gate assertions

Base: `codex/p2-cross-machine-target-client` while #426 is under CI. After #426 lands it can be retargeted to `codex/development-2026-09-11`.

Refs #371