### PR TITLE
fix(P1): recover shell PATH for packaged desktop runtime

### DIFF
--- a/docs/desktop-local-runtime.md
+++ b/docs/desktop-local-runtime.md
@@ -1,0 +1,13 @@
+# Desktop local runtime
+
+Harness Remote Desktop owns the local embedded daemon for the machine on which the desktop app is running. Remote machines continue to use their own independently authoritative daemon/runtime.
+
+## Executable discovery
+
+GUI-launched applications on macOS and Linux can inherit a narrower `PATH` than the user's terminal. That can make an installed Codex, Claude, OpenCode, OMP or PI executable invisible to the embedded daemon even though it works from the user's shell.
+
+Before each embedded-daemon start or retry, the desktop main process asks the user's login shell for its exported `PATH`. The command is static, bounded by a short timeout and delimited so shell startup output cannot be mistaken for the value. Only `PATH` is imported; the rest of the shell environment is ignored. The discovered directories are placed before, and merged with, the `PATH` already inherited by Electron.
+
+If shell discovery fails or times out, startup continues with the inherited Electron environment. Windows keeps its native process environment and does not perform shell discovery.
+
+This recovery is deliberately part of daemon start/retry rather than application startup, so a user can install or expose a harness and retry the local runtime without restarting Harness Remote Desktop.

