### PR TITLE
test(opencode): codify fail-closed reliability contract

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -46,6 +46,10 @@ jobs:
         run: npm run test:ci:full
         working-directory: web
 
+      - name: Run OpenCode permission transport regression
+        run: node scripts/run-vite-test.mjs src/opencode-permission-api.test.mjs
+        working-directory: web
+
       - name: Run bridge tests
         run: npm test
         working-directory: bridge

--- a/docs/OPENCODE_RELIABILITY_CONTRACT.md
+++ b/docs/OPENCODE_RELIABILITY_CONTRACT.md
@@ -1,0 +1,63 @@
+# OpenCode reliability contract
+
+This document is a non-regression contract for Harness Remote's native OpenCode Session path.
+
+OpenCode has had several independent lifecycle failure modes that can look similar in the UI: a reply can be persisted without the final live event, a transient provider/interruption envelope can recover later, a terminal provider failure can arrive while Session status is incomplete, a silent accepted turn can produce no assistant signal, and a permission/question can intentionally leave the harness waiting for the user. Fixing one of those cases must never weaken another.
+
+## Product invariants
+
+The following are release-blocking invariants for OpenCode.
+
+1. **One prompt, one native dispatch.** Recovery, foregrounding, event loss, permission resolution and Session reopen must never resend an accepted prompt.
+2. **Persisted assistant output wins.** If the final assistant output is durable in the native transcript, the already-mounted Session must eventually show it even when the final live event is lost or `/session/status` is unavailable.
+3. **No navigation recovery requirement.** Leaving a Session and opening it again may refresh state, but it must never be required to reveal a durable reply or settle Working/Activity.
+4. **Transient interruption is not terminal.** Intermediate tool/error envelopes or short idle edges must not become a permanent red `Response interrupted` when OpenCode continues the same turn.
+5. **Real terminal interruption remains visible.** If OpenCode truly stops without a final answer, Harness Remote must not fabricate success or hide the interruption.
+6. **Provider failures settle without getting stuck Working.** Durable terminal errors remain visible and the mounted Session converges without navigation.
+7. **Accepted-but-silent turns fail visibly.** A prompt that OpenCode accepted but that produces neither assistant output nor usable lifecycle evidence must not spin forever.
+8. **Pending authorization/input is a waiting state, not a terminal state.** `permission.asked` / `question.asked` can refresh request detail and transcript, but cannot by themselves terminalize the turn or create `Response interrupted`.
+9. **Attention is authoritative while a request is unresolved.** Opening, selecting or rereading a Session cannot consume a pending permission/question.
+10. **Permission replies are fail-closed.** `Deny` maps exactly to OpenCode `reject`; `Allow once` maps to `once`; `Always allow` maps to `always`. The native reply must succeed before Harness Remote records observational approval metadata or treats the request as resolved.
+11. **Failed permission replies stay visible.** A failed reply POST must not optimistically filter/remove the request or clear Attention locally.
+12. **Permission resolution converges in place.** After OpenCode acknowledges a decision, the mounted Session must refresh durable transcript/lifecycle state without reload or navigation.
+13. **Foreground recovery is read/reconcile only.** Returning from background may reread durable state, but must never resend prompts or permission decisions.
+14. **OpenCode authority stays native.** Harness Remote does not invent a second permission engine, transcript, or Session lifecycle.
+
+## Required blocking browser coverage
+
+The PR Chromium gate must continue to execute all three scripts:
+
+- `web/scripts/native-opencode-browser-smoke.mjs`
+- `web/scripts/native-opencode-real-regression-smoke.mjs`
+- `web/scripts/native-opencode-permission-regression-smoke.mjs`
+
+The first two preserve the historical interruption/retry/provider-error/lost-final-event/mounted-convergence cases. The permission regression additionally drives a long-pending native permission through normal reconciliation ticks, verifies Attention survives opening the Session, sends exact `reject` and `once` replies, and requires the mounted Session to settle without a reload.
+
+`web/src/taskdesk-live-event-routing.test.mjs` intentionally checks that these scripts remain wired into the required PR workflow. Removing a historical OpenCode regression from CI is itself a test failure.
+
+## Historical fixes this contract protects
+
+Important OpenCode reliability work includes, among others:
+
+- #304 / #306 / #337 — Session-first transcript convergence and shared conversation stabilization.
+- #351 — transient interruption, late recovery and true terminal interruption semantics.
+- #355 — terminal provider errors settling without a stuck Working state.
+- #391 — accepted silent OpenCode turns becoming visible failures instead of indefinite Working.
+- #421 / #422 — persisted replies recovered when final events/status are lost, including already-mounted Sessions.
+- #425 — port of the released 3.0.2 OpenCode persisted-reply stability into the development integration line.
+- #451 — unresolved native OpenCode permission/question remains in the global Attention index.
+- #452 — permission lifecycle reconciliation, false-interruption prevention and production-browser permission regression coverage.
+
+A future refactor must preserve the behavior represented by those regressions even if implementation structure changes.
+
+## Native permission boundary and upstream OpenCode behavior
+
+Harness Remote can only deny a native OpenCode permission request that OpenCode actually emits before the protected action executes.
+
+A known upstream OpenCode issue (`anomalyco/opencode#32628`) describes shell redirect targets such as `echo value > /outside/file` bypassing the `external_directory` check. In that situation the shell side effect can occur before any permission request reaches Harness Remote; a later permission for a different operation cannot retroactively undo it.
+
+Do not "fix" this in Harness Remote by fabricating a second sandbox/authorization layer or by claiming that a later Deny blocked an earlier un-gated native action. Track upstream behavior separately while keeping Harness Remote's own permission reply path strictly fail-closed and observable.
+
+## Merge/release rule
+
+Changes touching OpenCode Session projection, live-event routing, transcript reconciliation, Attention, permissions/questions, foreground recovery, or native prompt dispatch are not considered safe merely because type-check/unit tests pass. The historical OpenCode browser matrix above must be green on the exact candidate SHA before integration or release.

