### PR TITLE
P2: recover portable handoff state in lineage UI

### DIFF
--- a/web/src/components/native-session-lineage-panel.tsx
+++ b/web/src/components/native-session-lineage-panel.tsx
@@ -27,12 +27,27 @@ function formatTime(value: string): string {
     : value
 }
 
+function projectStateLabel(entry: NativeSessionLineageEntry): string | null {
+  const state = entry.portableState
+  if (!state) return null
+  if (state.project.decision === "automatic") return "Project: exact workspace"
+  if (state.project.reason === "workspace_diverged") return "Project: workspace differs — review accepted"
+  return "Project: continuity unverified — review accepted"
+}
+
+function evidenceLabel(entry: NativeSessionLineageEntry): string | null {
+  const evidence = entry.portableState?.project.evidence
+  if (!evidence) return null
+  return `Evidence: repo ${evidence.repository}, history ${evidence.history}, branch ${evidence.branch}, HEAD ${evidence.head}`
+}
+
 /**
  * Durable, read-only handoff lineage for one real native Session.
  *
  * The daemon stores the edge on both machines, so this survives navigation/restart without importing
  * either provider transcript. The surface intentionally never displays the other machine's path and
- * never treats source permission metadata as target authority.
+ * never treats source permission metadata as target authority. Structured portable state is displayed
+ * only after the lineage projector validates the daemon payload against the v1 portable-state contract.
  */
 export function NativeSessionLineagePanel({ target, routes, interactionEnabled, onConnectionIssue }: Props) {
   const [entries, setEntries] = useState<NativeSessionLineageEntry[]>([])
@@ -72,29 +87,41 @@ export function NativeSessionLineagePanel({ target, routes, interactionEnabled, 
     <section className="hr-native-lineage" aria-label="Session handoff lineage">
       <header>
         <strong>Handoff lineage</strong>
-        <span>Native Sessions stay separate; only the explicit handoff edge and bounded control context are shared.</span>
+        <span>Durable task and Project evidence can be recovered here; native transcripts and authority stay separate.</span>
       </header>
       <div className="hr-native-lineage-list">
-        {entries.map((entry) => (
-          <article
-            key={`${entry.direction}:${entry.other.machineID}:${entry.other.agentID}:${entry.other.sessionID}:${entry.createdAt}`}
-            className={`hr-native-lineage-entry ${entry.direction}`}
-          >
-            <div className="hr-native-lineage-identity">
-              <span>{entry.direction === "incoming" ? "Handoff source" : "Handoff target"}</span>
-              <strong>{identityLabel(entry)}</strong>
-              <small>Session {entry.other.sessionID} · {formatTime(entry.createdAt)}</small>
-            </div>
-            <div className="hr-native-lineage-boundary" aria-label="Handoff boundary state">
-              <span className={entry.contextCarried ? "carried" : "neutral"}>
-                {entry.contextCarried ? "Task context carried" : "No portable task context recorded"}
-              </span>
-              <span className="invalidated">Source authority invalidated</span>
-              <span className="fresh">Target authorization is evaluated independently</span>
-              <span className="neutral">Attachments not transferred</span>
-            </div>
-          </article>
-        ))}
+        {entries.map((entry) => {
+          const projectLabel = projectStateLabel(entry)
+          const evidence = evidenceLabel(entry)
+          return (
+            <article
+              key={`${entry.direction}:${entry.other.machineID}:${entry.other.agentID}:${entry.other.sessionID}:${entry.createdAt}`}
+              className={`hr-native-lineage-entry ${entry.direction}`}
+            >
+              <div className="hr-native-lineage-identity">
+                <span>{entry.direction === "incoming" ? "Handoff source" : "Handoff target"}</span>
+                <strong>{identityLabel(entry)}</strong>
+                <small>Session {entry.other.sessionID} · {formatTime(entry.createdAt)}</small>
+              </div>
+              <div className="hr-native-lineage-boundary" aria-label="Handoff boundary state">
+                {entry.portableState ? (
+                  <>
+                    <span className="carried">Task: {entry.portableState.task.title}</span>
+                    {projectLabel ? <span className={entry.portableState.project.decision === "automatic" ? "fresh" : "invalidated"}>{projectLabel}</span> : null}
+                    {evidence ? <span className="neutral">{evidence}</span> : null}
+                  </>
+                ) : (
+                  <span className={entry.contextCarried ? "carried" : "neutral"}>
+                    {entry.contextCarried ? "Bounded task context carried" : "No portable task context recorded"}
+                  </span>
+                )}
+                <span className="invalidated">Source authority invalidated</span>
+                <span className="fresh">Target authorization is evaluated independently</span>
+                <span className="neutral">Attachments not transferred</span>
+              </div>
+            </article>
+          )
+        })}
       </div>
     </section>
   )

--- a/web/src/components/native-session-lineage-panel.tsx
+++ b/web/src/components/native-session-lineage-panel.tsx
@@ -35,10 +35,23 @@ function projectStateLabel(entry: NativeSessionLineageEntry): string | null {
   return "Project: continuity unverified — review accepted"
 }
 
+function worktreeLabel(value: boolean | undefined): string {
+  if (value === true) return "dirty"
+  if (value === false) return "clean"
+  return "unverified"
+}
+
 function evidenceLabel(entry: NativeSessionLineageEntry): string | null {
   const evidence = entry.portableState?.project.evidence
   if (!evidence) return null
-  return `Evidence: repo ${evidence.repository}, history ${evidence.history}, branch ${evidence.branch}, HEAD ${evidence.head}`
+  return [
+    `repo ${evidence.repository}`,
+    `history ${evidence.history}`,
+    `branch ${evidence.branch}`,
+    `HEAD ${evidence.head}`,
+    `source worktree ${worktreeLabel(evidence.sourceDirty)}`,
+    `target worktree ${worktreeLabel(evidence.targetDirty)}`
+  ].join(", ")
 }
 
 /**
@@ -108,7 +121,7 @@ export function NativeSessionLineagePanel({ target, routes, interactionEnabled, 
                   <>
                     <span className="carried">Task: {entry.portableState.task.title}</span>
                     {projectLabel ? <span className={entry.portableState.project.decision === "automatic" ? "fresh" : "invalidated"}>{projectLabel}</span> : null}
-                    {evidence ? <span className="neutral">{evidence}</span> : null}
+                    {evidence ? <span className="neutral">Evidence: {evidence}</span> : null}
                   </>
                 ) : (
                   <span className={entry.contextCarried ? "carried" : "neutral"}>

--- a/web/src/native-session-lineage.test.mjs
+++ b/web/src/native-session-lineage.test.mjs
@@ -6,6 +6,32 @@ const current = { machineID: "machine-b", agentID: "claude", sessionID: "target-
 const source = { machineID: "machine-a", agentID: "codex", sessionID: "source-1", directory: "/repo" }
 const next = { machineID: "machine-c", agentID: "pi", sessionID: "next-1", directory: "/work/repo" }
 
+const portableState = {
+  version: 1,
+  task: { title: "Finish cross-machine recovery", state: "continuing" },
+  project: {
+    sourceProjectId: "project-source",
+    targetProjectId: "project-target",
+    decision: "automatic",
+    reason: "exact_workspace",
+    evidence: {
+      project: "match",
+      repository: "match",
+      history: "match",
+      branch: "match",
+      head: "match",
+      sourceDirty: false,
+      targetDirty: false,
+      exactWorkspace: true
+    }
+  },
+  controls: {
+    sourceAuthority: "invalidated",
+    targetAuthorization: "re_evaluate",
+    attachments: "not_transferred"
+  }
+}
+
 function link(overrides = {}) {
   return {
     type: "handoff",
@@ -26,6 +52,29 @@ test("incoming lineage exposes portable context but invalidates source authority
   assert.equal(entries[0].authority, "invalidated")
   assert.equal(entries[0].targetAuthorization, "re_evaluate")
   assert.equal(entries[0].attachments, "not_transferred")
+})
+
+test("validated portable state is recovered from the durable link after restart", () => {
+  const entries = nativeSessionLineage(current, [link({ transferredContext: undefined, portableState })])
+  assert.equal(entries.length, 1)
+  assert.equal(entries[0].contextCarried, true)
+  assert.deepEqual(entries[0].portableState, portableState)
+  assert.equal(entries[0].portableState.task.title, "Finish cross-machine recovery")
+  assert.equal(entries[0].portableState.project.evidence.repository, "match")
+})
+
+test("malformed or authority-bearing portable state is ignored instead of reaching the UI", () => {
+  const poisoned = {
+    ...portableState,
+    controls: { ...portableState.controls, sourceAuthority: "preserved" },
+    permission: "allow-all",
+    path: "/remote/secret",
+    toolState: { shell: "trusted" }
+  }
+  const entries = nativeSessionLineage(current, [link({ transferredContext: undefined, portableState: poisoned })])
+  assert.equal(entries.length, 1)
+  assert.equal(entries[0].contextCarried, false)
+  assert.equal(entries[0].portableState, undefined)
 })
 
 test("outgoing lineage points at the exact target without comparing machine-local paths", () => {

--- a/web/src/native-session-lineage.ts
+++ b/web/src/native-session-lineage.ts
@@ -1,4 +1,8 @@
 import type { NativeSessionIdentityPayload, NativeSessionLinkRecord } from "./api"
+import {
+  parsePortableHandoffState,
+  type NativeSessionPortableHandoffState
+} from "./portable-handoff-state"
 
 export type NativeSessionLineageDirection = "incoming" | "outgoing"
 
@@ -7,6 +11,7 @@ export type NativeSessionLineageEntry = {
   other: NativeSessionIdentityPayload
   createdAt: string
   contextCarried: boolean
+  portableState?: NativeSessionPortableHandoffState
   authority: "invalidated"
   targetAuthorization: "re_evaluate"
   attachments: "not_transferred"
@@ -33,9 +38,9 @@ function lineageKey(link: NativeSessionLinkRecord): string {
 /**
  * Project a daemon-owned handoff edge into a UI-safe lineage record.
  *
- * Paths stay machine-local and are deliberately not part of the displayed identity. The boundary
- * state is derived from the cross-machine contract rather than source Session metadata: portable
- * task context may be carried, while permissions and attachments are never inherited.
+ * Paths stay machine-local and are deliberately not part of the displayed identity. Any structured
+ * portable state is treated as untrusted daemon input and must pass the same v1 parser used during
+ * handoff recovery before it can reach the UI. Permissions and attachments are never inherited.
  */
 export function nativeSessionLineage(
   identity: NativeSessionIdentityPayload,
@@ -54,11 +59,16 @@ export function nativeSessionLineage(
     if (seen.has(key)) continue
     seen.add(key)
 
+    const portableState = parsePortableHandoffState(
+      (link as NativeSessionLinkRecord & { portableState?: unknown }).portableState
+    )
+
     entries.push({
       direction: targetMatch ? "incoming" : "outgoing",
       other: targetMatch ? link.source : link.target,
       createdAt: link.createdAt,
-      contextCarried: Boolean(link.transferredContext?.trim()),
+      contextCarried: Boolean(link.transferredContext?.trim() || portableState),
+      ...(portableState ? { portableState } : {}),
       authority: "invalidated",
       targetAuthorization: "re_evaluate",
       attachments: "not_transferred"


### PR DESCRIPTION
Completes the read-only recovery surface for the structured cross-machine handoff state introduced by #434.

- reads portableState from the durable Session handoff edge after navigation/restart
- treats daemon metadata as untrusted and validates it with parsePortableHandoffState before exposing it to the UI
- surfaces the carried task title, Project continuity decision, reduced repository/history/branch/HEAD evidence, and source/target worktree dirty/clean/unverified state
- keeps native transcripts separate and never displays remote paths
- continues to state that source authority is invalidated, target authorization is re-evaluated, and attachments are not transferred
- ignores malformed or authority-bearing portable payloads instead of rendering them
- adds regression coverage for valid recovery and poisoned payload rejection

Target: codex/development-2026-09-11 only. Never merge to main.

Refs #371