### PR TITLE
P2: persist structured portable handoff state

### DIFF
--- a/bridge/src/portable-handoff-state.js
+++ b/bridge/src/portable-handoff-state.js
@@ -38,6 +38,28 @@ function normalizedEvidence(value) {
   }
 }
 
+function validateDecisionEvidence(decision, reason, evidence) {
+  if (evidence.project === "different" || evidence.repository === "different" || evidence.history === "different") {
+    throw invalidState("Portable handoff state cannot represent a blocked Project mismatch")
+  }
+  if (decision === "automatic") {
+    if (reason !== "exact_workspace"
+        || evidence.project !== "match"
+        || evidence.repository !== "match"
+        || evidence.branch !== "match"
+        || evidence.head !== "match"
+        || evidence.sourceDirty !== false
+        || evidence.targetDirty !== false
+        || evidence.exactWorkspace !== true) {
+      throw invalidState("Automatic portable handoff state requires internally consistent exact workspace evidence")
+    }
+    return
+  }
+  if (reason === "exact_workspace" || evidence.exactWorkspace !== false) {
+    throw invalidState("Reviewed portable handoff state must represent a non-exact workspace")
+  }
+}
+
 /**
  * Validate and canonicalize the only structured metadata allowed to cross a machine handoff.
  * Unknown fields are discarded, so permission/approval/tool/path material cannot become durable
@@ -60,22 +82,8 @@ export function normalizePortableHandoffState(value) {
   if (!DECISIONS.has(project.decision) || !REASONS.has(project.reason)) {
     throw invalidState("Portable handoff Project decision is invalid")
   }
-  if (project.decision === "automatic" && project.reason !== "exact_workspace") {
-    throw invalidState("Automatic portable handoff state requires exact workspace evidence")
-  }
-  if (project.decision === "review" && project.reason === "exact_workspace") {
-    throw invalidState("Reviewed portable handoff state cannot claim exact workspace continuity")
-  }
   const evidence = normalizedEvidence(project.evidence)
-  if (evidence.project === "different" || evidence.repository === "different" || evidence.history === "different") {
-    throw invalidState("Portable handoff state cannot represent a blocked Project mismatch")
-  }
-  if (project.decision === "automatic" && !evidence.exactWorkspace) {
-    throw invalidState("Automatic portable handoff state requires exactWorkspace=true")
-  }
-  if (project.decision === "review" && evidence.exactWorkspace) {
-    throw invalidState("Reviewed portable handoff state requires exactWorkspace=false")
-  }
+  validateDecisionEvidence(project.decision, project.reason, evidence)
   if (!controls || typeof controls !== "object" || Array.isArray(controls)
       || controls.sourceAuthority !== "invalidated"
       || controls.targetAuthorization !== "re_evaluate"

--- a/bridge/src/portable-handoff-state.js
+++ b/bridge/src/portable-handoff-state.js
@@ -1,0 +1,107 @@
+const EVIDENCE = new Set(["match", "different", "unverified"])
+const DECISIONS = new Set(["automatic", "review"])
+const REASONS = new Set(["exact_workspace", "workspace_diverged", "project_unverified"])
+const MAX_PROJECT_ID = 500
+const MAX_TITLE = 200
+const MAX_SERIALIZED = 4_096
+
+function invalidState(message) {
+  const error = new Error(message)
+  error.code = "invalid_request"
+  return error
+}
+
+function normalizedString(value, label, maxLength) {
+  const normalized = typeof value === "string" ? value.trim() : ""
+  if (!normalized || normalized.length > maxLength) throw invalidState(`${label} is invalid`)
+  return normalized
+}
+
+function normalizedEvidence(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw invalidState("Portable handoff Project evidence is required")
+  }
+  const names = ["project", "repository", "history", "branch", "head"]
+  const normalized = {}
+  for (const name of names) {
+    if (!EVIDENCE.has(value[name])) throw invalidState(`Portable handoff ${name} evidence is invalid`)
+    normalized[name] = value[name]
+  }
+  if (typeof value.exactWorkspace !== "boolean") throw invalidState("Portable handoff exactWorkspace evidence is invalid")
+  if (value.sourceDirty !== undefined && typeof value.sourceDirty !== "boolean") throw invalidState("Portable handoff sourceDirty evidence is invalid")
+  if (value.targetDirty !== undefined && typeof value.targetDirty !== "boolean") throw invalidState("Portable handoff targetDirty evidence is invalid")
+  return {
+    ...normalized,
+    ...(typeof value.sourceDirty === "boolean" ? { sourceDirty: value.sourceDirty } : {}),
+    ...(typeof value.targetDirty === "boolean" ? { targetDirty: value.targetDirty } : {}),
+    exactWorkspace: value.exactWorkspace
+  }
+}
+
+/**
+ * Validate and canonicalize the only structured metadata allowed to cross a machine handoff.
+ * Unknown fields are discarded, so permission/approval/tool/path material cannot become durable
+ * merely because a client smuggled it alongside an otherwise valid record.
+ */
+export function normalizePortableHandoffState(value) {
+  if (value === undefined || value === null) return undefined
+  if (!value || typeof value !== "object" || Array.isArray(value) || value.version !== 1) {
+    throw invalidState("Portable handoff state version is invalid")
+  }
+  const task = value.task
+  const project = value.project
+  const controls = value.controls
+  if (!task || typeof task !== "object" || Array.isArray(task) || task.state !== "continuing") {
+    throw invalidState("Portable handoff task state is invalid")
+  }
+  if (!project || typeof project !== "object" || Array.isArray(project)) {
+    throw invalidState("Portable handoff Project state is required")
+  }
+  if (!DECISIONS.has(project.decision) || !REASONS.has(project.reason)) {
+    throw invalidState("Portable handoff Project decision is invalid")
+  }
+  if (project.decision === "automatic" && project.reason !== "exact_workspace") {
+    throw invalidState("Automatic portable handoff state requires exact workspace evidence")
+  }
+  if (project.decision === "review" && project.reason === "exact_workspace") {
+    throw invalidState("Reviewed portable handoff state cannot claim exact workspace continuity")
+  }
+  const evidence = normalizedEvidence(project.evidence)
+  if (evidence.project === "different" || evidence.repository === "different" || evidence.history === "different") {
+    throw invalidState("Portable handoff state cannot represent a blocked Project mismatch")
+  }
+  if (project.decision === "automatic" && !evidence.exactWorkspace) {
+    throw invalidState("Automatic portable handoff state requires exactWorkspace=true")
+  }
+  if (project.decision === "review" && evidence.exactWorkspace) {
+    throw invalidState("Reviewed portable handoff state requires exactWorkspace=false")
+  }
+  if (!controls || typeof controls !== "object" || Array.isArray(controls)
+      || controls.sourceAuthority !== "invalidated"
+      || controls.targetAuthorization !== "re_evaluate"
+      || controls.attachments !== "not_transferred") {
+    throw invalidState("Portable handoff control boundary is invalid")
+  }
+
+  const normalized = {
+    version: 1,
+    task: {
+      title: normalizedString(task.title, "Portable handoff task title", MAX_TITLE),
+      state: "continuing"
+    },
+    project: {
+      sourceProjectId: normalizedString(project.sourceProjectId, "Portable handoff source Project id", MAX_PROJECT_ID),
+      targetProjectId: normalizedString(project.targetProjectId, "Portable handoff target Project id", MAX_PROJECT_ID),
+      decision: project.decision,
+      reason: project.reason,
+      evidence
+    },
+    controls: {
+      sourceAuthority: "invalidated",
+      targetAuthorization: "re_evaluate",
+      attachments: "not_transferred"
+    }
+  }
+  if (JSON.stringify(normalized).length > MAX_SERIALIZED) throw invalidState("Portable handoff state is too large")
+  return normalized
+}

