### PR TITLE
P2: feed structured attention into federated Session Home

### DIFF
--- a/web/src/components/native-session-home-attention.tsx
+++ b/web/src/components/native-session-home-attention.tsx
@@ -16,7 +16,8 @@ import "../native-session-attention-inbox.css"
 export { appendCursorPage, refreshCursorPage, sessionTreeRows } from "./native-session-home-base"
 export type { CursorPageState } from "./native-session-home-base"
 
-type Props = ComponentProps<typeof NativeSessionHomeBase>
+type BaseProps = ComponentProps<typeof NativeSessionHomeBase>
+type Props = Omit<BaseProps, "attentionSessionKeys" | "onAttentionKeysChange">
 
 type AttentionTarget = NativeSessionAttentionLiveTarget & {
   machineID: string
@@ -125,6 +126,12 @@ export function attentionInboxCounts(items: NativeSessionAttentionIndexItem[]): 
   }, { authorization: 0, recoverable: 0, rejected: 0, total: 0 })
 }
 
+export function mergedAttentionSessionCount(...groups: ReadonlySet<string>[]): number {
+  const keys = new Set<string>()
+  for (const group of groups) for (const key of group) keys.add(key)
+  return keys.size
+}
+
 /**
  * Compose the mature Session browser with the global attention read model without changing its
  * pagination, ordering or writer semantics. Attention has its own tiny refresh loop and event path;
@@ -135,7 +142,7 @@ export function NativeSessionHome(props: Props) {
   const [knownTargets, setKnownTargets] = useState<Record<string, NativeSessionSurfaceTarget>>({})
   const [openingKey, setOpeningKey] = useState<string | null>(null)
   const [openError, setOpenError] = useState<string | null>(null)
-  const [baseAttentionCount, setBaseAttentionCount] = useState(0)
+  const [baseAttentionKeys, setBaseAttentionKeys] = useState<ReadonlySet<string>>(() => new Set())
   const generationRef = useRef(0)
   const notificationStateRef = useRef<NativeSessionAttentionNotificationState>({
     scopes: { ...EMPTY_NATIVE_SESSION_ATTENTION_NOTIFICATION_STATE.scopes }
@@ -290,11 +297,18 @@ export function NativeSessionHome(props: Props) {
     ), [scopes])
 
   const counts = useMemo(() => attentionInboxCounts(inbox.map((entry) => entry.item)), [inbox])
+  const inboxSessionKeys = useMemo<ReadonlySet<string>>(() => new Set(
+    inbox.map((entry) => sessionKey(entry.target, entry.item.sessionID))
+  ), [inbox])
+  const totalAttentionCount = useMemo(
+    () => mergedAttentionSessionCount(baseAttentionKeys, inboxSessionKeys),
+    [baseAttentionKeys, inboxSessionKeys]
+  )
   const incomplete = Object.values(scopes).some((scope) => !scope.index.complete)
 
   useEffect(() => {
-    props.onAttentionCountChange?.(baseAttentionCount + counts.total)
-  }, [baseAttentionCount, counts.total, props.onAttentionCountChange])
+    props.onAttentionCountChange?.(totalAttentionCount)
+  }, [props.onAttentionCountChange, totalAttentionCount])
 
   return (
     <>
@@ -345,7 +359,13 @@ export function NativeSessionHome(props: Props) {
           {openError ? <div className="hr-native-attention-error" role="alert">{openError}</div> : null}
         </section>
       ) : null}
-      <NativeSessionHomeBase {...props} onAttentionCountChange={setBaseAttentionCount} onOpen={rememberAndOpen} />
+      <NativeSessionHomeBase
+        {...props}
+        attentionSessionKeys={inboxSessionKeys}
+        onAttentionCountChange={() => {}}
+        onAttentionKeysChange={setBaseAttentionKeys}
+        onOpen={rememberAndOpen}
+      />
     </>
   )
 }

--- a/web/src/components/native-session-home-base.tsx
+++ b/web/src/components/native-session-home-base.tsx
@@ -92,6 +92,10 @@ type Props = {
   refreshToken?: number
   /** The rail already counts Sessions needing input; the mobile nav needs that count outside it. */
   onAttentionCountChange?: (count: number) => void
+  /** Structured pending permission/question identities from the global attention index. */
+  attentionSessionKeys?: ReadonlySet<string>
+  /** Exposes the currently scoped attention identities so the Inbox wrapper can union counts. */
+  onAttentionKeysChange?: (keys: ReadonlySet<string>) => void
   selectedKey?: string
   selectedState?: SessionPresentationState
   /** Fires when native Session discovery has settled at least once for the current machines. */
