### PR TITLE
test(P0): require real-harness Session rediscovery evidence

### DIFF
--- a/bridge/scripts/real-harness-release-gate.mjs
+++ b/bridge/scripts/real-harness-release-gate.mjs
@@ -3,6 +3,7 @@ import { execFileSync, spawn } from "node:child_process"
 import fs from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
+import { verifyRealHarnessSessionDiscovery } from "./real-harness-session-discovery.mjs"
 
 export const SUPPORTED_HARNESSES = ["opencode", "codex", "claude", "omp", "pi"]
 
@@ -205,7 +206,6 @@ export function parseSoakEvidence(output = "") {
     missingCoverage,
     complete: checks.length > 0 && failedChecks.length === 0 && missingCoverage.length === 0,
     notExercised: [
-      "pre-existing native Session discovery",
       "daemon restart/reconnect",
       "physical mobile background/foreground"
     ]
@@ -213,7 +213,7 @@ export function parseSoakEvidence(output = "") {
 }
 
 export function gateUsage() {
-  return `Usage: npm run gate:real-harness -- [options]\n\nOptions:\n  --harnesses <list>  Comma-separated harnesses to verify (default: ${SUPPORTED_HARNESSES.join(",")})\n  --mode <mode>       release (default) or control-plane\n  --report <path>     JSON evidence report path (default: artifacts/real-harness-gate-<timestamp>.json)\n  --help              Show this help\n\nThe gate first checks /v1/diagnostics and stops early if the daemon is unreachable, credentials are rejected, a requested harness is not registered, or model discovery is not configured. Each real-harness leg must also emit the complete scenario evidence contract (Session creation, multi-turn streaming, model selection, cross-harness isolation, transcript fidelity, Stop/recovery and bounded resources); a zero exit code without that evidence fails closed. Shared soak settings use HR_URL, HR_USER, HR_PASS, HR_DIR_A, HR_DIR_B, HR_CYCLES, HR_TURN_BUDGET_MS and HR_ECHO_MARKERS. Release mode always disables HR_ALLOW_TURN_ERRORS. Use --mode control-plane when inference is unavailable; that mode is recorded as not release-eligible.`
+  return `Usage: npm run gate:real-harness -- [options]\n\nOptions:\n  --harnesses <list>  Comma-separated harnesses to verify (default: ${SUPPORTED_HARNESSES.join(",")})\n  --mode <mode>       release (default) or control-plane\n  --report <path>     JSON evidence report path (default: artifacts/real-harness-gate-<timestamp>.json)\n  --help              Show this help\n\nThe gate first checks /v1/diagnostics and stops early if the daemon is unreachable, credentials are rejected, a requested harness is not registered, or model discovery is not configured. It then creates one harmless probe Session per requested harness and requires that exact native id to be rediscovered through the Session index before inference-heavy soak legs begin. Each real-harness leg must also emit the complete scenario evidence contract (Session creation, multi-turn streaming, model selection, cross-harness isolation, transcript fidelity, Stop/recovery and bounded resources); a zero exit code without that evidence fails closed. Shared soak settings use HR_URL, HR_USER, HR_PASS, HR_DIR_A, HR_DIR_B, HR_CYCLES, HR_TURN_BUDGET_MS and HR_ECHO_MARKERS. Release mode always disables HR_ALLOW_TURN_ERRORS. Use --mode control-plane when inference is unavailable; that mode is recorded as not release-eligible.`
 }
 
 async function runSoak({ primary, secondary, mode, soakPath }) {
@@ -277,7 +277,8 @@ export async function runGate({
   mode,
   reportPath,
   soakPath = fileURLToPath(new URL("./session-first-soak.mjs", import.meta.url)),
-  preflight = preflightDaemon
+  preflight = preflightDaemon,
+  sessionDiscovery = verifyRealHarnessSessionDiscovery
 }) {
   const echoMarkers = process.env.HR_ECHO_MARKERS !== "0"
   const eligibility = releaseEligibility({ mode, echoMarkers })
@@ -301,7 +302,25 @@ export async function runGate({
     if (preflightResult.missingModelCatalogs?.length) console.error(`       model discovery unavailable: ${preflightResult.missingModelCatalogs.join(", ")}`)
   }
 
+  let discoveryResult = {
+    schemaVersion: 1,
+    passed: false,
+    skipped: true,
+    results: []
+  }
   if (preflightResult.passed) {
+    console.log("\n== native Session create + rediscovery ==")
+    discoveryResult = await sessionDiscovery({ harnesses })
+    for (const result of discoveryResult.results ?? []) {
+      if (result.passed) {
+        console.log(`  ok   ${result.agentID}: created Session rediscovered in ${result.pages} page(s)`)
+      } else {
+        console.error(`  FAIL ${result.agentID}: ${result.error ?? "native Session rediscovery failed"}`)
+      }
+    }
+  }
+
+  if (preflightResult.passed && discoveryResult.passed) {
     for (const pair of plan) {
       console.log(`\n========================================`)
       console.log(`Primary ${pair.primary} / secondary ${pair.secondary}`)
@@ -315,17 +334,38 @@ export async function runGate({
     }
   }
 
-  const allPassed = preflightResult.passed && runs.length === plan.length && runs.every((run) => run.passed)
+  const allPassed = preflightResult.passed
+    && discoveryResult.passed
+    && runs.length === plan.length
+    && runs.every((run) => run.passed)
   const verdict = !allPassed ? "failed" : eligibility.releaseEligible ? "verified" : "control-plane-only"
-  const coverageMatrix = Object.fromEntries(runs.map((run) => [run.primary, {
-    secondary: run.secondary,
-    complete: run.evidence?.complete ?? false,
-    coverage: run.evidence?.coverage ?? {},
-    missingCoverage: run.evidence?.missingCoverage ?? [],
-    notExercised: run.evidence?.notExercised ?? []
-  }]))
+  const runByPrimary = new Map(runs.map((run) => [run.primary, run]))
+  const discoveryByHarness = new Map((discoveryResult.results ?? []).map((result) => [result.agentID, result]))
+  const coverageMatrix = Object.fromEntries(plan.map(({ primary, secondary }) => {
+    const run = runByPrimary.get(primary)
+    const discovery = discoveryByHarness.get(primary)
+    const sessionDiscovery = discovery?.passed ?? false
+    const coverage = {
+      sessionDiscovery,
+      ...(run?.evidence?.coverage ?? {})
+    }
+    const missingCoverage = [
+      ...(sessionDiscovery ? [] : ["sessionDiscovery"]),
+      ...(run?.evidence?.missingCoverage ?? (run ? [] : REQUIRED_SOAK_COVERAGE))
+    ]
+    return [primary, {
+      secondary,
+      complete: sessionDiscovery && (run?.evidence?.complete ?? false),
+      coverage,
+      missingCoverage,
+      notExercised: run?.evidence?.notExercised ?? [
+        "daemon restart/reconnect",
+        "physical mobile background/foreground"
+      ]
+    }]
+  }))
   const report = {
-    schemaVersion: 3,
+    schemaVersion: 4,
     kind: "harness-remote-real-harness-gate",
     generatedAt: new Date().toISOString(),
     source: { commit: gitCommit() },
@@ -342,6 +382,7 @@ export async function runGate({
       allowTurnErrors: mode === "control-plane"
     },
     preflight: preflightResult,
+    sessionDiscovery: discoveryResult,
     coverageMatrix,
     runs,
     verdict

--- a/bridge/scripts/real-harness-session-discovery.mjs
+++ b/bridge/scripts/real-harness-session-discovery.mjs
@@ -1,5 +1,3 @@
-import path from "node:path"
-
 function authorization(user = process.env.HR_USER ?? "", pass = process.env.HR_PASS ?? "") {
   return `Basic ${Buffer.from(`${user}:${pass}`, "utf8").toString("base64")}`
 }
@@ -98,7 +96,7 @@ async function listNativeSessions({
   }
 
   return {
-    passed: true,
+    passed: !cursor,
     status: lastStatus,
     pages,
     ids: [...ids],
@@ -173,7 +171,6 @@ export async function verifyRealHarnessSessionDiscovery({
   return {
     schemaVersion: 1,
     passed: results.length === harnesses.length && results.every((result) => result.passed),
-    probeDirectoryName: path.basename(directory),
     results
   }
 }

--- a/bridge/scripts/real-harness-session-discovery.mjs
+++ b/bridge/scripts/real-harness-session-discovery.mjs
@@ -35,14 +35,14 @@ async function requestJSON(url, {
     const text = await response.text()
     let data
     try { data = text ? JSON.parse(text) : null } catch { data = null }
-    return { response, data, error: null }
+    return { response, data, transportError: null }
   } catch (error) {
     return {
       response: null,
       data: null,
-      error: error?.name === "AbortError"
-        ? `request timed out after ${timeoutMs}ms`
-        : (error instanceof Error ? error.message : String(error))
+      transportError: error?.name === "AbortError"
+        ? `Request timed out after ${timeoutMs}ms.`
+        : "Request failed before receiving an HTTP response."
     }
   } finally {
     clearTimeout(timer)
@@ -79,7 +79,7 @@ async function listNativeSessions({
         status: lastStatus,
         pages,
         ids: [...ids],
-        error: result.error ?? result.data?.error ?? `Session discovery returned HTTP ${lastStatus}.`
+        error: result.transportError ?? `Session discovery returned HTTP ${lastStatus}.`
       }
     }
 
@@ -132,15 +132,19 @@ export async function verifyRealHarnessSessionDiscovery({
     )
     const createdID = sessionID(created.data)
     if (!created.response?.ok || !createdID) {
+      const createStatus = created.response?.status ?? 0
       results.push({
         agentID,
         passed: false,
         created: false,
-        createStatus: created.response?.status ?? 0,
+        createStatus,
         discovered: false,
         listStatus: 0,
         pages: 0,
-        error: created.error ?? created.data?.error ?? "Native Session creation did not return an id."
+        error: created.transportError
+          ?? (created.response?.ok
+            ? "Native Session creation did not return an id."
+            : `Native Session creation returned HTTP ${createStatus}.`)
       })
       continue
     }

--- a/bridge/scripts/real-harness-session-discovery.mjs
+++ b/bridge/scripts/real-harness-session-discovery.mjs
@@ -1,0 +1,179 @@
+import path from "node:path"
+
+function authorization(user = process.env.HR_USER ?? "", pass = process.env.HR_PASS ?? "") {
+  return `Basic ${Buffer.from(`${user}:${pass}`, "utf8").toString("base64")}`
+}
+
+function sessionID(entry) {
+  return entry?.id ?? entry?.sessionID ?? entry?.sessionId ?? null
+}
+
+function sessionList(value) {
+  if (Array.isArray(value)) return value
+  if (Array.isArray(value?.sessions)) return value.sessions
+  return []
+}
+
+async function requestJSON(url, {
+  method = "GET",
+  body,
+  authorizationHeader,
+  fetchImpl,
+  timeoutMs
+}) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await fetchImpl(url, {
+      method,
+      headers: {
+        Accept: "application/json",
+        Authorization: authorizationHeader,
+        ...(body ? { "Content-Type": "application/json" } : {})
+      },
+      body: body ? JSON.stringify(body) : undefined,
+      signal: controller.signal
+    })
+    const text = await response.text()
+    let data
+    try { data = text ? JSON.parse(text) : null } catch { data = null }
+    return { response, data, error: null }
+  } catch (error) {
+    return {
+      response: null,
+      data: null,
+      error: error?.name === "AbortError"
+        ? `request timed out after ${timeoutMs}ms`
+        : (error instanceof Error ? error.message : String(error))
+    }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+async function listNativeSessions({
+  root,
+  agentID,
+  directory,
+  authorizationHeader,
+  fetchImpl,
+  timeoutMs,
+  maxPages
+}) {
+  const ids = new Set()
+  let cursor
+  let pages = 0
+  let lastStatus = 0
+
+  while (pages < maxPages) {
+    const query = new URLSearchParams()
+    query.set("directory", directory)
+    if (cursor) query.set("cursor", cursor)
+    const result = await requestJSON(
+      `${root}/v1/agents/${encodeURIComponent(agentID)}/experimental/session?${query.toString()}`,
+      { authorizationHeader, fetchImpl, timeoutMs }
+    )
+    pages += 1
+    lastStatus = result.response?.status ?? 0
+    if (!result.response?.ok) {
+      return {
+        passed: false,
+        status: lastStatus,
+        pages,
+        ids: [...ids],
+        error: result.error ?? result.data?.error ?? `Session discovery returned HTTP ${lastStatus}.`
+      }
+    }
+
+    for (const entry of sessionList(result.data)) {
+      const id = sessionID(entry)
+      if (id) ids.add(String(id))
+    }
+
+    cursor = result.response.headers.get("x-next-cursor")
+      ?? result.response.headers.get("x-cursor")
+      ?? result.data?.nextCursor
+      ?? null
+    if (!cursor) break
+  }
+
+  return {
+    passed: true,
+    status: lastStatus,
+    pages,
+    ids: [...ids],
+    exhausted: Boolean(cursor),
+    error: cursor ? `Session discovery exceeded the bounded ${maxPages}-page scan.` : null
+  }
+}
+
+export async function verifyRealHarnessSessionDiscovery({
+  harnesses,
+  urlRoot = process.env.HR_URL ?? "http://127.0.0.1:4097",
+  user = process.env.HR_USER ?? "",
+  pass = process.env.HR_PASS ?? "",
+  directory = process.env.HR_DIR_A ?? process.cwd(),
+  fetchImpl = globalThis.fetch,
+  timeoutMs = 30_000,
+  maxPages = 12
+}) {
+  const root = urlRoot.replace(/\/$/, "")
+  const authorizationHeader = authorization(user, pass)
+  const results = []
+
+  for (const agentID of harnesses) {
+    const created = await requestJSON(
+      `${root}/v1/agents/${encodeURIComponent(agentID)}/session?directory=${encodeURIComponent(directory)}`,
+      {
+        method: "POST",
+        body: { title: `Harness Remote release-gate discovery (${agentID})` },
+        authorizationHeader,
+        fetchImpl,
+        timeoutMs
+      }
+    )
+    const createdID = sessionID(created.data)
+    if (!created.response?.ok || !createdID) {
+      results.push({
+        agentID,
+        passed: false,
+        created: false,
+        createStatus: created.response?.status ?? 0,
+        discovered: false,
+        listStatus: 0,
+        pages: 0,
+        error: created.error ?? created.data?.error ?? "Native Session creation did not return an id."
+      })
+      continue
+    }
+
+    const listed = await listNativeSessions({
+      root,
+      agentID,
+      directory,
+      authorizationHeader,
+      fetchImpl,
+      timeoutMs,
+      maxPages
+    })
+    const discovered = listed.passed && listed.ids.includes(String(createdID))
+    results.push({
+      agentID,
+      passed: discovered,
+      created: true,
+      createStatus: created.response.status,
+      createdSessionID: String(createdID),
+      discovered,
+      listStatus: listed.status,
+      pages: listed.pages,
+      error: listed.error ?? (discovered ? null : "Newly created native Session was absent from discovery results.")
+    })
+  }
+
+  return {
+    schemaVersion: 1,
+    passed: results.length === harnesses.length && results.every((result) => result.passed),
+    probeDirectoryName: path.basename(directory),
+    results
+  }
+}

--- a/bridge/test/real-harness-release-gate.test.js
+++ b/bridge/test/real-harness-release-gate.test.js
@@ -29,6 +29,24 @@ const COMPLETE_SOAK_OUTPUT = [
   "  ok   no unresolved native Session mutation left (0)"
 ].join("\n")
 
+function passingSessionDiscovery(harnesses) {
+  return {
+    schemaVersion: 1,
+    passed: true,
+    results: harnesses.map((agentID) => ({
+      agentID,
+      passed: true,
+      created: true,
+      createStatus: 200,
+      createdSessionID: `${agentID}-discovery-session`,
+      discovered: true,
+      listStatus: 200,
+      pages: 1,
+      error: null
+    }))
+  }
+}
+
 test("defaults the release gate to every supported harness", () => {
   assert.deepEqual(parseHarnessList(), SUPPORTED_HARNESSES)
 })
@@ -75,7 +93,7 @@ test("default report path stays outside source files and carries a timestamp", (
   assert.equal(report, path.join("/work", "artifacts", "real-harness-gate-2026-09-11T03-45-12-345Z.json"))
 })
 
-test("parses scenario-level soak evidence and exposes known real-boundary gaps", () => {
+test("parses scenario-level soak evidence and exposes only the remaining real-boundary gaps", () => {
   const evidence = parseSoakEvidence(COMPLETE_SOAK_OUTPUT)
   assert.equal(evidence.complete, true)
   assert.equal(evidence.summary.failed, 0)
@@ -87,6 +105,7 @@ test("parses scenario-level soak evidence and exposes known real-boundary gaps",
   assert.equal(evidence.coverage.stopAndResume, true)
   assert.equal(evidence.coverage.resourceBounds, true)
   assert.deepEqual(evidence.missingCoverage, [])
+  assert.equal(evidence.notExercised.includes("pre-existing native Session discovery"), false)
   assert.ok(evidence.notExercised.includes("daemon restart/reconnect"))
   assert.ok(evidence.notExercised.includes("physical mobile background/foreground"))
 })
@@ -178,18 +197,21 @@ test("orchestrates every primary and persists credential-free scenario evidence"
         agents: harnesses.map((id) => ({ id, registered: true, modelCatalog: { configured: true, source: "test", cachedModels: 2, phase: "ready" } })),
         missingHarnesses: [],
         missingModelCatalogs: []
-      })
+      }),
+      sessionDiscovery: async ({ harnesses }) => passingSessionDiscovery(harnesses)
     })
     assert.equal(report.verdict, "verified")
     assert.equal(report.releaseEligible, true)
-    assert.equal(report.schemaVersion, 3)
+    assert.equal(report.schemaVersion, 4)
     assert.equal(report.preflight.passed, true)
+    assert.equal(report.sessionDiscovery.passed, true)
     assert.deepEqual(report.runs.map(({ primary, secondary, passed }) => ({ primary, secondary, passed })), [
       { primary: "codex", secondary: "claude", passed: true },
       { primary: "claude", secondary: "codex", passed: true }
     ])
     assert.equal(report.runs[0].evidence.complete, true)
     assert.equal(report.runs[0].evidence.coverage.stopAndResume, true)
+    assert.equal(report.coverageMatrix.codex.coverage.sessionDiscovery, true)
     assert.equal(report.coverageMatrix.codex.coverage.resourceBounds, true)
     assert.equal(report.coverageMatrix.claude.coverage.crossHarnessIsolation, true)
 
@@ -225,7 +247,8 @@ test("a zero-exit soak without required scenario evidence fails the release gate
         agents: harnesses.map((id) => ({ id, registered: true, modelCatalog: { configured: true, source: "test", cachedModels: 2, phase: "ready" } })),
         missingHarnesses: [],
         missingModelCatalogs: []
-      })
+      }),
+      sessionDiscovery: async ({ harnesses }) => passingSessionDiscovery(harnesses)
     })
     assert.equal(report.verdict, "failed")
     assert.equal(report.runs[0].exitCode, 0)
@@ -237,12 +260,54 @@ test("a zero-exit soak without required scenario evidence fails the release gate
   }
 })
 
-test("does not launch any soak leg when daemon preflight fails", async () => {
+test("does not launch soak legs when native Session rediscovery fails", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "hr-real-gate-discovery-"))
+  const soakPath = path.join(root, "must-not-run.mjs")
+  const markerPath = path.join(root, "ran")
+  const reportPath = path.join(root, "report.json")
+  fs.writeFileSync(soakPath, `require('node:fs').writeFileSync(${JSON.stringify(markerPath)}, 'ran')\n`, "utf8")
+
+  try {
+    const report = await runGate({
+      harnesses: ["codex", "claude"],
+      mode: "release",
+      reportPath,
+      soakPath,
+      preflight: async ({ harnesses }) => ({
+        passed: true,
+        status: 200,
+        error: null,
+        machineID: "machine-1",
+        agents: harnesses.map((id) => ({ id, registered: true, modelCatalog: { configured: true, source: "test", cachedModels: 2, phase: "ready" } })),
+        missingHarnesses: [],
+        missingModelCatalogs: []
+      }),
+      sessionDiscovery: async () => ({
+        schemaVersion: 1,
+        passed: false,
+        results: [
+          { agentID: "codex", passed: false, error: "Session missing from index", pages: 1 },
+          { agentID: "claude", passed: true, pages: 1 }
+        ]
+      })
+    })
+    assert.equal(report.verdict, "failed")
+    assert.equal(report.runs.length, 0)
+    assert.equal(report.coverageMatrix.codex.coverage.sessionDiscovery, false)
+    assert.ok(report.coverageMatrix.codex.missingCoverage.includes("sessionDiscovery"))
+    assert.equal(fs.existsSync(markerPath), false)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test("does not launch any discovery or soak leg when daemon preflight fails", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "hr-real-gate-preflight-"))
   const soakPath = path.join(root, "must-not-run.mjs")
   const markerPath = path.join(root, "ran")
   const reportPath = path.join(root, "report.json")
   fs.writeFileSync(soakPath, `require('node:fs').writeFileSync(${JSON.stringify(markerPath)}, 'ran')\n`, "utf8")
+  let discoveryCalls = 0
 
   try {
     const report = await runGate({
@@ -258,10 +323,16 @@ test("does not launch any soak leg when daemon preflight fails", async () => {
         agents: [],
         missingHarnesses: ["claude"],
         missingModelCatalogs: []
-      })
+      }),
+      sessionDiscovery: async () => {
+        discoveryCalls += 1
+        return passingSessionDiscovery(["codex", "claude"])
+      }
     })
     assert.equal(report.verdict, "failed")
     assert.deepEqual(report.runs, [])
+    assert.equal(report.sessionDiscovery.skipped, true)
+    assert.equal(discoveryCalls, 0)
     assert.equal(fs.existsSync(markerPath), false)
     assert.equal(JSON.parse(fs.readFileSync(reportPath, "utf8")).preflight.missingHarnesses[0], "claude")
   } finally {

--- a/bridge/test/real-harness-session-discovery.test.js
+++ b/bridge/test/real-harness-session-discovery.test.js
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { verifyRealHarnessSessionDiscovery } from "../scripts/real-harness-session-discovery.mjs"
+
+function jsonResponse(value, status = 200, headers = {}) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "Content-Type": "application/json", ...headers }
+  })
+}
+
+test("creates and rediscovers the exact native Session for every requested harness", async () => {
+  const calls = []
+  const created = new Map([
+    ["codex", "codex-created"],
+    ["omp", "omp-created"]
+  ])
+  const fetchImpl = async (url, options = {}) => {
+    calls.push({ url: String(url), method: options.method ?? "GET", authorization: options.headers?.Authorization })
+    const parsed = new URL(url)
+    const match = /^\/v1\/agents\/([^/]+)\/(.*)$/.exec(parsed.pathname)
+    const agentID = decodeURIComponent(match?.[1] ?? "")
+    const rest = match?.[2] ?? ""
+    if (options.method === "POST" && rest === "session") {
+      return jsonResponse({ id: created.get(agentID) })
+    }
+    if (rest === "experimental/session") {
+      if (agentID === "codex" && !parsed.searchParams.get("cursor")) {
+        return jsonResponse([{ id: "older-codex" }], 200, { "X-Next-Cursor": "page-2" })
+      }
+      return jsonResponse([{ id: created.get(agentID) }])
+    }
+    return jsonResponse({ error: "unexpected route" }, 404)
+  }
+
+  const result = await verifyRealHarnessSessionDiscovery({
+    harnesses: ["codex", "omp"],
+    urlRoot: "http://127.0.0.1:4097",
+    user: "harness",
+    pass: "secret",
+    directory: "/work/private-project",
+    fetchImpl
+  })
+
+  assert.equal(result.passed, true)
+  assert.deepEqual(result.results.map(({ agentID, discovered, pages }) => ({ agentID, discovered, pages })), [
+    { agentID: "codex", discovered: true, pages: 2 },
+    { agentID: "omp", discovered: true, pages: 1 }
+  ])
+  assert.ok(calls.every((call) => call.authorization?.startsWith("Basic ")))
+  assert.equal(JSON.stringify(result).includes("secret"), false)
+  assert.equal(JSON.stringify(result).includes("private-project"), false)
+})
+
+test("fails closed when creation succeeds but the native index cannot rediscover that id", async () => {
+  const fetchImpl = async (_url, options = {}) => {
+    if (options.method === "POST") return jsonResponse({ id: "created-but-hidden" })
+    return jsonResponse([{ id: "some-other-session" }])
+  }
+
+  const result = await verifyRealHarnessSessionDiscovery({
+    harnesses: ["claude"],
+    directory: "/work/project",
+    fetchImpl
+  })
+
+  assert.equal(result.passed, false)
+  assert.equal(result.results[0].created, true)
+  assert.equal(result.results[0].discovered, false)
+  assert.match(result.results[0].error, /absent from discovery/i)
+})
+
+test("bounds pagination instead of scanning an unbounded native Session index", async () => {
+  const fetchImpl = async (_url, options = {}) => {
+    if (options.method === "POST") return jsonResponse({ id: "target" })
+    return jsonResponse([{ id: "older" }], 200, { "X-Next-Cursor": "again" })
+  }
+
+  const result = await verifyRealHarnessSessionDiscovery({
+    harnesses: ["pi"],
+    directory: "/work/project",
+    fetchImpl,
+    maxPages: 2
+  })
+
+  assert.equal(result.passed, false)
+  assert.equal(result.results[0].pages, 2)
+  assert.match(result.results[0].error, /bounded 2-page scan/i)
+})

--- a/bridge/test/real-harness-session-discovery.test.js
+++ b/bridge/test/real-harness-session-discovery.test.js
@@ -87,3 +87,21 @@ test("bounds pagination instead of scanning an unbounded native Session index", 
   assert.equal(result.results[0].pages, 2)
   assert.match(result.results[0].error, /bounded 2-page scan/i)
 })
