### PR TITLE
test(P0): make real-harness evidence scenario-complete

### DIFF
--- a/bridge/scripts/real-harness-release-gate.mjs
+++ b/bridge/scripts/real-harness-release-gate.mjs
@@ -6,6 +6,16 @@ import { fileURLToPath } from "node:url"
 
 export const SUPPORTED_HARNESSES = ["opencode", "codex", "claude", "omp", "pi"]
 
+const REQUIRED_SOAK_COVERAGE = [
+  "sessionCreation",
+  "multiTurnStreaming",
+  "modelSelection",
+  "crossHarnessIsolation",
+  "transcriptFidelity",
+  "stopAndResume",
+  "resourceBounds"
+]
+
 function optionValue(args, name) {
   const index = args.indexOf(name)
   return index >= 0 ? args[index + 1] : undefined
@@ -152,8 +162,58 @@ export function defaultReportPath(cwd = process.cwd(), date = new Date()) {
   return path.join(cwd, "artifacts", `real-harness-gate-${stamp(date)}.json`)
 }
 
+function hasPassed(checks, pattern) {
+  return checks.some((check) => check.passed && pattern.test(check.message))
+}
+
+export function parseSoakEvidence(output = "") {
+  const checks = []
+  for (const line of String(output).split(/\r?\n/)) {
+    const match = /^\s*(ok|FAIL)\s+(.+?)\s*$/.exec(line)
+    if (!match) continue
+    checks.push({ passed: match[1] === "ok", message: match[2] })
+  }
+
+  const coverage = {
+    sessionCreation: hasPassed(checks, /two native Sessions created on/i),
+    multiTurnStreaming: hasPassed(checks, /turn \d+ completed in \d+ms/i),
+    modelSelection: hasPassed(checks, /turn \d+ accepted with model /i),
+    crossHarnessIsolation:
+      hasPassed(checks, /catalog unchanged (?:while switching away and back|after visiting)/i)
+      && hasPassed(checks, /prompt accepted after harness switch and model change/i),
+    transcriptFidelity: hasPassed(checks, /one user turn per accepted prompt, no duplicates/i),
+    stopAndResume:
+      hasPassed(checks, /Stop accepted for /i)
+      && hasPassed(checks, /Session accepts a new prompt with a new model after Stop/i)
+      && hasPassed(checks, /interrupted turn stays visible in the transcript/i),
+    resourceBounds:
+      hasPassed(checks, /adapter listeners did not grow unboundedly/i)
+      && hasPassed(checks, /no unresolved native Session mutation left/i)
+  }
+  const missingCoverage = REQUIRED_SOAK_COVERAGE.filter((name) => !coverage[name])
+  const failedChecks = checks.filter((check) => !check.passed)
+
+  return {
+    schemaVersion: 1,
+    checks,
+    summary: {
+      total: checks.length,
+      passed: checks.length - failedChecks.length,
+      failed: failedChecks.length
+    },
+    coverage,
+    missingCoverage,
+    complete: checks.length > 0 && failedChecks.length === 0 && missingCoverage.length === 0,
+    notExercised: [
+      "pre-existing native Session discovery",
+      "daemon restart/reconnect",
+      "physical mobile background/foreground"
+    ]
+  }
+}
+
 export function gateUsage() {
-  return `Usage: npm run gate:real-harness -- [options]\n\nOptions:\n  --harnesses <list>  Comma-separated harnesses to verify (default: ${SUPPORTED_HARNESSES.join(",")})\n  --mode <mode>       release (default) or control-plane\n  --report <path>     JSON evidence report path (default: artifacts/real-harness-gate-<timestamp>.json)\n  --help              Show this help\n\nThe gate first checks /v1/diagnostics and stops early if the daemon is unreachable, credentials are rejected, a requested harness is not registered, or model discovery is not configured. Shared soak settings use HR_URL, HR_USER, HR_PASS, HR_DIR_A, HR_DIR_B, HR_CYCLES, HR_TURN_BUDGET_MS and HR_ECHO_MARKERS. Release mode always disables HR_ALLOW_TURN_ERRORS. Use --mode control-plane when inference is unavailable; that mode is recorded as not release-eligible.`
+  return `Usage: npm run gate:real-harness -- [options]\n\nOptions:\n  --harnesses <list>  Comma-separated harnesses to verify (default: ${SUPPORTED_HARNESSES.join(",")})\n  --mode <mode>       release (default) or control-plane\n  --report <path>     JSON evidence report path (default: artifacts/real-harness-gate-<timestamp>.json)\n  --help              Show this help\n\nThe gate first checks /v1/diagnostics and stops early if the daemon is unreachable, credentials are rejected, a requested harness is not registered, or model discovery is not configured. Each real-harness leg must also emit the complete scenario evidence contract (Session creation, multi-turn streaming, model selection, cross-harness isolation, transcript fidelity, Stop/recovery and bounded resources); a zero exit code without that evidence fails closed. Shared soak settings use HR_URL, HR_USER, HR_PASS, HR_DIR_A, HR_DIR_B, HR_CYCLES, HR_TURN_BUDGET_MS and HR_ECHO_MARKERS. Release mode always disables HR_ALLOW_TURN_ERRORS. Use --mode control-plane when inference is unavailable; that mode is recorded as not release-eligible.`
 }
 
 async function runSoak({ primary, secondary, mode, soakPath }) {
@@ -166,11 +226,32 @@ async function runSoak({ primary, secondary, mode, soakPath }) {
     HR_ALLOW_TURN_ERRORS: mode === "control-plane" ? "1" : "0"
   }
 
+  let stdout = ""
+  let stderr = ""
   const result = await new Promise((resolve) => {
-    const child = spawn(process.execPath, [soakPath], { env, stdio: "inherit" })
+    const child = spawn(process.execPath, [soakPath], { env, stdio: ["inherit", "pipe", "pipe"] })
+    child.stdout?.on("data", (chunk) => {
+      const text = chunk.toString("utf8")
+      stdout += text
+      process.stdout.write(text)
+    })
+    child.stderr?.on("data", (chunk) => {
+      const text = chunk.toString("utf8")
+      stderr += text
+      process.stderr.write(text)
+    })
     child.once("error", (error) => resolve({ exitCode: 1, signal: null, error: error.message }))
     child.once("exit", (code, signal) => resolve({ exitCode: code ?? (signal ? 1 : 0), signal: signal ?? null, error: null }))
   })
+
+  const evidence = parseSoakEvidence(`${stdout}\n${stderr}`)
+  const evidenceError = evidence.complete
+    ? null
+    : evidence.summary.total === 0
+      ? "Soak exited without machine-readable check evidence."
+      : evidence.missingCoverage.length
+        ? `Soak evidence is missing required coverage: ${evidence.missingCoverage.join(", ")}.`
+        : `Soak evidence contains ${evidence.summary.failed} failed check(s).`
 
   return {
     primary,
@@ -178,7 +259,9 @@ async function runSoak({ primary, secondary, mode, soakPath }) {
     startedAt: startedAt.toISOString(),
     durationMs: Date.now() - started,
     ...result,
-    passed: result.exitCode === 0
+    evidence,
+    evidenceError,
+    passed: result.exitCode === 0 && evidence.complete
   }
 }
 
@@ -227,14 +310,22 @@ export async function runGate({
       runs.push(result)
       if (!result.passed) {
         console.error(`Gate leg failed for ${pair.primary} (exit ${result.exitCode}${result.signal ? `, signal ${result.signal}` : ""}).`)
+        if (result.evidenceError) console.error(`Evidence failure: ${result.evidenceError}`)
       }
     }
   }
 
   const allPassed = preflightResult.passed && runs.length === plan.length && runs.every((run) => run.passed)
   const verdict = !allPassed ? "failed" : eligibility.releaseEligible ? "verified" : "control-plane-only"
+  const coverageMatrix = Object.fromEntries(runs.map((run) => [run.primary, {
+    secondary: run.secondary,
+    complete: run.evidence?.complete ?? false,
+    coverage: run.evidence?.coverage ?? {},
+    missingCoverage: run.evidence?.missingCoverage ?? [],
+    notExercised: run.evidence?.notExercised ?? []
+  }]))
   const report = {
-    schemaVersion: 2,
+    schemaVersion: 3,
     kind: "harness-remote-real-harness-gate",
     generatedAt: new Date().toISOString(),
     source: { commit: gitCommit() },
@@ -251,6 +342,7 @@ export async function runGate({
       allowTurnErrors: mode === "control-plane"
     },
     preflight: preflightResult,
+    coverageMatrix,
     runs,
     verdict
   }

--- a/bridge/test/real-harness-release-gate.test.js
+++ b/bridge/test/real-harness-release-gate.test.js
@@ -190,8 +190,8 @@ test("orchestrates every primary and persists credential-free scenario evidence"
     ])
     assert.equal(report.runs[0].evidence.complete, true)
     assert.equal(report.runs[0].evidence.coverage.stopAndResume, true)
-    assert.equal(report.coverageMatrix.codex.resourceBounds, true)
-    assert.equal(report.coverageMatrix.claude.crossHarnessIsolation, true)
+    assert.equal(report.coverageMatrix.codex.coverage.resourceBounds, true)
+    assert.equal(report.coverageMatrix.claude.coverage.crossHarnessIsolation, true)
 
     const persisted = JSON.parse(fs.readFileSync(reportPath, "utf8"))
     assert.equal(persisted.endpoint, "http://127.0.0.1:4097")

--- a/bridge/test/real-harness-release-gate.test.js
+++ b/bridge/test/real-harness-release-gate.test.js
@@ -8,11 +8,26 @@ import {
   buildHarnessPlan,
   defaultReportPath,
   parseHarnessList,
+  parseSoakEvidence,
   preflightDaemon,
   releaseEligibility,
   resolveGateMode,
   runGate
 } from "../scripts/real-harness-release-gate.mjs"
+
+const COMPLETE_SOAK_OUTPUT = [
+  "  ok   two native Sessions created on codex",
+  "  ok   A turn 1 accepted with model model-a",
+  "  ok   A turn 1 completed in 12ms",
+  "  ok   cycle 1: claude catalog unchanged while switching away and back",
+  "  ok   cycle 1: codex prompt accepted after harness switch and model change",
+  "  ok   A: one user turn per accepted prompt, no duplicates (1/1)",
+  "  ok   Stop accepted for codex (200)",
+  "  ok   Session accepts a new prompt with a new model after Stop",
+  "  ok   the interrupted turn stays visible in the transcript",
+  "  ok   codex: adapter listeners did not grow unboundedly (4 -> 4)",
+  "  ok   no unresolved native Session mutation left (0)"
+].join("\n")
 
 test("defaults the release gate to every supported harness", () => {
   assert.deepEqual(parseHarnessList(), SUPPORTED_HARNESSES)
@@ -58,6 +73,33 @@ test("only accepts the two explicit gate modes", () => {
 test("default report path stays outside source files and carries a timestamp", () => {
   const report = defaultReportPath("/work", new Date("2026-09-11T03:45:12.345Z"))
   assert.equal(report, path.join("/work", "artifacts", "real-harness-gate-2026-09-11T03-45-12-345Z.json"))
+})
+
+test("parses scenario-level soak evidence and exposes known real-boundary gaps", () => {
+  const evidence = parseSoakEvidence(COMPLETE_SOAK_OUTPUT)
+  assert.equal(evidence.complete, true)
+  assert.equal(evidence.summary.failed, 0)
+  assert.equal(evidence.coverage.sessionCreation, true)
+  assert.equal(evidence.coverage.multiTurnStreaming, true)
+  assert.equal(evidence.coverage.modelSelection, true)
+  assert.equal(evidence.coverage.crossHarnessIsolation, true)
+  assert.equal(evidence.coverage.transcriptFidelity, true)
+  assert.equal(evidence.coverage.stopAndResume, true)
+  assert.equal(evidence.coverage.resourceBounds, true)
+  assert.deepEqual(evidence.missingCoverage, [])
+  assert.ok(evidence.notExercised.includes("daemon restart/reconnect"))
+  assert.ok(evidence.notExercised.includes("physical mobile background/foreground"))
+})
+
+test("soak evidence fails closed on failed checks or silently missing scenarios", () => {
+  const failed = parseSoakEvidence(`${COMPLETE_SOAK_OUTPUT}\n  FAIL no unresolved native Session mutation left (2)`)
+  assert.equal(failed.complete, false)
+  assert.equal(failed.summary.failed, 1)
+
+  const incomplete = parseSoakEvidence("  ok   two native Sessions created on codex\n")
+  assert.equal(incomplete.complete, false)
+  assert.ok(incomplete.missingCoverage.includes("stopAndResume"))
+  assert.ok(incomplete.missingCoverage.includes("resourceBounds"))
 })
 
 test("preflight accepts registered harnesses even when their model inventories may be identical", async () => {
@@ -114,11 +156,11 @@ test("preflight turns authentication failures into a concise gate failure", asyn
   assert.match(result.error, /rejected.*credentials/i)
 })
 
-test("orchestrates every primary and persists credential-free release evidence", async () => {
+test("orchestrates every primary and persists credential-free scenario evidence", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "hr-real-gate-"))
   const soakPath = path.join(root, "fake-soak.mjs")
   const reportPath = path.join(root, "report.json")
-  fs.writeFileSync(soakPath, "process.exit(0)\n", "utf8")
+  fs.writeFileSync(soakPath, `console.log(${JSON.stringify(COMPLETE_SOAK_OUTPUT)})\n`, "utf8")
   const previousURL = process.env.HR_URL
   process.env.HR_URL = "http://user:secret@127.0.0.1:4097"
 
@@ -140,20 +182,57 @@ test("orchestrates every primary and persists credential-free release evidence",
     })
     assert.equal(report.verdict, "verified")
     assert.equal(report.releaseEligible, true)
-    assert.equal(report.schemaVersion, 2)
+    assert.equal(report.schemaVersion, 3)
     assert.equal(report.preflight.passed, true)
     assert.deepEqual(report.runs.map(({ primary, secondary, passed }) => ({ primary, secondary, passed })), [
       { primary: "codex", secondary: "claude", passed: true },
       { primary: "claude", secondary: "codex", passed: true }
     ])
+    assert.equal(report.runs[0].evidence.complete, true)
+    assert.equal(report.runs[0].evidence.coverage.stopAndResume, true)
+    assert.equal(report.coverageMatrix.codex.resourceBounds, true)
+    assert.equal(report.coverageMatrix.claude.crossHarnessIsolation, true)
 
     const persisted = JSON.parse(fs.readFileSync(reportPath, "utf8"))
     assert.equal(persisted.endpoint, "http://127.0.0.1:4097")
+    assert.equal(persisted.coverageMatrix.codex.complete, true)
     assert.equal(JSON.stringify(persisted).includes("secret"), false)
     assert.equal(JSON.stringify(persisted).includes("user:"), false)
   } finally {
     if (previousURL === undefined) delete process.env.HR_URL
     else process.env.HR_URL = previousURL
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test("a zero-exit soak without required scenario evidence fails the release gate", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "hr-real-gate-evidence-"))
+  const soakPath = path.join(root, "fake-empty-soak.mjs")
+  const reportPath = path.join(root, "report.json")
+  fs.writeFileSync(soakPath, "console.log('ALL CHECKS PASSED')\n", "utf8")
+
+  try {
+    const report = await runGate({
+      harnesses: ["codex", "claude"],
+      mode: "release",
+      reportPath,
+      soakPath,
+      preflight: async ({ harnesses }) => ({
+        passed: true,
+        status: 200,
+        error: null,
+        machineID: "machine-1",
+        agents: harnesses.map((id) => ({ id, registered: true, modelCatalog: { configured: true, source: "test", cachedModels: 2, phase: "ready" } })),
+        missingHarnesses: [],
+        missingModelCatalogs: []
+      })
+    })
+    assert.equal(report.verdict, "failed")
+    assert.equal(report.runs[0].exitCode, 0)
+    assert.equal(report.runs[0].passed, false)
+    assert.equal(report.runs[0].evidence.complete, false)
+    assert.match(report.runs[0].evidenceError, /without machine-readable check evidence/i)
+  } finally {
     fs.rmSync(root, { recursive: true, force: true })
   }
 })


### PR DESCRIPTION
## Scope

P0 release-safety infrastructure only. No runtime, ACP, daemon, Session controller or UI behavior changes.

This PR targets `codex/development-2026-09-11` and makes the real-harness release report prove which reliability scenarios actually ran for each primary harness instead of preserving only a coarse pass/fail result.

## What changes

- Captures and parses the existing soak check stream into structured evidence.
- Adds per-leg coverage for Session creation, multi-turn streaming, model selection, cross-harness isolation, transcript fidelity, Stop/recovery and bounded-resource cleanup.
- Fails closed if a soak exits 0 but required scenario evidence is absent or a parsed check failed.
- Adds a top-level `coverageMatrix` keyed by primary harness.
- Bumps the evidence report schema to v3.
- Explicitly records boundaries that this gate does **not** prove: pre-existing Session discovery, daemon restart/reconnect, and physical mobile background/foreground.
- Adds regressions proving complete evidence passes and silent/partial evidence fails.

## Why

The soak already exercised several important P0 invariants, but the final JSON report did not retain that scenario-level evidence. A release report could therefore say `verified` without making it obvious which P0 requirements had actually been exercised. This change makes the report traceable and fail-closed without pretending CI or fixtures cover real-device boundaries they cannot prove.

## Merge rule

Merge only into `codex/development-2026-09-11` after the complete PR gate is green. `main` must remain untouched.