### PR TITLE
feat(P1): add embedded desktop daemon runtime foundation

### DIFF
--- a/.github/workflows/desktop-menu.yml
+++ b/.github/workflows/desktop-menu.yml
@@ -49,6 +49,19 @@ jobs:
         run: npm run test:desktop
         working-directory: web
 
+      # The self-contained desktop claim depends on electron-builder actually copying the daemon
+      # beside the ASAR. Config-level assertions alone cannot catch a bad relative source path.
+      - name: Verify embedded daemon is present in packaged Windows app
+        if: runner.os == 'Windows'
+        shell: pwsh
+        working-directory: web
+        run: |
+          npm run package:win:dir
+          $daemon = Join-Path $PWD 'release/win-unpacked/resources/bridge-runtime/src/daemon-cli.js'
+          $package = Join-Path $PWD 'release/win-unpacked/resources/bridge-runtime/package.json'
+          if (-not (Test-Path $daemon)) { throw "Packaged desktop is missing embedded daemon: $daemon" }
+          if (-not (Test-Path $package)) { throw "Packaged desktop is missing bridge package metadata: $package" }
+
       # Boots Electron, installs the real menu and reads it back — the part the unit tests cannot
       # reach, on the platform that actually shows it.
       - name: Verify the application menu installs

--- a/.github/workflows/desktop-menu.yml
+++ b/.github/workflows/desktop-menu.yml
@@ -1,9 +1,8 @@
-name: Verify desktop application menu
+name: Verify desktop runtime and application menu
 
-# The packaging workflow only runs on main and on tags, so a change to the menu would not be
-# exercised on macOS until after it was merged. macOS is the one platform that installs a native
-# menu, and it is the one platform most contributors cannot test on — so this runs there, on the
-# pull request, and does nothing else.
+# Desktop runtime behavior is platform-sensitive: process lifecycle and paths differ on Windows,
+# while macOS is the platform that installs a native application menu. Keep this path-scoped signal
+# in addition to the universal PR gate so Electron changes get real desktop coverage before merge.
 
 "on":
   workflow_dispatch: {}
@@ -20,13 +19,17 @@ permissions:
   contents: read
 
 concurrency:
-  group: desktop-menu-${{ github.ref }}
+  group: desktop-runtime-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  menu:
-    name: Application menu on macOS
-    runs-on: macos-latest
+  desktop:
+    name: Desktop tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -49,5 +52,6 @@ jobs:
       # Boots Electron, installs the real menu and reads it back — the part the unit tests cannot
       # reach, on the platform that actually shows it.
       - name: Verify the application menu installs
+        if: runner.os == 'macOS'
         run: npm run test:desktop:menu
         working-directory: web

--- a/web/electron/embedded-daemon.test.mjs
+++ b/web/electron/embedded-daemon.test.mjs
@@ -33,18 +33,25 @@ test("desktop packaging carries the bridge runtime outside the app asar", async 
   assert.ok(resources.some((entry) => entry.from === "../bridge/package.json" && entry.to === "bridge-runtime/package.json"))
 })
 