+
+test("sanitizes transport failures before they enter release evidence", async () => {
+  const result = await verifyRealHarnessSessionDiscovery({
+    harnesses: ["opencode"],
+    urlRoot: "http://private-user:private-pass@127.0.0.1:4097",
+    directory: "/work/private-project",
+    fetchImpl: async (url) => {
+      throw new Error(`could not fetch ${url}`)
+    }
+  })
+
+  const evidence = JSON.stringify(result)
+  assert.equal(result.passed, false)
+  assert.match(result.results[0].error, /failed before receiving an HTTP response/i)
+  assert.equal(evidence.includes("private-user"), false)
+  assert.equal(evidence.includes("private-pass"), false)
+  assert.equal(evidence.includes("private-project"), false)
+})

--- a/docs/NATIVE_SESSION_RELIABILITY_CONTRACT.md
+++ b/docs/NATIVE_SESSION_RELIABILITY_CONTRACT.md
@@ -98,7 +98,9 @@ The daemon-reconnect browser smoke proves the client-side boundary with a restar
 
 Automated fixtures cannot prove compatibility with the installed versions of every harness. Before a release is called fully verified, run the traceable real-harness gate for OpenCode, Codex, Claude Code, OMP and PI. A control-plane-only pass is not equivalent to real inference evidence.
 
