### PR TITLE
P2: expose structured gate details in Session outcome (superseded)

### DIFF
--- a/web/src/components/native-session-outcome-panel.tsx
+++ b/web/src/components/native-session-outcome-panel.tsx
@@ -5,6 +5,10 @@ import { listMachineProjects } from "../machineClient"
 import { resolveSourceSessionProject } from "../cross-machine-route-projects"
 import type { NativeSessionSurfaceTarget } from "../native-session-discovery"
 import {
+  nativeSessionGateEvidence,
+  type NativeSessionGateEvidence
+} from "../native-session-gate-evidence"
+import {
   nativeSessionReviewEvidence,
   type NativeSessionReviewAttention
 } from "../native-session-review-evidence"
@@ -13,6 +17,7 @@ import {
   type MachineProjectOutcome,
   type MachineProjectOutcomeFile
 } from "../project-outcome-client"
+import type { PermissionRequest, QuestionRequest } from "../types"
 import "../native-session-outcome.css"
 
 const MAX_VISIBLE_FILES = 12
@@ -34,11 +39,12 @@ type ProjectOutcomeView = {
 type OutcomeView = {
   project?: ProjectOutcomeView
   attention: NativeSessionReviewAttention
+  gate?: NativeSessionGateEvidence
 }
 
 type AttentionLoad = {
-  questions?: number
-  permissions?: number
+  questions?: QuestionRequest[]
+  permissions?: PermissionRequest[]
   connectionIssue: boolean
 }
 
@@ -83,15 +89,32 @@ async function loadAttentionEvidence(target: NativeSessionSurfaceTarget): Promis
   ])
   return {
     ...(questionResult.status === "fulfilled" ? {
-      questions: questionResult.value.filter((request) => request.sessionID === target.sessionID).length
+      questions: questionResult.value.filter((request) => request.sessionID === target.sessionID)
     } : {}),
     ...(permissionResult.status === "fulfilled" ? {
-      permissions: permissionResult.value.filter((request) => request.sessionID === target.sessionID).length
+      permissions: permissionResult.value.filter((request) => request.sessionID === target.sessionID)
     } : {}),
     connectionIssue:
       (questionResult.status === "rejected" && connectionFailure(questionResult.reason))
       || (permissionResult.status === "rejected" && connectionFailure(permissionResult.reason))
   }
+}
+
+function gateFromAttentionLoad(
+  load: AttentionLoad,
+  previous?: NativeSessionGateEvidence
+): NativeSessionGateEvidence | undefined {
+  // A failed permission read cannot prove that an already-known authorization gate disappeared.
+  // Preserve that fail-closed evidence until the permission endpoint returns a complete replacement.
+  if (load.permissions === undefined && previous?.kind === "authorization") return previous
+
+  const permissionGate = nativeSessionGateEvidence(load.permissions ?? [], [])
+  if (permissionGate) return permissionGate
+
+  // Once permissions are known empty, questions may become the highest-priority gate. If that
+  // endpoint is the one that failed, retain only a previously known question instead of inventing one.
+  if (load.questions === undefined && previous?.kind === "question") return previous
+  return nativeSessionGateEvidence([], load.questions ?? []) ?? undefined
 }
 
 export function NativeSessionOutcomePanel({
@@ -142,11 +165,18 @@ export function NativeSessionOutcomePanel({
         const attention = attentionResult.status === "fulfilled"
           ? {
               complete: attentionResult.value.questions !== undefined && attentionResult.value.permissions !== undefined,
-              questions: attentionResult.value.questions ?? previousAttention.questions,
-              permissions: attentionResult.value.permissions ?? previousAttention.permissions
+              questions: attentionResult.value.questions?.length ?? previousAttention.questions,
+              permissions: attentionResult.value.permissions?.length ?? previousAttention.permissions
             }
           : { ...previousAttention, complete: false }
-        return { ...(project ? { project } : {}), attention }
+        const gate = attentionResult.status === "fulfilled"
+          ? gateFromAttentionLoad(attentionResult.value, current?.gate)
+          : current?.gate
+        return {
+          ...(project ? { project } : {}),
+          attention,
+          ...(gate ? { gate } : {})
+        }
       })
     })()
 
