### PR TITLE
P2: expose safe cross-machine continuation panel

### DIFF
--- a/web/scripts/cross-machine-continuation-browser-smoke.mjs
+++ b/web/scripts/cross-machine-continuation-browser-smoke.mjs
@@ -1,0 +1,344 @@
+import assert from "node:assert/strict"
+import http from "node:http"
+import { spawn } from "node:child_process"
+import { chromium } from "playwright"
+
+const PREVIEW_PORT = 4186
+const SOURCE_PORT = 4436
+const TARGET_PORT = 4437
+const APP_ORIGIN = `http://127.0.0.1:${PREVIEW_PORT}`
+const STORAGE_KEY = "harness-remote.workspace.machines.v1"
+const SOURCE_MACHINE = "machine-cross-source"
+const TARGET_MACHINE = "machine-cross-target"
+const SOURCE_PROJECT = "project-cross-source"
+const MATCH_PROJECT = "project-cross-match"
+const DIFFERENT_PROJECT = "project-cross-different"
+const SOURCE_DIRECTORY = "/work/source-repo"
+const SESSION_ID = "cross-machine-source-session"
+const SESSION_TITLE = "Cross-machine Source Session"
+const TRANSCRIPT_MARKER = "CROSS-MACHINE-SOURCE-TRANSCRIPT"
+const REPOSITORY = "a".repeat(64)
+const HISTORY = "b".repeat(64)
+const OTHER_REPOSITORY = "c".repeat(64)
+
+const sourceSession = {
+  id: SESSION_ID,
+  title: SESSION_TITLE,
+  directory: SOURCE_DIRECTORY,
+  external: true,
+  time: { created: 1000, updated: 1001 }
+}
+
+const sourceTranscript = [{
+  info: { id: "cross-source-user", role: "user", sessionID: SESSION_ID, time: { created: 1000 } },
+  parts: [{ id: "cross-source-text", type: "text", text: TRANSCRIPT_MARKER }]
+}]
+
+const CODEX_MODELS = [{
+  providerID: "codex",
+  providerName: "Codex",
+  modelID: "gpt-cross-source",
+  modelName: "Codex Source",
+  isDefault: true,
+  tools: true
+}]
+
+const CLAUDE_MODELS = [{
+  providerID: "anthropic",
+  providerName: "Anthropic",
+  modelID: "claude-cross-target",
+  modelName: "Claude Target",
+  isDefault: true,
+  tools: true
+}]
+
+const streams = new Set()
+
+function corsHeaders() {
+  return {
+    "Access-Control-Allow-Origin": APP_ORIGIN,
+    "Access-Control-Allow-Headers": "Authorization, Content-Type, X-Harness-Backend",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Private-Network": "true",
+    "Access-Control-Max-Age": "600"
+  }
+}
+
+function json(response, status, value, extra = {}) {
+  response.writeHead(status, { "Content-Type": "application/json", ...corsHeaders(), ...extra })
+  response.end(JSON.stringify(value))
+}
+
+function sse(request, response) {
+  response.writeHead(200, {
+    ...corsHeaders(),
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive"
+  })
+  response.write(": connected\n\n")
+  streams.add(response)
+  request.on("close", () => streams.delete(response))
+}
+
+function projectIdentity(repositoryFingerprint) {
+  return {
+    identity: {
+      version: 1,
+      vcs: "git",
+      repositoryFingerprint,
+      historyFingerprint: HISTORY,
+      branch: "main",
+      head: "deadbeef",
+      dirty: false
+    }
+  }
+}
+
+function startSourceDaemon() {
+  const server = http.createServer((request, response) => {
+    if (request.method === "OPTIONS") {
+      response.writeHead(204, corsHeaders())
+      response.end()
+      return
+    }
+    const url = new URL(request.url || "/", `http://127.0.0.1:${SOURCE_PORT}`)
+
+    if (request.method === "GET" && url.pathname === "/v1/machine") {
+      json(response, 200, {
+        machine: { id: SOURCE_MACHINE, name: "Source Machine", createdAt: new Date().toISOString() },
+        agents: [{
+          id: "codex",
+          label: "Codex",
+          backend: "codex",
+          transport: "acp",
+          managed: true,
+          state: "available",
+          capabilities: { sessions: true, prompt: true, abort: true, streaming: true, models: true },
+          contract: { sessions: { stop: "owned-session-native-cancel" } }
+        }]
+      })
+      return
+    }
+    if (request.method === "GET" && url.pathname === "/v1/projects") {
+      json(response, 200, { projects: [{ id: SOURCE_PROJECT, machineId: SOURCE_MACHINE, name: "Source Project", path: SOURCE_DIRECTORY, kind: "git", configured: true }] })
+      return
+    }
+    if (request.method === "GET" && url.pathname === "/v1/project-identity") {
+      assert.equal(url.searchParams.get("projectId"), SOURCE_PROJECT)
+      json(response, 200, projectIdentity(REPOSITORY))
+      return
+    }
+    if (request.method === "GET" && url.pathname === "/v1/agents/codex/experimental/session") {
+      json(response, 200, [sourceSession])
+      return
+    }
+    if (request.method === "GET" && url.pathname === "/v1/agents/codex/session/status") {
+      json(response, 200, { [SESSION_ID]: { type: "idle" } })
+      return
+    }
+    if (request.method === "GET" && url.pathname === `/v1/agents/codex/session/${SESSION_ID}/message`) {
+      json(response, 200, sourceTranscript, { "X-Has-More": "0" })
+      return
+    }
+    if (request.method === "GET" && url.pathname === "/v1/agents/codex/models") {
+      json(response, 200, { models: CODEX_MODELS, stale: false, source: "cross-machine-source" })
+      return
+    }
+    if (request.method === "GET" && url.pathname.includes("/global/event")) {
+      sse(request, response)
+      return
+    }
+    if (request.method === "GET" && (url.pathname.includes("/question") || url.pathname.includes("/permission"))) {
+      json(response, 200, [])
+      return
+    }
+    json(response, 404, { error: `No source route for ${request.method} ${url.pathname}` })
+  })
+  return new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(SOURCE_PORT, "127.0.0.1", () => resolve(server))
+  })
+}
+
+function startTargetDaemon() {
+  const server = http.createServer((request, response) => {
+    if (request.method === "OPTIONS") {
+      response.writeHead(204, corsHeaders())
+      response.end()
+      return
+    }
+    const url = new URL(request.url || "/", `http://127.0.0.1:${TARGET_PORT}`)
+
+    if (request.method === "GET" && url.pathname === "/v1/machine") {
+      json(response, 200, {
+        machine: { id: TARGET_MACHINE, name: "Target Machine", createdAt: new Date().toISOString() },
+        agents: [{
+          id: "claude",
+          label: "Claude",
+          backend: "claude",
+          transport: "acp",
+          managed: true,
+          state: "available",
+          capabilities: { sessions: true, prompt: true, abort: true, streaming: true, models: true },
+          contract: { sessions: { stop: "owned-session-native-cancel" } }
+        }]
+      })
+      return
+    }
+    if (request.method === "GET" && url.pathname === "/v1/projects") {
+      json(response, 200, {
+        projects: [
+          { id: MATCH_PROJECT, machineId: TARGET_MACHINE, name: "Matching Project", path: "/target/matching", kind: "git", configured: true },
+          { id: DIFFERENT_PROJECT, machineId: TARGET_MACHINE, name: "Different Project", path: "/target/different", kind: "git", configured: true }
+        ]
+      })
+      return
+    }
+    if (request.method === "GET" && url.pathname === "/v1/project-identity") {
+      const projectId = url.searchParams.get("projectId")
+      if (projectId === MATCH_PROJECT) json(response, 200, projectIdentity(REPOSITORY))
+      else if (projectId === DIFFERENT_PROJECT) json(response, 200, projectIdentity(OTHER_REPOSITORY))
+      else json(response, 404, { error: "Unknown Project" })
+      return
+    }
+    if (request.method === "GET" && url.pathname === "/v1/agents/claude/experimental/session") {
+      json(response, 200, [])
+      return
+    }
+    if (request.method === "GET" && url.pathname === "/v1/agents/claude/session/status") {
+      json(response, 200, {})
+      return
+    }
+    if (request.method === "GET" && url.pathname === "/v1/agents/claude/models") {
+      json(response, 200, { models: CLAUDE_MODELS, stale: false, source: "cross-machine-target" })
+      return
+    }
+    if (request.method === "GET" && url.pathname.includes("/global/event")) {
+      sse(request, response)
+      return
+    }
+    if (request.method === "GET" && (url.pathname.includes("/question") || url.pathname.includes("/permission"))) {
+      json(response, 200, [])
+      return
+    }
+    json(response, 404, { error: `No target route for ${request.method} ${url.pathname}` })
+  })
+  return new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(TARGET_PORT, "127.0.0.1", () => resolve(server))
+  })
+}
+
+function startPreview() {
+  const command = process.platform === "win32" ? "npm.cmd" : "npm"
+  return spawn(command, ["run", "preview", "--", "--host", "127.0.0.1", "--port", String(PREVIEW_PORT), "--strictPort"], {
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: process.platform !== "win32"
+  })
+}
+
+async function ready(url) {
+  const deadline = Date.now() + 30_000
+  let lastError
+  while (Date.now() < deadline) {
+    try {
+      if ((await fetch(url)).ok) return
+    } catch (error) {
+      lastError = error
+    }
+    await new Promise((resolve) => setTimeout(resolve, 150))
+  }
+  throw lastError || new Error(`Preview did not become ready: ${url}`)
+}
+
+async function seed(page) {
+  await page.addInitScript(({ key, sourcePort, targetPort }) => {
+    localStorage.setItem(key, JSON.stringify([
+      { id: "source-profile", name: "Source Machine", config: { backend: "codex", host: "127.0.0.1", port: sourcePort, username: "harness", password: "testpw" } },
+      { id: "target-profile", name: "Target Machine", config: { backend: "claude", host: "127.0.0.1", port: targetPort, username: "harness", password: "testpw" } }
+    ]))
+  }, { key: STORAGE_KEY, sourcePort: SOURCE_PORT, targetPort: TARGET_PORT })
+}
+
+function stopPreview(child) {
+  if (!child || child.killed || !child.pid) return
+  try {
+    if (process.platform === "win32") child.kill("SIGTERM")
+    else process.kill(-child.pid, "SIGTERM")
+  } catch {
+    try { child.kill("SIGTERM") } catch {}
+  }
+}
+
+function stopServer(server) {
+  try { server.closeAllConnections?.() } catch {}
+  try { server.close() } catch {}
+}
+
+let sourceDaemon
+let targetDaemon
+let preview
+let browser
+try {
+  sourceDaemon = await startSourceDaemon()
+  targetDaemon = await startTargetDaemon()
+  preview = startPreview()
+  await ready(APP_ORIGIN)
+  browser = await chromium.launch({ headless: true })
+  const context = await browser.newContext({ viewport: { width: 1280, height: 800 }, deviceScaleFactor: 1 })
+  const page = await context.newPage()
+  const pageErrors = []
+  page.on("pageerror", (error) => pageErrors.push(error.message))
+  await seed(page)
+  await page.goto(APP_ORIGIN, { waitUntil: "domcontentloaded" })
+
+  await page.locator('.hr-native-workspace[aria-label="Sessions"]').waitFor({ state: "visible", timeout: 12_000 })
+  await page.getByRole("button", { name: new RegExp(SESSION_TITLE) }).click()
+  await page.getByRole("heading", { name: SESSION_TITLE }).waitFor({ state: "visible", timeout: 12_000 })
+  await page.getByText(TRANSCRIPT_MARKER, { exact: true }).waitFor({ state: "visible", timeout: 12_000 })
+
+  const sourceComposer = page.getByRole("textbox", { name: "Message Codex" })
+  await sourceComposer.waitFor({ state: "visible", timeout: 12_000 })
+  assert.equal(await sourceComposer.isDisabled(), false, "ordinary source composer was destabilized by cross-machine UI")
+
+  const toggle = page.getByRole("button", { name: "Continue on another machine" })
+  await toggle.waitFor({ state: "visible", timeout: 12_000 })
+  await toggle.click()
+
+  const panel = page.locator('.hr-cross-machine-panel')
+  await panel.getByText("Target Machine", { exact: true }).first().waitFor({ state: "visible", timeout: 12_000 })
+  const projectSelect = panel.locator('label').filter({ hasText: "Project" }).locator('select')
+  await projectSelect.selectOption(MATCH_PROJECT)
+
+  await panel.getByText("Same repository, branch and HEAD verified; both worktrees are clean.", { exact: true }).waitFor({ state: "visible", timeout: 12_000 })
+  await panel.getByText("Attachments and source permissions are not transferred.", { exact: true }).waitFor({ state: "visible", timeout: 12_000 })
+
+  const modelButton = panel.locator('.tdw-model-trigger')
+  await modelButton.waitFor({ state: "visible", timeout: 12_000 })
+  await modelButton.click()
+  assert.match(await panel.locator('.tdw-model-picker').innerText(), /Claude Target/, "target route did not load the target harness model catalog")
+  await page.keyboard.press("Escape")
+
+  const firstMessage = panel.getByRole("textbox", { name: "First message on the target Session" })
+  await firstMessage.fill("Continue the fix on the target machine")
+  const continueButton = panel.getByRole("button", { name: "Continue on target machine" })
+  assert.equal(await continueButton.isDisabled(), false, "verified matching workspace did not become sendable")
+
+  await projectSelect.selectOption(DIFFERENT_PROJECT)
+  await panel.getByText("This Project does not match the source repository/history. Cross-machine continuation is blocked.", { exact: true }).waitFor({ state: "visible", timeout: 12_000 })
+  assert.equal(await continueButton.isDisabled(), true, "mismatched Project left the cross-machine mutation enabled")
+  assert.equal(await sourceComposer.isDisabled(), false, "blocked cross-machine plan disabled the ordinary source composer")
+  assert.deepEqual(pageErrors, [], `browser errors in cross-machine planning surface: ${pageErrors.join(" | ")}`)
+
+  console.log("cross-machine continuation Project/model safety browser smoke passed")
+  await context.close()
+} finally {
+  if (browser) await browser.close().catch(() => {})
+  for (const response of streams) {
+    try { response.end() } catch {}
+  }
+  stopPreview(preview)
+  stopServer(sourceDaemon)
+  stopServer(targetDaemon)
+}