@@ -341,6 +345,8 @@ export function NativeSessionHome({
   onOpen,
   refreshToken = 0,
   onAttentionCountChange,
+  attentionSessionKeys,
+  onAttentionKeysChange,
   onDiscoveredChange,
   onRefreshComplete,
   selectedKey,
@@ -567,10 +573,13 @@ export function NativeSessionHome({
 
   const liveStateForItem = useCallback((item: RecordWithMachine): SessionPresentationState | undefined => {
     const targetKey = recordKey(item)
+    // A pending native permission/question is stronger evidence than a stale discovery/live state.
+    // This is presentation-only: no authority, writer ownership or harness state is changed here.
+    if (attentionSessionKeys?.has(targetKey)) return "attention"
     return targetKey === selectedKey && selectedState
       ? selectedState
       : presentationOverrides[targetKey]
-  }, [presentationOverrides, selectedKey, selectedState])
+  }, [attentionSessionKeys, presentationOverrides, selectedKey, selectedState])
 
   const presentationForItem = useCallback((item: RecordWithMachine) => {
     const liveState = liveStateForItem(item)
@@ -731,14 +740,20 @@ export function NativeSessionHome({
     return counts
   }, [projectionForItem, scopedRecords])
   const activeCount = bucketCounts.active
-  const attentionCount = bucketCounts.attention
+  const attentionKeys = useMemo<ReadonlySet<string>>(() => new Set(
+    scopedRecords
+      .filter((item) => projectionForItem(item).bucket === "attention")
+      .map(recordKey)
+  ), [projectionForItem, scopedRecords])
+  const attentionCount = attentionKeys.size
   const operationalFilter: FederatedOperationalBucket | "" =
     filter === "failed" || filter === "completed" || filter === "recent" ? filter : ""
   const showOperationalFilter = bucketCounts.failed + bucketCounts.completed + bucketCounts.recent > 0 || Boolean(operationalFilter)
 
   useEffect(() => {
     onAttentionCountChange?.(attentionCount)
-  }, [attentionCount, onAttentionCountChange])
+    onAttentionKeysChange?.(attentionKeys)
+  }, [attentionCount, attentionKeys, onAttentionCountChange, onAttentionKeysChange])
 
   useEffect(() => {
     onDiscoveredChange?.(loaded)

--- a/web/src/native-session-attention-severity.test.mjs
+++ b/web/src/native-session-attention-severity.test.mjs
@@ -29,7 +29,8 @@ assert.match(source, /Needs input/, "question-driven recoverable attention must 
 assert.match(source, /Request rejected/, "rejected\/fail-closed attention must not look retryable")
 assert.match(source, /This request was rejected and will not proceed automatically/, "rejected attention must explain that it will not resume by itself")
 assert.match(source, /counts\.authorization[\s\S]*counts\.recoverable[\s\S]*counts\.rejected/, "the heading must expose severity-specific counts")
-assert.match(source, /baseAttentionCount \+ counts\.total/, "the mobile badge must continue to include all explicit Inbox entries")
+assert.match(source, /inbox\.map\(\(entry\) => sessionKey\(entry\.target, entry\.item\.sessionID\)\)/, "every explicit Inbox entry must contribute its canonical Session identity to the mobile badge")
+assert.match(source, /mergedAttentionSessionCount\(baseAttentionKeys, inboxSessionKeys\)/, "the mobile badge must include Inbox attention without double-counting Sessions already marked by the rail")
 assert.doesNotMatch(source, /loadMessagePage|continueConversation|stopConversation|startTaskDeskSessionLiveRefresh/, "severity presentation must stay outside transcript and writer paths")
 
 const css = readFileSync(new URL("./native-session-attention-inbox.css", import.meta.url), "utf8")

--- a/web/src/native-session-home.test.mjs
+++ b/web/src/native-session-home.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import { readFileSync } from "node:fs"
 import { appendCursorPage, refreshCursorPage, sessionTreeRows } from "./components/native-session-home.tsx"
+import { mergedAttentionSessionCount } from "./components/native-session-home-attention.tsx"
 import { canCreateNativeSession } from "./native-session-create.ts"
 import { classifyNativeSessionAttention, sessionNeedsAttention } from "./native-session-attention.ts"
 
@@ -159,11 +160,18 @@ for (const type of ["working", "waiting", "retry", "busy", "running", "in_progre
   assert.equal(classifyNativeSessionAttention({ status: { type } }).kind, "none", `${type} must not be promoted into attention without evidence`)
 }
 
+assert.equal(mergedAttentionSessionCount(
+  new Set(["machine:agent:one", "machine:agent:two"]),
+  new Set(["machine:agent:two", "machine:agent:three"])
+), 3, "the nav attention count must be a Session-identity union rather than double-counting Inbox overlap")
+
 const source = readFileSync(new URL("./components/native-session-home-base.tsx", import.meta.url), "utf8")
 assert.match(source, /presentationOverrides/, "live detail status must survive selecting another Session")
 assert.match(source, /\{ \.\.\.current, \[selectedKey\]: selectedState \}/, "the status bridge must be keyed by native Session identity")
 assert.match(source, /setPresentationOverrides\(\{\}\)[\s\S]*setRecords\(uniqueSessionRecords/, "a successful native discovery must retire temporary presentation overrides")
 assert.match(source, /presentationOverrides\[targetKey\]/, "non-selected rows must retain their last observed live state until discovery reconciles them")
+assert.match(source, /attentionSessionKeys\?\.has\(targetKey\)[\s\S]*return "attention"/, "structured pending requests must override stale discovery state in the federated rail")
+assert.match(source, /onAttentionKeysChange\?\.\(attentionKeys\)/, "the rail must expose attention identities so global counts can be deduplicated")
 assert.match(source, /createMachineID/, "native Session creation must have an explicit machine selection independent of the list filter")
 assert.match(source, /createMachines\.map/, "the create panel must render the available machine choices")
 assert.match(source, /selectedActivityAnchor/, "the currently open Session must keep a stable activity ordering anchor")
@@ -193,6 +201,8 @@ assert.match(inboxSource, /loadNativeSessionAttentionIndex/, "the global Inbox m
 assert.match(inboxSource, /startNativeSessionAttentionLiveRefresh/, "the global Inbox must use its dedicated attention event path")
 assert.match(inboxSource, /!result\.complete && previous[\s\S]*items: previous\.index\.items/, "a partial refresh must fail closed and preserve known pending attention")
 assert.match(inboxSource, /openAttentionSession[\s\S]*discoverAgentNativeSessionPage/, "native history lookup must happen only when a user opens an Inbox item or notification")
+assert.match(inboxSource, /attentionSessionKeys=\{inboxSessionKeys\}/, "the Inbox must feed pending Session identities into the existing federated filter instead of starting a second discovery path")
+assert.match(inboxSource, /mergedAttentionSessionCount\(baseAttentionKeys, inboxSessionKeys\)/, "mobile nav attention must union native and Inbox identities")
 assert.match(inboxSource, /Authorization required/, "global permissions must remain visibly distinct from generic attention")
 assert.doesNotMatch(inboxSource, /startTaskDeskSessionLiveRefresh|loadMessagePage|continueConversation|stopConversation/, "global attention must stay outside transcript and Session writer paths")
 

--- a/web/src/ui-regression.test.mjs
+++ b/web/src/ui-regression.test.mjs
@@ -26,8 +26,9 @@ assert.match(homeBase, /hr-native-project-group/, 'Session navigation must prese
 assert.match(homeBase, /hr-native-session-row/, 'Session navigation must render native Session rows')
 assert.match(attentionInbox, /loadNativeSessionAttentionIndex/, 'the Inbox must use the capability-driven attention read model')
 assert.match(attentionInbox, /startNativeSessionAttentionLiveRefresh/, 'the Inbox must use its dedicated capability-scoped live refresh')
-assert.match(attentionInbox, /baseAttentionCount \+ counts\.total/, 'mobile navigation must carry explicit global attention as well as legacy rail attention')
-assert.match(attentionInbox, /onAttentionCountChange=\{setBaseAttentionCount\}/, 'the wrapper must intercept the base count before forwarding the combined badge count')
+assert.match(attentionInbox, /mergedAttentionSessionCount\(baseAttentionKeys, inboxSessionKeys\)/, 'mobile navigation must union explicit global and rail attention without double-counting a Session')
+assert.match(attentionInbox, /onAttentionKeysChange=\{setBaseAttentionKeys\}/, 'the wrapper must receive base attention identities before forwarding the deduplicated badge count')
+assert.match(attentionInbox, /attentionSessionKeys=\{inboxSessionKeys\}/, 'pending structured attention must feed the existing federated Session rail')
 assert.doesNotMatch(attentionInbox, /startTaskDeskSessionLiveRefresh|loadMessagePage|continueConversation|stopConversation/, 'global attention must not reuse transcript or Session writer paths')
 
 assert.match(observer, /<WorkThreadConversation/, 'native Session detail must reuse the mature v3 controller')


### PR DESCRIPTION
## Summary

Connect the already-loaded native permission/question Attention Index to the existing federated Session Home without adding another discovery path.

- Pending structured permission/question evidence promotes the matching native Session to the existing `attention` presentation/bucket.
- Reuses the canonical `machine:agent:session` identity already shared by Inbox and Session Home.
- Makes the existing Needs attention filter and per-machine attention metrics reflect structured pending requests even when discovery status is stale.
- Deduplicates the external/mobile attention count by Session identity instead of adding Inbox and rail counts.
- Partial Attention Index refreshes retain the existing fail-closed behavior.
- Adds regression coverage for attention precedence and count union semantics.

No daemon, ACP, harness adapter, writer-ownership, transcript, prompt, permission-decision, or lifecycle mutation code changes.

Refs #371

Target is `codex/development-2026-09-11` only. Do not merge to `main`.