### PR TITLE
P2: add task identity to attention notifications

### DIFF
--- a/web/src/components/native-session-home-attention.tsx
+++ b/web/src/components/native-session-home-attention.tsx
@@ -3,10 +3,11 @@ import { notifyDesktopAttention, subscribeDesktopAttentionActivation } from "../
 import { discoverAgentNativeSessionPage, nativeSessionSurfaceTarget, type NativeSessionSurfaceTarget } from "../native-session-discovery"
 import { loadNativeSessionAttentionIndex, type NativeSessionAttentionIndex, type NativeSessionAttentionIndexItem } from "../native-session-attention-index"
 import { startNativeSessionAttentionLiveRefresh, type NativeSessionAttentionLiveTarget } from "../native-session-attention-live"
-import { desktopAttentionNotification } from "../native-session-attention-notification-presentation"
+import { desktopAttentionNotification, type NativeSessionAttentionNotificationContext } from "../native-session-attention-notification-presentation"
 import {
   EMPTY_NATIVE_SESSION_ATTENTION_NOTIFICATION_STATE,
   reconcileNativeSessionAttentionNotifications,
+  type NativeSessionAttentionNotificationEvent,
   type NativeSessionAttentionNotificationState
 } from "../native-session-attention-notifications"
 import type { MachineAgentHost, ServerConfig } from "../types"
@@ -43,6 +44,7 @@ export type AttentionInboxCounts = {
 }
 
 const ATTENTION_FALLBACK_MS = 30_000
+const NOTIFICATION_CONTEXT_MAX_PAGES = 4
 
 function supportsAttention(agent: MachineAgentHost): boolean {
   return agent.state === "available"
@@ -132,10 +134,38 @@ export function mergedAttentionSessionCount(...groups: ReadonlySet<string>[]): n
   return keys.size
 }
 
