### PR TITLE
P2: expose bounded Project outcome snapshots

### DIFF
--- a/bridge/src/agent-router.js
+++ b/bridge/src/agent-router.js
@@ -2,11 +2,12 @@ import http from "node:http"
 import { allowedOrigin, applyCorsHeaders, matchesCredentials, writeJSON } from "./http-policy.js"
 import { ManagedEventFanout } from "./managed-event-fanout.js"
 import { inspectGitProjectIdentity } from "./project-identity.js"
+import { inspectGitProjectOutcome } from "./project-outcome.js"
 import { normalizeTaskModel } from "./task-model.js"
 
 const AGENT_ROUTE = /^\/v1\/agents\/([^/]+)(\/.*)?$/
 const TASK_WORKTREE_ROUTE = /^\/v1\/tasks\/([^/]+)\/worktree$/
-const MACHINE_ROUTES = new Set(["/v1/machine", "/global/machine", "/v1/projects", "/v1/project-identity", "/v1/tasks", "/v1/diagnostics"])
+const MACHINE_ROUTES = new Set(["/v1/machine", "/global/machine", "/v1/projects", "/v1/project-identity", "/v1/project-outcome", "/v1/tasks", "/v1/diagnostics"])
 const HOP_BY_HOP = new Set([
   "connection",
   "keep-alive",
@@ -203,6 +204,7 @@ export function createAgentRoutingServer({
   taskStore,
   projectCatalog,
   projectIdentity = inspectGitProjectIdentity,
+  projectOutcome = inspectGitProjectOutcome,
   worktreeManager,
   diagnostics,
   createServer = http.createServer,
@@ -280,6 +282,24 @@ export function createAgentRoutingServer({
           // the daemon itself already admitted into the canonical Project catalog.
           const identity = project.kind === "git" ? await projectIdentity(project.path) : null
           writeJSON(response, 200, { projectId: project.id, identity })
+          return
+        }
+        if (request.method === "GET" && requestURL.pathname === "/v1/project-outcome") {
+          const projectId = requestURL.searchParams.get("projectId")?.trim() || ""
+          if (!projectId) {
+            writeJSON(response, 400, { error: "A projectId is required" })
+            return
+          }
+          const projects = await projectCatalog()
+          const project = projects.find((candidate) => candidate.id === projectId)
+          if (!project) {
+            writeJSON(response, 404, { error: `Unknown project: ${projectId}` })
+            return
+          }
+          // Outcome inspection has the same Project-scoped boundary as identity inspection: a caller
+          // chooses only a catalog id, never a filesystem path. Returned file names stay repo-relative.
+          const outcome = project.kind === "git" ? await projectOutcome(project.path) : null
+          writeJSON(response, 200, { projectId: project.id, outcome })
           return
         }
         if (request.method === "GET" && requestURL.pathname === "/v1/tasks") {

--- a/bridge/src/project-outcome.js
+++ b/bridge/src/project-outcome.js
@@ -1,5 +1,4 @@
 import { execFile } from "node:child_process"
-import path from "node:path"
 import { promisify } from "node:util"
 
 const execFileAsync = promisify(execFile)

--- a/bridge/src/project-outcome.js
+++ b/bridge/src/project-outcome.js
@@ -1,0 +1,121 @@
+import { execFile } from "node:child_process"
+import path from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const GIT_TIMEOUT_MS = 8_000
+const MAX_GIT_OUTPUT = 1024 * 1024
+export const MAX_PROJECT_OUTCOME_FILES = 200
+export const MAX_PROJECT_OUTCOME_PATH_LENGTH = 1024
+
+async function defaultRunGit(args) {
+  return execFileAsync("git", args, {
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: GIT_TIMEOUT_MS,
+    maxBuffer: MAX_GIT_OUTPUT
+  })
+}
+
+async function readGit(runGit, args) {
+  try {
+    const result = await runGit(args)
+    return { ok: true, value: String(result?.stdout ?? "") }
+  } catch {
+    return { ok: false, value: "" }
+  }
+}
+
+function safeRelativeGitPath(value) {
+  const raw = String(value ?? "")
+  if (!raw || raw.includes("\0") || raw.length > MAX_PROJECT_OUTCOME_PATH_LENGTH) return undefined
+  const normalized = raw.replace(/\\/g, "/")
+  if (
+    normalized.startsWith("/") ||
+    /^[A-Za-z]:\//.test(normalized) ||
+    normalized.split("/").some((part) => part === "..")
+  ) return undefined
+  return normalized
+}
+
+/**
+ * Parse `git status --porcelain=v1 -z` without shell quoting or locale-dependent arrows.
+ *
+ * With `-z`, rename/copy entries are emitted as `XY new-path\0old-path\0`. Only repository-relative
+ * paths are returned; malformed or escaping paths are ignored rather than exposed to the client.
+ */
+export function parseGitPorcelainV1Z(value, { maxFiles = MAX_PROJECT_OUTCOME_FILES } = {}) {
+  const fields = String(value ?? "").split("\0")
+  if (fields.at(-1) === "") fields.pop()
+
+  const files = []
+  let totalFiles = 0
+  for (let index = 0; index < fields.length; index += 1) {
+    const field = fields[index]
+    if (field.length < 4 || field[2] !== " ") continue
+
+    const status = field.slice(0, 2)
+    const candidatePath = safeRelativeGitPath(field.slice(3))
+    const renameOrCopy = status.includes("R") || status.includes("C")
+    let originalPath
+    if (renameOrCopy && index + 1 < fields.length) {
+      originalPath = safeRelativeGitPath(fields[index + 1])
+      index += 1
+    }
+
+    if (!candidatePath) continue
+    totalFiles += 1
+    if (files.length >= maxFiles) continue
+
+    files.push({
+      path: candidatePath,
+      indexStatus: status[0],
+      worktreeStatus: status[1],
+      ...(originalPath ? { originalPath } : {})
+    })
+  }
+
+  return {
+    files,
+    totalFiles,
+    truncated: totalFiles > files.length
+  }
+}
+
+/**
+ * Read a bounded, provider-neutral outcome snapshot from the daemon-local Git worktree.
+ *
+ * The snapshot is intentionally metadata-only: no diff hunks, file contents, remotes, credentials,
+ * absolute paths, command output or harness/provider state cross the daemon boundary. Missing Git
+ * evidence stays absent instead of being invented. This function never mutates the repository.
+ */
+export async function inspectGitProjectOutcome(projectPath, { runGit = defaultRunGit, maxFiles = MAX_PROJECT_OUTCOME_FILES } = {}) {
+  if (typeof projectPath !== "string" || !projectPath.trim()) return null
+
+  const root = await readGit(runGit, ["-C", projectPath, "rev-parse", "--show-toplevel"])
+  if (!root.ok || !root.value.trim()) return null
+
+  const repoRoot = root.value.trim()
+  const [head, branch, status] = await Promise.all([
+    readGit(runGit, ["-C", repoRoot, "rev-parse", "HEAD"]),
+    readGit(runGit, ["-C", repoRoot, "branch", "--show-current"]),
+    readGit(runGit, ["-C", repoRoot, "status", "--porcelain=v1", "-z", "--untracked-files=all"])
+  ])
+
+  const parsed = status.ok
+    ? parseGitPorcelainV1Z(status.value, { maxFiles })
+    : { files: [], totalFiles: 0, truncated: false }
+
+  return {
+    version: 1,
+    vcs: "git",
+    ...(head.ok && head.value.trim() ? { head: head.value.trim() } : {}),
+    ...(branch.ok && branch.value.trim() ? { branch: branch.value.trim() } : {}),
+    ...(status.ok ? {
+      dirty: parsed.totalFiles > 0,
+      files: parsed.files,
+      totalChangedFiles: parsed.totalFiles,
+      filesTruncated: parsed.truncated
+    } : {})
+  }
+}

--- a/bridge/src/project-outcome.js
+++ b/bridge/src/project-outcome.js
@@ -40,8 +40,10 @@ function safeRelativeGitPath(value) {
 /**
  * Parse `git status --porcelain=v1 -z` without shell quoting or locale-dependent arrows.
  *
- * With `-z`, rename/copy entries are emitted as `XY new-path\0old-path\0`. Only repository-relative
- * paths are returned; malformed or escaping paths are ignored rather than exposed to the client.
+ * With `-z`, rename/copy entries are emitted as `XY new-path\0old-path\0`. The changed-entry count
+ * includes every syntactically valid porcelain record even when its path is unsafe to expose. This
+ * keeps dirty state conservative: hiding an absolute/escaping/oversized name must never turn a dirty
+ * worktree into an apparently clean one. The returned file list contains only safe repo-relative paths.
  */
 export function parseGitPorcelainV1Z(value, { maxFiles = MAX_PROJECT_OUTCOME_FILES } = {}) {
   const fields = String(value ?? "").split("\0")
@@ -62,9 +64,8 @@ export function parseGitPorcelainV1Z(value, { maxFiles = MAX_PROJECT_OUTCOME_FIL
       index += 1
     }
 
-    if (!candidatePath) continue
     totalFiles += 1
-    if (files.length >= maxFiles) continue
+    if (!candidatePath || files.length >= maxFiles) continue
 
     files.push({
       path: candidatePath,

--- a/bridge/test/project-outcome-route.test.js
+++ b/bridge/test/project-outcome-route.test.js
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import test from "node:test"
+import { createAgentRoutingServer } from "../src/agent-router.js"
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  return server.address().port
+}
+
+async function close(server) {
+  await new Promise((resolve) => server.close(resolve))
+}
+
+class BridgeServer extends EventEmitter {}
+
+function daemon() {
+  return {
+    registry: { host: () => ({ state: "available" }) },
+    hostEntry: () => undefined,
+    snapshot: () => ({ machine: { id: "machine-1" }, agents: [] })
+  }
+}
+
+function serverWith({ projects, projectOutcome }) {
+  return createAgentRoutingServer({
+    daemon: daemon(),
+    config: { username: "", password: "", corsOrigins: [] },
+    primaryAgentID: "codex",
+    bridgeServer: new BridgeServer(),
+    taskStore: { async list() { return [] } },
+    projectCatalog: async () => projects,
+    projectOutcome,
+    worktreeManager: {}
+  })
+}
+
+test("Project outcome is read only and scoped to an exact catalog project id", async () => {
+  const calls = []
+  const server = serverWith({
+    projects: [{ id: "machine-1:repo", machineId: "machine-1", name: "repo", path: "/repo", kind: "git" }],
+    projectOutcome: async (projectPath) => {
+      calls.push(projectPath)
+      return {
+        version: 1,
+        vcs: "git",
+        head: "abc",
+        branch: "feature/outcome",
+        dirty: true,
+        files: [{ path: "src/app.js", indexStatus: " ", worktreeStatus: "M" }],
+        totalChangedFiles: 1,
+        filesTruncated: false
+      }
+    }
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/project-outcome?projectId=${encodeURIComponent("machine-1:repo")}`)
+    assert.equal(response.status, 200)
+    assert.deepEqual(await response.json(), {
+      projectId: "machine-1:repo",
+      outcome: {
+        version: 1,
+        vcs: "git",
+        head: "abc",
+        branch: "feature/outcome",
+        dirty: true,
+        files: [{ path: "src/app.js", indexStatus: " ", worktreeStatus: "M" }],
+        totalChangedFiles: 1,
+        filesTruncated: false
+      }
+    })
+    assert.deepEqual(calls, ["/repo"])
+  } finally {
+    await close(server)
+  }
+})
+
+test("unknown Project ids cannot be turned into arbitrary filesystem outcome probes", async () => {
+  let inspected = false
+  const server = serverWith({
+    projects: [{ id: "machine-1:repo", machineId: "machine-1", name: "repo", path: "/repo", kind: "git" }],
+    projectOutcome: async () => { inspected = true; return null }
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/project-outcome?projectId=${encodeURIComponent("/etc")}`)
+    assert.equal(response.status, 404)
+    assert.equal(inspected, false)
+  } finally {
+    await close(server)
+  }
+})
+
+test("non Git Projects have no Git outcome and never invoke the inspector", async () => {
+  let inspected = false
+  const server = serverWith({
+    projects: [{ id: "machine-1:notes", machineId: "machine-1", name: "notes", path: "/notes", kind: "directory" }],
+    projectOutcome: async () => { inspected = true; return { version: 1, vcs: "git" } }
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/project-outcome?projectId=${encodeURIComponent("machine-1:notes")}`)
+    assert.equal(response.status, 200)
+    assert.deepEqual(await response.json(), { projectId: "machine-1:notes", outcome: null })
+    assert.equal(inspected, false)
+  } finally {
+    await close(server)
+  }
+})
+
+test("missing projectId is rejected before any Project inspection", async () => {
+  let inspected = false
+  const server = serverWith({
+    projects: [],
+    projectOutcome: async () => { inspected = true; return null }
+  })
+  const port = await listen(server)
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/project-outcome`)
+    assert.equal(response.status, 400)
+    assert.equal(inspected, false)
+  } finally {
+    await close(server)
+  }
+})

--- a/bridge/test/project-outcome.test.js
+++ b/bridge/test/project-outcome.test.js
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import {
+  inspectGitProjectOutcome,
+  MAX_PROJECT_OUTCOME_FILES,
+  parseGitPorcelainV1Z
+} from "../src/project-outcome.js"
+
+function gitFixture(statusOutput) {
+  return async (args) => {
+    const command = args.slice(2).join(" ")
+    if (command === "rev-parse --show-toplevel") return { stdout: "/repo\n" }
+    if (command === "rev-parse HEAD") return { stdout: "deadbeef\n" }
+    if (command === "branch --show-current") return { stdout: "feature/outcome\n" }
+    if (command === "status --porcelain=v1 -z --untracked-files=all") return { stdout: statusOutput }
+    throw new Error(`Unexpected git command: ${command}`)
+  }
+}
+
+test("porcelain -z parses modified, untracked and rename entries without shell quoting", () => {
+  const parsed = parseGitPorcelainV1Z(
+    " M src/app.js\0?? docs/new notes.md\0R  src/new-name.js\0src/old-name.js\0"
+  )
+
+  assert.deepEqual(parsed, {
+    files: [
+      { path: "src/app.js", indexStatus: " ", worktreeStatus: "M" },
+      { path: "docs/new notes.md", indexStatus: "?", worktreeStatus: "?" },
+      { path: "src/new-name.js", indexStatus: "R", worktreeStatus: " ", originalPath: "src/old-name.js" }
+    ],
+    totalFiles: 3,
+    truncated: false
+  })
+})
+
+test("outcome is bounded while preserving the total changed-file count", async () => {
+  const status = Array.from({ length: MAX_PROJECT_OUTCOME_FILES + 7 }, (_, index) => ` M src/file-${index}.js\0`).join("")
+  const outcome = await inspectGitProjectOutcome("/repo", { runGit: gitFixture(status) })
+
+  assert.equal(outcome.dirty, true)
+  assert.equal(outcome.files.length, MAX_PROJECT_OUTCOME_FILES)
+  assert.equal(outcome.totalChangedFiles, MAX_PROJECT_OUTCOME_FILES + 7)
+  assert.equal(outcome.filesTruncated, true)
+})
+
+test("snapshot returns only metadata and repository-relative paths", async () => {
+  const outcome = await inspectGitProjectOutcome("/repo", {
+    runGit: gitFixture("M  src/index.js\0?? test/new.test.js\0")
+  })
+
+  assert.deepEqual(outcome, {
+    version: 1,
+    vcs: "git",
+    head: "deadbeef",
+    branch: "feature/outcome",
+    dirty: true,
+    files: [
+      { path: "src/index.js", indexStatus: "M", worktreeStatus: " " },
+      { path: "test/new.test.js", indexStatus: "?", worktreeStatus: "?" }
+    ],
+    totalChangedFiles: 2,
+    filesTruncated: false
+  })
+  const wire = JSON.stringify(outcome)
+  assert.equal(wire.includes("/repo"), false)
+  assert.equal(wire.includes("diff"), false)
+})
+
+test("escaping, absolute and oversized paths are never exposed", () => {
+  const huge = "x".repeat(1100)
+  const parsed = parseGitPorcelainV1Z(
+    ` M ../outside.js\0 M /etc/passwd\0 M C:\\secret.txt\0 M ${huge}\0 M safe/file.js\0`
+  )
+
+  assert.deepEqual(parsed, {
+    files: [{ path: "safe/file.js", indexStatus: " ", worktreeStatus: "M" }],
+    totalFiles: 1,
+    truncated: false
+  })
+})
+
+test("missing status evidence stays unverified instead of inventing a clean worktree", async () => {
+  const outcome = await inspectGitProjectOutcome("/repo", {
+    runGit: async (args) => {
+      const command = args.slice(2).join(" ")
+      if (command === "rev-parse --show-toplevel") return { stdout: "/repo\n" }
+      if (command === "rev-parse HEAD") return { stdout: "abc123\n" }
+      if (command === "branch --show-current") return { stdout: "main\n" }
+      throw new Error("status unavailable")
+    }
+  })
+
+  assert.deepEqual(outcome, { version: 1, vcs: "git", head: "abc123", branch: "main" })
+})
+
+test("a path that is no longer a Git worktree has no outcome", async () => {
+  const outcome = await inspectGitProjectOutcome("/gone", {
+    runGit: async () => { throw new Error("not a git repository") }
+  })
+  assert.equal(outcome, null)
+})

--- a/bridge/test/project-outcome.test.js
+++ b/bridge/test/project-outcome.test.js
@@ -66,17 +66,22 @@ test("snapshot returns only metadata and repository-relative paths", async () =>
   assert.equal(wire.includes("diff"), false)
 })
 
-test("escaping, absolute and oversized paths are never exposed", () => {
+test("escaping, absolute and oversized paths are never exposed but still keep the worktree dirty", async () => {
   const huge = "x".repeat(1100)
-  const parsed = parseGitPorcelainV1Z(
-    ` M ../outside.js\0 M /etc/passwd\0 M C:\\secret.txt\0 M ${huge}\0 M safe/file.js\0`
-  )
+  const status = ` M ../outside.js\0 M /etc/passwd\0 M C:\\secret.txt\0 M ${huge}\0 M safe/file.js\0`
+  const parsed = parseGitPorcelainV1Z(status)
 
   assert.deepEqual(parsed, {
     files: [{ path: "safe/file.js", indexStatus: " ", worktreeStatus: "M" }],
-    totalFiles: 1,
-    truncated: false
+    totalFiles: 5,
+    truncated: true
   })
+
+  const hiddenOnly = await inspectGitProjectOutcome("/repo", { runGit: gitFixture(" M ../outside.js\0") })
+  assert.equal(hiddenOnly.dirty, true, "a hidden changed path must never make a dirty worktree look clean")
+  assert.equal(hiddenOnly.totalChangedFiles, 1)
+  assert.deepEqual(hiddenOnly.files, [])
+  assert.equal(hiddenOnly.filesTruncated, true)
 })
 
 test("missing status evidence stays unverified instead of inventing a clean worktree", async () => {


### PR DESCRIPTION
Adds a provider-neutral, read-only Project outcome snapshot for the cross-machine continuity/review flow.

- adds `/v1/project-outcome?projectId=...` on the existing daemon Project boundary
- resolves only daemon-catalog Project IDs; caller-supplied filesystem paths remain impossible
- reports Git branch, HEAD, dirty state and changed-file metadata
- bounds changed files to 200 while preserving the total count and truncation flag
- exposes only repository-relative paths/status metadata; no diff hunks, file contents, remotes, credentials or absolute paths
- handles modified, untracked and rename/copy porcelain entries
- rejects escaping, absolute and oversized paths from the visible file list fail-closed
- still counts hidden/unsafe Git entries for dirty/total state, so sanitization can never make a dirty worktree appear clean
- non-Git Projects and unavailable Git evidence remain explicitly unverified/null instead of inventing results
- adds parser and HTTP boundary regression coverage, including a hidden-only dirty-worktree case

This slice is daemon-only/read-only and does not modify ACP or any harness-specific runtime.

Target: `codex/development-2026-09-11` only. Never merge to `main`.

Refs #371