### PR TITLE
P0: keep unresolved OpenCode requests in Attention

### DIFF
--- a/bridge/src/daemon-cli.js
+++ b/bridge/src/daemon-cli.js
@@ -193,8 +193,9 @@ async function main() {
       label: "OpenCode",
       backend: "opencode",
       // These are native OpenCode HTTP primitives, not Session-first inventions. Advertising the
-      // complete mutation subset lets the UI expose the same rename/delete/stop/model controls as
-      // the direct OpenCode surface instead of treating a managed host as read-only.
+      // complete native subset is also what lets the global Attention index stay authoritative:
+      // if permission/question support is omitted here, selecting an OpenCode Session can replace
+      // its blocked list status with the detail runtime state and make an unresolved request vanish.
       capabilities: {
         sessions: true,
         prompt: true,
@@ -202,6 +203,8 @@ async function main() {
         streaming: true,
         models: true,
         commands: true,
+        questions: true,
+        permissions: true,
         sessionRename: true,
         sessionDelete: true
       },

--- a/bridge/test/opencode-attention-capability.test.js
+++ b/bridge/test/opencode-attention-capability.test.js
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import path from "node:path"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const daemonSource = fs.readFileSync(path.join(here, "../src/daemon-cli.js"), "utf8")
+
+test("managed OpenCode advertises the native question and permission endpoints", () => {
+  const registration = daemonSource.match(/daemon\.registerManagedHttpHost\(\{[\s\S]*?\n\s*\}\)/)
+  assert.ok(registration, "managed OpenCode registration must remain explicit")
+  assert.match(registration[0], /id: "opencode"/)
+  assert.match(registration[0], /questions: true/)
+  assert.match(registration[0], /permissions: true/)
+})


### PR DESCRIPTION
Fixes a real-user reliability regression where an unresolved OpenCode permission could disappear from the `Attention` filter after the Session was opened.

Root cause: the managed OpenCode host exposes native `/question` and `/permission` endpoints, but its machine capability snapshot did not advertise them. That excluded OpenCode from the global structured Attention index, so opening the Session could let the selected detail/runtime state override the previously blocked list state.

This slice is deliberately small:
- advertise OpenCode's existing native `questions` and `permissions` capabilities;
- let the existing capability-driven Attention index remain authoritative while a request is pending;
- add a regression guard so those capabilities cannot silently disappear again.

No new UI, no transcript polling, no ACP behavior changes, no permission-policy changes.

Target: `codex/development-2026-09-11` only. Never merge to `main`.

Refs #449 #368 #369