@@ -166,6 +196,7 @@ export function NativeSessionOutcomePanel({
   const hiddenCount = total === undefined ? 0 : Math.max(0, total - visibleFiles.length)
   const branchOrHead = outcome?.branch || (outcome?.head ? outcome.head.slice(0, 8) : undefined)
   const state = outcome ? outcomeState(outcome) : undefined
+  const gate = view?.gate
   const summary = [
     review?.label,
     branchOrHead,
@@ -198,10 +229,29 @@ export function NativeSessionOutcomePanel({
                 <span>Session <strong>{review.label}</strong></span>
                 {view?.attention.permissions ? <span>Authorization <strong>{view.attention.permissions} pending</strong></span> : null}
                 {view?.attention.questions ? <span>Questions <strong>{view.attention.questions} pending</strong></span> : null}
+                {gate ? (
+                  <span>{gate.kind === "authorization" ? "Requested action" : "Waiting for"} <strong>{gate.label}</strong></span>
+                ) : null}
               </div>
               <p className="hr-native-outcome-note">
                 {review.summary}{review.detail ? ` ${review.detail}` : ""} {review.nextAction}
               </p>
+              {gate?.detail ? <p className="hr-native-outcome-note">{gate.detail}</p> : null}
+              {gate?.kind === "authorization" && gate.boundaries.length ? (
+                <div className="hr-native-outcome-files" aria-label="Authorization boundaries">
+                  {gate.boundaries.map((boundary, index) => (
+                    <div className="hr-native-outcome-file" key={`${boundary}:${index}`}>
+                      <span>Gated scope</span>
+                      <code title={boundary}>{boundary}</code>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+              {gate?.omittedBoundaries ? (
+                <p className="hr-native-outcome-note">
+                  {gate.omittedBoundaries} additional gated {gate.omittedBoundaries === 1 ? "scope is" : "scopes are"} omitted by display bounds.
+                </p>
+              ) : null}
             </>
           ) : null}
 

--- a/web/src/native-session-attention-desktop.test.mjs
+++ b/web/src/native-session-attention-desktop.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import { readFileSync } from "node:fs"
 import test from "node:test"
+import { nativeSessionGateEvidence } from "./native-session-gate-evidence.ts"
 import { desktopAttentionNotification } from "./native-session-attention-notification-presentation.ts"
 
 function event(overrides = {}) {
@@ -81,6 +82,46 @@ test("rejected and question attention keep distinct notification semantics", () 
   assert.match(question.body, /remains blocked until you answer/)
 })
 
+test("structured gate evidence prioritizes authorization and bounds displayed scopes", () => {
+  const evidence = nativeSessionGateEvidence([
+    {
+      id: "perm-1",
+      sessionID: "session-123",
+      permission: "write_file",
+      patterns: ["src/**", "src/**", "tests/**", "x".repeat(220), "docs/**"],
+      metadata: { reason: "Apply the requested source changes" },
+      always: []
+    }
+  ], [
+    {
+      id: "question-1",
+      sessionID: "session-123",
+      questions: [{ header: "Deploy", question: "Which target?", options: [] }]
+    }
+  ])
+
+  assert.equal(evidence?.kind, "authorization")
+  assert.equal(evidence?.label, "write_file")
+  assert.equal(evidence?.detail, "Apply the requested source changes")
+  assert.equal(evidence?.boundaries.length, 3)
+  assert.deepEqual(evidence?.boundaries.slice(0, 2), ["src/**", "tests/**"])
+  assert.match(evidence?.boundaries[2] || "", /…$/)
+  assert.equal(evidence?.omittedBoundaries, 1)
+})
+
+test("structured gate evidence falls back to a bounded question and never invents a gate", () => {
+  const question = nativeSessionGateEvidence([], [{
+    id: "question-1",
+    sessionID: "session-123",
+    questions: [{ header: "Deploy", question: `Choose ${"target ".repeat(60)}`, options: [] }]
+  }])
+  assert.equal(question?.kind, "question")
+  assert.ok((question?.label.length || 0) <= 240)
+  assert.match(question?.label || "", /…$/)
+  assert.deepEqual(question?.boundaries, [])
+  assert.equal(nativeSessionGateEvidence([], []), null)
+})
+
 test("Attention Inbox enriches only emitted notifications with bounded native metadata and deep-links by identity", () => {
   const source = readFileSync(new URL("./components/native-session-home-attention.tsx", import.meta.url), "utf8")
   assert.match(source, /reconcileNativeSessionAttentionNotifications\(notificationStateRef\.current, \[\{/)
@@ -96,4 +137,16 @@ test("Attention Inbox enriches only emitted notifications with bounded native me
   assert.match(source, /candidate\.machineID === activation\.machineID && candidate\.agent\.id === activation\.agentID/)
   assert.match(source, /openAttentionSession\(target, activation\.sessionID\)/)
   assert.doesNotMatch(source, /loadMessagePage|loadMessages|loadTranscript/)
+})
+
+test("Session outcome renders bounded structured gate detail without transcript inference", () => {
+  const source = readFileSync(new URL("./components/native-session-outcome-panel.tsx", import.meta.url), "utf8")
+  assert.match(source, /nativeSessionGateEvidence/)
+  assert.match(source, /gateFromAttentionLoad/)
+  assert.match(source, /Requested action/)
+  assert.match(source, /Gated scope/)
+  assert.match(source, /Authorization boundaries/)
+  assert.match(source, /loadPermissions\(target\.config, target\.directory\)/)
+  assert.match(source, /loadQuestions\(target\.config, target\.directory\)/)
+  assert.doesNotMatch(source, /loadMessagePage|loadMessages|loadTranscript|loadDiff/)
 })

--- a/web/src/native-session-gate-evidence.ts
+++ b/web/src/native-session-gate-evidence.ts
@@ -51,10 +51,11 @@ export function nativeSessionGateEvidence(
   const permission = permissions[0]
   if (permission) {
     const boundary = boundedBoundaries(permission.patterns || [])
+    const detail = permissionDetail(permission.metadata || {})
     return {
       kind: "authorization",
       label: compact(permission.permission, MAX_LABEL_LENGTH) || "Permission requested",
-      ...(permissionDetail(permission.metadata || {}) ? { detail: permissionDetail(permission.metadata || {}) } : {}),
+      ...(detail ? { detail } : {}),
       ...boundary
     }
   }

--- a/web/src/native-session-gate-evidence.ts
+++ b/web/src/native-session-gate-evidence.ts
@@ -1,0 +1,75 @@
+import type { PermissionRequest, QuestionRequest } from "./types"
+
+export type NativeSessionGateEvidence = {
+  kind: "authorization" | "question"
+  label: string
+  detail?: string
+  boundaries: string[]
+  omittedBoundaries: number
+}
+
+const MAX_LABEL_LENGTH = 240
+const MAX_DETAIL_LENGTH = 240
+const MAX_BOUNDARY_LENGTH = 160
+const MAX_VISIBLE_BOUNDARIES = 3
+
+function compact(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== "string") return undefined
+  const normalized = value.replace(/\s+/g, " ").trim()
+  if (!normalized) return undefined
+  return normalized.length > maxLength ? `${normalized.slice(0, maxLength - 1)}…` : normalized
+}
+
+function permissionDetail(metadata: Record<string, unknown>): string | undefined {
+  for (const key of ["reason", "description", "message"]) {
+    const value = compact(metadata[key], MAX_DETAIL_LENGTH)
+    if (value) return value
+  }
+  return undefined
+}
+
+function boundedBoundaries(patterns: readonly string[]): { boundaries: string[]; omittedBoundaries: number } {
+  const safe = [...new Set(patterns
+    .map((pattern) => compact(pattern, MAX_BOUNDARY_LENGTH))
+    .filter((pattern): pattern is string => Boolean(pattern)))]
+  return {
+    boundaries: safe.slice(0, MAX_VISIBLE_BOUNDARIES),
+    omittedBoundaries: Math.max(0, safe.length - MAX_VISIBLE_BOUNDARIES)
+  }
+}
+
+/**
+ * Convert structured native permission/question requests into a bounded review-only gate summary.
+ * Permission evidence wins over questions because authorization is fail-closed and blocks execution.
+ * No transcript/tool prose is read here; every displayed string comes from the native structured
+ * request and is length/count bounded before presentation.
+ */
+export function nativeSessionGateEvidence(
+  permissions: readonly PermissionRequest[],
+  questions: readonly QuestionRequest[]
+): NativeSessionGateEvidence | null {
+  const permission = permissions[0]
+  if (permission) {
+    const boundary = boundedBoundaries(permission.patterns || [])
+    return {
+      kind: "authorization",
+      label: compact(permission.permission, MAX_LABEL_LENGTH) || "Permission requested",
+      ...(permissionDetail(permission.metadata || {}) ? { detail: permissionDetail(permission.metadata || {}) } : {}),
+      ...boundary
+    }
+  }
+
+  const question = questions[0]?.questions?.[0]
+  if (question) {
+    return {
+      kind: "question",
+      label: compact(question.question, MAX_LABEL_LENGTH)
+        || compact(question.header, MAX_LABEL_LENGTH)
+        || "Input requested",
+      boundaries: [],
+      omittedBoundaries: 0
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
Closed after real-user validation.

The implementation was technically correct and CI was fully green, but the resulting UX duplicated information already presented clearly by the native permission surface (`Authorization required`, requested action/scope, Deny/Allow). Keeping a second copy in Project/Session outcome would add UI complexity without enough user value.

Decision: do not merge this slice. Keep Project outcome focused on useful review information (Git/worktree/result) and keep permission handling in the native attention surface.

Follow-up priority is reliability: keep a Session in Attention until the underlying condition is actually resolved, ensure Deny is truly fail-closed, and realign development with the current 3.0.2 `main` before further P2 work.

Target remains `codex/development-2026-09-11`; `main` was never modified by this PR.

Refs #369 #371