--- a/web/electron/embedded-daemon-environment-provider.test.mjs
+++ b/web/electron/embedded-daemon-environment-provider.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import test from "node:test"
+
+const { EmbeddedDaemonRuntime } = await import("../dist-electron/electron/embedded-daemon.js")
+
+test("awaits a fresh environment provider before each embedded daemon launch", async () => {
+  const root = await mkdtemp(join(tmpdir(), "hr-embedded-daemon-env-"))
+  const script = join(root, "fake-daemon.mjs")
+  await writeFile(script, `
+const port = process.argv[process.argv.indexOf("--port") + 1]
+if (process.env.HARNESS_REMOTE_ENV_PROVIDER_SENTINEL !== "ready") process.exit(12)
+process.stdout.write("Harness daemon ready at http://127.0.0.1:" + port + "\\n")
+const timer = setInterval(() => {}, 1000)
+process.on("SIGTERM", () => { clearInterval(timer); process.exit(0) })
+`, "utf8")
+
+  let calls = 0
+  const runtime = new EmbeddedDaemonRuntime({
+    entryPath: script,
+    environment: async () => {
+      calls += 1
+      return { ...process.env, HARNESS_REMOTE_ENV_PROVIDER_SENTINEL: "ready" }
+    },
+    startupTimeoutMs: 2_000,
+    shutdownTimeoutMs: 2_000
+  })
+
+  try {
+    await runtime.start()
+    assert.equal(calls, 1)
+    await runtime.stop()
+    await runtime.start()
+    assert.equal(calls, 2, "a retry/restart must refresh PATH rather than reusing a stale environment")
+  } finally {
+    await runtime.stop()
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/web/electron/embedded-daemon.ts
+++ b/web/electron/embedded-daemon.ts
@@ -33,6 +33,8 @@ export type EmbeddedDaemonPathOptions = {
   resourcesPath: string
 }
 
+type EmbeddedDaemonEnvironment = NodeJS.ProcessEnv | (() => Promise<NodeJS.ProcessEnv>)
+
 export function embeddedDaemonEntry({ isPackaged, appPath, resourcesPath }: EmbeddedDaemonPathOptions): string {
   return isPackaged
     ? join(resourcesPath, "bridge-runtime", "src", "daemon-cli.js")
@@ -63,6 +65,13 @@ export function embeddedDaemonEnvironment(
         }
       : {})
   }
+}
+
+export async function resolveEmbeddedDaemonEnvironment(
+  environment: EmbeddedDaemonEnvironment | undefined
+): Promise<NodeJS.ProcessEnv> {
+  if (typeof environment === "function") return await environment()
+  return environment ?? process.env
 }
 
 export async function findLoopbackPort(startPort: number, excluded: readonly number[] = [], attempts = 64): Promise<number> {
@@ -109,7 +118,7 @@ export class EmbeddedDaemonRuntime {
   constructor(private readonly options: {
     entryPath: string
     executable?: string
-    environment?: NodeJS.ProcessEnv
+    environment?: EmbeddedDaemonEnvironment
     stateDirectory?: string
     startupTimeoutMs?: number
     shutdownTimeoutMs?: number
@@ -130,12 +139,13 @@ export class EmbeddedDaemonRuntime {
   }
 
   private async launch(): Promise<EmbeddedDaemonReady> {
+    const environment = await resolveEmbeddedDaemonEnvironment(this.options.environment)
     const port = await findLoopbackPort(4097)
     const openCodePort = await findLoopbackPort(4096, [port])
     const auth = credentials()
     const args = embeddedDaemonArgs(port, openCodePort, this.options.stateDirectory)
     const child = spawn(this.options.executable ?? process.execPath, [this.options.entryPath, ...args], {
-      env: embeddedDaemonEnvironment(this.options.environment, auth),
+      env: embeddedDaemonEnvironment(environment, auth),
       stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true
     })

--- a/web/electron/main.ts
+++ b/web/electron/main.ts
@@ -8,6 +8,7 @@ import { DesktopEventTransport } from "./event-transport.js"
 import { IPC_CHANNELS, parseDesktopAttentionNotification, parseDesktopMenuTemplate } from "./ipc-contract.js"
 import { DesktopProfileError, ProfileRegistry } from "./profile-registry.js"
 import { executeDesktopRequest } from "./request-transport.js"
+import { resolveDesktopRuntimeEnvironment } from "./shell-path.js"
 import type { DesktopAttentionNotification, DesktopCompletionNotification, DesktopEventSubscriptionOptions, DesktopLocalRuntimeState, DesktopMenuCommand, DesktopRequest } from "./ipc-contract.js"
 import { MIN_WINDOW_HEIGHT, MIN_WINDOW_WIDTH, restoredBounds as calculateRestoredBounds } from "./window-state.js"
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -358,6 +359,10 @@ async function start(): Promise<void> {
       appPath: app.getAppPath(),
       resourcesPath: process.resourcesPath
     }),
+    // Resolve PATH lazily on every start/retry. GUI-launched macOS/Linux apps frequently do not
+    // inherit the user's shell PATH, which is where Codex/Claude/OpenCode/OMP/PI are commonly
+    // installed. The resolver imports PATH only and falls back to process.env on any shell failure.
+    environment: () => resolveDesktopRuntimeEnvironment(),
     stateDirectory: join(app.getPath("userData"), "embedded-daemon"),
     onExit: embeddedDaemonExited
   })

--- a/web/electron/shell-path.test.mjs
+++ b/web/electron/shell-path.test.mjs
@@ -13,6 +13,8 @@ test("extracts only the delimited exported PATH from noisy shell startup output"
     "welcome from shell startup",
     "__HARNESS_REMOTE_PATH_START__",
     "PATH=/opt/homebrew/bin:/Users/me/.local/bin:/usr/bin",
+    "HOME=/shell/home/that/must/not/be/imported",
+    "SECRET_FROM_SHELL=must-not-leak",
     "__HARNESS_REMOTE_PATH_END__",
     "trailing shell output"
   ].join("\n")

--- a/web/electron/shell-path.test.mjs
+++ b/web/electron/shell-path.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test"
 const {
   mergeExecutablePath,
   parseLoginShellPathOutput,
+  readLoginShellPath,
   resolveDesktopRuntimeEnvironment
 } = await import("../dist-electron/electron/shell-path.js")
 
@@ -84,4 +85,15 @@ test("Windows keeps its native process environment and never starts shell discov
   })
   assert.equal(called, false)
   assert.deepEqual(resolved, inherited)
+})
+
+test("a real POSIX login shell emits a usable exported PATH", { skip: process.platform === "win32" }, async () => {
+  const discovered = await readLoginShellPath(process.env, {
+    platform: process.platform,
+    shell: "/bin/sh",
+    timeoutMs: 2_000
+  })
+  assert.equal(typeof discovered, "string")
+  assert.ok(discovered.length > 0)
+  assert.equal(discovered.includes("\n"), false)
 })