--- a/bridge/src/session-claim-server.js
+++ b/bridge/src/session-claim-server.js
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto"
 import http from "node:http"
 import { authenticateDaemonRequest, writeJSON } from "./http-policy.js"
+import { normalizePortableHandoffState } from "./portable-handoff-state.js"
 
 const SESSION_OPERATION_ROUTE = /^\/v1\/agents\/([^/]+)\/session\/([^/]+)\/(claim|prompt|command|stop|handoff)$/
 const SESSION_LINK_ROUTE = "/v1/session-links"
@@ -159,11 +160,13 @@ function sessionLinkInput(body) {
   if (typeof transferredContext === "string" && transferredContext.length > 12_000) {
     throw requestError("Transferred Session context is too large")
   }
+  const portableState = normalizePortableHandoffState(candidate.portableState)
   return {
     source: nativeSessionIdentityInput(candidate.source, "Source Session"),
     target: nativeSessionIdentityInput(candidate.target, "Target Session"),
     createdAt: typeof candidate.createdAt === "string" && candidate.createdAt ? candidate.createdAt : new Date().toISOString(),
-    ...(typeof transferredContext === "string" && transferredContext ? { transferredContext } : {})
+    ...(typeof transferredContext === "string" && transferredContext ? { transferredContext } : {}),
+    ...(portableState ? { portableState } : {})
   }
 }
 

--- a/bridge/src/session-link-store.js
+++ b/bridge/src/session-link-store.js
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto"
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
 import path from "node:path"
+import { normalizePortableHandoffState } from "./portable-handoff-state.js"
 
 const VERSION = 1
 
