### PR TITLE
P2: resolve machine-local Projects for cross-machine routes

### DIFF
--- a/web/src/cross-machine-route-projects.test.mjs
+++ b/web/src/cross-machine-route-projects.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import {
+  requireTargetRouteProject,
+  resolveSourceSessionProject,
+  targetRouteProjects
+} from "./cross-machine-route-projects.ts"
+
+function project(id, machineId, name, path, overrides = {}) {
+  return { id, machineId, name, path, kind: "git", configured: true, ...overrides }
+}
+
+test("source Project resolution stays machine-local and picks the deepest containing root", () => {
+  const projects = [
+    project("wrong-machine", "machine-b", "Wrong", "/work/repo"),
+    project("parent", "machine-a", "Parent", "/work"),
+    project("repo", "machine-a", "Repo", "/work/repo")
+  ]
+  const resolved = resolveSourceSessionProject({ machineID: "machine-a", directory: "/work/repo/packages/web" }, projects)
+  assert.equal(resolved?.id, "repo")
+  assert.equal(resolved?.machineID, "machine-a")
+  assert.equal("path" in resolved, false, "route metadata must not expose filesystem paths")
+})
+
+test("Windows source paths use drive-local case-insensitive containment", () => {
+  const resolved = resolveSourceSessionProject(
+    { machineID: "machine-a", directory: "C:\\Work\\Repo\\packages\\web\\" },
+    [project("repo", "machine-a", "Repo", "c:/work/repo")]
+  )
+  assert.equal(resolved?.id, "repo")
+})
+
+test("POSIX source paths remain case-sensitive and boundary-aware", () => {
+  const projects = [project("repo", "machine-a", "Repo", "/work/repo")]
+  assert.equal(resolveSourceSessionProject({ machineID: "machine-a", directory: "/Work/Repo" }, projects), null)
+  assert.equal(resolveSourceSessionProject({ machineID: "machine-a", directory: "/work/repository" }, projects), null)
+})
+
+test("target catalog exposes only identities owned by the selected target machine", () => {
+  const routed = targetRouteProjects("machine-b", [
+    project("z", "machine-b", "Zulu", "/secret/z"),
+    project("a", "machine-a", "Alpha source", "/secret/a"),
+    project("b", "machine-b", "Beta", "/secret/b")
+  ])
+  assert.deepEqual(routed.map((entry) => entry.id), ["b", "z"])
+  assert.ok(routed.every((entry) => entry.machineID === "machine-b"))
+  assert.ok(routed.every((entry) => !("path" in entry)), "cross-machine route choices must not carry target paths")
+})
+
+test("target Project validation fails closed if the catalog changed", () => {
+  const projects = targetRouteProjects("machine-b", [project("repo", "machine-b", "Repo", "/repo")])
+  assert.equal(requireTargetRouteProject("machine-b", "repo", projects).id, "repo")
+  assert.throws(
+    () => requireTargetRouteProject("machine-b", "missing", projects),
+    /no longer available/
+  )
+  assert.throws(
+    () => requireTargetRouteProject("machine-a", "repo", projects),
+    /no longer available/
+  )
+})