--- a/web/electron/shell-path.test.mjs
+++ b/web/electron/shell-path.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+const {
+  mergeExecutablePath,
+  parseLoginShellPathOutput,
+  resolveDesktopRuntimeEnvironment
+} = await import("../dist-electron/electron/shell-path.js")
+
+test("extracts only the delimited PATH from noisy shell startup output", () => {
+  const output = [
+    "welcome from shell startup",
+    "__HARNESS_REMOTE_PATH_START__/opt/homebrew/bin:/Users/me/.local/bin:/usr/bin__HARNESS_REMOTE_PATH_END__",
+    "trailing shell output"
+  ].join("\n")
+  assert.equal(
+    parseLoginShellPathOutput(output),
+    "/opt/homebrew/bin:/Users/me/.local/bin:/usr/bin"
+  )
+  assert.equal(parseLoginShellPathOutput("PATH=/untrusted/no-marker"), undefined)
+  assert.equal(parseLoginShellPathOutput("__HARNESS_REMOTE_PATH_START__/bin\n/evil__HARNESS_REMOTE_PATH_END__"), undefined)
+})
+
+test("merges shell PATH first without losing inherited executable directories", () => {
+  assert.equal(
+    mergeExecutablePath("/opt/homebrew/bin:/usr/local/bin:/usr/bin", "/usr/bin:/bin", ":"),
+    "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+  )
+  assert.equal(mergeExecutablePath(undefined, "/usr/bin:/bin", ":"), "/usr/bin:/bin")
+  assert.equal(mergeExecutablePath("/opt/bin;;/usr/bin", "/usr/bin;;/bin", ";"), "/opt/bin;/usr/bin;/bin")
+})
+
+test("desktop runtime imports only the discovered PATH and preserves the inherited environment", async () => {
+  const inherited = {
+    PATH: "/usr/bin:/bin",
+    HOME: "/Users/example",
+    HARNESS_REMOTE_TEST_SECRET: "keep-me"
+  }
+  let readerEnvironment
+  const resolved = await resolveDesktopRuntimeEnvironment(inherited, {
+    platform: "darwin",
+    delimiter: ":",
+    readShellPath: async (environment) => {
+      readerEnvironment = environment
+      return "/opt/homebrew/bin:/usr/bin"
+    }
+  })
+
+  assert.equal(readerEnvironment, inherited)
+  assert.deepEqual(resolved, {
+    PATH: "/opt/homebrew/bin:/usr/bin:/bin",
+    HOME: "/Users/example",
+    HARNESS_REMOTE_TEST_SECRET: "keep-me"
+  })
+})
+
+test("shell discovery failure falls back to the inherited environment", async () => {
+  const inherited = { PATH: "/usr/bin:/bin", HOME: "/home/example" }
+  const resolved = await resolveDesktopRuntimeEnvironment(inherited, {
+    platform: "linux",
+    delimiter: ":",
+    readShellPath: async () => { throw new Error("shell startup failed") }
+  })
+  assert.deepEqual(resolved, inherited)
+  assert.notEqual(resolved, inherited, "the caller receives an isolated environment object")
+})
+
+test("Windows keeps its native process environment and never starts shell discovery", async () => {
+  const inherited = { Path: "C:\\Windows\\System32", HOME: "C:\\Users\\example" }
+  let called = false
+  const resolved = await resolveDesktopRuntimeEnvironment(inherited, {
+    platform: "win32",
+    delimiter: ";",
+    readShellPath: async () => {
+      called = true
+      return "C:\\tools"
+    }
+  })
+  assert.equal(called, false)
+  assert.deepEqual(resolved, inherited)
+})

--- a/web/electron/shell-path.test.mjs
+++ b/web/electron/shell-path.test.mjs
@@ -7,10 +7,12 @@ const {
   resolveDesktopRuntimeEnvironment
 } = await import("../dist-electron/electron/shell-path.js")
 
-test("extracts only the delimited PATH from noisy shell startup output", () => {
+test("extracts only the delimited exported PATH from noisy shell startup output", () => {
   const output = [
     "welcome from shell startup",
-    "__HARNESS_REMOTE_PATH_START__/opt/homebrew/bin:/Users/me/.local/bin:/usr/bin__HARNESS_REMOTE_PATH_END__",
+    "__HARNESS_REMOTE_PATH_START__",
+    "PATH=/opt/homebrew/bin:/Users/me/.local/bin:/usr/bin",
+    "__HARNESS_REMOTE_PATH_END__",
     "trailing shell output"
   ].join("\n")
   assert.equal(
@@ -18,7 +20,11 @@ test("extracts only the delimited PATH from noisy shell startup output", () => {
     "/opt/homebrew/bin:/Users/me/.local/bin:/usr/bin"
   )
   assert.equal(parseLoginShellPathOutput("PATH=/untrusted/no-marker"), undefined)
-  assert.equal(parseLoginShellPathOutput("__HARNESS_REMOTE_PATH_START__/bin\n/evil__HARNESS_REMOTE_PATH_END__"), undefined)
+  assert.equal(parseLoginShellPathOutput([
+    "__HARNESS_REMOTE_PATH_START__",
+    "HOME=/do/not/import",
+    "__HARNESS_REMOTE_PATH_END__"
+  ].join("\n")), undefined)
 })
 
 test("merges shell PATH first without losing inherited executable directories", () => {

--- a/web/electron/shell-path.ts
+++ b/web/electron/shell-path.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process"
+import { spawn, type ChildProcess } from "node:child_process"
 import { userInfo } from "node:os"
 import { delimiter as platformPathDelimiter } from "node:path"
 
@@ -7,9 +7,10 @@ const PATH_END_MARKER = "__HARNESS_REMOTE_PATH_END__"
 const DEFAULT_SHELL_TIMEOUT_MS = 2_000
 const MAX_CAPTURED_STDOUT = 32_768
 
-// Keep this command static. The shell is used only to materialize its effective PATH; no user or
-// repository-controlled value is interpolated into the command string.
-const PRINT_PATH_COMMAND = `printf '${PATH_START_MARKER}%s${PATH_END_MARKER}\\n' "$PATH"`
+// Keep this command static. The shell is used only to materialize its exported PATH; no user or
+// repository-controlled value is interpolated into the command string. Reading PATH through env
+// also avoids shell-specific list semantics (for example Fish exposes PATH internally as a list).
+const PRINT_PATH_COMMAND = `printf '${PATH_START_MARKER}\\n'; /usr/bin/env | /usr/bin/grep '^PATH='; printf '${PATH_END_MARKER}\\n'`
 
 type ShellPathReader = (environment: NodeJS.ProcessEnv) => Promise<string | undefined>
 
@@ -19,7 +20,10 @@ export function parseLoginShellPathOutput(output: string): string | undefined {
   const valueStart = start + PATH_START_MARKER.length
   const end = output.indexOf(PATH_END_MARKER, valueStart)
   if (end < 0) return undefined
-  const value = output.slice(valueStart, end)
+  const block = output.slice(valueStart, end)
+  const pathLine = block.split(/\r?\n/).find((line) => line.startsWith("PATH="))
+  if (!pathLine) return undefined
+  const value = pathLine.slice("PATH=".length)
   if (!value || /[\u0000\r\n]/.test(value)) return undefined
   return value
 }
@@ -42,14 +46,14 @@ export function mergeExecutablePath(
   return values.length > 0 ? values.join(delimiter) : undefined
 }
 
-function loginShell(environment: NodeJS.ProcessEnv): string {
+function loginShell(environment: NodeJS.ProcessEnv, platform: NodeJS.Platform): string {
   try {
     const configured = userInfo().shell
     if (configured) return configured
   } catch {
     // userInfo can fail in unusual sandbox/container setups; SHELL and the platform default remain.
   }
-  return environment.SHELL || (process.platform === "darwin" ? "/bin/zsh" : "/bin/sh")
+  return environment.SHELL || (platform === "darwin" ? "/bin/zsh" : "/bin/sh")
 }
 
 export async function readLoginShellPath(
@@ -58,27 +62,23 @@ export async function readLoginShellPath(
 ): Promise<string | undefined> {
   const platform = options.platform ?? process.platform
   if (platform === "win32") return undefined
-  const shell = options.shell || loginShell(environment)
+  const shell = options.shell || loginShell(environment, platform)
   const timeoutMs = options.timeoutMs ?? DEFAULT_SHELL_TIMEOUT_MS
 
   return await new Promise<string | undefined>((resolve) => {
     let stdout = ""
     let settled = false
-    let child
+    let child: ChildProcess | undefined
+    let timer: NodeJS.Timeout | undefined
     const finish = (value?: string) => {
       if (settled) return
       settled = true
-      clearTimeout(timer)
+      if (timer) clearTimeout(timer)
       child?.stdout?.removeAllListeners("data")
       child?.removeAllListeners("error")
       child?.removeAllListeners("exit")
       resolve(value)
     }
-    const timer = setTimeout(() => {
-      if (child && child.exitCode === null && !child.killed) child.kill("SIGKILL")
-      finish()
-    }, timeoutMs)
-    timer.unref?.()
 
     try {
       child = spawn(shell, ["-ilc", PRINT_PATH_COMMAND], {
@@ -90,6 +90,11 @@ export async function readLoginShellPath(
       finish()
       return
     }
+    timer = setTimeout(() => {
+      if (child && child.exitCode === null && !child.killed) child.kill("SIGKILL")
+      finish()
+    }, timeoutMs)
+    timer.unref?.()
     child.stdout?.on("data", (chunk: Buffer | string) => {
       stdout = `${stdout}${chunk.toString()}`.slice(-MAX_CAPTURED_STDOUT)
     })

--- a/web/electron/shell-path.ts
+++ b/web/electron/shell-path.ts
@@ -1,0 +1,124 @@
+import { spawn } from "node:child_process"
+import { userInfo } from "node:os"
+import { delimiter as platformPathDelimiter } from "node:path"
+
+const PATH_START_MARKER = "__HARNESS_REMOTE_PATH_START__"
+const PATH_END_MARKER = "__HARNESS_REMOTE_PATH_END__"
+const DEFAULT_SHELL_TIMEOUT_MS = 2_000
+const MAX_CAPTURED_STDOUT = 32_768
+
+// Keep this command static. The shell is used only to materialize its effective PATH; no user or
+// repository-controlled value is interpolated into the command string.
+const PRINT_PATH_COMMAND = `printf '${PATH_START_MARKER}%s${PATH_END_MARKER}\\n' "$PATH"`
+
+type ShellPathReader = (environment: NodeJS.ProcessEnv) => Promise<string | undefined>
+
+export function parseLoginShellPathOutput(output: string): string | undefined {
+  const start = output.lastIndexOf(PATH_START_MARKER)
+  if (start < 0) return undefined
+  const valueStart = start + PATH_START_MARKER.length
+  const end = output.indexOf(PATH_END_MARKER, valueStart)
+  if (end < 0) return undefined
+  const value = output.slice(valueStart, end)
+  if (!value || /[\u0000\r\n]/.test(value)) return undefined
+  return value
+}
+
+export function mergeExecutablePath(
+  shellPath: string | undefined,
+  processPath: string | undefined,
+  delimiter = platformPathDelimiter
+): string | undefined {
+  const values: string[] = []
+  const seen = new Set<string>()
+  for (const source of [shellPath, processPath]) {
+    if (!source) continue
+    for (const entry of source.split(delimiter)) {
+      if (!entry || seen.has(entry)) continue
+      seen.add(entry)
+      values.push(entry)
+    }
+  }
+  return values.length > 0 ? values.join(delimiter) : undefined
+}
+
+function loginShell(environment: NodeJS.ProcessEnv): string {
+  try {
+    const configured = userInfo().shell
+    if (configured) return configured
+  } catch {
+    // userInfo can fail in unusual sandbox/container setups; SHELL and the platform default remain.
+  }
+  return environment.SHELL || (process.platform === "darwin" ? "/bin/zsh" : "/bin/sh")
+}
+
+export async function readLoginShellPath(
+  environment: NodeJS.ProcessEnv = process.env,
+  options: { platform?: NodeJS.Platform; timeoutMs?: number; shell?: string } = {}
+): Promise<string | undefined> {
+  const platform = options.platform ?? process.platform
+  if (platform === "win32") return undefined
+  const shell = options.shell || loginShell(environment)
+  const timeoutMs = options.timeoutMs ?? DEFAULT_SHELL_TIMEOUT_MS
+
+  return await new Promise<string | undefined>((resolve) => {
+    let stdout = ""
+    let settled = false
+    let child
+    const finish = (value?: string) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      child?.stdout?.removeAllListeners("data")
+      child?.removeAllListeners("error")
+      child?.removeAllListeners("exit")
+      resolve(value)
+    }
+    const timer = setTimeout(() => {
+      if (child && child.exitCode === null && !child.killed) child.kill("SIGKILL")
+      finish()
+    }, timeoutMs)
+    timer.unref?.()
+
+    try {
+      child = spawn(shell, ["-ilc", PRINT_PATH_COMMAND], {
+        env: environment,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true
+      })
+    } catch {
+      finish()
+      return
+    }
+    child.stdout?.on("data", (chunk: Buffer | string) => {
+      stdout = `${stdout}${chunk.toString()}`.slice(-MAX_CAPTURED_STDOUT)
+    })
+    child.once("error", () => finish())
+    child.once("exit", (code) => finish(code === 0 ? parseLoginShellPathOutput(stdout) : undefined))
+  })
+}
+
+export async function resolveDesktopRuntimeEnvironment(
+  environment: NodeJS.ProcessEnv = process.env,
+  options: {
+    platform?: NodeJS.Platform
+    delimiter?: string
+    readShellPath?: ShellPathReader
+  } = {}
+): Promise<NodeJS.ProcessEnv> {
+  const platform = options.platform ?? process.platform
+  const resolved = { ...environment }
+  if (platform === "win32") return resolved
+
+  let shellPath: string | undefined
+  try {
+    shellPath = await (options.readShellPath ?? ((env) => readLoginShellPath(env, { platform })))(environment)
+  } catch {
+    // Discovery is a reliability enhancement, never a startup dependency. The inherited PATH remains
+    // usable for terminals, CI and machines whose shell startup is slow or intentionally unusual.
+    return resolved
+  }
+  const mergedPath = mergeExecutablePath(shellPath, environment.PATH, options.delimiter)
+  if (mergedPath) resolved.PATH = mergedPath
+  return resolved
+}

--- a/web/electron/shell-path.ts
+++ b/web/electron/shell-path.ts
@@ -31,7 +31,7 @@ export function parseLoginShellPathOutput(output: string): string | undefined {
 export function mergeExecutablePath(
   shellPath: string | undefined,
   processPath: string | undefined,
-  delimiter = platformPathDelimiter
+  delimiter: string = platformPathDelimiter
 ): string | undefined {
   const values: string[] = []
   const seen = new Set<string>()


### PR DESCRIPTION
## Scope

Follow-up P1 reliability slice for the self-contained desktop runtime. Packaged GUI apps on macOS/Linux can inherit a narrower PATH than the user's shell, making installed harness CLIs invisible even though they work in Terminal.

Target is **only** `codex/development-2026-09-11`. `main` must remain untouched.

## Change

- recover the login shell's exported `PATH` before each embedded-daemon start/retry on macOS/Linux;
- use a static bounded shell command with explicit markers and a 2s timeout;
- read exported PATH via `/usr/bin/env | /usr/bin/grep '^PATH='` so Fish/list-style PATH semantics do not truncate discovery;
- merge shell PATH first with Electron's inherited PATH, deduplicating entries without losing inherited executable directories;
- import **only PATH** from the shell; no other shell environment variables are adopted;
- fail open to Electron's inherited environment if shell startup, parsing or timeout fails;
- leave Windows environment behavior unchanged;
- resolve the environment lazily on every daemon launch, so Retry can pick up a newly installed/exposed harness without restarting the desktop app;
- document the desktop executable-discovery contract.

## Validation added

- noisy shell output / marker parsing;
- no-shell-env leakage beyond PATH;
- PATH merge/deduplication;
- discovery failure fallback;
- Windows no-op behavior;
- real POSIX login-shell discovery on macOS/Linux CI;
- async environment provider is refreshed and actually reaches each embedded daemon launch.

No bridge/ACP/provider/session protocol behavior is changed.

Merge only after complete CI is green on the final head.

Refs #369