--- a/web/src/opencode-permission-api.test.mjs
+++ b/web/src/opencode-permission-api.test.mjs
@@ -34,7 +34,7 @@ test("OpenCode Deny sends the exact native reject payload", async () => {
   assert.equal(calls.length, 1)
   const call = calls[0]
   const target = new URL(call.url)
-  assert.equal(target.pathname, "/permission/per_fail_closed/reply")
+  assert.equal(target.pathname, "/v1/agents/opencode/permission/per_fail_closed/reply")
   assert.equal(target.searchParams.get("directory"), "/repo")
   assert.equal(call.options?.method, "POST")
   assert.deepEqual(JSON.parse(call.options?.body || "{}"), { reply: "reject" })

--- a/web/src/opencode-permission-api.test.mjs
+++ b/web/src/opencode-permission-api.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { api } from "./api"
+
+const config = {
+  backend: "opencode",
+  host: "127.0.0.1",
+  port: 4096,
+  username: "",
+  password: "",
+  agentId: "opencode"
+}
+
+async function withFetch(fake, run) {
+  const previous = globalThis.fetch
+  globalThis.fetch = fake
+  try {
+    return await run()
+  } finally {
+    globalThis.fetch = previous
+  }
+}
+
+test("OpenCode Deny sends the exact native reject payload", async () => {
+  const calls = []
+  await withFetch(async (url, options) => {
+    calls.push({ url: String(url), options })
+    return new Response("true", { status: 200, headers: { "Content-Type": "application/json" } })
+  }, async () => {
+    const result = await api.replyPermission(config, "per_fail_closed", "reject", "/repo")
+    assert.equal(result, true)
+  })
+
+  assert.equal(calls.length, 1)
+  const call = calls[0]
+  const target = new URL(call.url)
+  assert.equal(target.pathname, "/permission/per_fail_closed/reply")
+  assert.equal(target.searchParams.get("directory"), "/repo")
+  assert.equal(call.options?.method, "POST")
+  assert.deepEqual(JSON.parse(call.options?.body || "{}"), { reply: "reject" })
+})
+
+test("a failed OpenCode permission reply rejects and remains retryable", async () => {
+  let attempts = 0
+  await withFetch(async (_url, options) => {
+    attempts += 1
+    assert.deepEqual(JSON.parse(options?.body || "{}"), { reply: "reject" })
+    if (attempts === 1) {
+      return new Response(JSON.stringify({ error: "native permission reply failed" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" }
+      })
+    }
+    return new Response("true", { status: 200, headers: { "Content-Type": "application/json" } })
+  }, async () => {
+    await assert.rejects(
+      api.replyPermission(config, "per_retry", "reject", "/repo"),
+      /native permission reply failed/
+    )
+
+    // The transport layer must not turn a failed mutation into a synthetic success. The exact same
+    // native decision can be retried after the UI keeps the authoritative request visible.
+    assert.equal(await api.replyPermission(config, "per_retry", "reject", "/repo"), true)
+  })
+
+  assert.equal(attempts, 2)
+})

--- a/web/src/taskdesk-live-event-routing.test.mjs
+++ b/web/src/taskdesk-live-event-routing.test.mjs
@@ -68,6 +68,29 @@ test("pending permission/question never masquerades as terminal lifecycle", () =
   assert.doesNotMatch(attentionLifecycle, /send|prompt|continueWorkThread/)
 })
 
+test("OpenCode permission replies stay fail-closed at the UI boundary", () => {
+  const attention = readFileSync(new URL("./components/work-thread-attention.tsx", import.meta.url), "utf8")
+  const api = readFileSync(new URL("./api.ts", import.meta.url), "utf8")
+  const responder = attention.match(/async function respondPermission\([\s\S]*?\n  \}/)?.[0] || ""
+
+  assert.match(api, /replyPermission\(config: ServerConfig, requestID: string, reply: "once" \| "always" \| "reject"/)
+  assert.match(api, /body: \{ reply \}/)
+  assert.match(responder, /await api\.replyPermission\(config, request\.id, reply, directory\)/)
+  assert.match(responder, /void persistSuccessfulPermissionDecision\(request, reply\)\.catch/)
+  assert.match(responder, /await onResolved\(\)/)
+  assert.match(responder, /catch \(reason\)[\s\S]*?setError\(/)
+
+  const nativeReply = responder.indexOf("await api.replyPermission")
+  const metadata = responder.indexOf("persistSuccessfulPermissionDecision")
+  const refresh = responder.indexOf("await onResolved()")
+  assert.ok(nativeReply >= 0 && metadata > nativeReply && refresh > nativeReply, "native OpenCode reply must succeed before local metadata or resolution refresh")
+
+  // A failed POST must leave the authoritative request in props. Never optimistically remove it,
+  // clear Attention, or record an allow/deny before the native harness acknowledges the decision.
+  assert.doesNotMatch(responder.slice(0, nativeReply), /persistSuccessfulPermissionDecision|onResolved|setPermissions|filter\(/)
+  assert.doesNotMatch(responder, /setPermissions|permissions\.filter/)
+})
+
 test("OpenCode reliability regressions stay in the required browser gate", () => {
   const workflow = readFileSync(new URL("../../.github/workflows/pr-checks.yml", import.meta.url), "utf8")
   const browserSmoke = readFileSync(new URL("../scripts/native-opencode-browser-smoke.mjs", import.meta.url), "utf8")

--- a/web/src/taskdesk-live-event-routing.test.mjs
+++ b/web/src/taskdesk-live-event-routing.test.mjs
@@ -96,6 +96,7 @@ test("OpenCode reliability regressions stay in the required browser gate", () =>
   const browserSmoke = readFileSync(new URL("../scripts/native-opencode-browser-smoke.mjs", import.meta.url), "utf8")
   const realSmoke = readFileSync(new URL("../scripts/native-opencode-real-regression-smoke.mjs", import.meta.url), "utf8")
   const permissionSmoke = readFileSync(new URL("../scripts/native-opencode-permission-regression-smoke.mjs", import.meta.url), "utf8")
+  const permissionApi = readFileSync(new URL("./opencode-permission-api.test.mjs", import.meta.url), "utf8")
 
   for (const marker of [
     "OPENCODE-TRANSIENT-INTERRUPTION-PROMPT",
@@ -115,6 +116,13 @@ test("OpenCode reliability regressions stay in the required browser gate", () =>
   assert.match(permissionSmoke, /opening an unresolved Session must not consume Attention/)
   assert.match(permissionSmoke, /permission resolution left mounted Activity running/)
   assert.doesNotMatch(permissionSmoke, /page\.reload\(/)
+
+  assert.match(permissionApi, /failed OpenCode permission reply rejects and remains retryable/)
+  assert.match(permissionApi, /native permission reply failed/)
+  assert.ok(
+    workflow.includes("node scripts/run-vite-test.mjs src/opencode-permission-api.test.mjs"),
+    "OpenCode permission transport failure regression is not a required PR gate"
+  )
 
   for (const script of [
     "native-opencode-browser-smoke.mjs",


### PR DESCRIPTION
P0 reliability hardening after #452. No product/runtime behavior changes.

This PR turns the recurring OpenCode failures into explicit blocking invariants rather than one-off regressions.

- Adds a source-level guard around the native permission mutation boundary: replies remain `once | always | reject`; the exact native reply goes through `api.replyPermission`; native acknowledgement must happen before approval-decision metadata or authoritative resolution refresh; a failed native reply cannot optimistically remove/filter the request or clear Attention locally.
- Adds a dynamic transport regression that sends an exact native `{ reply: "reject" }`, forces the first permission reply to fail with HTTP 500, requires the API call to reject rather than synthesize success, and verifies that the same native Deny remains retryable and succeeds on the second attempt.
- Wires that failure regression into the required PR workflow and adds a guard that fails if somebody removes it from CI.
- Adds `docs/OPENCODE_RELIABILITY_CONTRACT.md`, codifying single-dispatch, persisted-reply recovery, no-navigation convergence, transient vs terminal interruption, provider failure, silent turns, permission/question waiting semantics, Attention persistence, fail-closed permission replies, foreground recovery, and required browser coverage.
- Records historical OpenCode reliability fixes (#304/#306/#337/#351/#355/#391/#421/#422/#425/#451/#452) and separates the upstream OpenCode shell-redirection permission gap from Harness Remote's own deny semantics.

This complements #452's production-browser matrix, which drives long-pending authorization through normal reconciliation ticks, Attention persistence, exact Deny/Allow-once mapping, no false `Response interrupted`, no-navigation mounted convergence, and single dispatch on desktop/mobile.

Final validation on head `2dc6f470d92949ba30a9d210e65597bd199bb548`, PR checks run `34697767792`: Type-check/regressions including the new permission transport failure gate ✅, bridge Windows/macOS ✅, full Chromium product/OpenCode regression matrix ✅, Debug APK build/signature/upload ✅.

Target: `codex/development-2026-09-11` only. Never `main`.

Refs #450 #452 #368