--- a/web/src/components/cross-machine-continue-panel.tsx
+++ b/web/src/components/cross-machine-continue-panel.tsx
@@ -1,0 +1,369 @@
+import { useEffect, useMemo, useRef, useState } from "react"
+import { continueNativeSessionAcrossMachine } from "../cross-machine-continuation"
+import {
+  loadCrossMachineProjectRoute,
+  requireTargetRouteProject,
+  type CrossMachineProjectRoute
+} from "../cross-machine-route-projects"
+import {
+  planCrossMachineContinuation,
+  type CrossMachineRoutePlan
+} from "../cross-machine-route-plan"
+import type { NativeSessionSurfaceTarget } from "../native-session-discovery"
+import type { NativeSessionRouteMachine } from "../native-session-routing"
+import { taskClient, type AgentModelScope } from "../taskClient"
+import type { BackendKind, MachineAgentHost, ModelOption, ModelSelection, ServerConfig } from "../types"
+import { ModelPicker, modelOptionKey } from "./model-picker"
+
+const ROUTE_MODEL_SCOPE: AgentModelScope = {}
+
+type Props = {
+  source: NativeSessionSurfaceTarget
+  routes: NativeSessionRouteMachine[]
+  interactionEnabled: boolean
+  onOpenSession: (target: NativeSessionSurfaceTarget) => void
+  onSessionRefresh?: () => void
+  onConnectionIssue?: () => void
+}
+
+function supportedBackend(value: string | undefined, fallback: BackendKind): BackendKind {
+  return value === "opencode" || value === "omp" || value === "pi" || value === "claude" || value === "codex"
+    ? value
+    : fallback
+}
+
+function configForAgent(base: ServerConfig, agent: MachineAgentHost): ServerConfig {
+  return {
+    ...base,
+    backend: supportedBackend(agent.backend, base.backend),
+    agentId: agent.id
+  }
+}
+
+function modelKey(model?: ModelSelection | null): string {
+  return model ? modelOptionKey(model as ModelOption) : ""
+}
+
+function transportFailure(reason: unknown): boolean {
+  return /cannot reach|timed out|network|connection|failed to fetch/i.test(reason instanceof Error ? reason.message : String(reason))
+}
+
+function planSummary(plan: CrossMachineRoutePlan | null, loading: boolean): string {
+  if (loading) return "Verifying Project continuity…"
+  if (!plan) return "Choose a target Project to verify the workspace before anything is created."
+  if (plan.disposition === "blocked") {
+    return "This Project does not match the source repository/history. Cross-machine continuation is blocked."
+  }
+  if (plan.disposition === "confirm") {
+    if (plan.preflight.reason === "workspace_diverged") {
+      return "The repository matches, but branch, HEAD or working-tree state differs. Review the target workspace before continuing."
+    }
+    return "Harness Remote cannot fully prove that the two workspaces are identical. Explicit confirmation is required."
+  }
+  return "Same repository, branch and HEAD verified; both worktrees are clean."
+}
+
+/**
+ * Explicit cross-machine continuation surface.
+ *
+ * This is deliberately separate from the mature same-machine composer. Selection and planning are
+ * read-only until Send: no target Session is created while browsing machines, Projects, harnesses or
+ * models. The final orchestrator re-runs Project continuity immediately before mutation, so this UI
+ * never turns a stale plan into authorization.
+ */
+export function CrossMachineContinuePanel({
+  source,
+  routes,
+  interactionEnabled,
+  onOpenSession,
+  onSessionRefresh,
+  onConnectionIssue
+}: Props) {
+  const availableRoutes = useMemo(
+    () => routes.filter((route) => route.machineID !== source.machineID && route.agents.length > 0),
+    [routes, source.machineID]
+  )
+  const [open, setOpen] = useState(false)
+  const [machineID, setMachineID] = useState("")
+  const [projectRoute, setProjectRoute] = useState<CrossMachineProjectRoute | null>(null)
+  const [projectID, setProjectID] = useState("")
+  const [agentID, setAgentID] = useState("")
+  const [models, setModels] = useState<ModelOption[]>([])
+  const [modelKeyValue, setModelKeyValue] = useState("")
+  const [projectsLoading, setProjectsLoading] = useState(false)
+  const [modelsLoading, setModelsLoading] = useState(false)
+  const [planLoading, setPlanLoading] = useState(false)
+  const [plan, setPlan] = useState<CrossMachineRoutePlan | null>(null)
+  const [confirmed, setConfirmed] = useState(false)
+  const [prompt, setPrompt] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [sending, setSending] = useState(false)
+  const projectGeneration = useRef(0)
+  const modelGeneration = useRef(0)
+  const planGeneration = useRef(0)
+
+  const machine = availableRoutes.find((candidate) => candidate.machineID === machineID)
+  const agent = machine?.agents.find((candidate) => candidate.id === agentID)
+  const selectedModel = models.find((candidate) => modelKey(candidate) === modelKeyValue)
+  const modelRequired = agent?.capabilities?.models === true
+  const modelReady = !modelRequired || (!modelsLoading && Boolean(selectedModel))
+  const targetProject = projectRoute?.targetProjects.find((candidate) => candidate.id === projectID)
+  const blocked = plan?.disposition === "blocked"
+  const confirmationRequired = plan?.disposition === "confirm"
+  const planReady = plan?.disposition === "ready" || (confirmationRequired && confirmed)
+  const canSend = interactionEnabled
+    && Boolean(machine && agent && targetProject)
+    && modelReady
+    && !projectsLoading
+    && !modelsLoading
+    && !planLoading
+    && !blocked
+    && planReady
+    && Boolean(prompt.trim())
+    && !sending
+
+  useEffect(() => {
+    if (!open || availableRoutes.length === 0) return
+    if (availableRoutes.some((candidate) => candidate.machineID === machineID)) return
+    setMachineID(availableRoutes[0].machineID)
+  }, [open, availableRoutes, machineID])
+
+  useEffect(() => {
+    const generation = ++projectGeneration.current
+    setProjectRoute(null)
+    setProjectID("")
+    setPlan(null)
+    setConfirmed(false)
+    setError(null)
+    if (!open || !machine) {
+      setProjectsLoading(false)
+      return
+    }
+    setProjectsLoading(true)
+    void loadCrossMachineProjectRoute({ source, targetMachine: machine })
+      .then((route) => {
+        if (projectGeneration.current !== generation) return
+        setProjectRoute(route)
+        if (route.targetProjects.length === 1) setProjectID(route.targetProjects[0].id)
+      })
+      .catch((reason) => {
+        if (projectGeneration.current !== generation) return
+        if (transportFailure(reason)) onConnectionIssue?.()
+        setError(reason instanceof Error ? reason.message : String(reason))
+      })
+      .finally(() => {
+        if (projectGeneration.current === generation) setProjectsLoading(false)
+      })
+  }, [open, machineID, machine, source.key, onConnectionIssue])
+
+  useEffect(() => {
+    const generation = ++modelGeneration.current
+    setModels([])
+    setModelKeyValue("")
+    setPlan(null)
+    setConfirmed(false)
+    if (!open || !machine) {
+      setAgentID("")
+      setModelsLoading(false)
+      return
+    }
+
+    const nextAgent = machine.agents.some((candidate) => candidate.id === agentID)
+      ? machine.agents.find((candidate) => candidate.id === agentID)!
+      : machine.agents[0]
+    if (nextAgent.id !== agentID) {
+      setAgentID(nextAgent.id)
+      return
+    }
+    if (nextAgent.capabilities?.models !== true) {
+      setModelsLoading(false)
+      return
+    }
+
+    setModelsLoading(true)
+    void taskClient.listAgentModels(configForAgent(machine.config, nextAgent), nextAgent.id, ROUTE_MODEL_SCOPE)
+      .then((catalog) => {
+        if (modelGeneration.current !== generation) return
+        setModels(catalog.models)
+        const fallback = catalog.models.find((candidate) => candidate.isDefault) || catalog.models[0]
+        setModelKeyValue(fallback ? modelKey(fallback) : "")
+      })
+      .catch((reason) => {
+        if (modelGeneration.current !== generation) return
+        if (transportFailure(reason)) onConnectionIssue?.()
+        setError(reason instanceof Error ? reason.message : String(reason))
+      })
+      .finally(() => {
+        if (modelGeneration.current === generation) setModelsLoading(false)
+      })
+  }, [open, machineID, machine, agentID, onConnectionIssue])
+
+  useEffect(() => {
+    const generation = ++planGeneration.current
+    setPlan(null)
+    setConfirmed(false)
+    if (!open || !machine || !agent || !projectID) {
+      setPlanLoading(false)
+      return
+    }
+    setPlanLoading(true)
+    void planCrossMachineContinuation({
+      source,
+      targetMachine: machine,
+      targetAgent: agent,
+      targetProjectId: projectID
+    })
+      .then((next) => {
+        if (planGeneration.current === generation) setPlan(next)
+      })
+      .catch((reason) => {
+        if (planGeneration.current !== generation) return
+        if (transportFailure(reason)) onConnectionIssue?.()
+        setError(reason instanceof Error ? reason.message : String(reason))
+      })
+      .finally(() => {
+        if (planGeneration.current === generation) setPlanLoading(false)
+      })
+  }, [open, machineID, agentID, projectID, machine, agent, source.key, onConnectionIssue])
+
+  if (!availableRoutes.length) return null
+
+  const submit = async () => {
+    if (!canSend || !machine || !agent || !projectRoute || !targetProject || !plan) return
+    setSending(true)
+    setError(null)
+    try {
+      // Revalidate that the selected Project still belongs to this target catalog before crossing the
+      // mutation boundary. The orchestrator then re-runs Git identity preflight once more.
+      requireTargetRouteProject(machine.machineID, projectID, projectRoute.targetProjects)
+      const model: ModelSelection | null = selectedModel
+        ? { providerID: selectedModel.providerID, modelID: selectedModel.modelID, variant: selectedModel.variant }
+        : null
+      const result = await continueNativeSessionAcrossMachine({
+        source,
+        sourceProjectId: projectRoute.sourceProject.id,
+        targetMachine: machine,
+        targetProjectId: targetProject.id,
+        targetAgent: agent,
+        prompt: prompt.trim(),
+        attachments: [],
+        model,
+        confirmedProjectContinuity: confirmationRequired && confirmed
+      })
+      setPrompt("")
+      setConfirmed(false)
+      onSessionRefresh?.()
+      onOpenSession(result.target)
+    } catch (reason) {
+      if (transportFailure(reason)) onConnectionIssue?.()
+      setError(reason instanceof Error ? reason.message : String(reason))
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return (
+    <section className="hr-cross-machine-panel" aria-label="Continue on another machine">
+      <button
+        type="button"
+        className="hr-cross-machine-toggle"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+        disabled={!interactionEnabled || sending}
+      >
+        Continue on another machine
+      </button>
+
+      {open ? (
+        <div className="hr-cross-machine-body">
+          <div className="hr-cross-machine-fields">
+            <label>
+              <span>Machine</span>
+              <select value={machineID} disabled={sending} onChange={(event) => {
+                setMachineID(event.target.value)
+                setAgentID("")
+                setError(null)
+              }}>
+                {availableRoutes.map((route) => <option key={route.machineID} value={route.machineID}>{route.label}</option>)}
+              </select>
+            </label>
+
+            <label>
+              <span>Project</span>
+              <select
+                value={projectID}
+                disabled={sending || projectsLoading || !projectRoute}
+                onChange={(event) => { setProjectID(event.target.value); setError(null) }}
+              >
+                <option value="">{projectsLoading ? "Loading Projects…" : "Select Project…"}</option>
+                {(projectRoute?.targetProjects || []).map((project) => (
+                  <option key={project.id} value={project.id}>{project.name}</option>
+                ))}
+              </select>
+            </label>
+
+            <label>
+              <span>Harness</span>
+              <select value={agentID} disabled={sending || !machine} onChange={(event) => {
+                setAgentID(event.target.value)
+                setError(null)
+              }}>
+                {(machine?.agents || []).map((candidate) => <option key={candidate.id} value={candidate.id}>{candidate.label}</option>)}
+              </select>
+            </label>
+
+            <label>
+              <span>Model</span>
+              <ModelPicker
+                compact
+                models={models}
+                value={modelKeyValue}
+                onChange={setModelKeyValue}
+                disabled={sending || modelsLoading || !agent || agent.capabilities?.models !== true}
+                loading={modelsLoading}
+                placeholder={agent?.capabilities?.models === true ? "Select model" : "Harness default"}
+                unavailableHint={modelRequired && !modelsLoading && !models.length ? "No verified models available" : undefined}
+              />
+            </label>
+          </div>
+
+          <div className={`hr-cross-machine-preflight ${plan?.disposition || "idle"}`} role="status" aria-live="polite">
+            <strong>{targetProject ? `${targetProject.name} on ${machine?.label || "target machine"}` : "Project verification"}</strong>
+            <span>{planSummary(plan, planLoading)}</span>
+            {confirmationRequired ? (
+              <label className="hr-cross-machine-confirm">
+                <input
+                  type="checkbox"
+                  checked={confirmed}
+                  disabled={sending}
+                  onChange={(event) => setConfirmed(event.target.checked)}
+                />
+                <span>I understand the target workspace differs and want to continue there.</span>
+              </label>
+            ) : null}
+          </div>
+
+          <label className="hr-cross-machine-prompt">
+            <span>First message on the target Session</span>
+            <textarea
+              value={prompt}
+              disabled={sending || blocked}
+              rows={3}
+              placeholder="Continue the work on this machine…"
+              onChange={(event) => setPrompt(event.target.value)}
+            />
+          </label>
+
+          {error ? <div className="tdw-chat-error" role="alert"><span>{error}</span><button type="button" onClick={() => setError(null)}>×</button></div> : null}
+
+          <div className="hr-cross-machine-actions">
+            <small>Attachments and source permissions are not transferred.</small>
+            <button type="button" disabled={!canSend} onClick={() => void submit()}>
+              {sending ? "Creating linked Session…" : "Continue on target machine"}
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/web/src/components/native-session-observer.tsx
+++ b/web/src/components/native-session-observer.tsx
@@ -1,6 +1,16 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { api } from "../api"
 import type { ConversationController } from "../conversation-controller"
+import { continueNativeSessionAcrossMachine } from "../cross-machine-continuation"
+import {
+  loadCrossMachineProjectRoute,
+  requireTargetRouteProject,
+  type CrossMachineProjectRoute
+} from "../cross-machine-route-projects"
+import {
+  planCrossMachineContinuation,
+  type CrossMachineRoutePlan
+} from "../cross-machine-route-plan"
 import type { NativeSessionSurfaceTarget } from "../native-session-discovery"
 import { canCreateNativeSession } from "../native-session-create"
 import { resolveNativeSessionTargetModel } from "../native-session-model"
@@ -149,30 +159,84 @@ export function NativeSessionObserver({
   }), [target.agentID, target.agentLabel, target.backend, target.transport, target.canStop, target.modelsSupported, attachmentsSupported, commands.length])
 
   const routableRoutes = useMemo<NativeSessionRouteMachine[]>(() => routes.flatMap((machine) => {
-    if (machine.machineID !== target.machineID) return []
     const available = machine.agents.filter((candidate) => canCreateNativeSession(candidate))
+    if (machine.machineID !== target.machineID) {
+      return available.length ? [{ ...machine, agents: available }] : []
+    }
     const current = available.some((candidate) => candidate.id === target.agentID)
       ? available
       : [agent, ...available.filter((candidate) => candidate.id !== target.agentID)]
     return [{ ...machine, agents: current }]
   }), [routes, target.machineID, target.agentID, agent])
 
-  const handleRoutedContinue = useCallback(async (input: NativeSessionRouteContinueInput) => {
-    if (!interactionEnabled) throw new Error("The machine is reconnecting. Continue will be available when the connection is healthy again.")
-    const machine = routableRoutes.find((candidate) => candidate.machineID === input.machineID)
-    const targetAgent = machine?.agents.find((candidate) => candidate.id === input.agentID)
-    if (!machine || !targetAgent) throw new Error("That harness is no longer available on this machine.")
-    const next = await continueNativeSessionOnRoute({
+  const routeMachine = useCallback((machineID: string): NativeSessionRouteMachine => {
+    const machine = routableRoutes.find((candidate) => candidate.machineID === machineID)
+    if (!machine) throw new Error("That machine is no longer available for continuation.")
+    return machine
+  }, [routableRoutes])
+
+  const loadRouteProjects = useCallback(async (machineID: string): Promise<CrossMachineProjectRoute> => {
+    const machine = routeMachine(machineID)
+    return loadCrossMachineProjectRoute({ source: target, targetMachine: machine })
+  }, [routeMachine, target])
+
+  const planRoute = useCallback(async ({
+    machineID,
+    agentID,
+    projectID
+  }: {
+    machineID: string
+    agentID: string
+    projectID: string
+  }): Promise<CrossMachineRoutePlan> => {
+    const machine = routeMachine(machineID)
+    const targetAgent = machine.agents.find((candidate) => candidate.id === agentID)
+    if (!targetAgent) throw new Error("That harness is no longer available on the target machine.")
+    return planCrossMachineContinuation({
       source: target,
       targetMachine: machine,
       targetAgent,
-      prompt: input.prompt,
-      attachments: input.attachments,
-      model: input.model
+      targetProjectId: projectID
     })
+  }, [routeMachine, target])
+
+  const handleRoutedContinue = useCallback(async (input: NativeSessionRouteContinueInput) => {
+    if (!interactionEnabled) throw new Error("The machine is reconnecting. Continue will be available when the connection is healthy again.")
+    const machine = routeMachine(input.machineID)
+    const targetAgent = machine.agents.find((candidate) => candidate.id === input.agentID)
+    if (!targetAgent) throw new Error("That harness is no longer available on this machine.")
+
+    let next: NativeSessionSurfaceTarget
+    if (machine.machineID === target.machineID) {
+      next = await continueNativeSessionOnRoute({
+        source: target,
+        targetMachine: machine,
+        targetAgent,
+        prompt: input.prompt,
+        attachments: input.attachments,
+        model: input.model
+      })
+    } else {
+      if (!input.projectID) throw new Error("Choose a Project on the target machine before continuing.")
+      const projectRoute = await loadCrossMachineProjectRoute({ source: target, targetMachine: machine })
+      const targetProject = requireTargetRouteProject(machine.machineID, input.projectID, projectRoute.targetProjects)
+      const result = await continueNativeSessionAcrossMachine({
+        source: target,
+        sourceProjectId: projectRoute.sourceProject.id,
+        targetMachine: machine,
+        targetProjectId: targetProject.id,
+        targetAgent,
+        prompt: input.prompt,
+        attachments: input.attachments,
+        model: input.model,
+        confirmedProjectContinuity: input.confirmedProjectContinuity === true
+      })
+      next = result.target
+    }
+
     onSessionRefresh?.()
     onOpenSession?.(next)
-  }, [routableRoutes, target, onSessionRefresh, onOpenSession, interactionEnabled])
+  }, [routeMachine, target, onSessionRefresh, onOpenSession, interactionEnabled])
 
   useEffect(() => {
     let registration: ReturnType<typeof registerNativeSessionV3Adapter> | undefined
@@ -238,6 +302,8 @@ export function NativeSessionObserver({
         routing={onOpenSession && routableRoutes.length ? {
           currentMachineID: target.machineID,
           machines: routableRoutes,
+          loadCrossMachineProjects: loadRouteProjects,
+          planCrossMachineRoute: planRoute,
           onContinue: handleRoutedContinue
         } : undefined}
       />

--- a/web/src/components/native-session-observer.tsx
+++ b/web/src/components/native-session-observer.tsx
@@ -1,16 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { api } from "../api"
 import type { ConversationController } from "../conversation-controller"
-import { continueNativeSessionAcrossMachine } from "../cross-machine-continuation"
-import {
-  loadCrossMachineProjectRoute,
-  requireTargetRouteProject,
-  type CrossMachineProjectRoute
-} from "../cross-machine-route-projects"
-import {
-  planCrossMachineContinuation,
-  type CrossMachineRoutePlan
-} from "../cross-machine-route-plan"
 import type { NativeSessionSurfaceTarget } from "../native-session-discovery"
 import { canCreateNativeSession } from "../native-session-create"
 import { resolveNativeSessionTargetModel } from "../native-session-model"
@@ -28,6 +18,7 @@ import type { ConversationRuntime } from "../conversation-runtime"
 import type { AgentModelScope } from "../taskClient"
 import type { CommandInfo, MachineAgentHost } from "../types"
 import { LoadingIcon } from "../Icons"
+import { CrossMachineContinuePanel } from "./cross-machine-continue-panel"
 import { WorkThreadConversation } from "./work-thread-conversation"
 import "../native-session-observer.css"
 
@@ -50,7 +41,6 @@ function visualState(conversation: ConversationRuntime, attention = false): Nati
   if (nativeSessionIsWorking(conversation.status)) return "working"
   return "ready"
 }
-
 
 export { nativeSessionIsWorking }
 
@@ -169,74 +159,34 @@ export function NativeSessionObserver({
     return [{ ...machine, agents: current }]
   }), [routes, target.machineID, target.agentID, agent])
 
-  const routeMachine = useCallback((machineID: string): NativeSessionRouteMachine => {
-    const machine = routableRoutes.find((candidate) => candidate.machineID === machineID)
-    if (!machine) throw new Error("That machine is no longer available for continuation.")
-    return machine
-  }, [routableRoutes])
-
-  const loadRouteProjects = useCallback(async (machineID: string): Promise<CrossMachineProjectRoute> => {
-    const machine = routeMachine(machineID)
-    return loadCrossMachineProjectRoute({ source: target, targetMachine: machine })
-  }, [routeMachine, target])
-
-  const planRoute = useCallback(async ({
-    machineID,
-    agentID,
-    projectID
-  }: {
-    machineID: string
-    agentID: string
-    projectID: string
-  }): Promise<CrossMachineRoutePlan> => {
-    const machine = routeMachine(machineID)
-    const targetAgent = machine.agents.find((candidate) => candidate.id === agentID)
-    if (!targetAgent) throw new Error("That harness is no longer available on the target machine.")
-    return planCrossMachineContinuation({
-      source: target,
-      targetMachine: machine,
-      targetAgent,
-      targetProjectId: projectID
-    })
-  }, [routeMachine, target])
+  // Keep the mature composer scoped to same-machine harness switching. Cross-machine continuation
+  // has a separate explicit panel until that newer state machine has enough product-smoke coverage
+  // to be safely folded into the composer without destabilizing ordinary Session sends.
+  const sameMachineRoutes = useMemo(
+    () => routableRoutes.filter((machine) => machine.machineID === target.machineID),
+    [routableRoutes, target.machineID]
+  )
+  const crossMachineRoutes = useMemo(
+    () => routableRoutes.filter((machine) => machine.machineID !== target.machineID),
+    [routableRoutes, target.machineID]
+  )
 
   const handleRoutedContinue = useCallback(async (input: NativeSessionRouteContinueInput) => {
     if (!interactionEnabled) throw new Error("The machine is reconnecting. Continue will be available when the connection is healthy again.")
-    const machine = routeMachine(input.machineID)
-    const targetAgent = machine.agents.find((candidate) => candidate.id === input.agentID)
-    if (!targetAgent) throw new Error("That harness is no longer available on this machine.")
-
-    let next: NativeSessionSurfaceTarget
-    if (machine.machineID === target.machineID) {
-      next = await continueNativeSessionOnRoute({
-        source: target,
-        targetMachine: machine,
-        targetAgent,
-        prompt: input.prompt,
-        attachments: input.attachments,
-        model: input.model
-      })
-    } else {
-      if (!input.projectID) throw new Error("Choose a Project on the target machine before continuing.")
-      const projectRoute = await loadCrossMachineProjectRoute({ source: target, targetMachine: machine })
-      const targetProject = requireTargetRouteProject(machine.machineID, input.projectID, projectRoute.targetProjects)
-      const result = await continueNativeSessionAcrossMachine({
-        source: target,
-        sourceProjectId: projectRoute.sourceProject.id,
-        targetMachine: machine,
-        targetProjectId: targetProject.id,
-        targetAgent,
-        prompt: input.prompt,
-        attachments: input.attachments,
-        model: input.model,
-        confirmedProjectContinuity: input.confirmedProjectContinuity === true
-      })
-      next = result.target
-    }
-
+    const machine = sameMachineRoutes.find((candidate) => candidate.machineID === input.machineID)
+    const targetAgent = machine?.agents.find((candidate) => candidate.id === input.agentID)
+    if (!machine || !targetAgent) throw new Error("That harness is no longer available on this machine.")
+    const next = await continueNativeSessionOnRoute({
+      source: target,
+      targetMachine: machine,
+      targetAgent,
+      prompt: input.prompt,
+      attachments: input.attachments,
+      model: input.model
+    })
     onSessionRefresh?.()
     onOpenSession?.(next)
-  }, [routeMachine, target, onSessionRefresh, onOpenSession, interactionEnabled])
+  }, [sameMachineRoutes, target, onSessionRefresh, onOpenSession, interactionEnabled])
 
   useEffect(() => {
     let registration: ReturnType<typeof registerNativeSessionV3Adapter> | undefined
@@ -285,6 +235,17 @@ export function NativeSessionObserver({
 
   return (
     <div className="hr-native-session-observer writable">
+      {onOpenSession && crossMachineRoutes.length ? (
+        <CrossMachineContinuePanel
+          source={target}
+          routes={crossMachineRoutes}
+          interactionEnabled={interactionEnabled}
+          onOpenSession={onOpenSession}
+          onSessionRefresh={onSessionRefresh}
+          onConnectionIssue={onConnectionIssue}
+        />
+      ) : null}
+
       <WorkThreadConversation
         key={target.key}
         conversation={conversation}
@@ -299,11 +260,9 @@ export function NativeSessionObserver({
         commands={commands}
         interactionEnabled={interactionEnabled}
         onConnectionIssue={onConnectionIssue}
-        routing={onOpenSession && routableRoutes.length ? {
+        routing={onOpenSession && sameMachineRoutes.length ? {
           currentMachineID: target.machineID,
-          machines: routableRoutes,
-          loadCrossMachineProjects: loadRouteProjects,
-          planCrossMachineRoute: planRoute,
+          machines: sameMachineRoutes,
           onContinue: handleRoutedContinue
         } : undefined}
       />

--- a/web/src/native-session-observer.css
+++ b/web/src/native-session-observer.css
@@ -62,7 +62,139 @@
   line-height: 1.4;
 }
 
+.hr-cross-machine-panel {
+  flex: 0 0 auto;
+  margin: 0 10px 8px;
+  border: 1px solid var(--uw-border, rgba(127, 127, 127, 0.24));
+  border-radius: 12px;
+  background: var(--tdw-panel, rgba(127, 127, 127, 0.04));
+  overflow: hidden;
+}
 
+.hr-cross-machine-toggle {
+  width: 100%;
+  min-height: 36px;
+  padding: 8px 11px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.hr-cross-machine-toggle::after {
+  content: "›";
+  float: right;
+  transform: rotate(90deg);
+  opacity: .58;
+}
+
+.hr-cross-machine-toggle[aria-expanded="true"]::after {
+  transform: rotate(-90deg);
+}
+
+.hr-cross-machine-body {
+  display: grid;
+  gap: 10px;
+  padding: 0 11px 11px;
+}
+
+.hr-cross-machine-fields {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.hr-cross-machine-fields > label,
+.hr-cross-machine-prompt {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--tdw-muted, #9299a8);
+}
+
+.hr-cross-machine-fields select,
+.hr-cross-machine-prompt textarea {
+  min-width: 0;
+  width: 100%;
+  border: 1px solid var(--uw-border, rgba(127, 127, 127, 0.28));
+  border-radius: 8px;
+  background: var(--tdw-input, rgba(127, 127, 127, 0.06));
+  color: inherit;
+}
+
+.hr-cross-machine-fields select {
+  height: 34px;
+  padding: 0 8px;
+}
+
+.hr-cross-machine-prompt textarea {
+  resize: vertical;
+  min-height: 68px;
+  padding: 8px 9px;
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.hr-cross-machine-preflight {
+  display: grid;
+  gap: 3px;
+  padding: 8px 9px;
+  border: 1px solid var(--uw-border, rgba(127, 127, 127, 0.22));
+  border-radius: 9px;
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.hr-cross-machine-preflight strong {
+  font-size: 11.5px;
+}
+
+.hr-cross-machine-preflight span {
+  color: var(--tdw-muted, #9299a8);
+}
+
+.hr-cross-machine-preflight.blocked {
+  border-color: var(--td3-red-border, rgba(190, 60, 60, .38));
+  background: var(--td3-red-soft, rgba(190, 60, 60, .07));
+}
+
+.hr-cross-machine-preflight.confirm {
+  border-color: var(--td3-yellow-border, rgba(191, 135, 0, .34));
+  background: var(--td3-yellow-soft, rgba(191, 135, 0, .06));
+}
+
+.hr-cross-machine-confirm {
+  display: flex;
+  align-items: flex-start;
+  gap: 7px;
+  margin-top: 4px;
+  color: inherit;
+}
+
+.hr-cross-machine-confirm input {
+  margin-top: 2px;
+}
+
+.hr-cross-machine-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.hr-cross-machine-actions small {
+  color: var(--tdw-muted, #9299a8);
+  font-size: 10.5px;
+}
+
+.hr-cross-machine-actions button {
+  min-height: 34px;
+  flex: 0 0 auto;
+}
 
 .hr-native-session-continuation {
   flex: 0 0 auto;
@@ -89,6 +221,12 @@
 
 .hr-native-session-continuation button {
   flex: 0 0 auto;
+}
+
+@media (max-width: 900px) {
+  .hr-cross-machine-fields {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 780px), (pointer: coarse) and (min-width: 600px) and (max-height: 640px) {
@@ -168,11 +306,17 @@
 }
 
 @media (max-width: 640px) {
+  .hr-cross-machine-fields {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .hr-cross-machine-actions,
   .hr-native-session-continuation {
     align-items: stretch;
     flex-direction: column;
   }
 
+  .hr-cross-machine-actions button,
   .hr-native-session-continuation button {
     width: 100%;
   }

--- a/web/src/native-session-observer.test.mjs
+++ b/web/src/native-session-observer.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 
 const observer = readFileSync(new URL('./components/native-session-observer.tsx', import.meta.url), 'utf8')
+const crossMachinePanel = readFileSync(new URL('./components/cross-machine-continue-panel.tsx', import.meta.url), 'utf8')
 const adapter = readFileSync(new URL('./native-session-v3-adapter.ts', import.meta.url), 'utf8')
 const workThread = readFileSync(new URL('./components/work-thread-conversation.tsx', import.meta.url), 'utf8')
 const nativeModel = readFileSync(new URL('./native-session-model.ts', import.meta.url), 'utf8')
@@ -21,6 +22,25 @@ assert.equal(observer.includes('startTaskDeskSessionLiveRefresh'), false, 'obser
 assert.equal(observer.includes('sendNativeSessionPrompt'), false, 'observer must not own a parallel send controller')
 assert.equal(observer.includes('stopNativeSession'), false, 'observer must not own a parallel Stop controller')
 assert.equal(observer.includes('ModelSelectionControl'), false, 'observer must not own a parallel model picker')
+
+// Cross-machine continuation is intentionally isolated from the mature same-machine composer. This
+// protects normal Session sends while the newer route state machine gains browser/mobile coverage.
+assert.ok(observer.includes('const sameMachineRoutes = useMemo'), 'same-machine routing must remain an explicit isolated set')
+assert.ok(observer.includes('const crossMachineRoutes = useMemo'), 'cross-machine destinations must remain an explicit isolated set')
+assert.ok(observer.includes('<CrossMachineContinuePanel'), 'cross-machine continuation must use its explicit safety surface')
+assert.ok(observer.includes('routes={crossMachineRoutes}'), 'the cross-machine panel must never receive the source-machine route')
+assert.ok(observer.includes('machines: sameMachineRoutes'), 'the mature composer must stay scoped to same-machine harness routing')
+assert.equal(observer.includes('machines: routableRoutes'), false, 'cross-machine routes must not silently enter the mature composer yet')
+
+assert.ok(crossMachinePanel.includes('loadCrossMachineProjectRoute'), 'cross-machine selection must resolve canonical machine-local Projects')
+assert.ok(crossMachinePanel.includes('planCrossMachineContinuation'), 'cross-machine UI must preflight Project continuity before mutation')
+assert.ok(crossMachinePanel.includes('continueNativeSessionAcrossMachine'), 'the final UI mutation must use the crash-safe orchestrator')
+assert.ok(crossMachinePanel.includes('confirmedProjectContinuity: confirmationRequired && confirmed'), 'diverged workspaces must require explicit user confirmation')
+assert.ok(crossMachinePanel.includes('plan?.disposition === "blocked"'), 'repository/history mismatch must be visibly blocked')
+assert.ok(crossMachinePanel.includes('taskClient.listAgentModels'), 'target model choice must come from the selected harness current catalog')
+assert.ok(crossMachinePanel.includes('attachments: []'), 'the first cross-machine UI must make its no-attachment boundary explicit')
+assert.ok(crossMachinePanel.includes('Attachments and source permissions are not transferred.'), 'the authority and attachment boundary must be visible in the UI')
+assert.ok(crossMachinePanel.indexOf('planCrossMachineContinuation') < crossMachinePanel.indexOf('continueNativeSessionAcrossMachine'), 'read-only planning must exist before the mutation path')
 
 assert.ok(adapter.includes('async loadMessagePage(config, sessionID, directory, before, limit, refreshHistory)'), 'adapter must observe the pages requested by the v3 controller through its scoped boundary')
 assert.equal(adapter.includes('api.loadMessagePage ='), false, 'native Session mounting must not mutate the shared API client')

--- a/web/src/native-session-observer.test.mjs
+++ b/web/src/native-session-observer.test.mjs
@@ -40,7 +40,8 @@ assert.ok(crossMachinePanel.includes('plan?.disposition === "blocked"'), 'reposi
 assert.ok(crossMachinePanel.includes('taskClient.listAgentModels'), 'target model choice must come from the selected harness current catalog')
 assert.ok(crossMachinePanel.includes('attachments: []'), 'the first cross-machine UI must make its no-attachment boundary explicit')
 assert.ok(crossMachinePanel.includes('Attachments and source permissions are not transferred.'), 'the authority and attachment boundary must be visible in the UI')
-assert.ok(crossMachinePanel.indexOf('planCrossMachineContinuation') < crossMachinePanel.indexOf('continueNativeSessionAcrossMachine'), 'read-only planning must exist before the mutation path')
+assert.ok(crossMachinePanel.includes('&& planReady'), 'the mutation button must remain gated on a completed safe plan or explicit review confirmation')
+assert.ok(crossMachinePanel.includes('if (!canSend || !machine || !agent || !projectRoute || !targetProject || !plan) return'), 'the submit path must enforce the same plan gate instead of trusting disabled-button presentation')
 
 assert.ok(adapter.includes('async loadMessagePage(config, sessionID, directory, before, limit, refreshHistory)'), 'adapter must observe the pages requested by the v3 controller through its scoped boundary')
 assert.equal(adapter.includes('api.loadMessagePage ='), false, 'native Session mounting must not mutate the shared API client')

--- a/web/src/native-session-routing.ts
+++ b/web/src/native-session-routing.ts
@@ -27,6 +27,10 @@ export type NativeSessionRouteContinueInput = {
   prompt: string
   attachments: AttachmentPart[]
   model: ModelSelection | null
+  /** Required only when the destination is another machine. Same-machine routing ignores it. */
+  projectID?: string
+  /** Explicit acknowledgement of a reviewed-but-not-identical cross-machine workspace. */
+  confirmedProjectContinuity?: boolean
 }
 
 type PendingRouteContinue = {


### PR DESCRIPTION
Stacked on #431. Adds the first explicit cross-machine continuation UI while deliberately leaving the mature same-machine composer unchanged.

- shows `Continue on another machine` only when another connected machine exposes a writable native harness
- keeps machine, Project, harness and model selection read-only until the final submit
- resolves target Projects from the target daemon and never displays/carries cross-machine filesystem paths
- loads the selected target harness's current model catalog and requires a verified model when that harness exposes model selection
- runs the read-only Project planner and surfaces `ready`, `confirm`, or `blocked`
- requires an explicit checkbox before a reviewed/diverged workspace may mutate anything
- blocks repository/history mismatch completely
- executes through the crash-safe cross-machine orchestrator, which re-runs Project preflight at the mutation boundary
- explicitly transfers no attachments or source permissions
- keeps existing same-machine harness switching scoped to the mature WorkThread composer, reducing regression risk
- adds static regression assertions that preserve the UI/authority boundary and same-machine isolation
- adds responsive styling for desktop and mobile

Base: `codex/p2-cross-machine-authority-boundary` while #431 completes CI. After the parent integrates, retarget this PR to `codex/development-2026-09-11`.

Never merge to `main`.

Refs #371