### PR TITLE
P0: reconcile mounted Session after permission resolution

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -115,6 +115,7 @@ jobs:
           node scripts/native-session-browser-smoke.mjs
           node scripts/native-opencode-browser-smoke.mjs
           node scripts/native-opencode-real-regression-smoke.mjs
+          node scripts/native-opencode-permission-regression-smoke.mjs
           node scripts/native-session-model-switch-smoke.mjs
           node scripts/native-session-outcome-browser-smoke.mjs
         working-directory: web

--- a/web/scripts/native-opencode-permission-regression-smoke.mjs
+++ b/web/scripts/native-opencode-permission-regression-smoke.mjs
@@ -118,7 +118,7 @@ function beginPermissionTurn(body) {
     if (!activePrompt || activePrompt.assistantID !== assistantID) return
     // Reproduce the dangerous edge: an approval request is visible while lifecycle enrichment is
     // terminal-looking. The request itself is authoritative evidence that the turn is waiting for
-    // the user and must never manufacture a red terminal interruption before a decision exists.
+    // the user and must never manufacture a red "Response interrupted" before a decision exists.
     status = { type: "idle" }
     pendingPermission = {
       id: PERMISSION_ID,
@@ -377,14 +377,15 @@ async function waitForPermission(page) {
   await page.getByText("external_directory", { exact: true }).waitFor({ state: "visible", timeout: 4_000 })
 }
 
-async function assertPendingNeverTerminalizes(page, label) {
-  // Wait beyond OpenCode's 750 ms terminal-looking debounce and the 900 ms lifecycle settle window.
-  // A pending native permission is a waiting state, not a completed/interrupted turn.
-  await page.waitForTimeout(1_300)
+async function assertPendingNeverTerminalizes(page, label, duration = 1_300) {
+  // One scenario intentionally waits through two normal 5s reconcile ticks. This makes the test an
+  // invariant rather than an event-edge test: an unresolved native permission must remain waiting
+  // even if /session/status looks idle for long enough to pass OpenCode's terminal debounce twice.
+  await page.waitForTimeout(duration)
   assert.equal(
     await page.getByText("Response interrupted", { exact: true }).count(),
     0,
-    `${label}: permission.asked must never manufacture a terminal interruption before a decision`
+    `${label}: unresolved authorization must never become a terminal interruption`
   )
   assert.equal(
     await page.getByText("The coding agent stopped before producing a final answer.", { exact: true }).count(),
@@ -394,6 +395,11 @@ async function assertPendingNeverTerminalizes(page, label) {
 }
 
 async function assertAttentionSurvivesOpen(page) {
+  // On mobile the Session detail intentionally covers the list. Use the product's real Back control
+  // instead of force-clicking through the overlay; desktop keeps both panes visible and skips this.
+  const back = page.getByRole("button", { name: "Back to Sessions" })
+  if (await back.isVisible().catch(() => false)) await back.click()
+
   const attentionTab = page.getByRole("button", { name: /Attention\s+1/ }).first()
   await attentionTab.waitFor({ state: "visible", timeout: 3_000 })
   await attentionTab.click()
@@ -424,7 +430,7 @@ async function runScenario(browser, viewport, label) {
 
   await send(page, DENY_PROMPT)
   await waitForPermission(page)
-  await assertPendingNeverTerminalizes(page, `${label} deny`)
+  await assertPendingNeverTerminalizes(page, `${label} deny`, 11_500)
   await assertAttentionSurvivesOpen(page)
 
   await page.getByRole("button", { name: "Deny" }).click()
@@ -441,8 +447,12 @@ async function runScenario(browser, viewport, label) {
 
   // Return to All before the next Send; the important point is that the same Session stayed mounted
   // through the first resolution. No reload or navigation-away recovery has occurred.
+  const back = page.getByRole("button", { name: "Back to Sessions" })
+  if (await back.isVisible().catch(() => false)) await back.click()
   const allTab = page.getByRole("button", { name: /All\s+\d+/ }).first()
   if (await allTab.count()) await allTab.click()
+  const row = page.getByRole("button", { name: new RegExp(`Open ${SESSION_TITLE}`) })
+  if (await row.isVisible().catch(() => false)) await row.click()
 
   await send(page, ALLOW_PROMPT)
   await waitForPermission(page)
@@ -487,7 +497,7 @@ try {
   browser = await chromium.launch({ headless: true })
   await runScenario(browser, { width: 1366, height: 768 }, "desktop")
   await runScenario(browser, { width: 412, height: 915 }, "mobile")
-  console.log("native OpenCode permission regression smoke: pending, Attention persistence, deny, allow and mounted convergence passed")
+  console.log("native OpenCode permission regression smoke: long pending, Attention persistence, deny, allow and mounted convergence passed")
 } finally {
   if (browser) await browser.close().catch(() => {})
   for (const response of sseResponses || []) {

--- a/web/scripts/native-opencode-permission-regression-smoke.mjs
+++ b/web/scripts/native-opencode-permission-regression-smoke.mjs
@@ -405,6 +405,15 @@ async function assertAttentionSurvivesOpen(page) {
   assert.equal(await row.count(), 1, "unresolved Session disappeared from Attention after being opened")
 }
 
+async function waitForMountedTurnToStop(page, label) {
+  const deadline = Date.now() + 4_000
+  while (Date.now() < deadline) {
+    if (await page.locator(".tdw-conversation-state.working").count() === 0) return
+    await page.waitForTimeout(50)
+  }
+  assert.equal(await page.locator(".tdw-conversation-state.working").count(), 0, `${label}: permission resolution left mounted Activity running`)
+}
+
 async function runScenario(browser, viewport, label) {
   resetState()
   const context = await browser.newContext({ viewport, hasTouch: viewport.width < 600, locale: "en-US" })
@@ -423,8 +432,12 @@ async function runScenario(browser, viewport, label) {
   while (Date.now() < denyDeadline && permissionReplies.length < 1) await new Promise((resolve) => setTimeout(resolve, 20))
   assert.deepEqual(permissionReplies[0], { id: PERMISSION_ID, body: { reply: "reject" } }, `${label}: Deny must send the exact native reject reply`)
   await page.getByRole("button", { name: "Deny" }).waitFor({ state: "detached", timeout: 3_000 })
-  await page.getByText("Response interrupted", { exact: true }).waitFor({ state: "visible", timeout: 4_000 })
-  assert.equal(await page.locator(".tdw-conversation-state.working").count(), 0, `${label}: denied permission must not leave mounted Activity running`)
+  await waitForMountedTurnToStop(page, `${label} deny`)
+
+  // A reject may be presented as a terminal interruption or as a completed tool error depending on
+  // the OpenCode version. Reliability is the invariant: it must settle in this mounted Session and
+  // must not require navigation away/back. Do not lock the UI to one provider-version presentation.
+  assert.equal(await page.getByRole("button", { name: "Deny" }).count(), 0, `${label}: resolved permission card remained visible`)
 
   // Return to All before the next Send; the important point is that the same Session stayed mounted
   // through the first resolution. No reload or navigation-away recovery has occurred.

--- a/web/scripts/native-opencode-permission-regression-smoke.mjs
+++ b/web/scripts/native-opencode-permission-regression-smoke.mjs
@@ -1,0 +1,485 @@
+import assert from "node:assert/strict"
+import http from "node:http"
+import { spawn } from "node:child_process"
+import { fileURLToPath } from "node:url"
+import { chromium } from "playwright"
+
+const PREVIEW_PORT = 4181
+const DAEMON_PORT = 4427
+const APP_ORIGIN = `http://127.0.0.1:${PREVIEW_PORT}`
+const STORAGE_KEY = "harness-remote.workspace.machines.v1"
+const MACHINE_ID = "machine-opencode-permission-regression"
+const SESSION_ID = "opencode-permission-regression-session"
+const SESSION_TITLE = "OpenCode permission reliability"
+const DIRECTORY = "/work/opencode-permission-regression"
+const PERMISSION_ID = "per_regression_1"
+const DENY_PROMPT = "OPENCODE-PERMISSION-DENY"
+const ALLOW_PROMPT = "OPENCODE-PERMISSION-ALLOW"
+const ALLOW_FINAL = "Permission accepted and the turn completed normally."
+
+let transcript
+let status
+let pendingPermission
+let permissionReplies
+let promptBodies
+let sseResponses
+let clock
+let activePrompt
+
+function textPart(id, text) {
+  return { id, type: "text", text }
+}
+
+function userMessage(id, text, created) {
+  return {
+    info: { id, role: "user", sessionID: SESSION_ID, time: { created } },
+    parts: [textPart(`${id}-text`, text)]
+  }
+}
+
+function assistantToolMessage(id, created) {
+  return {
+    info: { id, role: "assistant", sessionID: SESSION_ID, time: { created } },
+    parts: [
+      { id: `${id}-reasoning`, messageID: id, sessionID: SESSION_ID, type: "reasoning", text: "The requested operation needs approval." },
+      {
+        id: `${id}-tool`,
+        messageID: id,
+        sessionID: SESSION_ID,
+        type: "tool",
+        tool: "bash",
+        callID: "call-permission-regression",
+        state: {
+          status: "running",
+          input: { command: "cat /tmp/harness-remote-permission-test" },
+          time: { start: created }
+        }
+      }
+    ]
+  }
+}
+
+function resetState() {
+  transcript = [
+    userMessage("history-user", "Earlier prompt", 1_000),
+    {
+      info: { id: "history-assistant", role: "assistant", sessionID: SESSION_ID, time: { created: 1_001, completed: 1_001 }, finish: "stop" },
+      parts: [textPart("history-assistant-text", "Earlier reply")]
+    }
+  ]
+  status = { type: "idle" }
+  pendingPermission = null
+  permissionReplies = []
+  promptBodies = []
+  sseResponses = new Set()
+  clock = 10_000
+  activePrompt = null
+}
+
+function corsHeaders() {
+  return {
+    "Access-Control-Allow-Origin": APP_ORIGIN,
+    "Access-Control-Allow-Headers": "Authorization, Content-Type, X-Harness-Backend",
+    "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
+    "Access-Control-Max-Age": "600"
+  }
+}
+
+function json(response, code, value, extra = {}) {
+  response.writeHead(code, { "Content-Type": "application/json", ...corsHeaders(), ...extra })
+  response.end(JSON.stringify(value))
+}
+
+async function readJSON(request) {
+  const chunks = []
+  for await (const chunk of request) chunks.push(chunk)
+  const raw = Buffer.concat(chunks).toString("utf8")
+  return raw ? JSON.parse(raw) : {}
+}
+
+function emit(type, properties) {
+  const frame = `data: ${JSON.stringify({ directory: DIRECTORY, payload: { type, properties } })}\n\n`
+  for (const response of [...sseResponses]) {
+    try { response.write(frame) } catch { sseResponses.delete(response) }
+  }
+}
+
+function beginPermissionTurn(body) {
+  const created = clock++
+  const assistantID = `assistant-${created}`
+  transcript.push(userMessage(`user-${created}`, body.text, created))
+  transcript.push(assistantToolMessage(assistantID, created + 1))
+  activePrompt = { text: body.text, assistantID }
+  status = { type: "busy" }
+  emit("message.part.updated", { sessionID: SESSION_ID, part: transcript.at(-1).parts[0] })
+  emit("session.status", { sessionID: SESSION_ID, status })
+
+  setTimeout(() => {
+    if (!activePrompt || activePrompt.assistantID !== assistantID) return
+    // Reproduce the dangerous edge: an approval request is visible while lifecycle enrichment is
+    // terminal-looking. The request itself is authoritative evidence that the turn is waiting for
+    // the user and must never manufacture a red terminal interruption before a decision exists.
+    status = { type: "idle" }
+    pendingPermission = {
+      id: PERMISSION_ID,
+      sessionID: SESSION_ID,
+      permission: "external_directory",
+      patterns: ["/tmp/*"],
+      metadata: { reason: "Read a file outside the project" },
+      always: ["/tmp/*"],
+      tool: { messageID: assistantID, callID: "call-permission-regression" }
+    }
+    emit("permission.asked", pendingPermission)
+  }, 180)
+}
+
+function resolvePermission(reply) {
+  const current = pendingPermission
+  assert.ok(current, "permission reply arrived without a pending request")
+  pendingPermission = null
+  emit("permission.replied", {
+    sessionID: SESSION_ID,
+    permissionID: current.id,
+    response: reply
+  })
+
+  const assistant = transcript.find((message) => message.info.id === activePrompt?.assistantID)
+  assert.ok(assistant, "active assistant envelope disappeared")
+  const tool = assistant.parts.find((part) => part.type === "tool")
+  assert.ok(tool, "active tool part disappeared")
+
+  if (reply === "reject") {
+    tool.state = {
+      ...tool.state,
+      status: "error",
+      error: "The user rejected permission to use this specific tool call.",
+      time: { ...tool.state.time, end: clock++ }
+    }
+    assistant.info.time.completed = clock++
+    assistant.info.finish = "tool-calls"
+    status = { type: "idle" }
+    emit("message.part.updated", { sessionID: SESSION_ID, part: tool })
+    // Deliberately no final message.updated. A denied tool may terminate the OpenCode turn here.
+    return
+  }
+
+  status = { type: "busy" }
+  emit("session.status", { sessionID: SESSION_ID, status })
+  setTimeout(() => {
+    tool.state = {
+      ...tool.state,
+      status: "completed",
+      output: "allowed",
+      title: "Allowed",
+      time: { ...tool.state.time, end: clock++ }
+    }
+    assistant.parts.push(textPart(`${assistant.info.id}-final`, ALLOW_FINAL))
+    assistant.info.time.completed = clock++
+    assistant.info.finish = "stop"
+    status = { type: "idle" }
+    // Deliberately emit no message.updated after the final text. The bounded reconciliation after
+    // permission.replied must recover the durable final while this Session remains mounted.
+  }, 350)
+}
+
+function startDaemon() {
+  const server = http.createServer(async (request, response) => {
+    if (request.method === "OPTIONS") {
+      response.writeHead(204, corsHeaders())
+      response.end()
+      return
+    }
+    const url = new URL(request.url || "/", `http://127.0.0.1:${DAEMON_PORT}`)
+
+    if (request.method === "GET" && url.pathname === "/v1/machine") {
+      json(response, 200, {
+        machine: { id: MACHINE_ID, name: "OpenCode permission regression", createdAt: new Date().toISOString() },
+        agents: [{
+          id: "opencode",
+          label: "OpenCode",
+          backend: "opencode",
+          transport: "http",
+          managed: true,
+          state: "available",
+          capabilities: {
+            sessions: true,
+            prompt: true,
+            abort: true,
+            streaming: true,
+            models: true,
+            questions: true,
+            permissions: true
+          },
+          contract: { sessions: { stop: "native-abort" } }
+        }]
+      })
+      return
+    }
+
+    if (request.method === "GET" && url.pathname === "/v1/projects") {
+      json(response, 200, {
+        projects: [{ id: "project-opencode-permission", machineId: MACHINE_ID, name: "opencode-permission-regression", path: DIRECTORY, kind: "git", configured: true }]
+      })
+      return
+    }
+
+    if (request.method === "GET" && url.pathname === "/v1/project-outcome") {
+      json(response, 200, { projectId: "project-opencode-permission", outcome: null })
+      return
+    }
+
+    if (request.method === "GET" && url.pathname === "/v1/session-links") {
+      json(response, 200, { links: [] })
+      return
+    }
+
+    if (request.method === "GET" && url.pathname === "/v1/agents/opencode/experimental/session") {
+      json(response, 200, [{
+        id: SESSION_ID,
+        title: SESSION_TITLE,
+        directory: DIRECTORY,
+        external: true,
+        time: { created: 900, updated: clock }
+      }])
+      return
+    }
+
+    if (request.method === "GET" && url.pathname === "/v1/agents/opencode/session/status") {
+      json(response, 200, { [SESSION_ID]: status })
+      return
+    }
+
+    if (request.method === "GET" && url.pathname === "/v1/agents/opencode/models") {
+      json(response, 200, {
+        models: [{ providerID: "openai", providerName: "OpenAI", modelID: "gpt-5.6-codex", modelName: "GPT-5.6 Codex", isDefault: true, tools: true }],
+        stale: false,
+        refreshedAt: new Date().toISOString(),
+        source: "permission-regression"
+      })
+      return
+    }
+
+    const messageMatch = /^\/v1\/agents\/opencode\/session\/([^/]+)\/message$/.exec(url.pathname)
+    if (request.method === "GET" && messageMatch) {
+      json(response, 200, transcript, { "X-Has-More": "0" })
+      return
+    }
+
+    if (request.method === "GET" && url.pathname === "/v1/agents/opencode/permission") {
+      json(response, 200, pendingPermission ? [pendingPermission] : [])
+      return
+    }
+
+    if (request.method === "GET" && url.pathname === "/v1/agents/opencode/question") {
+      json(response, 200, [])
+      return
+    }
+
+    const permissionReply = /^\/v1\/agents\/opencode\/permission\/([^/]+)\/reply$/.exec(url.pathname)
+    if (request.method === "POST" && permissionReply) {
+      const body = await readJSON(request)
+      permissionReplies.push({ id: decodeURIComponent(permissionReply[1]), body })
+      json(response, 200, true)
+      setTimeout(() => resolvePermission(body.reply), 20)
+      return
+    }
+
+    const promptMatch = /^\/v1\/agents\/opencode\/session\/([^/]+)\/prompt$/.exec(url.pathname)
+    if (request.method === "POST" && promptMatch) {
+      const body = await readJSON(request)
+      promptBodies.push(body)
+      beginPermissionTurn(body)
+      json(response, 200, { status: "accepted", clientRequestId: body.clientRequestId })
+      return
+    }
+
+    if (request.method === "GET" && url.pathname === "/v1/agents/opencode/global/event") {
+      response.writeHead(200, {
+        ...corsHeaders(),
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive"
+      })
+      response.write(": connected\n\n")
+      sseResponses.add(response)
+      request.on("close", () => sseResponses.delete(response))
+      return
+    }
+
+    if (request.method === "GET" && url.pathname.endsWith("/command")) {
+      json(response, 200, [])
+      return
+    }
+
+    if (request.method === "GET" && url.pathname.endsWith("/vcs")) {
+      json(response, 200, {})
+      return
+    }
+
+    json(response, 404, { error: `No fake route for ${request.method} ${url.pathname}` })
+  })
+
+  return new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(DAEMON_PORT, "127.0.0.1", () => resolve(server))
+  })
+}
+
+function startPreview() {
+  const viteCLI = fileURLToPath(new URL("../node_modules/vite/bin/vite.js", import.meta.url))
+  return spawn(process.execPath, [viteCLI, "preview", "--host", "127.0.0.1", "--port", String(PREVIEW_PORT), "--strictPort"], {
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: process.platform !== "win32"
+  })
+}
+
+async function ready(url) {
+  const deadline = Date.now() + 30_000
+  while (Date.now() < deadline) {
+    try {
+      if ((await fetch(url)).ok) return
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 150))
+  }
+  throw new Error(`Preview did not become ready: ${url}`)
+}
+
+async function seed(page) {
+  await page.addInitScript(({ key, port, machineID }) => {
+    localStorage.setItem(key, JSON.stringify([{
+      id: machineID,
+      name: "OpenCode permission regression",
+      config: { backend: "opencode", host: "127.0.0.1", port, username: "harness", password: "testpw" }
+    }]))
+  }, { key: STORAGE_KEY, port: DAEMON_PORT, machineID: MACHINE_ID })
+}
+
+async function openSession(page) {
+  await page.locator('.hr-native-workspace[aria-label="Sessions"], .hr-native-home[aria-label="Sessions"]').first().waitFor({ state: "visible" })
+  await page.getByRole("button", { name: new RegExp(`Open ${SESSION_TITLE}`) }).click()
+  await page.locator(".tdw-work-thread-conversation").waitFor({ state: "visible" })
+  await page.getByRole("textbox", { name: "Message OpenCode" }).waitFor({ state: "visible" })
+  const deadline = Date.now() + 5_000
+  while (Date.now() < deadline && sseResponses.size === 0) await new Promise((resolve) => setTimeout(resolve, 25))
+  assert.ok(sseResponses.size > 0, "OpenCode event stream did not connect")
+}
+
+async function send(page, text) {
+  await page.getByRole("textbox", { name: "Message OpenCode" }).fill(text)
+  await page.getByRole("button", { name: "Send" }).click()
+  const deadline = Date.now() + 2_000
+  while (Date.now() < deadline && promptBodies.at(-1)?.text !== text) await new Promise((resolve) => setTimeout(resolve, 20))
+  assert.equal(promptBodies.at(-1)?.text, text, "prompt did not reach the native OpenCode route")
+}
+
+async function waitForPermission(page) {
+  await page.getByRole("button", { name: "Deny" }).waitFor({ state: "visible", timeout: 4_000 })
+  await page.getByText("external_directory", { exact: true }).waitFor({ state: "visible", timeout: 4_000 })
+}
+
+async function assertPendingNeverTerminalizes(page, label) {
+  // Wait beyond OpenCode's 750 ms terminal-looking debounce and the 900 ms lifecycle settle window.
+  // A pending native permission is a waiting state, not a completed/interrupted turn.
+  await page.waitForTimeout(1_300)
+  assert.equal(
+    await page.getByText("Response interrupted", { exact: true }).count(),
+    0,
+    `${label}: permission.asked must never manufacture a terminal interruption before a decision`
+  )
+  assert.equal(
+    await page.getByText("The coding agent stopped before producing a final answer.", { exact: true }).count(),
+    0,
+    `${label}: pending authorization must remain non-terminal`
+  )
+}
+
+async function assertAttentionSurvivesOpen(page) {
+  const attentionTab = page.getByRole("button", { name: /Attention\s+1/ }).first()
+  await attentionTab.waitFor({ state: "visible", timeout: 3_000 })
+  await attentionTab.click()
+  const row = page.getByRole("button", { name: new RegExp(`Open ${SESSION_TITLE}`) })
+  await row.waitFor({ state: "visible", timeout: 3_000 })
+  await row.click()
+  await page.waitForTimeout(250)
+  assert.equal(await page.getByRole("button", { name: /Attention\s+1/ }).count() > 0, true, "opening an unresolved Session must not consume Attention")
+  assert.equal(await row.count(), 1, "unresolved Session disappeared from Attention after being opened")
+}
+
+async function runScenario(browser, viewport, label) {
+  resetState()
+  const context = await browser.newContext({ viewport, hasTouch: viewport.width < 600, locale: "en-US" })
+  const page = await context.newPage()
+  await seed(page)
+  await page.goto(APP_ORIGIN, { waitUntil: "domcontentloaded" })
+  await openSession(page)
+
+  await send(page, DENY_PROMPT)
+  await waitForPermission(page)
+  await assertPendingNeverTerminalizes(page, `${label} deny`)
+  await assertAttentionSurvivesOpen(page)
+
+  await page.getByRole("button", { name: "Deny" }).click()
+  const denyDeadline = Date.now() + 3_000
+  while (Date.now() < denyDeadline && permissionReplies.length < 1) await new Promise((resolve) => setTimeout(resolve, 20))
+  assert.deepEqual(permissionReplies[0], { id: PERMISSION_ID, body: { reply: "reject" } }, `${label}: Deny must send the exact native reject reply`)
+  await page.getByRole("button", { name: "Deny" }).waitFor({ state: "detached", timeout: 3_000 })
+  await page.getByText("Response interrupted", { exact: true }).waitFor({ state: "visible", timeout: 4_000 })
+  assert.equal(await page.locator(".tdw-conversation-state.working").count(), 0, `${label}: denied permission must not leave mounted Activity running`)
+
+  // Return to All before the next Send; the important point is that the same Session stayed mounted
+  // through the first resolution. No reload or navigation-away recovery has occurred.
+  const allTab = page.getByRole("button", { name: /All\s+\d+/ }).first()
+  if (await allTab.count()) await allTab.click()
+
+  await send(page, ALLOW_PROMPT)
+  await waitForPermission(page)
+  await assertPendingNeverTerminalizes(page, `${label} allow`)
+  await page.getByRole("button", { name: "Allow once" }).click()
+
+  const allowDeadline = Date.now() + 3_000
+  while (Date.now() < allowDeadline && permissionReplies.length < 2) await new Promise((resolve) => setTimeout(resolve, 20))
+  assert.deepEqual(permissionReplies[1], { id: PERMISSION_ID, body: { reply: "once" } }, `${label}: Allow once must preserve the native permission reply`)
+  await page.getByText(ALLOW_FINAL, { exact: true }).waitFor({ state: "visible", timeout: 4_000 })
+  await page.locator(".tdw-conversation-state.ready").waitFor({ state: "attached", timeout: 4_000 })
+  assert.equal(await page.getByText("Response interrupted", { exact: true }).count(), 0, `${label}: recovered allowed turn must not retain a stale interruption`)
+  assert.equal(promptBodies.filter((body) => body.text === DENY_PROMPT).length, 1, `${label}: deny flow duplicated the native prompt`)
+  assert.equal(promptBodies.filter((body) => body.text === ALLOW_PROMPT).length, 1, `${label}: allow flow duplicated the native prompt`)
+
+  await context.close()
+}
+
+function stopPreview(child) {
+  if (!child || child.killed || !child.pid) return
+  try {
+    if (process.platform === "win32") child.kill("SIGTERM")
+    else process.kill(-child.pid, "SIGTERM")
+  } catch {
+    try { child.kill("SIGTERM") } catch {}
+  }
+}
+
+function stopServer(server) {
+  try { server?.closeAllConnections?.() } catch {}
+  try { server?.close() } catch {}
+}
+
+let daemon
+let preview
+let browser
+try {
+  resetState()
+  daemon = await startDaemon()
+  preview = startPreview()
+  await ready(APP_ORIGIN)
+  browser = await chromium.launch({ headless: true })
+  await runScenario(browser, { width: 1366, height: 768 }, "desktop")
+  await runScenario(browser, { width: 412, height: 915 }, "mobile")
+  console.log("native OpenCode permission regression smoke: pending, Attention persistence, deny, allow and mounted convergence passed")
+} finally {
+  if (browser) await browser.close().catch(() => {})
+  for (const response of sseResponses || []) {
+    try { response.end() } catch {}
+  }
+  stopPreview(preview)
+  stopServer(daemon)
+}

--- a/web/src/taskdesk-live-event-routing.test.mjs
+++ b/web/src/taskdesk-live-event-routing.test.mjs
@@ -47,20 +47,63 @@ test("OpenCode completion lifecycle reconciles status and the selected transcrip
   assert.doesNotMatch(lifecycle, /send|prompt|continueWorkThread/)
 })
 
-test("permission and question lifecycle keeps the mounted Session live", () => {
+test("pending permission/question never masquerades as terminal lifecycle", () => {
   const refresh = readFileSync(new URL("./taskdesk-session-live-refresh.ts", import.meta.url), "utf8")
   const attentionLifecycle = refresh.match(/if \(isAttentionEvent\(event\.type\)\) \{[\s\S]*?\n      \}/)?.[0] || ""
 
-  // Resolving a permission can end or resume a native turn without a trailing message event.
-  // The selected Session therefore needs the permission card, transcript and Conversation state
-  // reconciled from their existing authoritative reads, plus the same bounded durability settle
-  // used by ordinary lifecycle edges. Navigation/remount must never be the recovery mechanism.
-  assert.match(attentionLifecycle, /selectedEvent/)
+  assert.match(refresh, /type === "permission\.replied"/)
+  assert.match(refresh, /type === "question\.replied"/)
+  assert.match(refresh, /type === "question\.rejected"/)
   assert.match(attentionLifecycle, /throttle\("detail", [^,]+, onDetail\)/)
   assert.match(attentionLifecycle, /throttle\("message", [^,]+, onMessage\)/)
+  assert.match(attentionLifecycle, /if \(isAttentionResolutionEvent\(event\.type\)\)/)
   assert.match(attentionLifecycle, /throttle\("index", [^,]+, onIndex\)/)
   assert.match(attentionLifecycle, /settleAfterLifecycle\(\)/)
+
+  // The index/terminal reconciliation is nested under the resolution guard. An asked event can
+  // refresh the visible request and transcript, but it cannot by itself complete the Conversation.
+  const resolutionGuard = attentionLifecycle.indexOf("if (isAttentionResolutionEvent(event.type))")
+  assert.ok(resolutionGuard >= 0)
+  assert.ok(attentionLifecycle.indexOf('throttle("index"', resolutionGuard) > resolutionGuard)
+  assert.ok(attentionLifecycle.indexOf("settleAfterLifecycle()", resolutionGuard) > resolutionGuard)
+  assert.doesNotMatch(attentionLifecycle.slice(0, resolutionGuard), /throttle\("index"|settleAfterLifecycle\(\)/)
   assert.doesNotMatch(attentionLifecycle, /send|prompt|continueWorkThread/)
+})
+
+test("OpenCode reliability regressions stay in the required browser gate", () => {
+  const workflow = readFileSync(new URL("../../.github/workflows/pr-checks.yml", import.meta.url), "utf8")
+  const browserSmoke = readFileSync(new URL("../scripts/native-opencode-browser-smoke.mjs", import.meta.url), "utf8")
+  const realSmoke = readFileSync(new URL("../scripts/native-opencode-real-regression-smoke.mjs", import.meta.url), "utf8")
+  const permissionSmoke = readFileSync(new URL("../scripts/native-opencode-permission-regression-smoke.mjs", import.meta.url), "utf8")
+
+  // Historical regressions remain executable rather than being replaced by the newest scenario.
+  for (const marker of [
+    "OPENCODE-TRANSIENT-INTERRUPTION-PROMPT",
+    "OPENCODE-LATE-RECOVERY-PROMPT",
+    "OPENCODE-TERMINAL-INTERRUPTION-PROMPT",
+    "OPENCODE-TERMINAL-PROVIDER-ERROR-PROMPT",
+    "OPENCODE-PERSISTED-WITHOUT-FINAL-EVENT-PROMPT"
+  ]) assert.ok(browserSmoke.includes(marker), `missing historical OpenCode browser regression: ${marker}`)
+  assert.match(realSmoke, /mounted completion lag/)
+  assert.match(realSmoke, /without navigation/)
+
+  // Permission regression reproduces a terminal-looking status while permission is pending, checks
+  // Attention persistence, verifies the exact native reject/once replies and proves both deny and
+  // allow converge while the same Session remains mounted.
+  assert.match(permissionSmoke, /permission\.asked/)
+  assert.match(permissionSmoke, /permission\.replied/)
+  assert.match(permissionSmoke, /Response interrupted/)
+  assert.match(permissionSmoke, /reply: "reject"/)
+  assert.match(permissionSmoke, /reply: "once"/)
+  assert.match(permissionSmoke, /opening an unresolved Session must not consume Attention/)
+  assert.match(permissionSmoke, /denied permission must not leave mounted Activity running/)
+  assert.doesNotMatch(permissionSmoke, /page\.reload\(/)
+
+  for (const script of [
+    "native-opencode-browser-smoke.mjs",
+    "native-opencode-real-regression-smoke.mjs",
+    "native-opencode-permission-regression-smoke.mjs"
+  ]) assert.ok(workflow.includes(`node scripts/${script}`), `${script} is not a required Chromium PR gate`)
 })
 
 test("foregrounding the app immediately reconciles durable conversation state", () => {

--- a/web/src/taskdesk-live-event-routing.test.mjs
+++ b/web/src/taskdesk-live-event-routing.test.mjs
@@ -47,6 +47,22 @@ test("OpenCode completion lifecycle reconciles status and the selected transcrip
   assert.doesNotMatch(lifecycle, /send|prompt|continueWorkThread/)
 })
 
+test("permission and question lifecycle keeps the mounted Session live", () => {
+  const refresh = readFileSync(new URL("./taskdesk-session-live-refresh.ts", import.meta.url), "utf8")
+  const attentionLifecycle = refresh.match(/if \(isAttentionEvent\(event\.type\)\) \{[\s\S]*?\n      \}/)?.[0] || ""
+
+  // Resolving a permission can end or resume a native turn without a trailing message event.
+  // The selected Session therefore needs the permission card, transcript and Conversation state
+  // reconciled from their existing authoritative reads, plus the same bounded durability settle
+  // used by ordinary lifecycle edges. Navigation/remount must never be the recovery mechanism.
+  assert.match(attentionLifecycle, /selectedEvent/)
+  assert.match(attentionLifecycle, /throttle\("detail", [^,]+, onDetail\)/)
+  assert.match(attentionLifecycle, /throttle\("message", [^,]+, onMessage\)/)
+  assert.match(attentionLifecycle, /throttle\("index", [^,]+, onIndex\)/)
+  assert.match(attentionLifecycle, /settleAfterLifecycle\(\)/)
+  assert.doesNotMatch(attentionLifecycle, /send|prompt|continueWorkThread/)
+})
+
 test("foregrounding the app immediately reconciles durable conversation state", () => {
   const refresh = readFileSync(new URL("./taskdesk-session-live-refresh.ts", import.meta.url), "utf8")
 

--- a/web/src/taskdesk-live-event-routing.test.mjs
+++ b/web/src/taskdesk-live-event-routing.test.mjs
@@ -60,8 +60,6 @@ test("pending permission/question never masquerades as terminal lifecycle", () =
   assert.match(attentionLifecycle, /throttle\("index", [^,]+, onIndex\)/)
   assert.match(attentionLifecycle, /settleAfterLifecycle\(\)/)
 
-  // The index/terminal reconciliation is nested under the resolution guard. An asked event can
-  // refresh the visible request and transcript, but it cannot by itself complete the Conversation.
   const resolutionGuard = attentionLifecycle.indexOf("if (isAttentionResolutionEvent(event.type))")
   assert.ok(resolutionGuard >= 0)
   assert.ok(attentionLifecycle.indexOf('throttle("index"', resolutionGuard) > resolutionGuard)
@@ -76,7 +74,6 @@ test("OpenCode reliability regressions stay in the required browser gate", () =>
   const realSmoke = readFileSync(new URL("../scripts/native-opencode-real-regression-smoke.mjs", import.meta.url), "utf8")
   const permissionSmoke = readFileSync(new URL("../scripts/native-opencode-permission-regression-smoke.mjs", import.meta.url), "utf8")
 
-  // Historical regressions remain executable rather than being replaced by the newest scenario.
   for (const marker of [
     "OPENCODE-TRANSIENT-INTERRUPTION-PROMPT",
     "OPENCODE-LATE-RECOVERY-PROMPT",
@@ -87,16 +84,13 @@ test("OpenCode reliability regressions stay in the required browser gate", () =>
   assert.match(realSmoke, /mounted completion lag/)
   assert.match(realSmoke, /without navigation/)
 
-  // Permission regression reproduces a terminal-looking status while permission is pending, checks
-  // Attention persistence, verifies the exact native reject/once replies and proves both deny and
-  // allow converge while the same Session remains mounted.
   assert.match(permissionSmoke, /permission\.asked/)
   assert.match(permissionSmoke, /permission\.replied/)
   assert.match(permissionSmoke, /Response interrupted/)
   assert.match(permissionSmoke, /reply: "reject"/)
   assert.match(permissionSmoke, /reply: "once"/)
   assert.match(permissionSmoke, /opening an unresolved Session must not consume Attention/)
-  assert.match(permissionSmoke, /denied permission must not leave mounted Activity running/)
+  assert.match(permissionSmoke, /permission resolution left mounted Activity running/)
   assert.doesNotMatch(permissionSmoke, /page\.reload\(/)
 
   for (const script of [
@@ -109,22 +103,17 @@ test("OpenCode reliability regressions stay in the required browser gate", () =>
 test("foregrounding the app immediately reconciles durable conversation state", () => {
   const refresh = readFileSync(new URL("./taskdesk-session-live-refresh.ts", import.meta.url), "utf8")
 
-  // Android may keep the native SSE reader alive while WebView JavaScript is suspended, so events
-  // produced in the background cannot be the only way the renderer catches up on resume.
   assert.match(refresh, /CapacitorApp\.addListener\("appStateChange"/)
   assert.match(refresh, /if \(isActive\) reconcileAfterForeground\(\)/)
   assert.match(refresh, /document\.addEventListener\("visibilitychange", onVisibilityChange\)/)
   assert.match(refresh, /window\.addEventListener\("pageshow", onPageShow\)/)
 
-  // Resume must re-read both authoritative Conversation state and the selected transcript/attention
-  // surfaces. It must not resend a prompt or depend on a new live event arriving.
   const foreground = refresh.match(/const reconcileAfterForeground = \(\) => \{[\s\S]*?\n  \}/)?.[0] || ""
   assert.match(foreground, /onIndex\(\)/)
   assert.match(foreground, /onMessage\(\)/)
   assert.match(foreground, /onDetail\(\)/)
   assert.doesNotMatch(foreground, /send|prompt|continueWorkThread/)
 
-  // Lifecycle listeners cannot accumulate as Conversations are opened and closed.
   assert.match(refresh, /document\.removeEventListener\("visibilitychange", onVisibilityChange\)/)
   assert.match(refresh, /window\.removeEventListener\("pageshow", onPageShow\)/)
   assert.match(refresh, /appStateHandle.*remove\(\)/)

--- a/web/src/taskdesk-session-live-refresh.ts
+++ b/web/src/taskdesk-session-live-refresh.ts
@@ -24,6 +24,12 @@ function isAttentionEvent(type: string): boolean {
   return type.startsWith("permission.") || type.startsWith("question.")
 }
 
+function isAttentionResolutionEvent(type: string): boolean {
+  return type === "permission.replied"
+    || type === "question.replied"
+    || type === "question.rejected"
+}
+
 /**
  * Drive Session freshness from the existing per-agent event stream without turning every streamed
  * token into a full workspace refresh. Message chunks refresh only the selected transcript tail;
@@ -156,17 +162,20 @@ export function startTaskDeskSessionLiveRefresh({
         return
       }
 
-      // Permission/question resolution can itself end or resume a turn. OpenCode does not guarantee
-      // a trailing message.updated after a rejected tool call, so refreshing only the permission card
-      // can leave the mounted Session painted as Activity until it is reopened. Reconcile all three
-      // authoritative surfaces on this low-frequency lifecycle edge, with one bounded settle read for
-      // transcript persistence that lands just after the permission event.
+      // A request becoming pending is not a terminal lifecycle edge. In particular OpenCode can emit
+      // permission.asked while the current assistant envelope contains only reasoning/tool activity;
+      // forcing status reconciliation at that point can manufacture a red "Response interrupted"
+      // before the user has even answered. Refresh the card and transcript immediately, but only a
+      // *resolution* event may start the bounded lifecycle reconciliation that recovers a final/error
+      // envelope which OpenCode persists just after Allow/Deny/answer.
       if (isAttentionEvent(event.type)) {
         if (selectedEvent) {
           throttle("detail", 80, onDetail)
           throttle("message", 100, onMessage)
-          throttle("index", 120, onIndex)
-          settleAfterLifecycle()
+          if (isAttentionResolutionEvent(event.type)) {
+            throttle("index", 120, onIndex)
+            settleAfterLifecycle()
+          }
         }
         return
       }

--- a/web/src/taskdesk-session-live-refresh.ts
+++ b/web/src/taskdesk-session-live-refresh.ts
@@ -156,10 +156,18 @@ export function startTaskDeskSessionLiveRefresh({
         return
       }
 
-      // OpenCode and ACP adapters can expose permission/question lifecycle events with different
-      // suffixes. They all mean the selected conversation detail must be re-read immediately.
+      // Permission/question resolution can itself end or resume a turn. OpenCode does not guarantee
+      // a trailing message.updated after a rejected tool call, so refreshing only the permission card
+      // can leave the mounted Session painted as Activity until it is reopened. Reconcile all three
+      // authoritative surfaces on this low-frequency lifecycle edge, with one bounded settle read for
+      // transcript persistence that lands just after the permission event.
       if (isAttentionEvent(event.type)) {
-        if (selectedEvent) throttle("detail", 80, onDetail)
+        if (selectedEvent) {
+          throttle("detail", 80, onDetail)
+          throttle("message", 100, onMessage)
+          throttle("index", 120, onIndex)
+          settleAfterLifecycle()
+        }
         return
       }
 


### PR DESCRIPTION
P0 reliability fix for the real-user OpenCode regressions around permission lifecycle and mounted Session convergence.

Two distinct bugs were exposed by the real test:
1. resolving a native permission could leave the already-mounted Session stuck in Activity until navigation/remount;
2. the first fix treated `permission.asked` itself like a terminal lifecycle edge and could manufacture a red `Response interrupted` before the user had answered.

The final design keeps native OpenCode authority and adds no UI:
- `permission.asked` / `question.asked` refresh only the request detail and selected transcript; they cannot trigger terminal Session reconciliation;
- only `permission.replied`, `question.replied`, or `question.rejected` start lifecycle reconciliation and the bounded 900 ms durability settle read;
- the existing lost-event, retry, terminal-error, silent-turn and no-navigation OpenCode regression cases remain intact;
- a new production-browser regression drives pending permission -> Attention -> reopen same Session -> Deny, then a second pending permission -> Allow once, on desktop and mobile;
- the browser test verifies that pending authorization never becomes `Response interrupted`, Attention is not consumed by opening the Session, Deny sends exactly `{ reply: "reject" }`, Allow once sends exactly `{ reply: "once" }`, Activity settles without remount, final durable output is recovered without a trailing `message.updated`, and prompts are single-dispatch;
- a static reliability gate asserts that all historical OpenCode browser scenarios and the new permission regression remain wired into the required Chromium PR workflow, so a future refactor cannot silently remove them from CI.

No ACP behavior change, no prompt resend, no synthetic permission engine, no new polling loop, no redundant UI.

Important upstream finding from the reported `/tmp` test: the file-creation command used shell redirection (`echo ... > /tmp/...`). Current OpenCode has an upstream `external_directory` gap for shell redirect targets: the write can happen before OpenCode emits any permission request. The later `cat /tmp/...` request is the action that Harness Remote actually denied. Harness Remote must not pretend that a later native Deny can retroactively block an operation OpenCode already executed; this is tracked separately in #450.

Target: `codex/development-2026-09-11` only. Never merge to `main`.

Refs #450 #449 #368 #369