### PR TITLE
test(P0): remove scheduler timing flakes from model loading gates

### DIFF
--- a/bridge/test/agent-model-server.test.js
+++ b/bridge/test/agent-model-server.test.js
@@ -32,9 +32,15 @@ test("GET agent models returns daemon refresh result", async () => {
   } finally { await close(server) }
 })
 
-test("cold ACP catalog returns loading before the caller transport budget expires", async () => {
+test("cold ACP catalog returns loading without waiting for discovery to settle", { timeout: 10_000 }, async () => {
   let release
-  const pending = new Promise((resolve) => { release = resolve })
+  let discoverySettled = false
+  const pending = new Promise((resolve) => {
+    release = (value) => {
+      discoverySettled = true
+      resolve(value)
+    }
+  })
   let calls = 0
   const daemon = {
     listModels() {
@@ -49,10 +55,12 @@ test("cold ACP catalog returns loading before the caller transport budget expire
   const server = createAgentModelServer({ innerServer, config: config(), daemon, taskStore: {} })
   const base = await listen(server)
   try {
-    const started = Date.now()
     const response = await fetch(`${base}/v1/agents/pi/models?waitMs=15`, { headers: auth() })
     assert.equal(response.status, 202)
-    assert.ok(Date.now() - started < 500)
+    // The response itself proves the bounded wait won the race: this test deliberately does not
+    // settle model discovery until cleanup. Avoid asserting scheduler wall time here; a loaded CI
+    // runner may pause the process for seconds without changing the server's contract.
+    assert.equal(discoverySettled, false)
     assert.equal(response.headers.get("retry-after"), "1")
     const body = await response.json()
     assert.equal(body.loading, true)

--- a/bridge/test/agent-model-timeout.test.js
+++ b/bridge/test/agent-model-timeout.test.js
@@ -90,7 +90,7 @@ test("optional ACP variant probing is bounded and cannot invalidate base models"
   }
 })
 
-test("HTTP model discovery obeys the catalog-wide timeout budget", async () => {
+test("HTTP model discovery obeys the catalog-wide timeout budget", { timeout: 10_000 }, async () => {
   const host = { host: "127.0.0.1", port: 4096, async start() {} }
   const catalog = new HttpAgentModelCatalog({
     host,
@@ -98,7 +98,8 @@ test("HTTP model discovery obeys the catalog-wide timeout budget", async () => {
     fetchImpl: never,
     timeoutMs: 25
   })
-  const started = Date.now()
+  // The catalog's own timeout message proves its 25ms budget won against a fetch that never settles.
+  // Do not assert process wall time: a paused CI runner can resume seconds later even though the
+  // catalog used the correct internal budget.
   await assert.rejects(() => catalog.list({ allowStale: false }), /timed out after 25ms/)
-  assert.ok(Date.now() - started < 500)
 })


### PR DESCRIPTION
## Scope

P0 release-safety / CI determinism only. This is a two-file test-only change; no runtime, UI, ACP, provider adapter or daemon behavior changes.

Target is **only** `codex/development-2026-09-11`. `main` must remain untouched.

## Why

While validating #458, the first Windows bridge job failed only on `cold ACP catalog returns loading before the caller transport budget expires`: 576/577 tests passed, but the test asserted that a response scheduled around a 15ms model wait must arrive within `<500ms` of process wall-clock time. The unchanged rerun passed 577/577.

A follow-up scan found the same `<500ms` scheduler assumption in the HTTP model-catalog timeout regression. Both assertions measure GitHub runner scheduling/load rather than Harness Remote semantics, and conflict with #368's requirement that blocking validation be deterministic rather than require reruns.

## Change

The regressions now prove the actual contracts:

- cold model discovery remains deliberately unresolved while the HTTP route still returns `202 loading`;
- discovery is still unresolved when that response arrives;
- `Retry-After`, source and single-flight call count remain asserted;
- HTTP model discovery with a fetch that never resolves still rejects with the catalog's own exact `25ms` timeout contract;
- generous test-level timeouts only prevent an actual deadlock from hanging the suite.

Neither test asserts scheduler elapsed time anymore. A production regression that waits indefinitely still fails, but a busy CI runner pausing the process no longer creates a false product failure.

The separate native prompt cold-catalog test retains its broader end-to-end timeout assertion because it exercises the real 8s prompt fallback budget; this PR intentionally removes only the two fragile sub-second runner assertions found by the audit.

## Merge rule

Merge only into `codex/development-2026-09-11` after the complete PR gate is green. Never merge this PR into `main`.

Refs #368