-Physical Android background/foreground and real network-interruption checks remain separate release evidence where a real device boundary is required.
+The gate first creates one harmless Native Session for every requested installed harness and requires that exact native Session id to be rediscovered through that harness's bounded Session index. A successful create response alone is not discovery evidence, and a missing id fails the gate before inference-heavy soak legs begin. The evidence report records this per harness together with multi-turn streaming, model selection, cross-harness isolation, transcript fidelity, Stop/recovery and resource bounds.
+
+Create-and-rediscover evidence does **not** substitute for a real daemon/adapter process restart. Installed-harness restart/reconnect and physical Android background/foreground or network-interruption behavior remain separate release evidence where a real process/device boundary is required.
 
 ## CI wiring is itself a regression contract
 


### PR DESCRIPTION
## Scope

P0 release-safety evidence only. No runtime, UI, ACP, provider adapter or daemon behavior changes.

This PR targets **only** `codex/development-2026-09-11`. `main` must remain untouched.

## What this closes

The real-harness soak already proved Session creation, multi-turn inference, model selection, cross-harness isolation, transcript fidelity, Stop/recovery and bounded resources, but a successful create response did not prove that the same Native Session became discoverable through the harness Session index.

The new pre-soak discovery phase now runs for every requested installed harness:

1. create one harmless Native Session through the normal agent-scoped endpoint;
2. capture its exact native Session id;
3. query that harness's `/experimental/session` index using the same agent-scoped contract used by the product;
4. follow native pagination with a strict bound;
5. require that exact id to be rediscovered before inference-heavy soak legs may run.

If creation succeeds but rediscovery fails, listing fails, or pagination cannot converge within the bound, the release gate fails closed and does not continue with the soak.

## Evidence/report changes

- Adds `coverage.sessionDiscovery` per harness.
- Persists a dedicated `sessionDiscovery` evidence section.
- Bumps the release report schema from v3 to v4.
- Keeps credentials and local project paths out of the report.
- Adds regressions for exact rediscovery, pagination, missing-id failure, and gate short-circuiting.
- Updates the shared Native Session reliability contract.

## Boundaries deliberately not claimed

Create-and-rediscover does **not** prove that a real installed harness survives daemon/adapter process restart. That remains real-machine release evidence. Physical Android background/foreground and network-interruption behavior also remain separate device evidence, and `main` branch protection still requires repository-admin configuration.

## Merge rule

Merge only into `codex/development-2026-09-11` after the complete PR gate is green. Never merge this PR into `main`.

Refs #368