### PR TITLE
P2: surface durable handoff lineage and boundary state

### DIFF
--- a/web/src/components/native-session-lineage-panel.tsx
+++ b/web/src/components/native-session-lineage-panel.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useMemo, useState } from "react"
+import { api } from "../api"
+import type { NativeSessionSurfaceTarget } from "../native-session-discovery"
+import { nativeSessionLineage, type NativeSessionLineageEntry } from "../native-session-lineage"
+import type { NativeSessionRouteMachine } from "../native-session-routing"
+import type { ServerConfig } from "../types"
+
+type Props = {
+  target: NativeSessionSurfaceTarget
+  routes: NativeSessionRouteMachine[]
+  interactionEnabled: boolean
+  onConnectionIssue?: () => void
+}
+
+function machineConfig(config: ServerConfig): ServerConfig {
+  return { ...config, agentId: undefined }
+}
+
+function transportFailure(reason: unknown): boolean {
+  return /cannot reach|timed out|network|connection|failed to fetch/i.test(reason instanceof Error ? reason.message : String(reason))
+}
+
+function formatTime(value: string): string {
+  const time = Date.parse(value)
+  return Number.isFinite(time)
+    ? new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(time)
+    : value
+}
+
+/**
+ * Durable, read-only handoff lineage for one real native Session.
+ *
+ * The daemon stores the edge on both machines, so this survives navigation/restart without importing
+ * either provider transcript. The surface intentionally never displays the other machine's path and
+ * never treats source permission metadata as target authority.
+ */
+export function NativeSessionLineagePanel({ target, routes, interactionEnabled, onConnectionIssue }: Props) {
+  const [entries, setEntries] = useState<NativeSessionLineageEntry[]>([])
+
+  useEffect(() => {
+    let disposed = false
+    setEntries([])
+    if (!interactionEnabled) return () => { disposed = true }
+
+    void api.listNativeSessionLinks(machineConfig(target.config), target.ref)
+      .then(({ links }) => {
+        if (!disposed) setEntries(nativeSessionLineage(target.ref, links))
+      })
+      .catch((reason) => {
+        if (!disposed && transportFailure(reason)) onConnectionIssue?.()
+        // Lineage is enrichment. An older daemon or unavailable optional endpoint must never make an
+        // otherwise readable native Session fail to open.
+      })
+
+    return () => { disposed = true }
+  }, [target.key, target.machineID, target.agentID, target.sessionID, target.config.host, target.config.port, interactionEnabled, onConnectionIssue])
+
+  const routeByMachine = useMemo(
+    () => new Map(routes.map((route) => [route.machineID, route])),
+    [routes]
+  )
+
+  if (!entries.length) return null
+
+  const identityLabel = (entry: NativeSessionLineageEntry) => {
+    const machine = routeByMachine.get(entry.other.machineID)
+    const agent = machine?.agents.find((candidate) => candidate.id === entry.other.agentID)
+    return `${agent?.label || entry.other.agentID} · ${machine?.label || entry.other.machineID}`
+  }
+
+  return (
+    <section className="hr-native-lineage" aria-label="Session handoff lineage">
+      <header>
+        <strong>Handoff lineage</strong>
+        <span>Native Sessions stay separate; only the explicit handoff edge and bounded control context are shared.</span>
+      </header>
+      <div className="hr-native-lineage-list">
+        {entries.map((entry) => (
+          <article
+            key={`${entry.direction}:${entry.other.machineID}:${entry.other.agentID}:${entry.other.sessionID}:${entry.createdAt}`}
+            className={`hr-native-lineage-entry ${entry.direction}`}
+          >
+            <div className="hr-native-lineage-identity">
+              <span>{entry.direction === "incoming" ? "Continued from" : "Continues on"}</span>
+              <strong>{identityLabel(entry)}</strong>
+              <small>Session {entry.other.sessionID} · {formatTime(entry.createdAt)}</small>
+            </div>
+            <div className="hr-native-lineage-boundary" aria-label="Handoff boundary state">
+              <span className={entry.contextCarried ? "carried" : "neutral"}>
+                {entry.contextCarried ? "Task context carried" : "No portable task context recorded"}
+              </span>
+              <span className="invalidated">Source authority invalidated</span>
+              <span className="fresh">Target authorization is evaluated independently</span>
+              <span className="neutral">Attachments not transferred</span>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/web/src/components/native-session-lineage-panel.tsx
+++ b/web/src/components/native-session-lineage-panel.tsx
@@ -81,7 +81,7 @@ export function NativeSessionLineagePanel({ target, routes, interactionEnabled, 
             className={`hr-native-lineage-entry ${entry.direction}`}
           >
             <div className="hr-native-lineage-identity">
-              <span>{entry.direction === "incoming" ? "Continued from" : "Continues on"}</span>
+              <span>{entry.direction === "incoming" ? "Handoff source" : "Handoff target"}</span>
               <strong>{identityLabel(entry)}</strong>
               <small>Session {entry.other.sessionID} · {formatTime(entry.createdAt)}</small>
             </div>

--- a/web/src/components/native-session-observer.tsx
+++ b/web/src/components/native-session-observer.tsx
@@ -19,6 +19,7 @@ import type { AgentModelScope } from "../taskClient"
 import type { CommandInfo, MachineAgentHost } from "../types"
 import { LoadingIcon } from "../Icons"
 import { CrossMachineContinuePanel } from "./cross-machine-continue-panel"
+import { NativeSessionLineagePanel } from "./native-session-lineage-panel"
 import { WorkThreadConversation } from "./work-thread-conversation"
 import "../native-session-observer.css"
 
@@ -235,6 +236,13 @@ export function NativeSessionObserver({
 
   return (
     <div className="hr-native-session-observer writable">
+      <NativeSessionLineagePanel
+        target={target}
+        routes={routableRoutes}
+        interactionEnabled={interactionEnabled}
+        onConnectionIssue={onConnectionIssue}
+      />
+
       {onOpenSession && crossMachineRoutes.length ? (
         <CrossMachineContinuePanel
           source={target}

--- a/web/src/native-session-continuation.test.mjs
+++ b/web/src/native-session-continuation.test.mjs
@@ -3,6 +3,7 @@ import { probeNativeSessionContinuation } from './native-session-continuation.ts
 import './cross-machine-continuation.test.mjs'
 import './cross-machine-route-projects.test.mjs'
 import './cross-machine-route-plan.test.mjs'
+import './native-session-lineage.test.mjs'
 
 function target(overrides = {}) {
   return {

--- a/web/src/native-session-lineage.test.mjs
+++ b/web/src/native-session-lineage.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { nativeSessionLineage } from "./native-session-lineage.ts"
+
+const current = { machineID: "machine-b", agentID: "claude", sessionID: "target-1", directory: "/repo-copy" }
+const source = { machineID: "machine-a", agentID: "codex", sessionID: "source-1", directory: "/repo" }
+const next = { machineID: "machine-c", agentID: "pi", sessionID: "next-1", directory: "/work/repo" }
+
+function link(overrides = {}) {
+  return {
+    type: "handoff",
+    source,
+    target: current,
+    createdAt: "2026-09-12T05:00:00.000Z",
+    transferredContext: "Task state and evidence",
+    ...overrides
+  }
+}
+
+test("incoming lineage exposes portable context but invalidates source authority", () => {
+  const entries = nativeSessionLineage(current, [link()])
+  assert.equal(entries.length, 1)
+  assert.equal(entries[0].direction, "incoming")
+  assert.deepEqual(entries[0].other, source)
+  assert.equal(entries[0].contextCarried, true)
+  assert.equal(entries[0].authority, "invalidated")
+  assert.equal(entries[0].targetAuthorization, "re_evaluate")
+  assert.equal(entries[0].attachments, "not_transferred")
+})
+
+test("outgoing lineage points at the exact target without comparing machine-local paths", () => {
+  const entries = nativeSessionLineage(
+    { ...current, directory: "/different/local/path" },
+    [{ ...link(), source: current, target: next }]
+  )
+  assert.equal(entries.length, 1)
+  assert.equal(entries[0].direction, "outgoing")
+  assert.deepEqual(entries[0].other, next)
+})
+
+test("unrelated and self links are excluded and duplicate edges collapse", () => {
+  const unrelated = {
+    ...link(),
+    source: { machineID: "x", agentID: "codex", sessionID: "x1", directory: "/x" },
+    target: { machineID: "y", agentID: "codex", sessionID: "y1", directory: "/y" }
+  }
+  const self = { ...link(), source: current, target: current }
+  assert.equal(nativeSessionLineage(current, [unrelated, self, link(), link()]).length, 1)
+})
+
+test("missing portable context is represented as not carried instead of inventing state", () => {
+  const entries = nativeSessionLineage(current, [link({ transferredContext: undefined })])
+  assert.equal(entries[0].contextCarried, false)
+})

--- a/web/src/native-session-lineage.ts
+++ b/web/src/native-session-lineage.ts
@@ -1,0 +1,74 @@
+import type { NativeSessionIdentityPayload, NativeSessionLinkRecord } from "./api"
+
+export type NativeSessionLineageDirection = "incoming" | "outgoing"
+
+export type NativeSessionLineageEntry = {
+  direction: NativeSessionLineageDirection
+  other: NativeSessionIdentityPayload
+  createdAt: string
+  contextCarried: boolean
+  authority: "invalidated"
+  targetAuthorization: "re_evaluate"
+  attachments: "not_transferred"
+}
+
+function sameNativeIdentity(left: NativeSessionIdentityPayload, right: NativeSessionIdentityPayload): boolean {
+  return left.machineID === right.machineID
+    && left.agentID === right.agentID
+    && left.sessionID === right.sessionID
+}
+
+function lineageKey(link: NativeSessionLinkRecord): string {
+  return [
+    link.source.machineID,
+    link.source.agentID,
+    link.source.sessionID,
+    link.target.machineID,
+    link.target.agentID,
+    link.target.sessionID,
+    link.createdAt
+  ].join("|")
+}
+
+/**
+ * Project a daemon-owned handoff edge into a UI-safe lineage record.
+ *
+ * Paths stay machine-local and are deliberately not part of the displayed identity. The boundary
+ * state is derived from the cross-machine contract rather than source Session metadata: portable
+ * task context may be carried, while permissions and attachments are never inherited.
+ */
+export function nativeSessionLineage(
+  identity: NativeSessionIdentityPayload,
+  links: NativeSessionLinkRecord[]
+): NativeSessionLineageEntry[] {
+  const seen = new Set<string>()
+  const entries: NativeSessionLineageEntry[] = []
+
+  for (const link of links) {
+    if (link.type !== "handoff") continue
+    const sourceMatch = sameNativeIdentity(identity, link.source)
+    const targetMatch = sameNativeIdentity(identity, link.target)
+    if (sourceMatch === targetMatch) continue
+
+    const key = lineageKey(link)
+    if (seen.has(key)) continue
+    seen.add(key)
+
+    entries.push({
+      direction: targetMatch ? "incoming" : "outgoing",
+      other: targetMatch ? link.source : link.target,
+      createdAt: link.createdAt,
+      contextCarried: Boolean(link.transferredContext?.trim()),
+      authority: "invalidated",
+      targetAuthorization: "re_evaluate",
+      attachments: "not_transferred"
+    })
+  }
+
+  return entries.sort((left, right) => {
+    const leftTime = Date.parse(left.createdAt)
+    const rightTime = Date.parse(right.createdAt)
+    if (Number.isFinite(leftTime) && Number.isFinite(rightTime)) return leftTime - rightTime
+    return left.createdAt.localeCompare(right.createdAt)
+  })
+}

--- a/web/src/native-session-observer.css
+++ b/web/src/native-session-observer.css
@@ -62,6 +62,102 @@
   line-height: 1.4;
 }
 
+.hr-native-lineage {
+  flex: 0 0 auto;
+  margin: 0 10px 8px;
+  border: 1px solid var(--uw-border, rgba(127, 127, 127, 0.24));
+  border-radius: 12px;
+  background: var(--tdw-panel, rgba(127, 127, 127, 0.04));
+  overflow: hidden;
+}
+
+.hr-native-lineage > header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--uw-border, rgba(127, 127, 127, 0.18));
+}
+
+.hr-native-lineage > header strong {
+  flex: 0 0 auto;
+  font-size: 11.5px;
+}
+
+.hr-native-lineage > header span {
+  min-width: 0;
+  color: var(--tdw-muted, #9299a8);
+  font-size: 10.5px;
+  line-height: 1.35;
+}
+
+.hr-native-lineage-list {
+  display: grid;
+  max-height: 180px;
+  overflow: auto;
+}
+
+.hr-native-lineage-entry {
+  display: grid;
+  grid-template-columns: minmax(150px, .8fr) minmax(280px, 1.8fr);
+  gap: 10px;
+  padding: 8px 10px;
+}
+
+.hr-native-lineage-entry + .hr-native-lineage-entry {
+  border-top: 1px solid var(--uw-border, rgba(127, 127, 127, 0.16));
+}
+
+.hr-native-lineage-identity {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.hr-native-lineage-identity > span,
+.hr-native-lineage-identity > small {
+  color: var(--tdw-muted, #9299a8);
+  font-size: 10.5px;
+}
+
+.hr-native-lineage-identity > strong,
+.hr-native-lineage-identity > small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hr-native-lineage-identity > strong {
+  font-size: 11.5px;
+}
+
+.hr-native-lineage-boundary {
+  min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-content: center;
+  gap: 5px;
+}
+
+.hr-native-lineage-boundary > span {
+  padding: 3px 6px;
+  border: 1px solid var(--uw-border, rgba(127, 127, 127, 0.22));
+  border-radius: 999px;
+  color: var(--tdw-muted, #9299a8);
+  font-size: 10px;
+  line-height: 1.2;
+}
+
+.hr-native-lineage-boundary > .invalidated {
+  border-color: var(--td3-yellow-border, rgba(191, 135, 0, .34));
+  background: var(--td3-yellow-soft, rgba(191, 135, 0, .06));
+}
+
+.hr-native-lineage-boundary > .carried,
+.hr-native-lineage-boundary > .fresh {
+  color: inherit;
+}
+
 .hr-cross-machine-panel {
   flex: 0 0 auto;
   margin: 0 10px 8px;
@@ -227,6 +323,10 @@
   .hr-cross-machine-fields {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
+  .hr-native-lineage-entry {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 @media (max-width: 780px), (pointer: coarse) and (min-width: 600px) and (max-height: 640px) {
@@ -306,6 +406,16 @@
 }
 
 @media (max-width: 640px) {
+  .hr-native-lineage > header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .hr-native-lineage-list {
+    max-height: 150px;
+  }
+
   .hr-cross-machine-fields {
     grid-template-columns: minmax(0, 1fr);
   }

--- a/web/src/native-session-observer.test.mjs
+++ b/web/src/native-session-observer.test.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs'
 
 const observer = readFileSync(new URL('./components/native-session-observer.tsx', import.meta.url), 'utf8')
 const crossMachinePanel = readFileSync(new URL('./components/cross-machine-continue-panel.tsx', import.meta.url), 'utf8')
+const lineagePanel = readFileSync(new URL('./components/native-session-lineage-panel.tsx', import.meta.url), 'utf8')
 const adapter = readFileSync(new URL('./native-session-v3-adapter.ts', import.meta.url), 'utf8')
 const workThread = readFileSync(new URL('./components/work-thread-conversation.tsx', import.meta.url), 'utf8')
 const nativeModel = readFileSync(new URL('./native-session-model.ts', import.meta.url), 'utf8')
@@ -42,6 +43,16 @@ assert.ok(crossMachinePanel.includes('attachments: []'), 'the first cross-machin
 assert.ok(crossMachinePanel.includes('Attachments and source permissions are not transferred.'), 'the authority and attachment boundary must be visible in the UI')
 assert.ok(crossMachinePanel.includes('&& planReady'), 'the mutation button must remain gated on a completed safe plan or explicit review confirmation')
 assert.ok(crossMachinePanel.includes('if (!canSend || !machine || !agent || !projectRoute || !targetProject || !plan) return'), 'the submit path must enforce the same plan gate instead of trusting disabled-button presentation')
+
+// Handoff lineage is read-only enrichment. It must survive restart through the machine-level link
+// store while keeping remote paths and source authority out of the presentation contract.
+assert.ok(observer.includes('<NativeSessionLineagePanel'), 'open linked Sessions must surface durable handoff lineage')
+assert.ok(lineagePanel.includes('api.listNativeSessionLinks(machineConfig(target.config), target.ref)'), 'lineage must come from the durable machine-level link store')
+assert.ok(lineagePanel.includes('agentId: undefined'), 'lineage lookup must use the machine-level endpoint rather than an agent-scoped path')
+assert.ok(lineagePanel.includes('Source authority invalidated'), 'the handoff boundary must visibly invalidate source authority')
+assert.ok(lineagePanel.includes('Target authorization is evaluated independently'), 'the target must visibly require independent authorization semantics')
+assert.ok(lineagePanel.includes('Attachments not transferred'), 'attachment non-transfer must remain visible after the handoff')
+assert.equal(lineagePanel.includes('entry.other.directory'), false, 'the lineage surface must never display another machine filesystem path')
 
 assert.ok(adapter.includes('async loadMessagePage(config, sessionID, directory, before, limit, refreshHistory)'), 'adapter must observe the pages requested by the v3 controller through its scoped boundary')
 assert.equal(adapter.includes('api.loadMessagePage ='), false, 'native Session mounting must not mutate the shared API client')


### PR DESCRIPTION
Adds the durable read-only handoff surface required by #371 after the cross-machine continuation UI landed.

- reads persisted handoff edges from the machine-level `/v1/session-links` store when a native Session is opened
- shows incoming/outgoing native Session lineage after navigation or restart without importing provider transcripts
- keeps other-machine filesystem paths completely out of the UI projection
- makes boundary semantics explicit: portable task context carried when present, source authority invalidated, target authorization evaluated independently, attachments not transferred
- never turns lineage reads into an availability dependency: older/unsupported link endpoints do not block opening the Session
- preserves same-machine/cross-machine routing behavior unchanged
- adds pure lineage projection tests plus static UI boundary guards
- responsive compact presentation for desktop/mobile

Target: `codex/development-2026-09-11` only. Never merge to `main`.

Refs #371