### PR TITLE
P2: orchestrate crash-safe cross-machine continuation

### DIFF
--- a/web/src/cross-machine-continuation.test.mjs
+++ b/web/src/cross-machine-continuation.test.mjs
@@ -1,0 +1,262 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { continueNativeSessionAcrossMachine } from "./cross-machine-continuation.ts"
+import { sendCrossMachineFirstPrompt } from "./cross-machine-first-prompt.ts"
+
+class MemoryStorage {
+  #values = new Map()
+  getItem(key) { return this.#values.has(key) ? this.#values.get(key) : null }
+  setItem(key, value) { this.#values.set(key, String(value)) }
+  removeItem(key) { this.#values.delete(key) }
+  clear() { this.#values.clear() }
+}
+
+globalThis.localStorage = new MemoryStorage()
+
+function sourceTarget() {
+  return {
+    key: "machine-a:codex:s1",
+    ref: { machineID: "machine-a", agentID: "codex", sessionID: "s1", directory: "/repo" },
+    machineID: "machine-a",
+    sessionID: "s1",
+    directory: "/repo",
+    title: "Source session",
+    agentID: "codex",
+    agentLabel: "Codex",
+    backend: "codex",
+    transport: "acp",
+    config: { backend: "codex", host: "source.local", port: 4317, username: "", password: "", agentId: "codex" },
+    external: false,
+    modelsSupported: true,
+    commandsSupported: true,
+    renameSupported: false,
+    deleteSupported: false,
+    model: null,
+    requiresExplicitClaim: false,
+    canStop: false
+  }
+}
+
+const targetAgent = {
+  id: "claude",
+  label: "Claude",
+  backend: "claude",
+  transport: "acp",
+  state: "available",
+  capabilities: { sessions: true, prompt: true, models: true, commands: true }
+}
+
+function targetMachine() {
+  return {
+    machineID: "machine-b",
+    label: "Machine B",
+    config: { backend: "opencode", host: "target.local", port: 4317, username: "", password: "" },
+    agents: [targetAgent]
+  }
+}
+
+function exactPreflight() {
+  return {
+    sourceMachineID: "machine-a",
+    targetMachineID: "machine-b",
+    sourceProjectId: "source-project",
+    targetProjectId: "target-project",
+    sourceIdentityVerified: true,
+    targetIdentityVerified: true,
+    decision: "automatic",
+    reason: "exact_workspace",
+    assessment: {
+      project: "match",
+      repository: "match",
+      history: "match",
+      branch: "match",
+      head: "match",
+      sourceDirty: false,
+      targetDirty: false,
+      exactWorkspace: true
+    }
+  }
+}
+
+function messages() {
+  return [
+    { info: { role: "user" }, parts: [{ type: "text", text: "Inspect the failing build" }] },
+    { info: { role: "assistant" }, parts: [{ type: "text", text: "The bridge test is the remaining failure." }] }
+  ]
+}
+
+function serviceHarness({ firstPrompt, preflight = exactPreflight() } = {}) {
+  const calls = {
+    create: 0,
+    acknowledge: 0,
+    links: [],
+    promptIds: [],
+    marked: 0,
+    preflight: 0
+  }
+  const services = {
+    async preflightProject() {
+      calls.preflight += 1
+      return preflight
+    },
+    requireProjectApproval(result, { confirmed = false } = {}) {
+      if (result.decision === "blocked") throw new Error("blocked project")
+      if (result.decision === "review" && !confirmed) throw new Error("needs confirmation")
+    },
+    async createTargetSession() {
+      calls.create += 1
+      return {
+        status: "accepted",
+        clientRequestId: "create-1",
+        result: {
+          target: { machineID: "machine-b", agentID: "claude", sessionID: "target-1", directory: "/repo-copy" }
+        }
+      }
+    },
+    acknowledgeTargetSession() { calls.acknowledge += 1 },
+    async loadSourceMessages() { return messages() },
+    async registerSessionLink(config, link) { calls.links.push({ host: config.host, link }) },
+    async sendFirstPrompt(input) {
+      calls.promptIds.push(input.clientRequestId)
+      if (firstPrompt) return firstPrompt(input, calls)
+      return { status: "accepted", clientRequestId: input.clientRequestId }
+    },
+    markHandoffContextSent() { calls.marked += 1 }
+  }
+  return { services, calls }
+}
+
+function continuationInput(services, overrides = {}) {
+  return {
+    source: sourceTarget(),
+    sourceProjectId: "source-project",
+    targetMachine: targetMachine(),
+    targetProjectId: "target-project",
+    targetAgent,
+    prompt: "Continue with the bridge fix",
+    attachments: [],
+    model: { providerID: "anthropic", modelID: "claude-sonnet-4-5", variant: "high" },
+    services,
+    ...overrides
+  }
+}
+
+test("lost first-prompt response retries the same target and prompt request id", async () => {
+  localStorage.clear()
+  let first = true
+  const { services, calls } = serviceHarness({
+    firstPrompt: async (input) => {
+      if (first) {
+        first = false
+        throw new Error("lost response after dispatch")
+      }
+      return { status: "accepted", clientRequestId: input.clientRequestId }
+    }
+  })
+
+  await assert.rejects(
+    continueNativeSessionAcrossMachine(continuationInput(services)),
+    /lost response after dispatch/
+  )
+  const result = await continueNativeSessionAcrossMachine(continuationInput(services))
+
+  assert.equal(calls.create, 1, "retry must reuse the already-created native target")
+  assert.equal(calls.promptIds.length, 2)
+  assert.equal(calls.promptIds[0], calls.promptIds[1], "ambiguous first-prompt retry must reuse the exact request id")
+  assert.equal(calls.preflight, 2, "Project continuity is rechecked before recovery mutations")
+  assert.equal(calls.links.length, 4, "the same lineage edge is retried on both machine-local stores")
+  assert.deepEqual(calls.links.map((entry) => entry.host), ["source.local", "target.local", "source.local", "target.local"])
+  assert.match(calls.links[0].link.transferredContext, /remaining failure/)
+  assert.equal(calls.marked, 1)
+  assert.equal(result.target.machineID, "machine-b")
+  assert.equal(result.target.sessionID, "target-1")
+  assert.equal(result.target.requiresExplicitClaim, false, "fresh target writer ownership must not require a synthetic source claim")
+  assert.equal(result.target.permission, undefined, "source authority metadata must not be copied")
+})
+
+test("review Project evidence blocks mutation until explicitly confirmed", async () => {
+  localStorage.clear()
+  const review = {
+    ...exactPreflight(),
+    decision: "review",
+    reason: "workspace_diverged",
+    assessment: { ...exactPreflight().assessment, head: "different", exactWorkspace: false }
+  }
+  const { services, calls } = serviceHarness({ preflight: review })
+
+  await assert.rejects(
+    continueNativeSessionAcrossMachine(continuationInput(services)),
+    /needs confirmation/
+  )
+  assert.equal(calls.create, 0)
+
+  const result = await continueNativeSessionAcrossMachine(continuationInput(services, { confirmedProjectContinuity: true }))
+  assert.equal(calls.create, 1)
+  assert.equal(result.preflight.decision, "review")
+})
+
+test("a conflicting retry cannot redirect an unresolved continuation", async () => {
+  localStorage.clear()
+  const { services, calls } = serviceHarness({
+    firstPrompt: async () => { throw new Error("network lost") }
+  })
+  await assert.rejects(continueNativeSessionAcrossMachine(continuationInput(services)), /network lost/)
+
+  await assert.rejects(
+    continueNativeSessionAcrossMachine(continuationInput(services, { prompt: "Do something else" })),
+    /already in progress/
+  )
+  assert.equal(calls.create, 1)
+  assert.equal(calls.promptIds.length, 1)
+})
+
+test("attachments are rejected before any cross-machine mutation", async () => {
+  localStorage.clear()
+  const { services, calls } = serviceHarness()
+  await assert.rejects(
+    continueNativeSessionAcrossMachine(continuationInput(services, {
+      attachments: [{ mime: "image/png", filename: "x.png", url: "data:image/png;base64,x" }]
+    })),
+    /does not transfer images yet/
+  )
+  assert.equal(calls.preflight, 0)
+  assert.equal(calls.create, 0)
+})
+
+test("first-prompt transport preserves the caller-owned id and bounded context packet", async () => {
+  const previousFetch = globalThis.fetch
+  let captured
+  globalThis.fetch = async (url, init) => {
+    captured = { url, init, body: JSON.parse(init.body) }
+    return new Response(JSON.stringify({ status: "accepted" }), { status: 200, headers: { "Content-Type": "application/json" } })
+  }
+  try {
+    const target = {
+      ...sourceTarget(),
+      key: "machine-b:claude:target-1",
+      ref: { machineID: "machine-b", agentID: "claude", sessionID: "target-1", directory: "/repo-copy" },
+      machineID: "machine-b",
+      sessionID: "target-1",
+      directory: "/repo-copy",
+      agentID: "claude",
+      agentLabel: "Claude",
+      backend: "claude",
+      config: { backend: "claude", host: "target.local", port: 4317, username: "", password: "", agentId: "claude" }
+    }
+    const result = await sendCrossMachineFirstPrompt({
+      target,
+      clientRequestId: "prompt-fixed-id",
+      text: "Proceed",
+      model: { providerID: "anthropic", modelID: "claude-sonnet-4-5" },
+      transferredContext: "Source evidence"
+    })
+
+    assert.equal(result.clientRequestId, "prompt-fixed-id")
+    assert.equal(captured.body.clientRequestId, "prompt-fixed-id")
+    assert.equal(captured.body.attachments.length, 0)
+    assert.match(captured.body.text, /TRANSFERRED TASK CONTEXT\nSource evidence/)
+    assert.match(captured.body.text, /USER INSTRUCTION\nProceed/)
+  } finally {
+    globalThis.fetch = previousFetch
+  }
+})

--- a/web/src/cross-machine-continuation.ts
+++ b/web/src/cross-machine-continuation.ts
@@ -1,0 +1,396 @@
+import { api, type NativeSessionLinkRecord } from "./api"
+import type { AttachmentPart } from "./attachments"
+import {
+  markCrossMachineHandoffContextSent,
+  sendCrossMachineFirstPrompt
+} from "./cross-machine-first-prompt"
+import {
+  preflightCrossMachineProject,
+  requireCrossMachineProjectApproval,
+  type CrossMachineProjectPreflight
+} from "./cross-machine-project-preflight"
+import {
+  acknowledgeCrossMachineTargetSession,
+  createCrossMachineTargetSession
+} from "./cross-machine-target-client"
+import { canCreateNativeSession } from "./native-session-create"
+import {
+  nativeSessionSurfaceTarget,
+  type NativeSessionHistoryEntry,
+  type NativeSessionRecord,
+  type NativeSessionRef,
+  type NativeSessionSurfaceTarget
+} from "./native-session-discovery"
+import { normalizeModel, sameModel } from "./native-session-model"
+import { nativeSessionTransferredContext } from "./native-session-prompt"
+import type { NativeSessionRouteMachine } from "./native-session-routing"
+import type { BackendKind, MachineAgentHost, MessageEnvelope, ModelSelection, ServerConfig } from "./types"
+
+export type CrossMachineContinuationResult = {
+  target: NativeSessionSurfaceTarget
+  preflight: CrossMachineProjectPreflight
+}
+
+type PendingCrossMachineContinuation = {
+  targetMachineID: string
+  sourceProjectId: string
+  targetProjectId: string
+  targetAgentID: string
+  target: NativeSessionRef
+  title: string
+  prompt: string
+  model?: ModelSelection | null
+  promptRequestId: string
+  createdAt: number
+  transferredContext?: string
+}
+
+export type CrossMachineContinuationServices = {
+  preflightProject: typeof preflightCrossMachineProject
+  requireProjectApproval: typeof requireCrossMachineProjectApproval
+  createTargetSession: typeof createCrossMachineTargetSession
+  acknowledgeTargetSession: typeof acknowledgeCrossMachineTargetSession
+  loadSourceMessages: (source: NativeSessionSurfaceTarget) => Promise<MessageEnvelope[]>
+  registerSessionLink: (config: ServerConfig, link: NativeSessionLinkRecord) => Promise<void>
+  sendFirstPrompt: typeof sendCrossMachineFirstPrompt
+  markHandoffContextSent: typeof markCrossMachineHandoffContextSent
+}
+
+const STORAGE_PREFIX = "harness-remote.cross-machine-continuation.v1"
+
+const defaultServices: CrossMachineContinuationServices = {
+  preflightProject: preflightCrossMachineProject,
+  requireProjectApproval: requireCrossMachineProjectApproval,
+  createTargetSession: createCrossMachineTargetSession,
+  acknowledgeTargetSession: acknowledgeCrossMachineTargetSession,
+  async loadSourceMessages(source) {
+    const page = await api.loadMessagePage(source.config, source.sessionID, source.directory, undefined, 100, false)
+    return page.messages
+  },
+  async registerSessionLink(config, link) {
+    await api.registerNativeSessionLink(config, link)
+  },
+  sendFirstPrompt: sendCrossMachineFirstPrompt,
+  markHandoffContextSent: markCrossMachineHandoffContextSent
+}
+
+function storageKey(source: NativeSessionSurfaceTarget): string {
+  return `${STORAGE_PREFIX}:${encodeURIComponent(source.machineID)}:${encodeURIComponent(source.agentID)}:${encodeURIComponent(source.sessionID)}`
+}
+
+function requestID(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") return crypto.randomUUID()
+  return `cross-machine-prompt-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+}
+
+function validRef(value: unknown): value is NativeSessionRef {
+  if (!value || typeof value !== "object") return false
+  const ref = value as Partial<NativeSessionRef>
+  return [ref.machineID, ref.agentID, ref.sessionID, ref.directory].every((entry) => typeof entry === "string" && entry.length > 0)
+}
+
+function loadPending(source: NativeSessionSurfaceTarget): PendingCrossMachineContinuation | null {
+  try {
+    const raw = localStorage.getItem(storageKey(source))
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<PendingCrossMachineContinuation>
+    if (!validRef(parsed.target)) return null
+    if (typeof parsed.targetMachineID !== "string" || !parsed.targetMachineID) return null
+    if (typeof parsed.sourceProjectId !== "string" || !parsed.sourceProjectId) return null
+    if (typeof parsed.targetProjectId !== "string" || !parsed.targetProjectId) return null
+    if (typeof parsed.targetAgentID !== "string" || !parsed.targetAgentID) return null
+    if (typeof parsed.title !== "string") return null
+    if (typeof parsed.prompt !== "string" || !parsed.prompt.trim()) return null
+    if (typeof parsed.promptRequestId !== "string" || !parsed.promptRequestId) return null
+    return {
+      targetMachineID: parsed.targetMachineID,
+      sourceProjectId: parsed.sourceProjectId,
+      targetProjectId: parsed.targetProjectId,
+      targetAgentID: parsed.targetAgentID,
+      target: parsed.target,
+      title: parsed.title,
+      prompt: parsed.prompt,
+      model: normalizeModel(parsed.model),
+      promptRequestId: parsed.promptRequestId,
+      createdAt: typeof parsed.createdAt === "number" ? parsed.createdAt : Date.now(),
+      ...(typeof parsed.transferredContext === "string" ? { transferredContext: parsed.transferredContext } : {})
+    }
+  } catch {
+    return null
+  }
+}
+
+function persistPending(source: NativeSessionSurfaceTarget, pending: PendingCrossMachineContinuation): boolean {
+  try {
+    localStorage.setItem(storageKey(source), JSON.stringify(pending))
+    return true
+  } catch {
+    return false
+  }
+}
+
+function clearPending(source: NativeSessionSurfaceTarget) {
+  try { localStorage.removeItem(storageKey(source)) } catch {}
+}
+
+function machineConfig(config: ServerConfig): ServerConfig {
+  return { ...config, agentId: undefined }
+}
+
+function supportedBackend(value: string | undefined, fallback: BackendKind): BackendKind {
+  return value === "opencode" || value === "omp" || value === "pi" || value === "claude" || value === "codex"
+    ? value
+    : fallback
+}
+
+function historyEntry(source: NativeSessionSurfaceTarget, messages: MessageEnvelope[]): NativeSessionHistoryEntry {
+  return {
+    ref: source.ref,
+    title: source.title,
+    agentID: source.agentID,
+    agentLabel: source.agentLabel,
+    backend: source.backend,
+    messages
+  }
+}
+
+function targetRecord(
+  pending: PendingCrossMachineContinuation,
+  targetMachine: NativeSessionRouteMachine,
+  targetAgent: MachineAgentHost
+): NativeSessionRecord {
+  const now = Date.now()
+  return {
+    key: `${targetAgent.id}:${pending.target.sessionID}`,
+    agentId: targetAgent.id,
+    agentLabel: targetAgent.label || targetAgent.id,
+    backend: supportedBackend(targetAgent.backend, targetMachine.config.backend),
+    transport: targetAgent.transport,
+    stopCapability: targetAgent.contract?.sessions?.stop,
+    abortSupported: targetAgent.capabilities?.abort === true,
+    modelsSupported: targetAgent.capabilities?.models === true,
+    commandsSupported: targetAgent.capabilities?.commands === true,
+    renameSupported: targetAgent.capabilities?.sessionRename === true,
+    deleteSupported: targetAgent.capabilities?.sessionDelete === true,
+    writerOwned: true,
+    session: {
+      id: pending.target.sessionID,
+      title: pending.title,
+      directory: pending.target.directory,
+      time: { created: now, updated: now },
+      external: false,
+      ...(pending.model ? {
+        model: {
+          providerID: pending.model.providerID,
+          id: pending.model.modelID,
+          ...(pending.model.variant ? { variant: pending.model.variant } : {})
+        }
+      } : {})
+    }
+  }
+}
+
+function targetSurface(
+  source: NativeSessionSurfaceTarget,
+  pending: PendingCrossMachineContinuation,
+  targetMachine: NativeSessionRouteMachine,
+  targetAgent: MachineAgentHost,
+  sourceMessages?: MessageEnvelope[]
+): NativeSessionSurfaceTarget {
+  const base = nativeSessionSurfaceTarget(targetMachine.machineID, targetMachine.config, targetRecord(pending, targetMachine, targetAgent))
+  const history = [
+    ...(source.history || []),
+    ...(sourceMessages ? [historyEntry(source, sourceMessages)] : [])
+  ]
+  return {
+    ...base,
+    model: pending.model ?? null,
+    ...(history.length ? { history } : {}),
+    handoffContextPending: true,
+    requiresExplicitClaim: false
+  }
+}
+
+function assertSamePendingRoute(
+  pending: PendingCrossMachineContinuation,
+  {
+    sourceProjectId,
+    targetProjectId,
+    targetMachineID,
+    targetAgentID,
+    prompt,
+    model
+  }: {
+    sourceProjectId: string
+    targetProjectId: string
+    targetMachineID: string
+    targetAgentID: string
+    prompt: string
+    model: ModelSelection | null
+  }
+) {
+  if (
+    pending.sourceProjectId !== sourceProjectId
+    || pending.targetProjectId !== targetProjectId
+    || pending.targetMachineID !== targetMachineID
+    || pending.targetAgentID !== targetAgentID
+    || pending.prompt !== prompt
+    || !sameModel(pending.model, model)
+  ) {
+    throw new Error("A cross-machine continuation is already in progress. Retry the same target machine, Project, harness, prompt and model until it is reconciled.")
+  }
+}
+
+/**
+ * Crash-safe orchestration for one explicit cross-machine continuation.
+ *
+ * Safety/order invariants:
+ * 1. Project continuity is checked before every mutation/recovery attempt.
+ * 2. Target creation remains exactly-once through cross-machine-target-client.
+ * 3. The exact target + first-prompt request id are persisted before creation is acknowledged.
+ * 4. A bounded context snapshot is persisted before lineage or prompt delivery.
+ * 5. The same lineage edge is durably stored on both source and target daemons before the prompt.
+ * 6. The first prompt uses its own durable id with no client TTL, so a lost accepted response cannot
+ *    become a duplicate turn on retry.
+ * 7. No source permission/approval/tool ownership state is copied into the target Session.
+ */
+export async function continueNativeSessionAcrossMachine({
+  source,
+  sourceProjectId,
+  targetMachine,
+  targetProjectId,
+  targetAgent,
+  prompt,
+  attachments,
+  model,
+  confirmedProjectContinuity = false,
+  services = defaultServices
+}: {
+  source: NativeSessionSurfaceTarget
+  sourceProjectId: string
+  targetMachine: NativeSessionRouteMachine
+  targetProjectId: string
+  targetAgent: MachineAgentHost
+  prompt: string
+  attachments: AttachmentPart[]
+  model: ModelSelection | null
+  confirmedProjectContinuity?: boolean
+  services?: CrossMachineContinuationServices
+}): Promise<CrossMachineContinuationResult> {
+  const sourceProject = sourceProjectId.trim()
+  const targetProject = targetProjectId.trim()
+  const normalizedPrompt = prompt.trim()
+  const normalizedModel = normalizeModel(model)
+
+  if (targetMachine.machineID === source.machineID) throw new Error("Choose a different machine for cross-machine continuation.")
+  if (!sourceProject || !targetProject) throw new Error("Source and target Project identities are required for cross-machine continuation.")
+  if (!normalizedPrompt) throw new Error("A text prompt is required")
+  if (attachments.length) throw new Error("Cross-machine continuation does not transfer images yet. Remove attachments before continuing.")
+  if (!targetMachine.agents.some((candidate) => candidate.id === targetAgent.id)) {
+    throw new Error("The selected harness does not belong to the target machine.")
+  }
+  if (!canCreateNativeSession(targetAgent)) {
+    throw new Error("The selected target harness cannot create a native Session right now.")
+  }
+
+  const preflight = await services.preflightProject({
+    sourceMachineID: source.machineID,
+    targetMachineID: targetMachine.machineID,
+    sourceConfig: source.config,
+    sourceProjectId: sourceProject,
+    targetConfig: targetMachine.config,
+    targetProjectId: targetProject
+  })
+  services.requireProjectApproval(preflight, { confirmed: confirmedProjectContinuity })
+
+  let pending = loadPending(source)
+  if (pending) {
+    assertSamePendingRoute(pending, {
+      sourceProjectId: sourceProject,
+      targetProjectId: targetProject,
+      targetMachineID: targetMachine.machineID,
+      targetAgentID: targetAgent.id,
+      prompt: normalizedPrompt,
+      model: normalizedModel
+    })
+  } else {
+    const created = await services.createTargetSession({
+      source,
+      targetMachineID: targetMachine.machineID,
+      targetConfig: targetMachine.config,
+      projectId: targetProject,
+      targetAgentID: targetAgent.id,
+      title: source.title,
+      model: normalizedModel
+    })
+    if (created.status !== "accepted" || !created.result?.target) {
+      throw new Error("Target Session creation is not confirmed yet. Retry the same destination to reconcile it.")
+    }
+    pending = {
+      targetMachineID: targetMachine.machineID,
+      sourceProjectId: sourceProject,
+      targetProjectId: targetProject,
+      targetAgentID: targetAgent.id,
+      target: created.result.target,
+      title: source.title,
+      prompt: normalizedPrompt,
+      model: normalizedModel,
+      promptRequestId: requestID(),
+      createdAt: Date.now()
+    }
+    if (!persistPending(source, pending)) {
+      throw new Error("The target Session exists, but cross-machine recovery state could not be persisted. Retry the same destination to recover that exact Session.")
+    }
+  }
+
+  // Once the exact target is in our own durable route record, the target-creation ledger key is no
+  // longer the only recovery handle. A crash before this acknowledgement is harmless: retrying the
+  // route calls the same acknowledgement again.
+  services.acknowledgeTargetSession(source)
+
+  let sourceMessages: MessageEnvelope[] | undefined
+  if (pending.transferredContext === undefined) {
+    sourceMessages = await services.loadSourceMessages(source)
+    const provisional = targetSurface(source, pending, targetMachine, targetAgent, sourceMessages)
+    const transferredContext = nativeSessionTransferredContext(provisional)
+    const enriched = { ...pending, transferredContext }
+    if (!persistPending(source, enriched)) {
+      throw new Error("The target Session exists, but its bounded handoff context could not be persisted. Retry the same destination before sending the first prompt.")
+    }
+    pending = enriched
+  } else {
+    // Once the bounded snapshot is durable, source transcript availability is presentation-only.
+    // Recovery may proceed while the source daemon is temporarily unavailable.
+    try { sourceMessages = await services.loadSourceMessages(source) } catch {}
+  }
+
+  const routedTarget = targetSurface(source, pending, targetMachine, targetAgent, sourceMessages)
+  const link: NativeSessionLinkRecord = {
+    type: "handoff",
+    source: source.ref,
+    target: pending.target,
+    createdAt: new Date(pending.createdAt).toISOString(),
+    ...(pending.transferredContext ? { transferredContext: pending.transferredContext } : {})
+  }
+
+  // Replicate the same metadata edge to both machine-local stores. addHandoff is idempotent, so a
+  // crash after either write simply retries the identical edge. Prompt delivery never starts until
+  // both sides can explain the lineage after restart.
+  await services.registerSessionLink(machineConfig(source.config), link)
+  await services.registerSessionLink(machineConfig(targetMachine.config), link)
+
+  const sent = await services.sendFirstPrompt({
+    target: routedTarget,
+    clientRequestId: pending.promptRequestId,
+    text: pending.prompt,
+    model: pending.model,
+    transferredContext: pending.transferredContext || ""
+  })
+  if (sent.status !== "accepted") {
+    throw new Error("The target Session and lineage exist, but first-prompt delivery is not confirmed. Retry the same continuation to reconcile it.")
+  }
+
+  services.markHandoffContextSent(routedTarget)
+  clearPending(source)
+  return { target: routedTarget, preflight }
+}

--- a/web/src/cross-machine-first-prompt.ts
+++ b/web/src/cross-machine-first-prompt.ts
@@ -1,0 +1,143 @@
+import { Capacitor, CapacitorHttp } from "@capacitor/core"
+import { desktopRequestResult, isDesktopPlatform } from "./desktopBridge"
+import type { NativeSessionSurfaceTarget } from "./native-session-discovery"
+import { authHeader, baseUrl, hasCredentials, routingHeaders } from "./serverConfig"
+import type { ModelSelection } from "./types"
+
+export type CrossMachineFirstPromptStatus = "accepted" | "pending" | "uncertain"
+
+const HANDOFF_SENT_PREFIX = "harness-remote.native-session-handoff-context.v1"
+
+function handoffSentKey(target: NativeSessionSurfaceTarget): string {
+  return `${HANDOFF_SENT_PREFIX}:${encodeURIComponent(target.machineID)}:${encodeURIComponent(target.agentID)}:${encodeURIComponent(target.sessionID)}`
+}
+
+function parseStatus(data: unknown): CrossMachineFirstPromptStatus {
+  if (data && typeof data === "object") {
+    const value = (data as { status?: unknown }).status
+    if (value === "accepted" || value === "pending" || value === "uncertain") return value
+  }
+  return "accepted"
+}
+
+function errorDetail(body: unknown, status: number): string {
+  if (typeof body === "string") {
+    try { return errorDetail(JSON.parse(body), status) }
+    catch { return body || `HTTP ${status}` }
+  }
+  if (body && typeof body === "object" && typeof (body as { error?: unknown }).error === "string") {
+    return (body as { error: string }).error
+  }
+  return `HTTP ${status}`
+}
+
+function wirePrompt(visibleText: string, transferredContext: string): string {
+  if (!transferredContext) return visibleText
+  return [
+    "You are taking over an existing TaskDesk task.",
+    "",
+    "TRANSFERRED TASK CONTEXT",
+    transferredContext,
+    "",
+    "USER INSTRUCTION",
+    visibleText,
+    "",
+    "Continue from the shared workspace and the transferred Task Context."
+  ].join("\n")
+}
+
+/**
+ * Send the first prompt of a cross-machine handoff with a caller-owned durable request id.
+ *
+ * Unlike an ordinary Session prompt, this function deliberately owns no local retry TTL and never
+ * clears the request identity: the cross-machine orchestrator persists that id together with the
+ * exact target Session before network I/O. A retry after a lost response therefore reaches the
+ * target daemon with the same id and converges on its mutation ledger instead of creating a second
+ * turn. Authority/approval state is not part of this request.
+ */
+export async function sendCrossMachineFirstPrompt({
+  target,
+  clientRequestId,
+  text,
+  model,
+  transferredContext
+}: {
+  target: NativeSessionSurfaceTarget
+  clientRequestId: string
+  text: string
+  model?: ModelSelection | null
+  transferredContext: string
+}): Promise<{ status: CrossMachineFirstPromptStatus; clientRequestId: string }> {
+  const requestId = clientRequestId.trim()
+  const normalized = text.trim()
+  if (!requestId) throw new Error("A durable cross-machine prompt request id is required.")
+  if (!normalized) throw new Error("A text prompt is required")
+
+  const path = `/session/${encodeURIComponent(target.sessionID)}/prompt`
+  const body = {
+    clientRequestId: requestId,
+    text: wirePrompt(normalized, transferredContext),
+    directory: target.directory,
+    model: model ? { providerID: model.providerID, modelID: model.modelID } : undefined,
+    variant: model?.variant || undefined,
+    attachments: []
+  }
+
+  let status: CrossMachineFirstPromptStatus
+  if (isDesktopPlatform()) {
+    const result = await desktopRequestResult(target.config, { path, method: "POST", body })
+    if (!result.ok) throw new Error(result.error.message)
+    status = parseStatus(result.response.data)
+  } else {
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      ...routingHeaders(target.config, { preflight: !Capacitor.isNativePlatform() })
+    }
+    if (hasCredentials(target.config)) headers.Authorization = authHeader(target.config)
+    const url = `${baseUrl(target.config)}${path}`
+
+    if (Capacitor.isNativePlatform()) {
+      let response
+      try {
+        response = await CapacitorHttp.request({
+          url,
+          method: "POST",
+          headers,
+          data: body,
+          connectTimeout: 12_000,
+          readTimeout: 30_000
+        })
+      } catch {
+        throw new Error(`Cannot reach ${target.config.host}:${target.config.port}. First prompt delivery status is unknown; retry will use the same request id.`)
+      }
+      if (response.status >= 400) throw new Error(errorDetail(response.data, response.status))
+      status = parseStatus(response.data)
+    } else {
+      let response: Response
+      try {
+        response = await fetch(url, { method: "POST", headers, body: JSON.stringify(body) })
+      } catch {
+        throw new Error(`Cannot reach ${target.config.host}:${target.config.port}. First prompt delivery status is unknown; retry will use the same request id.`)
+      }
+      let data: unknown
+      try {
+        const raw = await response.text()
+        data = raw ? JSON.parse(raw) : undefined
+      } catch {}
+      if (!response.ok) throw new Error(errorDetail(data, response.status))
+      status = parseStatus(data)
+    }
+  }
+
+  return { status, clientRequestId: requestId }
+}
+
+/**
+ * Keep ordinary native-session-prompt from replaying transferred context on the next prompt after
+ * this specialized first-prompt path succeeds. This key intentionally matches that module's v1
+ * handoff-context marker; it is presentation/context state, not writer authority.
+ */
+export function markCrossMachineHandoffContextSent(target: NativeSessionSurfaceTarget) {
+  try { localStorage.setItem(handoffSentKey(target), "1") } catch {}
+}

--- a/web/src/native-session-continuation.test.mjs
+++ b/web/src/native-session-continuation.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import { probeNativeSessionContinuation } from './native-session-continuation.ts'
+import './cross-machine-continuation.test.mjs'
 
 function target(overrides = {}) {
   return {


### PR DESCRIPTION
Adds the first headless end-to-end cross-machine continuation slice on top of the P2 primitives already integrated into `codex/development-2026-09-11`. No UI enablement and no changes to `main`.

- re-runs conservative Project preflight before mutation/recovery
- creates the target native Session exactly once through the existing durable target client
- persists the exact target identity plus an independent durable first-prompt request id before acknowledging creation
- snapshots bounded transferred context before lineage/prompt mutation
- replicates the same handoff edge to source and target machine-local lineage stores before first-prompt delivery
- sends the first target prompt with a caller-owned request id and no client TTL, so a lost accepted response retries the same daemon ledger entry instead of creating a duplicate turn
- explicitly rejects attachment transfer for now
- carries no source permission, approval, tool ownership or writer-authority metadata across the boundary
- marks transferred context as delivered after acceptance so later ordinary prompts do not replay it
- adds recovery tests for lost first-prompt responses, Project review gating, conflicting retries, attachments and the first-prompt wire contract

Target: `codex/development-2026-09-11` only. Never merge to `main`.

Refs #371