### PR TITLE
test(P1): verify embedded daemon from packaged macOS app

### DIFF
--- a/.github/workflows/desktop-menu.yml
+++ b/.github/workflows/desktop-menu.yml
@@ -73,6 +73,39 @@ jobs:
             Remove-Item Env:ELECTRON_RUN_AS_NODE -ErrorAction SilentlyContinue
           }
 
+      # Keep the PR smoke cheap: build an unpacked app for the runner's architecture instead of the
+      # release workflow's DMG/ZIP matrix, then execute the daemon from the exact Resources layout
+      # used by packaged macOS builds. This catches missing extraResources/module-graph regressions
+      # without duplicating release artifact production on every desktop PR.
+      - name: Verify embedded daemon runs from packaged macOS app
+        if: runner.os == 'macOS'
+        shell: bash
+        working-directory: web
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+        run: |
+          set -euo pipefail
+          case "$(uname -m)" in
+            arm64) arch_flag=--arm64 ;;
+            x86_64) arch_flag=--x64 ;;
+            *) echo "Unsupported macOS runner architecture: $(uname -m)" >&2; exit 1 ;;
+          esac
+          npm run build:desktop
+          npx electron-builder --publish never --mac dir "$arch_flag"
+          app_bundle="$(find release -type d -name 'Harness Remote.app' -print -quit)"
+          if [ -z "$app_bundle" ]; then
+            echo "Packaged macOS app bundle was not produced." >&2
+            exit 1
+          fi
+          resources="$app_bundle/Contents/Resources"
+          daemon="$resources/bridge-runtime/src/daemon-cli.js"
+          package="$resources/bridge-runtime/package.json"
+          electron="$app_bundle/Contents/MacOS/Harness Remote"
+          test -f "$daemon" || { echo "Packaged desktop is missing embedded daemon: $daemon" >&2; exit 1; }
+          test -f "$package" || { echo "Packaged desktop is missing bridge package metadata: $package" >&2; exit 1; }
+          test -x "$electron" || { echo "Packaged desktop executable is missing or not executable: $electron" >&2; exit 1; }
+          ELECTRON_RUN_AS_NODE=1 "$electron" "$daemon" --backend omp --help
+
       # Boots Electron, installs the real menu and reads it back — the part the unit tests cannot
       # reach, on the platform that actually shows it.
       - name: Verify the application menu installs


### PR DESCRIPTION
## Scope

P1 evidence hardening for the self-contained desktop runtime. The PR desktop gate already executes the embedded daemon from the packaged Windows app, but macOS only covered unit tests and the native application menu. This makes the packaged-runtime claim symmetric across the two desktop runners.

Target is **only** `codex/development-2026-09-11`. `main` must remain untouched.

## Change

- macOS PR desktop gate builds an unpacked `.app` for the runner's current architecture only;
- avoids DMG/ZIP release artifact production to keep the PR smoke focused;
- locates the produced `Harness Remote.app` without assuming `mac` vs `mac-arm64` output directory naming;
- verifies the embedded daemon and bridge package metadata exist under `Contents/Resources/bridge-runtime`;
- verifies the app executable exists and is executable;
- runs the copied daemon with the packaged Electron binary under `ELECTRON_RUN_AS_NODE=1` and `--backend omp --help`, proving the packaged module/bootstrap graph resolves;
- keeps the existing macOS native-menu smoke and Windows packaged-daemon smoke unchanged.

No runtime/UI/ACP/provider/session behavior changes. Workflow-only diff.

Merge only after the complete final-head CI is green.

Refs #369