-test("builds a loopback-only authenticated daemon launch contract", () => {
-  assert.deepEqual(embeddedDaemonArgs(4100, 4101, "desktop-user", "desktop-pass"), [
+test("keeps the embedded daemon loopback-only and credentials out of process arguments", () => {
+  const args = embeddedDaemonArgs(4100, 4101)
+  assert.deepEqual(args, [
     "--host", "127.0.0.1",
     "--port", "4100",
     "--opencode-host", "127.0.0.1",
-    "--opencode-port", "4101",
-    "--username", "desktop-user",
-    "--password", "desktop-pass"
+    "--opencode-port", "4101"
   ])
-  const env = embeddedDaemonEnvironment({ PATH: "/bin" })
+  assert.equal(args.includes("desktop-user"), false)
+  assert.equal(args.includes("desktop-pass"), false)
+
+  const env = embeddedDaemonEnvironment(
+    { PATH: "/bin" },
+    { username: "desktop-user", password: "desktop-pass" }
+  )
   assert.equal(env.ELECTRON_RUN_AS_NODE, "1")
   assert.equal(env.PATH, "/bin")
+  assert.equal(env.HARNESS_REMOTE_USERNAME, "desktop-user")
+  assert.equal(env.HARNESS_REMOTE_PASSWORD, "desktop-pass")
 })
 
 test("skips a loopback port that is already occupied", async () => {
@@ -69,6 +76,7 @@ test("owns one embedded daemon process from readiness through clean shutdown", a
   await writeFile(script, `
 const portIndex = process.argv.indexOf("--port")
 const port = process.argv[portIndex + 1]
+if (!process.env.HARNESS_REMOTE_USERNAME || !process.env.HARNESS_REMOTE_PASSWORD) process.exit(9)
 process.stdout.write("Harness daemon ready at http://127.0.0.1:" + port + "\\n")
 const timer = setInterval(() => {}, 1000)
 process.on("SIGTERM", () => { clearInterval(timer); process.exit(0) })

--- a/web/electron/embedded-daemon.test.mjs
+++ b/web/electron/embedded-daemon.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { createServer } from "node:net"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -26,6 +26,13 @@ test("resolves the daemon entry inside source checkout and packaged resources", 
   )
 })
 
+test("desktop packaging carries the bridge runtime outside the app asar", async () => {
+  const packageJson = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"))
+  const resources = packageJson.build?.extraResources ?? []
+  assert.ok(resources.some((entry) => entry.from === "../bridge/src" && entry.to === "bridge-runtime/src"))
+  assert.ok(resources.some((entry) => entry.from === "../bridge/package.json" && entry.to === "bridge-runtime/package.json"))
+})
+
 test("builds a loopback-only authenticated daemon launch contract", () => {
   assert.deepEqual(embeddedDaemonArgs(4100, 4101, "desktop-user", "desktop-pass"), [
     "--host", "127.0.0.1",
@@ -41,16 +48,16 @@ test("builds a loopback-only authenticated daemon launch contract", () => {
 })
 
 test("skips a loopback port that is already occupied", async () => {
+  const base = await findLoopbackPort(55_000, [], 1_000)
   const occupied = createServer()
   await new Promise((resolve, reject) => {
     occupied.once("error", reject)
-    occupied.listen(0, EMBEDDED_DAEMON_HOST, resolve)
+    occupied.listen(base, EMBEDDED_DAEMON_HOST, resolve)
   })
-  const address = occupied.address()
-  assert.ok(address && typeof address === "object")
   try {
-    const selected = await findLoopbackPort(address.port, [], 2)
-    assert.equal(selected, address.port + 1)
+    const selected = await findLoopbackPort(base, [], 16)
+    assert.notEqual(selected, base)
+    assert.ok(selected > base)
   } finally {
     await new Promise((resolve) => occupied.close(resolve))
   }

--- a/web/electron/embedded-daemon.test.mjs
+++ b/web/electron/embedded-daemon.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { createServer } from "node:net"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import test from "node:test"
+
+const {
+  EMBEDDED_DAEMON_HOST,
+  EMBEDDED_DAEMON_PROFILE_ID,
+  EmbeddedDaemonRuntime,
+  embeddedDaemonArgs,
+  embeddedDaemonEntry,
+  embeddedDaemonEnvironment,
+  findLoopbackPort
+} = await import("../dist-electron/electron/embedded-daemon.js")
+
+test("resolves the daemon entry inside source checkout and packaged resources", () => {
+  assert.equal(
+    embeddedDaemonEntry({ isPackaged: false, appPath: "/repo/web", resourcesPath: "/unused" }),
+    join("/repo/web", "..", "bridge", "src", "daemon-cli.js")
+  )
+  assert.equal(
+    embeddedDaemonEntry({ isPackaged: true, appPath: "/unused", resourcesPath: "/app/resources" }),
+    join("/app/resources", "bridge-runtime", "src", "daemon-cli.js")
+  )
+})
+
+test("builds a loopback-only authenticated daemon launch contract", () => {
+  assert.deepEqual(embeddedDaemonArgs(4100, 4101, "desktop-user", "desktop-pass"), [
+    "--host", "127.0.0.1",
+    "--port", "4100",
+    "--opencode-host", "127.0.0.1",
+    "--opencode-port", "4101",
+    "--username", "desktop-user",
+    "--password", "desktop-pass"
+  ])
+  const env = embeddedDaemonEnvironment({ PATH: "/bin" })
+  assert.equal(env.ELECTRON_RUN_AS_NODE, "1")
+  assert.equal(env.PATH, "/bin")
+})
+
+test("skips a loopback port that is already occupied", async () => {
+  const occupied = createServer()
+  await new Promise((resolve, reject) => {
+    occupied.once("error", reject)
+    occupied.listen(0, EMBEDDED_DAEMON_HOST, resolve)
+  })
+  const address = occupied.address()
+  assert.ok(address && typeof address === "object")
+  try {
+    const selected = await findLoopbackPort(address.port, [], 2)
+    assert.equal(selected, address.port + 1)
+  } finally {
+    await new Promise((resolve) => occupied.close(resolve))
+  }
+})
+
+test("owns one embedded daemon process from readiness through clean shutdown", async () => {
+  const root = await mkdtemp(join(tmpdir(), "hr-embedded-daemon-"))
+  const script = join(root, "fake-daemon.mjs")
+  await writeFile(script, `
+const portIndex = process.argv.indexOf("--port")
+const port = process.argv[portIndex + 1]
+process.stdout.write("Harness daemon ready at http://127.0.0.1:" + port + "\\n")
+const timer = setInterval(() => {}, 1000)
+process.on("SIGTERM", () => { clearInterval(timer); process.exit(0) })
+`, "utf8")
+
+  const runtime = new EmbeddedDaemonRuntime({
+    entryPath: script,
+    startupTimeoutMs: 2_000,
+    shutdownTimeoutMs: 2_000
+  })
+  try {
+    const first = await runtime.start()
+    const second = await runtime.start()
+    assert.equal(runtime.isRunning, true)
+    assert.equal(first.pid, second.pid)
+    assert.equal(first.endpoint.id, EMBEDDED_DAEMON_PROFILE_ID)
+    assert.equal(first.endpoint.host, EMBEDDED_DAEMON_HOST)
+    assert.ok(first.endpoint.port >= 4097)
+    assert.equal(first.endpoint.username, "harness-desktop")
+    assert.ok(first.endpoint.password.length >= 24)
+    await runtime.stop()
+    assert.equal(runtime.isRunning, false)
+  } finally {
+    await runtime.stop()
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test("surfaces an early daemon failure without leaking a permanently running child", async () => {
+  const root = await mkdtemp(join(tmpdir(), "hr-embedded-daemon-failure-"))
+  const script = join(root, "failing-daemon.mjs")
+  await writeFile(script, `process.stderr.write("no supported harness found\\n"); process.exit(2)\n`, "utf8")
+  const runtime = new EmbeddedDaemonRuntime({ entryPath: script, startupTimeoutMs: 2_000 })
+  try {
+    await assert.rejects(runtime.start(), /no supported harness found/i)
+    assert.equal(runtime.isRunning, false)
+  } finally {
+    await runtime.stop()
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/web/electron/embedded-daemon.ts
+++ b/web/electron/embedded-daemon.ts
@@ -201,7 +201,7 @@ export class EmbeddedDaemonRuntime {
         resolve()
       }
       const timer = setTimeout(() => {
-        if (child.exitCode === null && !child.killed) child.kill("SIGKILL")
+        if (child.exitCode === null) child.kill("SIGKILL")
         finish()
       }, shutdownTimeoutMs)
       timer.unref?.()

--- a/web/electron/embedded-daemon.ts
+++ b/web/electron/embedded-daemon.ts
@@ -34,19 +34,29 @@ export function embeddedDaemonEntry({ isPackaged, appPath, resourcesPath }: Embe
     : join(appPath, "..", "bridge", "src", "daemon-cli.js")
 }
 
-export function embeddedDaemonArgs(port: number, openCodePort: number, username: string, password: string): string[] {
+export function embeddedDaemonArgs(port: number, openCodePort: number): string[] {
   return [
     "--host", EMBEDDED_DAEMON_HOST,
     "--port", String(port),
     "--opencode-host", EMBEDDED_DAEMON_HOST,
-    "--opencode-port", String(openCodePort),
-    "--username", username,
-    "--password", password
+    "--opencode-port", String(openCodePort)
   ]
 }
 
-export function embeddedDaemonEnvironment(environment: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
-  return { ...environment, ELECTRON_RUN_AS_NODE: "1" }
+export function embeddedDaemonEnvironment(
+  environment: NodeJS.ProcessEnv = process.env,
+  auth?: { username: string; password: string }
+): NodeJS.ProcessEnv {
+  return {
+    ...environment,
+    ELECTRON_RUN_AS_NODE: "1",
+    ...(auth
+      ? {
+          HARNESS_REMOTE_USERNAME: auth.username,
+          HARNESS_REMOTE_PASSWORD: auth.password
+        }
+      : {})
+  }
 }
 
 export async function findLoopbackPort(startPort: number, excluded: readonly number[] = [], attempts = 64): Promise<number> {
@@ -115,9 +125,9 @@ export class EmbeddedDaemonRuntime {
     const port = await findLoopbackPort(4097)
     const openCodePort = await findLoopbackPort(4096, [port])
     const auth = credentials()
-    const args = embeddedDaemonArgs(port, openCodePort, auth.username, auth.password)
+    const args = embeddedDaemonArgs(port, openCodePort)
     const child = spawn(this.options.executable ?? process.execPath, [this.options.entryPath, ...args], {
-      env: embeddedDaemonEnvironment(this.options.environment),
+      env: embeddedDaemonEnvironment(this.options.environment, auth),
       stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true
     })

--- a/web/electron/embedded-daemon.ts
+++ b/web/electron/embedded-daemon.ts
@@ -1,0 +1,216 @@
+import { spawn, type ChildProcess } from "node:child_process"
+import { randomBytes } from "node:crypto"
+import { createServer } from "node:net"
+import { join } from "node:path"
+
+export const EMBEDDED_DAEMON_HOST = "127.0.0.1"
+export const EMBEDDED_DAEMON_PROFILE_ID = "desktop-local-runtime"
+const DEFAULT_STARTUP_TIMEOUT_MS = 30_000
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 5_000
+const MAX_CAPTURED_STDERR = 4_096
+
+export type EmbeddedDaemonEndpoint = {
+  id: typeof EMBEDDED_DAEMON_PROFILE_ID
+  host: typeof EMBEDDED_DAEMON_HOST
+  port: number
+  username: string
+  password: string
+}
+
+export type EmbeddedDaemonReady = {
+  endpoint: EmbeddedDaemonEndpoint
+  pid: number | null
+}
+
+export type EmbeddedDaemonPathOptions = {
+  isPackaged: boolean
+  appPath: string
+  resourcesPath: string
+}
+
+export function embeddedDaemonEntry({ isPackaged, appPath, resourcesPath }: EmbeddedDaemonPathOptions): string {
+  return isPackaged
+    ? join(resourcesPath, "bridge-runtime", "src", "daemon-cli.js")
+    : join(appPath, "..", "bridge", "src", "daemon-cli.js")
+}
+
+export function embeddedDaemonArgs(port: number, openCodePort: number, username: string, password: string): string[] {
+  return [
+    "--host", EMBEDDED_DAEMON_HOST,
+    "--port", String(port),
+    "--opencode-host", EMBEDDED_DAEMON_HOST,
+    "--opencode-port", String(openCodePort),
+    "--username", username,
+    "--password", password
+  ]
+}
+
+export function embeddedDaemonEnvironment(environment: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  return { ...environment, ELECTRON_RUN_AS_NODE: "1" }
+}
+
+export async function findLoopbackPort(startPort: number, excluded: readonly number[] = [], attempts = 64): Promise<number> {
+  const excludedPorts = new Set(excluded)
+  for (let offset = 0; offset < attempts; offset += 1) {
+    const port = startPort + offset
+    if (port > 65_535) break
+    if (excludedPorts.has(port)) continue
+    if (await canBindLoopback(port)) return port
+  }
+  throw new Error(`No free loopback port found from ${startPort} through ${Math.min(65_535, startPort + attempts - 1)}`)
+}
+
+function canBindLoopback(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const probe = createServer()
+    probe.unref()
+    probe.once("error", () => resolve(false))
+    probe.listen(port, EMBEDDED_DAEMON_HOST, () => probe.close(() => resolve(true)))
+  })
+}
+
+function credentials(): { username: string; password: string } {
+  return {
+    username: "harness-desktop",
+    password: randomBytes(24).toString("base64url")
+  }
+}
+
+function appendTail(current: string, chunk: Buffer | string): string {
+  return `${current}${chunk.toString()}`.slice(-MAX_CAPTURED_STDERR)
+}
+
+function cleanErrorDetail(value: string): string {
+  const lines = value.trim().split(/\r?\n/).map((line) => line.trim()).filter(Boolean)
+  return lines.slice(-3).join(" | ").slice(0, 1_000)
+}
+
+export class EmbeddedDaemonRuntime {
+  private child: ChildProcess | undefined
+  private ready: EmbeddedDaemonReady | undefined
+  private starting: Promise<EmbeddedDaemonReady> | undefined
+
+  constructor(private readonly options: {
+    entryPath: string
+    executable?: string
+    environment?: NodeJS.ProcessEnv
+    startupTimeoutMs?: number
+    shutdownTimeoutMs?: number
+  }) {}
+
+  get isRunning(): boolean {
+    return Boolean(this.child && this.child.exitCode === null && !this.child.killed && this.ready)
+  }
+
+  start(): Promise<EmbeddedDaemonReady> {
+    if (this.ready && this.isRunning) return Promise.resolve(this.ready)
+    if (this.starting) return this.starting
+    this.starting = this.launch().finally(() => {
+      this.starting = undefined
+    })
+    return this.starting
+  }
+
+  private async launch(): Promise<EmbeddedDaemonReady> {
+    const port = await findLoopbackPort(4097)
+    const openCodePort = await findLoopbackPort(4096, [port])
+    const auth = credentials()
+    const args = embeddedDaemonArgs(port, openCodePort, auth.username, auth.password)
+    const child = spawn(this.options.executable ?? process.execPath, [this.options.entryPath, ...args], {
+      env: embeddedDaemonEnvironment(this.options.environment),
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true
+    })
+    this.child = child
+    let stderr = ""
+    child.stderr?.on("data", (chunk) => { stderr = appendTail(stderr, chunk) })
+
+    const readyMarker = `Harness daemon ready at http://${EMBEDDED_DAEMON_HOST}:${port}`
+    const startupTimeoutMs = this.options.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS
+    try {
+      await new Promise<void>((resolve, reject) => {
+        let stdout = ""
+        let settled = false
+        const finish = (error?: Error) => {
+          if (settled) return
+          settled = true
+          clearTimeout(timer)
+          child.stdout?.off("data", onStdout)
+          child.off("error", onError)
+          child.off("exit", onExit)
+          if (error) reject(error)
+          else resolve()
+        }
+        const onStdout = (chunk: Buffer | string) => {
+          stdout = `${stdout}${chunk.toString()}`.slice(-8_192)
+          if (stdout.includes(readyMarker)) finish()
+        }
+        const onError = (error: Error) => finish(new Error(`Embedded daemon failed to start: ${error.message}`))
+        const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+          const detail = cleanErrorDetail(stderr)
+          const suffix = detail ? `: ${detail}` : ""
+          finish(new Error(`Embedded daemon exited before ready (${code ?? "unknown"}${signal ? `, ${signal}` : ""})${suffix}`))
+        }
+        const timer = setTimeout(() => {
+          const detail = cleanErrorDetail(stderr)
+          finish(new Error(`Embedded daemon did not become ready within ${startupTimeoutMs}ms${detail ? `: ${detail}` : ""}`))
+        }, startupTimeoutMs)
+        timer.unref?.()
+        child.stdout?.on("data", onStdout)
+        child.once("error", onError)
+        child.once("exit", onExit)
+      })
+    } catch (error) {
+      if (this.child === child) this.child = undefined
+      if (!child.killed && child.exitCode === null) child.kill("SIGTERM")
+      throw error
+    }
+
+    const result: EmbeddedDaemonReady = {
+      endpoint: {
+        id: EMBEDDED_DAEMON_PROFILE_ID,
+        host: EMBEDDED_DAEMON_HOST,
+        port,
+        username: auth.username,
+        password: auth.password
+      },
+      pid: child.pid ?? null
+    }
+    this.ready = result
+    child.once("exit", () => {
+      if (this.child === child) this.child = undefined
+      if (this.ready === result) this.ready = undefined
+    })
+    return result
+  }
+
+  async stop(): Promise<void> {
+    const child = this.child
+    this.child = undefined
+    this.ready = undefined
+    if (!child || child.exitCode !== null) return
+
+    const shutdownTimeoutMs = this.options.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS
+    await new Promise<void>((resolve) => {
+      let settled = false
+      const finish = () => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        child.off("exit", finish)
+        resolve()
+      }
+      const timer = setTimeout(() => {
+        if (child.exitCode === null && !child.killed) child.kill("SIGKILL")
+        finish()
+      }, shutdownTimeoutMs)
+      timer.unref?.()
+      child.once("exit", finish)
+      if (child.exitCode !== null) {
+        finish()
+        return
+      }
+      child.kill("SIGTERM")
+    })
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -46,7 +46,7 @@
     "test:ci:baseline": "npm run test:i18n && npm run test:config && npm run test:ui && npm run test:settings && npm run test:model && npm run test:events && npm run test:profiles",
     "test:ci:pages": "npm run test:ci:baseline && npm run test:attachments",
     "test:ci:desktop": "npm run test:i18n && npm run test:config && npm run test:ui && npm run test:settings && npm run test:platform && npm run test:model && npm run test:events && npm run test:profiles && npm run test:desktop",
-    "test:ci:full": "npm run test:i18n && npm run test:config && npm run test:ui && npm run test:settings && npm run test:v3-product-ui && npm run test:model && npm run test:events && npm run test:profiles && npm run test:attachments && npm run test:machine-payload && npm run test:platform && npm run test:completion-audio && npm run test:completion-timing && npm run test:native-response && node src/v3-mobile-regression-fixes.test.mjs && node src/session-first-regression.test.mjs && node scripts/run-vite-test.mjs src/native-session-discovery.test.mjs src/native-session-continuation.test.mjs src/native-session-machine-id-migration.test.mjs src/native-session-handoff-recovery.test.mjs && node scripts/run-vite-test.mjs src/omp-session-multi-turn.test.mjs src/omp-session-model-projection.test.mjs && node src/native-session-observer.test.mjs && npm run test:native-session-model-lifecycle"
+    "test:ci:full": "npm run test:i18n && npm run test:config && npm run test:ui && npm run test:settings && npm run test:v3-product-ui && npm run test:model && npm run test:events && npm run test:profiles && npm run test:attachments && npm run test:machine-payload && npm run test:platform && npm run test:completion-audio && npm run test:completion-timing && npm run test:native-response && node src/v3-mobile-regression-fixes.test.mjs && node src/session-first-regression.test.mjs && node scripts/run-vite-test.mjs src/native-session-discovery.test.mjs src/native-session-continuation.test.mjs src/native-session-machine-id-migration.test.mjs src/native-session-handoff-recovery.test.mjs && node scripts/run-vite-test.mjs src/omp-session-multi-turn.test.mjs src/omp-session-model-projection.test.mjs && node src/native-session-observer.test.mjs && npm run test:native-session-model-lifecycle && npm run test:desktop"
   },
   "build": {
     "appId": "com.harnessremote.desktop",
@@ -63,6 +63,17 @@
       "!node_modules/**/*",
       "!**/*.map",
       "!**/*.test.*"
+    ],
+    "extraResources": [
+      {
+        "from": "../bridge/src",
+        "to": "bridge-runtime/src",
+        "filter": ["**/*"]
+      },
+      {
+        "from": "../bridge/package.json",
+        "to": "bridge-runtime/package.json"
+      }
     ],
     "win": {
       "target": [


### PR DESCRIPTION
## Scope

First P1 self-contained-desktop slice. Foundation only: process ownership, packaging and cross-platform regression coverage. No renderer/workspace injection yet, no Native Session semantics change, and no external-machine behavior change.

Target is **only** `codex/development-2026-09-11`. `main` must remain untouched.

## Why

Today the Electron app is only a client/proxy. Packaged desktop builds do not contain the Harness Remote daemon runtime and therefore cannot own the local-machine backend lifecycle required by #369.

## Change

- add an Electron-side `EmbeddedDaemonRuntime` abstraction that:
  - resolves source-checkout vs packaged daemon entry paths;
  - selects free loopback ports for the machine daemon and managed OpenCode;
  - generates ephemeral local Basic Auth credentials;
  - keeps those credentials out of process arguments and supplies them only to the child environment;
  - launches the daemon with Electron's executable in `ELECTRON_RUN_AS_NODE=1` mode;
  - waits for the existing daemon readiness contract;
  - surfaces early startup failure with bounded stderr evidence;
  - provides idempotent start and deterministic shutdown with SIGKILL escalation;
- package `bridge/src` plus the bridge ESM package metadata into desktop `extraResources` as `bridge-runtime`;
- add lifecycle, port, path, packaging, credential-boundary and failure regression tests;
- make `test:desktop` part of the universal `test:ci:full` gate;
- extend the path-scoped desktop workflow so desktop unit tests run on both macOS and Windows, while the native menu smoke remains macOS-only;
- on Windows, build a real unpacked Electron app and assert the embedded daemon entrypoint and bridge package metadata are physically present under `resources/bridge-runtime`.

## Deliberate boundary

This PR does **not** start the embedded daemon from `electron/main.ts` and does not add a local machine to the renderer yet. That is the next slice after this lifecycle/packaging contract proves green across platforms. This avoids exposing an unmanaged local WorkspaceMachine before daemon ownership itself is stable.

## Merge rule

Merge only into `codex/development-2026-09-11` after the complete CI is green on the final head. Never merge into `main`.

Refs #369