@@ -36,7 +37,8 @@ function normalizedTransferredContext(value) {
  *
  * A link does not own either Session or create a second conversation identity. It records that
  * Harness Remote deliberately handed work from one native Session to another and may retain the
- * exact bounded context string used for that handoff so the UI can explain it after reopening.
+ * exact bounded context string and runtime-neutral task/evidence/control state used for that handoff
+ * so the UI can explain the boundary after reopening.
  *
  * Cross-machine links are replicated metadata, not shared authority: a daemon stores an edge only
  * when at least one endpoint belongs to that daemon. The same A -> B edge may therefore be present
@@ -70,7 +72,17 @@ export class SessionLinkStore {
         if (!link || typeof link !== "object" || link.type !== "handoff") continue
         if (!validIdentity(link.source) || !validIdentity(link.target)) continue
         if (!this.#isLocalLink(link.source, link.target)) continue
-        this.#links.set(linkKey(link.source, link.target), link)
+        let portableState
+        try { portableState = normalizePortableHandoffState(link.portableState) } catch { portableState = undefined }
+        const normalized = {
+          type: "handoff",
+          source: link.source,
+          target: link.target,
+          createdAt: link.createdAt,
+          ...(typeof link.transferredContext === "string" && link.transferredContext ? { transferredContext: link.transferredContext } : {}),
+          ...(portableState ? { portableState } : {})
+        }
+        this.#links.set(linkKey(link.source, link.target), normalized)
       }
     } catch (error) {
       if (error?.code === "ENOENT") return
@@ -100,19 +112,26 @@ export class SessionLinkStore {
     return next
   }
 
-  async addHandoff({ source, target, createdAt = new Date().toISOString(), transferredContext }) {
+  async addHandoff({ source, target, createdAt = new Date().toISOString(), transferredContext, portableState }) {
     if (!validIdentity(source) || !validIdentity(target)) throw new Error("Native Session link requires complete source and target identities")
     if (!this.#isLocalLink(source, target)) {
       throw invalidLink("Native Session link must include a Session owned by this machine")
     }
     const context = normalizedTransferredContext(transferredContext)
+    const state = normalizePortableHandoffState(portableState)
     return this.#serial(async () => {
       await this.#load()
       const key = linkKey(source, target)
       const existing = this.#links.get(key)
       if (existing) {
-        if (!context || existing.transferredContext === context) return structuredClone(existing)
-        const updated = { ...existing, transferredContext: context }
+        const sameContext = !context || existing.transferredContext === context
+        const sameState = !state || JSON.stringify(existing.portableState) === JSON.stringify(state)
+        if (sameContext && sameState) return structuredClone(existing)
+        const updated = {
+          ...existing,
+          ...(context ? { transferredContext: context } : {}),
+          ...(state ? { portableState: state } : {})
+        }
         this.#links.set(key, updated)
         await this.#persist()
         return structuredClone(updated)
@@ -122,7 +141,8 @@ export class SessionLinkStore {
         source: structuredClone(source),
         target: structuredClone(target),
         createdAt,
-        ...(context ? { transferredContext: context } : {})
+        ...(context ? { transferredContext: context } : {}),
+        ...(state ? { portableState: state } : {})
       }
       this.#links.set(key, link)
       await this.#persist()

--- a/bridge/test/portable-handoff-state.test.js
+++ b/bridge/test/portable-handoff-state.test.js
@@ -40,6 +40,26 @@ function portable(overrides = {}) {
   }
 }
 
+function exactPortable() {
+  return portable({
+    project: {
+      ...portable().project,
+      decision: "automatic",
+      reason: "exact_workspace",
+      evidence: {
+        project: "match",
+        repository: "match",
+        history: "match",
+        branch: "match",
+        head: "match",
+        sourceDirty: false,
+        targetDirty: false,
+        exactWorkspace: true
+      }
+    }
+  })
+}
+
 async function listen(server) {
   await new Promise((resolve, reject) => {
     server.once("error", reject)
@@ -66,7 +86,7 @@ test("portable handoff state is canonical and strips unknown authority/path/tool
   assert.equal(serialized.includes("toolState"), false)
 })
 
-test("blocked Project evidence cannot be persisted as portable handoff state", () => {
+test("blocked or contradictory Project evidence cannot be persisted as portable handoff state", () => {
   assert.throws(
     () => normalizePortableHandoffState(portable({
       project: {
@@ -77,6 +97,16 @@ test("blocked Project evidence cannot be persisted as portable handoff state", (
       }
     })),
     /blocked Project mismatch/
+  )
+  assert.throws(
+    () => normalizePortableHandoffState({
+      ...exactPortable(),
+      project: {
+        ...exactPortable().project,
+        evidence: { ...exactPortable().project.evidence, targetDirty: true }
+      }
+    }),
+    /internally consistent exact workspace evidence/
   )
 })
 

--- a/bridge/test/portable-handoff-state.test.js
+++ b/bridge/test/portable-handoff-state.test.js
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import test from "node:test"
+import { normalizePortableHandoffState } from "../src/portable-handoff-state.js"
+import { SessionLinkStore } from "../src/session-link-store.js"
+import { createSessionClaimServer } from "../src/session-claim-server.js"
+
+const source = { machineID: "machine-1", agentID: "codex", sessionID: "source-1", directory: "/private/source" }
+const target = { machineID: "machine-2", agentID: "claude", sessionID: "target-1", directory: "/private/target" }
+
+function portable(overrides = {}) {
+  return {
+    version: 1,
+    task: { title: "Fix bridge regression", state: "continuing" },
+    project: {
+      sourceProjectId: "source-project",
+      targetProjectId: "target-project",
+      decision: "review",
+      reason: "workspace_diverged",
+      evidence: {
+        project: "match",
+        repository: "match",
+        history: "match",
+        branch: "different",
+        head: "different",
+        sourceDirty: false,
+        targetDirty: true,
+        exactWorkspace: false
+      }
+    },
+    controls: {
+      sourceAuthority: "invalidated",
+      targetAuthorization: "re_evaluate",
+      attachments: "not_transferred"
+    },
+    ...overrides
+  }
+}
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  return server.address().port
+}
+
+test("portable handoff state is canonical and strips unknown authority/path/tool fields", () => {
+  const normalized = normalizePortableHandoffState({
+    ...portable(),
+    permission: [{ action: "allow", pattern: "deploy prod" }],
+    path: "/must/not/cross",
+    toolState: { shell: "owned" },
+    task: { ...portable().task, prompt: "secret prompt", approval: "allow" },
+    project: { ...portable().project, sourcePath: "/source", targetPath: "/target", branchName: "secret-branch" }
+  })
+  assert.deepEqual(normalized, portable())
+  const serialized = JSON.stringify(normalized)
+  assert.equal(serialized.includes("deploy prod"), false)
+  assert.equal(serialized.includes("must/not/cross"), false)
+  assert.equal(serialized.includes("secret prompt"), false)
+  assert.equal(serialized.includes("secret-branch"), false)
+  assert.equal(serialized.includes("toolState"), false)
+})
+
+test("blocked Project evidence cannot be persisted as portable handoff state", () => {
+  assert.throws(
+    () => normalizePortableHandoffState(portable({
+      project: {
+        ...portable().project,
+        decision: "review",
+        reason: "workspace_diverged",
+        evidence: { ...portable().project.evidence, repository: "different" }
+      }
+    })),
+    /blocked Project mismatch/
+  )
+})
+
+test("Session link store persists canonical portable state across restart", async () => {
+  const stateDirectory = await mkdtemp(path.join(tmpdir(), "harness-portable-link-"))
+  try {
+    const first = new SessionLinkStore({ machineID: "machine-1", stateDirectory })
+    const link = await first.addHandoff({
+      source,
+      target,
+      transferredContext: "bounded context",
+      portableState: { ...portable(), permission: "allow", remotePath: "/private/target" }
+    })
+    assert.deepEqual(link.portableState, portable())
+
+    const restarted = new SessionLinkStore({ machineID: "machine-1", stateDirectory })
+    const [reloaded] = await restarted.listFor(source)
+    assert.deepEqual(reloaded.portableState, portable())
+    assert.equal(JSON.stringify(reloaded).includes("permission"), false)
+    assert.equal(JSON.stringify(reloaded).includes("remotePath"), false)
+  } finally {
+    await rm(stateDirectory, { recursive: true, force: true })
+  }
+})
+
+test("Session-link HTTP boundary accepts safe portable state and rejects blocked evidence", async () => {
+  const stateDirectory = await mkdtemp(path.join(tmpdir(), "harness-portable-http-"))
+  const store = new SessionLinkStore({ machineID: "machine-1", stateDirectory })
+  const server = createSessionClaimServer({
+    innerServer: new EventEmitter(),
+    config: { username: "", password: "", corsOrigins: [] },
+    sessionLinkStore: store
+  })
+  const port = await listen(server)
+  const endpoint = `http://127.0.0.1:${port}/v1/session-links`
+  const baseLink = { type: "handoff", source, target, createdAt: "2026-09-12T05:00:00.000Z" }
+  try {
+    const accepted = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        link: {
+          ...baseLink,
+          portableState: { ...portable(), permission: "allow", path: "/must/not/persist" }
+        }
+      })
+    })
+    assert.equal(accepted.status, 200)
+    const acceptedBody = await accepted.json()
+    assert.deepEqual(acceptedBody.link.portableState, portable())
+    assert.equal(JSON.stringify(acceptedBody).includes("must/not/persist"), false)
+
+    const rejected = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        link: {
+          ...baseLink,
+          portableState: portable({
+            project: {
+              ...portable().project,
+              evidence: { ...portable().project.evidence, history: "different" }
+            }
+          })
+        }
+      })
+    })
+    assert.equal(rejected.status, 400)
+    assert.match((await rejected.json()).error, /blocked Project mismatch/)
+  } finally {
+    await new Promise((resolve) => server.close(resolve))
+    await rm(stateDirectory, { recursive: true, force: true })
+  }
+})

--- a/web/src/cross-machine-continuation.test.mjs
+++ b/web/src/cross-machine-continuation.test.mjs
@@ -176,6 +176,35 @@ test("lost first-prompt response retries the same target and prompt request id",
   assert.deepEqual(calls.links.map((entry) => entry.host), ["source.local", "target.local", "source.local", "target.local"])
   assert.match(calls.links[0].link.transferredContext, /remaining failure/)
   assert.doesNotMatch(calls.links[0].link.transferredContext, /deploy production/, "source authorization must not leak into portable context")
+  assert.deepEqual(calls.links[0].link.portableState, {
+    version: 1,
+    task: { title: "Source session", state: "continuing" },
+    project: {
+      sourceProjectId: "source-project",
+      targetProjectId: "target-project",
+      decision: "automatic",
+      reason: "exact_workspace",
+      evidence: {
+        project: "match",
+        repository: "match",
+        history: "match",
+        branch: "match",
+        head: "match",
+        sourceDirty: false,
+        targetDirty: false,
+        exactWorkspace: true
+      }
+    },
+    controls: {
+      sourceAuthority: "invalidated",
+      targetAuthorization: "re_evaluate",
+      attachments: "not_transferred"
+    }
+  })
+  const portableSerialized = JSON.stringify(calls.links[0].link.portableState)
+  assert.equal(portableSerialized.includes("/repo"), false, "portable state must not cross filesystem paths")
+  assert.equal(portableSerialized.includes("deploy production"), false, "portable state must not inherit source authorization")
+  assert.equal(portableSerialized.includes("Continue with the bridge fix"), false, "portable state must not duplicate the prompt")
   assert.equal(calls.promptInputs[0].target.permission, undefined, "first-prompt target must not inherit source authority")
   assert.equal(calls.marked, 1)
   assert.equal(result.target.machineID, "machine-b")
@@ -203,6 +232,10 @@ test("review Project evidence blocks mutation until explicitly confirmed", async
   const result = await continueNativeSessionAcrossMachine(continuationInput(services, { confirmedProjectContinuity: true }))
   assert.equal(calls.create, 1)
   assert.equal(result.preflight.decision, "review")
+  assert.equal(calls.links[0].link.portableState.project.decision, "review")
+  assert.equal(calls.links[0].link.portableState.project.reason, "workspace_diverged")
+  assert.equal(calls.links[0].link.portableState.project.evidence.head, "different")
+  assert.equal(calls.links[0].link.portableState.controls.targetAuthorization, "re_evaluate")
 })
 
 test("a conflicting retry cannot redirect an unresolved continuation", async () => {

--- a/web/src/cross-machine-continuation.ts
+++ b/web/src/cross-machine-continuation.ts
@@ -24,6 +24,11 @@ import {
 import { normalizeModel, sameModel } from "./native-session-model"
 import { nativeSessionTransferredContext } from "./native-session-prompt"
 import type { NativeSessionRouteMachine } from "./native-session-routing"
+import {
+  buildPortableHandoffState,
+  parsePortableHandoffState,
+  type NativeSessionPortableHandoffState
+} from "./portable-handoff-state"
 import type { BackendKind, MachineAgentHost, MessageEnvelope, ModelSelection, ServerConfig } from "./types"
 
 export type CrossMachineContinuationResult = {
@@ -43,6 +48,7 @@ type PendingCrossMachineContinuation = {
   promptRequestId: string
   createdAt: number
   transferredContext?: string
+  portableState?: NativeSessionPortableHandoffState
 }
 
 export type CrossMachineContinuationServices = {
@@ -102,6 +108,7 @@ function loadPending(source: NativeSessionSurfaceTarget): PendingCrossMachineCon
     if (typeof parsed.title !== "string") return null
     if (typeof parsed.prompt !== "string" || !parsed.prompt.trim()) return null
     if (typeof parsed.promptRequestId !== "string" || !parsed.promptRequestId) return null
+    const portableState = parsePortableHandoffState(parsed.portableState)
     return {
       targetMachineID: parsed.targetMachineID,
       sourceProjectId: parsed.sourceProjectId,
@@ -113,7 +120,8 @@ function loadPending(source: NativeSessionSurfaceTarget): PendingCrossMachineCon
       model: normalizeModel(parsed.model),
       promptRequestId: parsed.promptRequestId,
       createdAt: typeof parsed.createdAt === "number" ? parsed.createdAt : Date.now(),
-      ...(typeof parsed.transferredContext === "string" ? { transferredContext: parsed.transferredContext } : {})
+      ...(typeof parsed.transferredContext === "string" ? { transferredContext: parsed.transferredContext } : {}),
+      ...(portableState ? { portableState } : {})
     }
   } catch {
     return null
@@ -248,7 +256,8 @@ function assertSamePendingRoute(
  * 1. Project continuity is checked before every mutation/recovery attempt.
  * 2. Target creation remains exactly-once through cross-machine-target-client.
  * 3. The exact target + first-prompt request id are persisted before creation is acknowledged.
- * 4. A bounded context snapshot is persisted before lineage or prompt delivery.
+ * 4. A bounded context snapshot and runtime-neutral task/evidence/control state are persisted before
+ *    lineage or prompt delivery.
  * 5. The same lineage edge is durably stored on both source and target daemons before the prompt.
  * 6. The first prompt uses its own durable id with no client TTL, so a lost accepted response cannot
  *    become a duplicate turn on retry.
@@ -302,6 +311,7 @@ export async function continueNativeSessionAcrossMachine({
     targetProjectId: targetProject
   })
   services.requireProjectApproval(preflight, { confirmed: confirmedProjectContinuity })
+  const portableState = buildPortableHandoffState(source, preflight)
 
   let pending = loadPending(source)
   if (pending) {
@@ -336,7 +346,8 @@ export async function continueNativeSessionAcrossMachine({
       prompt: normalizedPrompt,
       model: normalizedModel,
       promptRequestId: requestID(),
-      createdAt: Date.now()
+      createdAt: Date.now(),
+      portableState
     }
     if (!persistPending(source, pending)) {
       throw new Error("The target Session exists, but cross-machine recovery state could not be persisted. Retry the same destination to recover that exact Session.")
@@ -347,6 +358,16 @@ export async function continueNativeSessionAcrossMachine({
   // longer the only recovery handle. A crash before this acknowledgement is harmless: retrying the
   // route calls the same acknowledgement again.
   services.acknowledgeTargetSession(source)
+
+  // Older recovery records may predate the structured portable-state contract. Rebuild only from
+  // the current safe preflight; malformed localStorage content is never forwarded to either daemon.
+  if (!pending.portableState) {
+    const enriched = { ...pending, portableState }
+    if (!persistPending(source, enriched)) {
+      throw new Error("The target Session exists, but its portable handoff state could not be persisted. Retry the same destination before sending the first prompt.")
+    }
+    pending = enriched
+  }
 
   let sourceMessages: MessageEnvelope[] | undefined
   if (pending.transferredContext === undefined) {
@@ -365,17 +386,18 @@ export async function continueNativeSessionAcrossMachine({
   }
 
   const routedTarget = targetSurface(source, pending, targetMachine, targetAgent, sourceMessages)
-  const link: NativeSessionLinkRecord = {
+  const link: NativeSessionLinkRecord & { portableState: NativeSessionPortableHandoffState } = {
     type: "handoff",
     source: source.ref,
     target: pending.target,
     createdAt: new Date(pending.createdAt).toISOString(),
-    ...(pending.transferredContext ? { transferredContext: pending.transferredContext } : {})
+    ...(pending.transferredContext ? { transferredContext: pending.transferredContext } : {}),
+    portableState: pending.portableState
   }
 
   // Replicate the same metadata edge to both machine-local stores. addHandoff is idempotent, so a
   // crash after either write simply retries the identical edge. Prompt delivery never starts until
-  // both sides can explain the lineage after restart.
+  // both sides can explain the lineage and portable boundary state after restart.
   await services.registerSessionLink(machineConfig(source.config), link)
   await services.registerSessionLink(machineConfig(targetMachine.config), link)
 

--- a/web/src/cross-machine-continuation.ts
+++ b/web/src/cross-machine-continuation.ts
@@ -386,13 +386,17 @@ export async function continueNativeSessionAcrossMachine({
   }
 
   const routedTarget = targetSurface(source, pending, targetMachine, targetAgent, sourceMessages)
+  const durablePortableState = pending.portableState
+  if (!durablePortableState) {
+    throw new Error("The target Session exists, but its portable handoff state is unavailable. Retry the same destination before sending the first prompt.")
+  }
   const link: NativeSessionLinkRecord & { portableState: NativeSessionPortableHandoffState } = {
     type: "handoff",
     source: source.ref,
     target: pending.target,
     createdAt: new Date(pending.createdAt).toISOString(),
     ...(pending.transferredContext ? { transferredContext: pending.transferredContext } : {}),
-    portableState: pending.portableState
+    portableState: durablePortableState
   }
 
   // Replicate the same metadata edge to both machine-local stores. addHandoff is idempotent, so a

--- a/web/src/native-session-continuation.test.mjs
+++ b/web/src/native-session-continuation.test.mjs
@@ -3,6 +3,7 @@ import { probeNativeSessionContinuation } from './native-session-continuation.ts
 import './cross-machine-continuation.test.mjs'
 import './cross-machine-route-projects.test.mjs'
 import './cross-machine-route-plan.test.mjs'
+import './portable-handoff-state.test.mjs'
 
 function target(overrides = {}) {
   return {

--- a/web/src/portable-handoff-state.test.mjs
+++ b/web/src/portable-handoff-state.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { buildPortableHandoffState } from "./portable-handoff-state.ts"
+
+function source(overrides = {}) {
+  return {
+    title: "Fix the bridge regression",
+    permission: [{ permission: "bash", pattern: "deploy prod", action: "allow" }],
+    directory: "/private/source/path",
+    ...overrides
+  }
+}
+
+function preflight(overrides = {}) {
+  return {
+    sourceProjectId: "source-project",
+    targetProjectId: "target-project",
+    decision: "review",
+    reason: "workspace_diverged",
+    assessment: {
+      project: "match",
+      repository: "match",
+      history: "match",
+      branch: "different",
+      head: "different",
+      sourceDirty: false,
+      targetDirty: true,
+      exactWorkspace: false
+    },
+    ...overrides
+  }
+}
+
+test("portable handoff state carries task identity and Project evidence without authority or paths", () => {
+  const state = buildPortableHandoffState(source(), preflight())
+  assert.deepEqual(state, {
+    version: 1,
+    task: { title: "Fix the bridge regression", state: "continuing" },
+    project: {
+      sourceProjectId: "source-project",
+      targetProjectId: "target-project",
+      decision: "review",
+      reason: "workspace_diverged",
+      evidence: {
+        project: "match",
+        repository: "match",
+        history: "match",
+        branch: "different",
+        head: "different",
+        sourceDirty: false,
+        targetDirty: true,
+        exactWorkspace: false
+      }
+    },
+    controls: {
+      sourceAuthority: "invalidated",
+      targetAuthorization: "re_evaluate",
+      attachments: "not_transferred"
+    }
+  })
+  const serialized = JSON.stringify(state)
+  assert.equal(serialized.includes("/private/source/path"), false)
+  assert.equal(serialized.includes("deploy prod"), false)
+  assert.equal(serialized.includes("permission"), false)
+  assert.equal(serialized.includes("approval"), false)
+})
+
+test("portable evidence records classification, never raw branch or HEAD values", () => {
+  const state = buildPortableHandoffState(source(), preflight({
+    decision: "automatic",
+    reason: "exact_workspace",
+    assessment: {
+      project: "match",
+      repository: "match",
+      history: "match",
+      branch: "match",
+      head: "match",
+      sourceDirty: false,
+      targetDirty: false,
+      exactWorkspace: true
+    }
+  }))
+  assert.equal(state.project.decision, "automatic")
+  assert.equal(state.project.evidence.branch, "match")
+  assert.equal(state.project.evidence.head, "match")
+  const serialized = JSON.stringify(state)
+  assert.equal(serialized.includes("refs/heads"), false)
+  assert.equal(serialized.includes("0123456789abcdef"), false)
+})
+
+test("blocked Project continuity can never be serialized for a handoff", () => {
+  assert.throws(
+    () => buildPortableHandoffState(source(), preflight({ decision: "blocked", reason: "project_mismatch" })),
+    /cannot produce portable handoff state/
+  )
+})

--- a/web/src/portable-handoff-state.test.mjs
+++ b/web/src/portable-handoff-state.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import test from "node:test"
-import { buildPortableHandoffState } from "./portable-handoff-state.ts"
+import { buildPortableHandoffState, parsePortableHandoffState } from "./portable-handoff-state.ts"
 
 function source(overrides = {}) {
   return {
@@ -29,6 +29,23 @@ function preflight(overrides = {}) {
     },
     ...overrides
   }
+}
+
+function exactState() {
+  return buildPortableHandoffState(source(), preflight({
+    decision: "automatic",
+    reason: "exact_workspace",
+    assessment: {
+      project: "match",
+      repository: "match",
+      history: "match",
+      branch: "match",
+      head: "match",
+      sourceDirty: false,
+      targetDirty: false,
+      exactWorkspace: true
+    }
+  }))
 }
 
 test("portable handoff state carries task identity and Project evidence without authority or paths", () => {
@@ -66,20 +83,7 @@ test("portable handoff state carries task identity and Project evidence without 
 })
 
 test("portable evidence records classification, never raw branch or HEAD values", () => {
-  const state = buildPortableHandoffState(source(), preflight({
-    decision: "automatic",
-    reason: "exact_workspace",
-    assessment: {
-      project: "match",
-      repository: "match",
-      history: "match",
-      branch: "match",
-      head: "match",
-      sourceDirty: false,
-      targetDirty: false,
-      exactWorkspace: true
-    }
-  }))
+  const state = exactState()
   assert.equal(state.project.decision, "automatic")
   assert.equal(state.project.evidence.branch, "match")
   assert.equal(state.project.evidence.head, "match")
@@ -93,4 +97,35 @@ test("blocked Project continuity can never be serialized for a handoff", () => {
     () => buildPortableHandoffState(source(), preflight({ decision: "blocked", reason: "project_mismatch" })),
     /cannot produce portable handoff state/
   )
+})
+
+test("recovered automatic state must be internally consistent with exact workspace evidence", () => {
+  const exact = exactState()
+  assert.deepEqual(parsePortableHandoffState(exact), exact)
+  assert.equal(parsePortableHandoffState({
+    ...exact,
+    project: {
+      ...exact.project,
+      evidence: { ...exact.project.evidence, targetDirty: true }
+    }
+  }), null)
+  assert.equal(parsePortableHandoffState({
+    ...exact,
+    project: {
+      ...exact.project,
+      evidence: { ...exact.project.evidence, repository: "unverified" }
+    }
+  }), null)
+})
+
+test("recovered review state cannot claim exact workspace continuity", () => {
+  const review = buildPortableHandoffState(source(), preflight())
+  assert.deepEqual(parsePortableHandoffState(review), review)
+  assert.equal(parsePortableHandoffState({
+    ...review,
+    project: {
+      ...review.project,
+      evidence: { ...review.project.evidence, exactWorkspace: true }
+    }
+  }), null)
 })

--- a/web/src/portable-handoff-state.ts
+++ b/web/src/portable-handoff-state.ts
@@ -1,0 +1,80 @@
+import type { CrossMachineProjectPreflight } from "./cross-machine-project-preflight"
+import type { ProjectContinuityAssessment, ProjectContinuityEvidence } from "./project-continuity"
+import type { NativeSessionSurfaceTarget } from "./native-session-discovery"
+
+export type NativeSessionPortableHandoffState = {
+  version: 1
+  task: {
+    title: string
+    state: "continuing"
+  }
+  project: {
+    sourceProjectId: string
+    targetProjectId: string
+    decision: "automatic" | "review"
+    reason: "exact_workspace" | "workspace_diverged" | "project_unverified"
+    evidence: {
+      project: ProjectContinuityEvidence
+      repository: ProjectContinuityEvidence
+      history: ProjectContinuityEvidence
+      branch: ProjectContinuityEvidence
+      head: ProjectContinuityEvidence
+      sourceDirty?: boolean
+      targetDirty?: boolean
+      exactWorkspace: boolean
+    }
+  }
+  controls: {
+    sourceAuthority: "invalidated"
+    targetAuthorization: "re_evaluate"
+    attachments: "not_transferred"
+  }
+}
+
+function portableEvidence(assessment: ProjectContinuityAssessment): NativeSessionPortableHandoffState["project"]["evidence"] {
+  return {
+    project: assessment.project,
+    repository: assessment.repository,
+    history: assessment.history,
+    branch: assessment.branch,
+    head: assessment.head,
+    ...(typeof assessment.sourceDirty === "boolean" ? { sourceDirty: assessment.sourceDirty } : {}),
+    ...(typeof assessment.targetDirty === "boolean" ? { targetDirty: assessment.targetDirty } : {}),
+    exactWorkspace: assessment.exactWorkspace
+  }
+}
+
+/**
+ * Runtime-neutral state that may cross the machine boundary without becoming a universal transcript.
+ *
+ * This deliberately carries no filesystem paths, branch/HEAD values, prompt text, permissions,
+ * approvals, tool state, credentials or provider-specific payloads. Project evidence is reduced to
+ * match/different/unverified classifications already produced by the conservative preflight.
+ */
+export function buildPortableHandoffState(
+  source: NativeSessionSurfaceTarget,
+  preflight: CrossMachineProjectPreflight
+): NativeSessionPortableHandoffState {
+  if (preflight.decision === "blocked" || preflight.reason === "project_mismatch") {
+    throw new Error("Blocked Project continuity cannot produce portable handoff state.")
+  }
+  return {
+    version: 1,
+    task: {
+      title: source.title.trim().slice(0, 200) || "Session",
+      state: "continuing"
+    },
+    project: {
+      sourceProjectId: preflight.sourceProjectId,
+      targetProjectId: preflight.targetProjectId,
+      decision: preflight.decision,
+      reason: preflight.reason,
+      evidence: portableEvidence(preflight.assessment)
+    },
+    controls: {
+      sourceAuthority: "invalidated",
+      targetAuthorization: "re_evaluate",
+      attachments: "not_transferred"
+    }
+  }
+}

--- a/web/src/portable-handoff-state.ts
+++ b/web/src/portable-handoff-state.ts
@@ -51,6 +51,25 @@ function portableEvidence(assessment: ProjectContinuityAssessment): NativeSessio
   }
 }
 
+function consistentPortableProject(
+  decision: NativeSessionPortableHandoffState["project"]["decision"],
+  reason: NativeSessionPortableHandoffState["project"]["reason"],
+  evidence: NativeSessionPortableHandoffState["project"]["evidence"]
+): boolean {
+  if (evidence.project === "different" || evidence.repository === "different" || evidence.history === "different") return false
+  if (decision === "automatic") {
+    return reason === "exact_workspace"
+      && evidence.project === "match"
+      && evidence.repository === "match"
+      && evidence.branch === "match"
+      && evidence.head === "match"
+      && evidence.sourceDirty === false
+      && evidence.targetDirty === false
+      && evidence.exactWorkspace === true
+  }
+  return reason !== "exact_workspace" && evidence.exactWorkspace === false
+}
+
 export function parsePortableHandoffState(value: unknown): NativeSessionPortableHandoffState | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null
   const candidate = value as Partial<NativeSessionPortableHandoffState>
@@ -68,6 +87,19 @@ export function parsePortableHandoffState(value: unknown): NativeSessionPortable
   if (evidence.sourceDirty !== undefined && typeof evidence.sourceDirty !== "boolean") return null
   if (evidence.targetDirty !== undefined && typeof evidence.targetDirty !== "boolean") return null
   if (!controls || controls.sourceAuthority !== "invalidated" || controls.targetAuthorization !== "re_evaluate" || controls.attachments !== "not_transferred") return null
+
+  const normalizedEvidence: NativeSessionPortableHandoffState["project"]["evidence"] = {
+    project: evidence.project as ProjectContinuityEvidence,
+    repository: evidence.repository as ProjectContinuityEvidence,
+    history: evidence.history as ProjectContinuityEvidence,
+    branch: evidence.branch as ProjectContinuityEvidence,
+    head: evidence.head as ProjectContinuityEvidence,
+    ...(typeof evidence.sourceDirty === "boolean" ? { sourceDirty: evidence.sourceDirty } : {}),
+    ...(typeof evidence.targetDirty === "boolean" ? { targetDirty: evidence.targetDirty } : {}),
+    exactWorkspace: evidence.exactWorkspace
+  }
+  if (!consistentPortableProject(project.decision, project.reason, normalizedEvidence)) return null
+
   return {
     version: 1,
     task: { title: task.title.trim(), state: "continuing" },
@@ -76,16 +108,7 @@ export function parsePortableHandoffState(value: unknown): NativeSessionPortable
       targetProjectId: project.targetProjectId.trim(),
       decision: project.decision,
       reason: project.reason,
-      evidence: {
-        project: evidence.project as ProjectContinuityEvidence,
-        repository: evidence.repository as ProjectContinuityEvidence,
-        history: evidence.history as ProjectContinuityEvidence,
-        branch: evidence.branch as ProjectContinuityEvidence,
-        head: evidence.head as ProjectContinuityEvidence,
-        ...(typeof evidence.sourceDirty === "boolean" ? { sourceDirty: evidence.sourceDirty } : {}),
-        ...(typeof evidence.targetDirty === "boolean" ? { targetDirty: evidence.targetDirty } : {}),
-        exactWorkspace: evidence.exactWorkspace
-      }
+      evidence: normalizedEvidence
     },
     controls: {
       sourceAuthority: "invalidated",

--- a/web/src/portable-handoff-state.ts
+++ b/web/src/portable-handoff-state.ts
@@ -31,6 +31,13 @@ export type NativeSessionPortableHandoffState = {
   }
 }
 
+const EVIDENCE = new Set<ProjectContinuityEvidence>(["match", "different", "unverified"])
+const REASONS = new Set<NativeSessionPortableHandoffState["project"]["reason"]>([
+  "exact_workspace",
+  "workspace_diverged",
+  "project_unverified"
+])
+
 function portableEvidence(assessment: ProjectContinuityAssessment): NativeSessionPortableHandoffState["project"]["evidence"] {
   return {
     project: assessment.project,
@@ -41,6 +48,50 @@ function portableEvidence(assessment: ProjectContinuityAssessment): NativeSessio
     ...(typeof assessment.sourceDirty === "boolean" ? { sourceDirty: assessment.sourceDirty } : {}),
     ...(typeof assessment.targetDirty === "boolean" ? { targetDirty: assessment.targetDirty } : {}),
     exactWorkspace: assessment.exactWorkspace
+  }
+}
+
+export function parsePortableHandoffState(value: unknown): NativeSessionPortableHandoffState | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null
+  const candidate = value as Partial<NativeSessionPortableHandoffState>
+  if (candidate.version !== 1) return null
+  const task = candidate.task as Partial<NativeSessionPortableHandoffState["task"]> | undefined
+  const project = candidate.project as Partial<NativeSessionPortableHandoffState["project"]> | undefined
+  const controls = candidate.controls as Partial<NativeSessionPortableHandoffState["controls"]> | undefined
+  const evidence = project?.evidence as Partial<NativeSessionPortableHandoffState["project"]["evidence"]> | undefined
+  if (!task || typeof task.title !== "string" || !task.title.trim() || task.title.length > 200 || task.state !== "continuing") return null
+  if (!project || typeof project.sourceProjectId !== "string" || !project.sourceProjectId.trim() || typeof project.targetProjectId !== "string" || !project.targetProjectId.trim()) return null
+  if (project.decision !== "automatic" && project.decision !== "review") return null
+  if (!project.reason || !REASONS.has(project.reason)) return null
+  if (!evidence || ![evidence.project, evidence.repository, evidence.history, evidence.branch, evidence.head].every((entry) => EVIDENCE.has(entry as ProjectContinuityEvidence))) return null
+  if (typeof evidence.exactWorkspace !== "boolean") return null
+  if (evidence.sourceDirty !== undefined && typeof evidence.sourceDirty !== "boolean") return null
+  if (evidence.targetDirty !== undefined && typeof evidence.targetDirty !== "boolean") return null
+  if (!controls || controls.sourceAuthority !== "invalidated" || controls.targetAuthorization !== "re_evaluate" || controls.attachments !== "not_transferred") return null
+  return {
+    version: 1,
+    task: { title: task.title.trim(), state: "continuing" },
+    project: {
+      sourceProjectId: project.sourceProjectId.trim(),
+      targetProjectId: project.targetProjectId.trim(),
+      decision: project.decision,
+      reason: project.reason,
+      evidence: {
+        project: evidence.project as ProjectContinuityEvidence,
+        repository: evidence.repository as ProjectContinuityEvidence,
+        history: evidence.history as ProjectContinuityEvidence,
+        branch: evidence.branch as ProjectContinuityEvidence,
+        head: evidence.head as ProjectContinuityEvidence,
+        ...(typeof evidence.sourceDirty === "boolean" ? { sourceDirty: evidence.sourceDirty } : {}),
+        ...(typeof evidence.targetDirty === "boolean" ? { targetDirty: evidence.targetDirty } : {}),
+        exactWorkspace: evidence.exactWorkspace
+      }
+    },
+    controls: {
+      sourceAuthority: "invalidated",
+      targetAuthorization: "re_evaluate",
+      attachments: "not_transferred"
+    }
   }
 }
 


### PR DESCRIPTION
Adds the runtime-neutral task/evidence/control record required by #371 without creating a universal transcript or transferring authority.

- builds a bounded v1 portable state from the already-approved cross-machine Project preflight
- carries only task title/state, source/target Project IDs, continuity classifications, dirty/exact-workspace evidence, and fixed control-boundary semantics
- never carries filesystem paths, raw branch/HEAD values, prompt text, permissions, approvals, tool state, credentials, attachments, or provider-specific state
- rejects blocked Project continuity before serialization
- validates recovered localStorage state before reuse; malformed/older state is rebuilt only from the current safe preflight
- persists the canonical portable state with the same replicated native Session handoff edge on both participating daemons before first-prompt delivery
- validates again at the daemon HTTP boundary and canonicalizes known fields only in the durable link store, dropping unknown authority/path/tool fields
- keeps the existing exactly-once target and first-prompt recovery domains unchanged
- adds web privacy/contract tests plus daemon HTTP/store/restart coverage

Target: `codex/development-2026-09-11` only. Never merge to `main`.

Refs #371