### PR TITLE
P2: add read-only cross-machine route planner

### DIFF
--- a/web/src/cross-machine-route-plan.test.mjs
+++ b/web/src/cross-machine-route-plan.test.mjs
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { planCrossMachineContinuation } from "./cross-machine-route-plan.ts"
+
+function source() {
+  return {
+    key: "machine-a:codex:s1",
+    ref: { machineID: "machine-a", agentID: "codex", sessionID: "s1", directory: "/repo" },
+    machineID: "machine-a",
+    sessionID: "s1",
+    directory: "/repo",
+    title: "Source",
+    agentID: "codex",
+    agentLabel: "Codex",
+    backend: "codex",
+    transport: "acp",
+    config: { backend: "codex", host: "source.local", port: 4317, username: "", password: "", agentId: "codex" },
+    external: false,
+    modelsSupported: true,
+    renameSupported: false,
+    deleteSupported: false,
+    model: null,
+    requiresExplicitClaim: false,
+    canStop: false
+  }
+}
+
+const targetAgent = {
+  id: "claude",
+  label: "Claude",
+  backend: "claude",
+  transport: "acp",
+  state: "available",
+  capabilities: { sessions: true, prompt: true, models: true }
+}
+
+function targetMachine(agent = targetAgent) {
+  return {
+    machineID: "machine-b",
+    label: "Machine B",
+    config: { backend: "opencode", host: "target.local", port: 4317, username: "", password: "" },
+    agents: [agent]
+  }
+}
+
+function preflight(decision = "automatic") {
+  return {
+    sourceMachineID: "machine-a",
+    targetMachineID: "machine-b",
+    sourceProjectId: "source-project",
+    targetProjectId: "target-project",
+    sourceIdentityVerified: decision !== "review",
+    targetIdentityVerified: decision !== "review",
+    decision,
+    reason: decision === "automatic" ? "exact_workspace" : decision === "blocked" ? "project_mismatch" : "workspace_diverged",
+    assessment: {
+      project: decision === "blocked" ? "different" : "match",
+      repository: decision === "blocked" ? "different" : "match",
+      history: "match",
+      branch: decision === "review" ? "different" : "match",
+      head: "match",
+      sourceDirty: false,
+      targetDirty: false,
+      exactWorkspace: decision === "automatic"
+    }
+  }
+}
+
+function services(decision = "automatic") {
+  const calls = { load: 0, preflight: 0, preflightInput: null }
+  return {
+    calls,
+    value: {
+      async loadProjectRoute() {
+        calls.load += 1
+        return {
+          sourceProject: { id: "source-project", machineID: "machine-a", name: "Repo", kind: "git", configured: true },
+          targetProjects: [
+            { id: "target-project", machineID: "machine-b", name: "Repo clone", kind: "git", configured: true }
+          ]
+        }
+      },
+      async preflightProject(input) {
+        calls.preflight += 1
+        calls.preflightInput = input
+        return preflight(decision)
+      }
+    }
+  }
+}
+
+test("automatic Project evidence yields a read-only ready plan", async () => {
+  const harness = services("automatic")
+  const plan = await planCrossMachineContinuation({
+    source: source(),
+    targetMachine: targetMachine(),
+    targetAgent,
+    targetProjectId: "target-project",
+    services: harness.value
+  })
+  assert.equal(plan.disposition, "ready")
+  assert.equal(plan.sourceProject.id, "source-project")
+  assert.equal(plan.targetProject.id, "target-project")
+  assert.equal(harness.calls.load, 1)
+  assert.equal(harness.calls.preflight, 1)
+  assert.equal(harness.calls.preflightInput.sourceProjectId, "source-project")
+  assert.equal(harness.calls.preflightInput.targetProjectId, "target-project")
+})
+
+test("diverged-but-compatible workspace requires explicit confirmation", async () => {
+  const harness = services("review")
+  const plan = await planCrossMachineContinuation({
+    source: source(),
+    targetMachine: targetMachine(),
+    targetAgent,
+    targetProjectId: "target-project",
+    services: harness.value
+  })
+  assert.equal(plan.disposition, "confirm")
+  assert.equal(plan.preflight.decision, "review")
+})
+
+test("Project mismatch remains blocked in the read-only plan", async () => {
+  const harness = services("blocked")
+  const plan = await planCrossMachineContinuation({
+    source: source(),
+    targetMachine: targetMachine(),
+    targetAgent,
+    targetProjectId: "target-project",
+    services: harness.value
+  })
+  assert.equal(plan.disposition, "blocked")
+  assert.equal(plan.preflight.reason, "project_mismatch")
+})
+
+test("unavailable target harness fails before Project reads", async () => {
+  const unavailable = { ...targetAgent, state: "unavailable" }
+  const harness = services()
+  await assert.rejects(
+    planCrossMachineContinuation({
+      source: source(),
+      targetMachine: targetMachine(unavailable),
+      targetAgent: unavailable,
+      targetProjectId: "target-project",
+      services: harness.value
+    }),
+    /cannot create a writable native Session/
+  )
+  assert.equal(harness.calls.load, 0)
+  assert.equal(harness.calls.preflight, 0)
+})
+
+test("stale target Project selection fails closed before Git preflight", async () => {
+  const harness = services()
+  harness.value.loadProjectRoute = async () => ({
+    sourceProject: { id: "source-project", machineID: "machine-a", name: "Repo", kind: "git", configured: true },
+    targetProjects: []
+  })
+  await assert.rejects(
+    planCrossMachineContinuation({
+      source: source(),
+      targetMachine: targetMachine(),
+      targetAgent,
+      targetProjectId: "target-project",
+      services: harness.value
+    }),
+    /no longer available/
+  )
+  assert.equal(harness.calls.preflight, 0)
+})