--- a/web/src/cross-machine-route-projects.ts
+++ b/web/src/cross-machine-route-projects.ts
@@ -1,0 +1,118 @@
+import { listMachineProjects, type MachineProject } from "./machineClient"
+import type { NativeSessionSurfaceTarget } from "./native-session-discovery"
+import type { NativeSessionRouteMachine } from "./native-session-routing"
+import type { ServerConfig } from "./types"
+
+export type CrossMachineRouteProject = {
+  id: string
+  machineID: string
+  name: string
+  kind: string
+  configured: boolean
+}
+
+export type CrossMachineProjectRoute = {
+  sourceProject: CrossMachineRouteProject
+  targetProjects: CrossMachineRouteProject[]
+}
+
+function machineConfig(config: ServerConfig): ServerConfig {
+  return { ...config, agentId: undefined }
+}
+
+function normalizedPath(value: string): { value: string; caseInsensitive: boolean } {
+  let normalized = value.trim().replace(/\\/g, "/").replace(/\/+$/, "")
+  if (!normalized) normalized = "/"
+  const caseInsensitive = /^[A-Za-z]:\//.test(normalized)
+  if (caseInsensitive) normalized = normalized.toLowerCase()
+  return { value: normalized, caseInsensitive }
+}
+
+function pathContains(projectPath: string, sessionDirectory: string): boolean {
+  if (!projectPath || !sessionDirectory) return false
+  const project = normalizedPath(projectPath)
+  const session = normalizedPath(sessionDirectory)
+  let root = project.value
+  let candidate = session.value
+  if (project.caseInsensitive || session.caseInsensitive) {
+    root = root.toLowerCase()
+    candidate = candidate.toLowerCase()
+  }
+  return candidate === root || candidate.startsWith(root === "/" ? "/" : `${root}/`)
+}
+
+function routeProject(project: MachineProject): CrossMachineRouteProject {
+  return {
+    id: project.id,
+    machineID: project.machineId,
+    name: project.name,
+    kind: project.kind,
+    configured: project.configured === true
+  }
+}
+
+/**
+ * Resolve the source Project only inside the source machine's own catalog. A native Session may run
+ * below a Project root, so the most-specific containing catalog entry wins. Windows drive paths are
+ * compared case-insensitively; POSIX paths keep their native case semantics.
+ *
+ * This helper must never be used to compare source and target filesystem paths. Cross-machine
+ * equivalence is established later by the privacy-preserving Git identity preflight.
+ */
+export function resolveSourceSessionProject(
+  source: Pick<NativeSessionSurfaceTarget, "machineID" | "directory">,
+  projects: MachineProject[]
+): CrossMachineRouteProject | null {
+  const candidates = projects
+    .filter((project) => project.machineId === source.machineID && pathContains(project.path, source.directory))
+    .sort((left, right) => normalizedPath(right.path).value.length - normalizedPath(left.path).value.length)
+  return candidates[0] ? routeProject(candidates[0]) : null
+}
+
+/** Return only Project identities owned by the selected target daemon; never expose their paths. */
+export function targetRouteProjects(machineID: string, projects: MachineProject[]): CrossMachineRouteProject[] {
+  return projects
+    .filter((project) => project.machineId === machineID)
+    .map(routeProject)
+    .sort((left, right) => left.name.localeCompare(right.name) || left.id.localeCompare(right.id))
+}
+
+export function requireTargetRouteProject(
+  machineID: string,
+  projectID: string,
+  projects: CrossMachineRouteProject[]
+): CrossMachineRouteProject {
+  const project = projects.find((candidate) => candidate.machineID === machineID && candidate.id === projectID)
+  if (!project) throw new Error("The selected Project is no longer available on the target machine.")
+  return project
+}
+
+/**
+ * Load exactly one Project catalog per endpoint. machineClient owns the short stale-grace cache, so
+ * opening a route picker does not create a per-Session or per-harness N+1 read pattern.
+ */
+export async function loadCrossMachineProjectRoute({
+  source,
+  targetMachine
+}: {
+  source: NativeSessionSurfaceTarget
+  targetMachine: NativeSessionRouteMachine
+}): Promise<CrossMachineProjectRoute> {
+  if (targetMachine.machineID === source.machineID) {
+    throw new Error("Cross-machine Project routing requires a different target machine.")
+  }
+
+  const [sourceCatalog, targetCatalog] = await Promise.all([
+    listMachineProjects(machineConfig(source.config)),
+    listMachineProjects(machineConfig(targetMachine.config))
+  ])
+  const sourceProject = resolveSourceSessionProject(source, sourceCatalog)
+  if (!sourceProject) {
+    throw new Error("This Session is not associated with a canonical Project on its source machine, so cross-machine continuation cannot be verified safely.")
+  }
+  const targetProjects = targetRouteProjects(targetMachine.machineID, targetCatalog)
+  if (!targetProjects.length) {
+    throw new Error("The target machine does not expose any canonical Projects for cross-machine continuation.")
+  }
+  return { sourceProject, targetProjects }
+}

--- a/web/src/native-session-continuation.test.mjs
+++ b/web/src/native-session-continuation.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { probeNativeSessionContinuation } from './native-session-continuation.ts'
 import './cross-machine-continuation.test.mjs'
+import './cross-machine-route-projects.test.mjs'
 
 function target(overrides = {}) {
   return {


### PR DESCRIPTION
Stacked on #428. Adds the Project-routing substrate needed before any cross-machine UI can safely select a destination. Still no cross-machine UI enablement and no changes to `main`.

- resolves the source Session to the most-specific canonical Project from the source daemon's own Project catalog
- keeps path matching strictly machine-local; source and target filesystem paths are never compared
- handles Windows drive paths case-insensitively while preserving POSIX case semantics and directory boundaries
- exposes target route choices as Project identity/name/kind only, never filesystem paths
- validates a selected target Project still belongs to the target machine and fails closed if the catalog changed
- loads one Project catalog per endpoint through the existing cached machineClient path, avoiding per-Session/per-harness N+1 reads
- adds regression coverage for nested roots, machine scoping, Windows/POSIX semantics, path privacy and stale target selections

Base: `codex/p2-cross-machine-orchestrator` while #428 is under CI. Once #428 is integrated, retarget this PR to `codex/development-2026-09-11`.

Refs #371