+/** Resolve only small, presentation-safe metadata and only when a new desktop notification is
+ * actually emitted. The 30s attention poll remains questions/permissions-only; transcript data is
+ * never touched and native history traversal is deliberately bounded. */
+async function loadAttentionNotificationContext(
+  target: AttentionTarget,
+  sessionID: string
+): Promise<NativeSessionAttentionNotificationContext | undefined> {
+  let cursor: string | undefined
+  const seen = new Set<string>()
+  for (let pageNumber = 0; pageNumber < NOTIFICATION_CONTEXT_MAX_PAGES; pageNumber += 1) {
+    const page = await discoverAgentNativeSessionPage(target.baseConfig, target.agent, cursor)
+    const record = page.records.find((candidate) => candidate.session.id === sessionID)
+    if (record) {
+      const surface = nativeSessionSurfaceTarget(target.machineID, target.baseConfig, record)
+      const projectLabel = record.session.project?.name?.trim()
+      return {
+        sessionTitle: surface.title,
+        ...(projectLabel ? { projectLabel } : {})
+      }
+    }
+    if (!page.nextCursor || seen.has(page.nextCursor)) break
+    seen.add(page.nextCursor)
+    cursor = page.nextCursor
+  }
+  return undefined
+}
+
 /**
  * Compose the mature Session browser with the global attention read model without changing its
  * pagination, ordering or writer semantics. Attention has its own tiny refresh loop and event path;
- * native Session history is touched only when the user explicitly asks to open an Inbox item.
+ * native Session history is touched only when the user explicitly opens an Inbox item or when a new
+ * desktop notification performs one bounded metadata lookup for task identity.
  */
 export function NativeSessionHome(props: Props) {
   const [scopes, setScopes] = useState<Record<string, AttentionScope>>({})
@@ -147,6 +177,7 @@ export function NativeSessionHome(props: Props) {
   const notificationStateRef = useRef<NativeSessionAttentionNotificationState>({
     scopes: { ...EMPTY_NATIVE_SESSION_ATTENTION_NOTIFICATION_STATE.scopes }
   })
+  const notificationContextRef = useRef<Map<string, NativeSessionAttentionNotificationContext>>(new Map())
 
   const attentionTargets = useMemo<AttentionTarget[]>(() => props.sources.flatMap(({ machine, snapshot, state }) => {
     if (!snapshot || state !== "online") return []
@@ -179,6 +210,7 @@ export function NativeSessionHome(props: Props) {
 
   const rememberAndOpen = useCallback((target: NativeSessionSurfaceTarget) => {
     setKnownTargets((current) => ({ ...current, [target.key]: target }))
+    notificationContextRef.current.set(target.key, { sessionTitle: target.title })
     props.onOpen(target)
   }, [props.onOpen])
 
@@ -194,7 +226,13 @@ export function NativeSessionHome(props: Props) {
         const page = await discoverAgentNativeSessionPage(target.baseConfig, target.agent, cursor)
         const record = page.records.find((candidate) => candidate.session.id === sessionID)
         if (record) {
-          rememberAndOpen(nativeSessionSurfaceTarget(target.machineID, target.baseConfig, record))
+          const surface = nativeSessionSurfaceTarget(target.machineID, target.baseConfig, record)
+          const projectLabel = record.session.project?.name?.trim()
+          notificationContextRef.current.set(key, {
+            sessionTitle: surface.title,
+            ...(projectLabel ? { projectLabel } : {})
+          })
+          rememberAndOpen(surface)
           return
         }
         if (!page.nextCursor || seen.has(page.nextCursor)) break
@@ -208,6 +246,23 @@ export function NativeSessionHome(props: Props) {
       setOpeningKey(null)
     }
   }, [openingKey, props.selectedKey, rememberAndOpen])
+
+  const notifyAttention = useCallback(async (
+    notification: NativeSessionAttentionNotificationEvent,
+    target: AttentionTarget
+  ) => {
+    const key = sessionKey(target, notification.sessionID)
+    let context = notificationContextRef.current.get(key)
+    if (!context) {
+      try {
+        context = await loadAttentionNotificationContext(target, notification.sessionID)
+        if (context) notificationContextRef.current.set(key, context)
+      } catch {
+        // Notification safety is more important than metadata enrichment. Keep the proven fallback.
+      }
+    }
+    notifyDesktopAttention(desktopAttentionNotification(notification, context))
+  }, [])
 
   const refreshAttentionTarget = useCallback(async (candidate: NativeSessionAttentionLiveTarget, generation: number) => {
     const target = targetsRef.current.get(candidate.key)
@@ -226,7 +281,7 @@ export function NativeSessionHome(props: Props) {
     }])
     notificationStateRef.current = notificationResult.state
     for (const notification of notificationResult.notifications) {
-      notifyDesktopAttention(desktopAttentionNotification(notification))
+      void notifyAttention(notification, latest)
     }
 
     setScopes((current) => {
@@ -236,7 +291,7 @@ export function NativeSessionHome(props: Props) {
         : result
       return { ...current, [candidate.key]: { target: latest, index } }
     })
-  }, [])
+  }, [notifyAttention])
 
   useEffect(() => subscribeDesktopAttentionActivation((activation) => {
     const target = [...targetsRef.current.values()].find((candidate) =>

--- a/web/src/components/native-session-home-attention.tsx
+++ b/web/src/components/native-session-home-attention.tsx
@@ -210,7 +210,11 @@ export function NativeSessionHome(props: Props) {
 
   const rememberAndOpen = useCallback((target: NativeSessionSurfaceTarget) => {
     setKnownTargets((current) => ({ ...current, [target.key]: target }))
-    notificationContextRef.current.set(target.key, { sessionTitle: target.title })
+    const existingContext = notificationContextRef.current.get(target.key)
+    notificationContextRef.current.set(target.key, {
+      ...existingContext,
+      sessionTitle: target.title
+    })
     props.onOpen(target)
   }, [props.onOpen])
 

--- a/web/src/native-session-attention-desktop.test.mjs
+++ b/web/src/native-session-attention-desktop.test.mjs
@@ -37,6 +37,25 @@ test("authorization desktop notification explains action, reason, boundary and n
   })
 })
 
+test("desktop notification includes bounded task identity when native metadata is available", () => {
+  const notification = desktopAttentionNotification(event(), {
+    sessionTitle: "Fix issue #371",
+    projectLabel: "Harness Remote"
+  })
+  assert.match(notification.body, /Session: Fix issue #371/)
+  assert.match(notification.body, /Project: Harness Remote/)
+  assert.match(notification.overlayDescription, /Fix issue #371/)
+  assert.match(notification.overlayDescription, /Harness Remote/)
+  assert.match(notification.body, /Workstation · Codex/)
+})
+
+test("task identity enrichment remains optional and preserves the proven fallback", () => {
+  const notification = desktopAttentionNotification(event())
+  assert.doesNotMatch(notification.body, /Session:/)
+  assert.doesNotMatch(notification.body, /Project:/)
+  assert.match(notification.body, /Workstation · Codex/)
+})
+
 test("rejected and question attention keep distinct notification semantics", () => {
   const rejected = desktopAttentionNotification(event({
     kind: "rejected",
@@ -62,13 +81,19 @@ test("rejected and question attention keep distinct notification semantics", () 
   assert.match(question.body, /remains blocked until you answer/)
 })
 
-test("Attention Inbox uses raw complete reads for notification dedup and notification click deep-links by identity", () => {
+test("Attention Inbox enriches only emitted notifications with bounded native metadata and deep-links by identity", () => {
   const source = readFileSync(new URL("./components/native-session-home-attention.tsx", import.meta.url), "utf8")
   assert.match(source, /reconcileNativeSessionAttentionNotifications\(notificationStateRef\.current, \[\{/)
   assert.match(source, /index: result/)
-  assert.match(source, /notifyDesktopAttention\(desktopAttentionNotification\(notification\)\)/)
+  assert.match(source, /for \(const notification of notificationResult\.notifications\)[\s\S]*void notifyAttention\(notification, latest\)/)
+  assert.match(source, /NOTIFICATION_CONTEXT_MAX_PAGES = 4/)
+  assert.match(source, /pageNumber < NOTIFICATION_CONTEXT_MAX_PAGES/)
+  assert.match(source, /record\.session\.project\?\.name\?\.trim\(\)/)
+  assert.match(source, /desktopAttentionNotification\(notification, context\)/)
+  assert.match(source, /const existingContext = notificationContextRef\.current\.get\(target\.key\)/)
+  assert.match(source, /\.\.\.existingContext,[\s\S]*sessionTitle: target\.title/, "remembering a Session must not discard an already resolved Project label")
   assert.match(source, /subscribeDesktopAttentionActivation/)
   assert.match(source, /candidate\.machineID === activation\.machineID && candidate\.agent\.id === activation\.agentID/)
   assert.match(source, /openAttentionSession\(target, activation\.sessionID\)/)
-  assert.doesNotMatch(source, /loadMessages|loadTranscript/)
+  assert.doesNotMatch(source, /loadMessagePage|loadMessages|loadTranscript/)
 })

--- a/web/src/native-session-attention-notification-presentation.ts
+++ b/web/src/native-session-attention-notification-presentation.ts
@@ -1,6 +1,11 @@
 import type { DesktopAttentionNotification } from "../electron/ipc-contract"
 import type { NativeSessionAttentionNotificationEvent } from "./native-session-attention-notifications"
 
+export type NativeSessionAttentionNotificationContext = {
+  sessionTitle?: string
+  projectLabel?: string
+}
+
 function title(event: NativeSessionAttentionNotificationEvent): string {
   if (event.kind === "authorization") return "Authorization required"
   if (event.kind === "rejected") return "Request rejected"
@@ -15,31 +20,46 @@ function compact(parts: Array<string | undefined>): string {
     .slice(0, 1000)
 }
 
+function taskIdentity(
+  event: NativeSessionAttentionNotificationEvent,
+  context?: NativeSessionAttentionNotificationContext
+): string[] {
+  const sessionTitle = context?.sessionTitle?.trim()
+  const projectLabel = context?.projectLabel?.trim()
+  return [
+    sessionTitle ? `Session: ${sessionTitle}` : undefined,
+    projectLabel ? `Project: ${projectLabel}` : undefined,
+    `${event.machineName} · ${event.agentLabel}`
+  ].filter((part): part is string => Boolean(part))
+}
+
 /** Keep the notification useful without requiring the full transcript. Authorization messages include
  * the requested action, harness-provided explanation/boundary when available, and the fail-closed
- * consequence required by the product contract. */
+ * consequence required by the product contract. Optional task context comes only from bounded native
+ * Session metadata; raw working-directory paths are never added to the notification. */
 export function desktopAttentionNotification(
-  event: NativeSessionAttentionNotificationEvent
+  event: NativeSessionAttentionNotificationEvent,
+  context?: NativeSessionAttentionNotificationContext
 ): DesktopAttentionNotification {
-  const identity = `${event.machineName} · ${event.agentLabel}`
+  const identity = taskIdentity(event, context)
   const body = event.kind === "authorization"
     ? compact([
         event.requestedAction,
         event.explanation,
         event.boundary ? `Boundary: ${event.boundary}` : undefined,
         event.consequence,
-        identity
+        ...identity
       ])
     : compact([
         event.requestedAction,
         event.consequence,
-        identity
+        ...identity
       ])
 
   return {
     title: title(event),
     body,
-    overlayDescription: `${title(event)} · ${identity}`.slice(0, 240),
+    overlayDescription: compact([title(event), ...identity]).replaceAll("\n", " · ").slice(0, 240),
     target: {
       machineID: event.machineID,
       agentID: event.agentID,

--- a/web/src/native-session-attention-notification-presentation.ts
+++ b/web/src/native-session-attention-notification-presentation.ts
@@ -59,7 +59,7 @@ export function desktopAttentionNotification(
   return {
     title: title(event),
     body,
-    overlayDescription: compact([title(event), ...identity]).replaceAll("\n", " · ").slice(0, 240),
+    overlayDescription: compact([title(event), ...identity]).split("\n").join(" · ").slice(0, 240),
     target: {
       machineID: event.machineID,
       agentID: event.agentID,


### PR DESCRIPTION
## Summary

Adds bounded task identity to desktop Attention notifications so a user can tell which native Session/Project needs input without opening every notification.

- keeps the existing notification transition/dedup model unchanged
- resolves Session title and Project name only when a genuinely new notification is emitted
- bounds native Session metadata lookup to 4 history pages
- never loads transcript/messages for notification enrichment
- never includes working-directory paths as task identity
- falls back to the existing machine + harness notification when metadata is unavailable
- caches presentation-safe metadata by canonical machine:agent:session identity
- preserves an already resolved Project label when the Session is later opened from the Inbox
- keeps notification deep-links on the exact native Session identity
- adds regression coverage for enriched and fallback presentation plus bounded/no-transcript invariants

No daemon, ACP, harness adapter, writer-ownership, permission-decision, prompt, transcript, or lifecycle mutation changes.

Refs #371

Target: `codex/development-2026-09-11` only. Never merge to `main`.