--- a/web/src/cross-machine-route-plan.ts
+++ b/web/src/cross-machine-route-plan.ts
@@ -1,0 +1,91 @@
+import { canCreateNativeSession } from "./native-session-create"
+import type { NativeSessionSurfaceTarget } from "./native-session-discovery"
+import type { NativeSessionRouteMachine } from "./native-session-routing"
+import {
+  preflightCrossMachineProject,
+  type CrossMachineProjectPreflight
+} from "./cross-machine-project-preflight"
+import {
+  loadCrossMachineProjectRoute,
+  requireTargetRouteProject,
+  type CrossMachineProjectRoute,
+  type CrossMachineRouteProject
+} from "./cross-machine-route-projects"
+import type { MachineAgentHost } from "./types"
+
+export type CrossMachineRoutePlan = {
+  sourceProject: CrossMachineRouteProject
+  targetProject: CrossMachineRouteProject
+  targetMachineID: string
+  targetAgentID: string
+  preflight: CrossMachineProjectPreflight
+  disposition: "ready" | "confirm" | "blocked"
+}
+
+export type CrossMachineRoutePlanServices = {
+  loadProjectRoute: typeof loadCrossMachineProjectRoute
+  preflightProject: typeof preflightCrossMachineProject
+}
+
+const defaultServices: CrossMachineRoutePlanServices = {
+  loadProjectRoute: loadCrossMachineProjectRoute,
+  preflightProject: preflightCrossMachineProject
+}
+
+function disposition(preflight: CrossMachineProjectPreflight): CrossMachineRoutePlan["disposition"] {
+  if (preflight.decision === "blocked") return "blocked"
+  if (preflight.decision === "review") return "confirm"
+  return "ready"
+}
+
+/**
+ * Read-only planning boundary for the cross-machine route picker.
+ *
+ * This function may tell the UI whether a selected route is ready, needs explicit confirmation, or
+ * is blocked. It creates no Session, sends no prompt, stores no lineage and grants no authority.
+ * Execution must still call continueNativeSessionAcrossMachine(), which reruns the Project preflight
+ * immediately before mutation so this plan can never be treated as a stale authorization token.
+ */
+export async function planCrossMachineContinuation({
+  source,
+  targetMachine,
+  targetAgent,
+  targetProjectId,
+  services = defaultServices
+}: {
+  source: NativeSessionSurfaceTarget
+  targetMachine: NativeSessionRouteMachine
+  targetAgent: MachineAgentHost
+  targetProjectId: string
+  services?: CrossMachineRoutePlanServices
+}): Promise<CrossMachineRoutePlan> {
+  if (targetMachine.machineID === source.machineID) {
+    throw new Error("Cross-machine route planning requires a different target machine.")
+  }
+  if (!targetMachine.agents.some((candidate) => candidate.id === targetAgent.id)) {
+    throw new Error("The selected harness does not belong to the target machine.")
+  }
+  if (!canCreateNativeSession(targetAgent)) {
+    throw new Error("The selected target harness cannot create a writable native Session right now.")
+  }
+
+  const route: CrossMachineProjectRoute = await services.loadProjectRoute({ source, targetMachine })
+  const targetProject = requireTargetRouteProject(targetMachine.machineID, targetProjectId.trim(), route.targetProjects)
+  const preflight = await services.preflightProject({
+    sourceMachineID: source.machineID,
+    targetMachineID: targetMachine.machineID,
+    sourceConfig: source.config,
+    sourceProjectId: route.sourceProject.id,
+    targetConfig: targetMachine.config,
+    targetProjectId: targetProject.id
+  })
+
+  return {
+    sourceProject: route.sourceProject,
+    targetProject,
+    targetMachineID: targetMachine.machineID,
+    targetAgentID: targetAgent.id,
+    preflight,
+    disposition: disposition(preflight)
+  }
+}

--- a/web/src/native-session-continuation.test.mjs
+++ b/web/src/native-session-continuation.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { probeNativeSessionContinuation } from './native-session-continuation.ts'
 import './cross-machine-continuation.test.mjs'
 import './cross-machine-route-projects.test.mjs'
+import './cross-machine-route-plan.test.mjs'
 
 function target(overrides = {}) {
   return {


### PR DESCRIPTION
Stacked on #429. Adds the read-only planning boundary needed before wiring cross-machine continuation into the route picker. No UI enablement and no changes to `main`.

- validates target machine + writable native harness before Project reads
- resolves source/target Project identities through the machine-local Project routing layer
- runs the existing Git continuity preflight without mutating either machine
- returns a UI-safe disposition: `ready`, `confirm`, or `blocked`
- keeps execution authority separate: the eventual mutation path must still rerun preflight immediately before target creation
- fails closed when a target Project disappears from the catalog
- adds regression coverage for automatic, review, blocked, unavailable-harness, and stale-Project cases

Base: `codex/p2-cross-machine-route-projects` while #429 is stacked. After its parents integrate, retarget to `codex/development-2026-09-11`.

Refs #371