### PR TITLE
fix(P1): make desktop-owned local machine read-only in manager

### DIFF
--- a/web/src/components/standalone-universal-workspace.tsx
+++ b/web/src/components/standalone-universal-workspace.tsx
@@ -1020,7 +1020,7 @@ function NativeSessionsWorkspace({
                halves are done. It used to end as soon as the machines answered, so the pane invited
                the user to open a Session while the rail beside it was still empty and, for a moment,
                still showing the machine that had failed - which reads as a failed startup rather
-               than one in progress. */}
+               than one in progress. */
             <div className="hr-native-workspace-empty hr-native-startup connecting" role="status" aria-live="polite">
               <LoadingIcon size={28} />
               <span>{t("sf.preparing")}</span>

--- a/web/src/components/standalone-universal-workspace.tsx
+++ b/web/src/components/standalone-universal-workspace.tsx
@@ -41,6 +41,7 @@ import type { MachineSnapshot, Session } from "../types"
 import { subscribeTaskDeskLiveEvents } from "../taskdesk-live-events"
 import {
   createWorkspaceMachine,
+  isDesktopLocalMachine,
   type WorkspaceMachine
 } from "../workspaceMachines"
 import { sameMachineConnection } from "../machineConnection"
@@ -187,7 +188,11 @@ function MachineManager({ machines, onClose, onPersist }: { machines: WorkspaceM
   const [health, setHealth] = useState<Record<string, MachineManagerHealth<MachineSnapshot> | undefined>>({})
   const probeRequestIDs = useRef<Record<string, number>>({})
   const dialogRef = useRef<HTMLElement>(null)
-  const draft = useMemo(() => editingID === "new" ? createWorkspaceMachine() : machines.find((machine) => machine.id === editingID) || null, [editingID, machines])
+  const draft = useMemo(() => {
+    if (editingID === "new") return createWorkspaceMachine()
+    const machine = machines.find((candidate) => candidate.id === editingID)
+    return machine && !isDesktopLocalMachine(machine) ? machine : null
+  }, [editingID, machines])
 
   const probeMachine = useCallback((machine: WorkspaceMachine) => {
     const requestID = (probeRequestIDs.current[machine.id] || 0) + 1
@@ -230,6 +235,7 @@ function MachineManager({ machines, onClose, onPersist }: { machines: WorkspaceM
   useDialogDismiss(dialogRef, onClose)
 
   const save = (machine: WorkspaceMachine) => {
+    if (isDesktopLocalMachine(machine)) return
     if (editingID === "new") onPersist([...machines, machine])
     else onPersist(machines.map((candidate) => candidate.id === machine.id ? machine : candidate))
     setEditingID(null)
@@ -238,6 +244,7 @@ function MachineManager({ machines, onClose, onPersist }: { machines: WorkspaceM
   // window.confirm is a blocking native dialog that the Android WebView renders as a bare,
   // unstyled system alert on top of the app. An inline confirmation stays inside the product.
   const remove = (machine: WorkspaceMachine) => {
+    if (isDesktopLocalMachine(machine)) return
     onPersist(machines.filter((candidate) => candidate.id !== machine.id))
     setConfirmRemoveID(null)
     if (editingID === machine.id) setEditingID(null)
@@ -259,10 +266,12 @@ function MachineManager({ machines, onClose, onPersist }: { machines: WorkspaceM
             const state = check?.state || "checking"
             const snapshot = check?.snapshot
             const error = check?.state === "offline" ? check.error : undefined
+            const runtimeOwned = isDesktopLocalMachine(machine)
             return (
-              <div className="uw-machine-config-card" data-machine-state={state} key={machine.id}>
+              <div className="uw-machine-config-card" data-machine-state={state} data-runtime-owned={runtimeOwned || undefined} key={machine.id}>
                 <div className="uw-machine-config-main">
                   <strong>{snapshot?.machine.name || machine.name}</strong>
+                  {runtimeOwned ? <small className="uw-machine-runtime-owned">Managed by Harness Remote</small> : null}
                   <span>{machine.config.host}:{machine.config.port}</span>
                   <small className={`uw-machine-connection-state ${state}`} aria-live="polite">
                     <i aria-hidden="true" />
@@ -280,7 +289,7 @@ function MachineManager({ machines, onClose, onPersist }: { machines: WorkspaceM
                   {snapshot?.agents.length ? <div className="uw-machine-harness-list">{snapshot.agents.map((agent) => <span className="uw-machine-harness" key={agent.id}><i className={agent.state} aria-hidden="true" /><strong>{agent.label}</strong><small>{machineAgentStateLabel(agent.state)}{agent.processID ? ` · PID ${agent.processID}` : ""}</small></span>)}</div> : null}
                 </div>
                 <div className="uw-machine-config-actions">
-                  {confirmRemoveID === machine.id ? (
+                  {confirmRemoveID === machine.id && !runtimeOwned ? (
                     <>
                       <span className="uw-machine-confirm" role="alert">{t("sf.removeQuestion", { name: machine.name })}</span>
                       <button type="button" className="uw-manager-button" onClick={() => setConfirmRemoveID(null)}>{t("sf.keep")}</button>
@@ -289,8 +298,12 @@ function MachineManager({ machines, onClose, onPersist }: { machines: WorkspaceM
                   ) : (
                     <>
                       {state === "offline" ? <button type="button" className="uw-manager-button" data-machine-retry onClick={() => probeMachine(machine)}>{t("sf.retry")}</button> : null}
-                      <button type="button" className="uw-manager-button" onClick={() => setEditingID(machine.id)}>{t("sf.edit")}</button>
-                      <button type="button" className="uw-manager-button danger" onClick={() => setConfirmRemoveID(machine.id)}>{t("sf.remove")}</button>
+                      {!runtimeOwned ? (
+                        <>
+                          <button type="button" className="uw-manager-button" onClick={() => setEditingID(machine.id)}>{t("sf.edit")}</button>
+                          <button type="button" className="uw-manager-button danger" onClick={() => setConfirmRemoveID(machine.id)}>{t("sf.remove")}</button>
+                        </>
+                      ) : null}
                     </>
                   )}
                 </div>
@@ -1007,7 +1020,7 @@ function NativeSessionsWorkspace({
                halves are done. It used to end as soon as the machines answered, so the pane invited
                the user to open a Session while the rail beside it was still empty and, for a moment,
                still showing the machine that had failed - which reads as a failed startup rather
-               than one in progress. */
+               than one in progress. */}
             <div className="hr-native-workspace-empty hr-native-startup connecting" role="status" aria-live="polite">
               <LoadingIcon size={28} />
               <span>{t("sf.preparing")}</span>

--- a/web/src/taskdesk-home.test.mjs
+++ b/web/src/taskdesk-home.test.mjs
@@ -79,6 +79,18 @@ test("Session-first workspace keeps machines projects harness filters models and
   assert.match(picker, /Search model, provider, variant/)
 })
 
+test("desktop-owned local machine stays visible but cannot be edited or removed", () => {
+  const standalone = read("./components/standalone-universal-workspace.tsx")
+
+  assert.match(standalone, /isDesktopLocalMachine/)
+  assert.match(standalone, /const runtimeOwned = isDesktopLocalMachine\(machine\)/)
+  assert.match(standalone, /data-runtime-owned=\{runtimeOwned \|\| undefined\}/)
+  assert.match(standalone, /Managed by Harness Remote/)
+  assert.match(standalone, /if \(isDesktopLocalMachine\(machine\)\) return[\s\S]*const remove = \(machine: WorkspaceMachine\) => \{[\s\S]*if \(isDesktopLocalMachine\(machine\)\) return/)
+  assert.match(standalone, /\{!runtimeOwned \? \([\s\S]*setEditingID\(machine\.id\)[\s\S]*setConfirmRemoveID\(machine\.id\)[\s\S]*\) : null\}/)
+  assert.match(standalone, /state === "offline" \? <button[^>]*data-machine-retry/, 'runtime-owned machines must keep the normal health retry action')
+})
+
 test("native Session metadata actions belong to the open Session, not the navigation rail", () => {
   const standalone = read("./components/standalone-universal-workspace.tsx")
   const home = read("./components/native-session-home-base.tsx")


### PR DESCRIPTION
## Scope

P1 productization follow-up for the self-contained desktop runtime. `This computer` is a projection of the Electron-owned embedded daemon, not a user-configured remote machine. The lower layers already refuse to persist or overwrite that runtime-owned profile, but the Machine Manager still presented Edit and Remove actions, which falsely suggested those settings were user-owned.

Target is **only** `codex/development-2026-09-11`. `main` must remain untouched.

## Change

- identify the reserved desktop-local machine through the existing `isDesktopLocalMachine()` contract;
- keep the local runtime visible in Machine Manager with normal health, detected harnesses and offline Retry;
- mark the card with `data-runtime-owned` and show `Managed by Harness Remote` so ownership is explicit;
- hide Edit and Remove for the runtime-owned local machine;
- make stale/programmatic edit and remove paths fail closed as defense in depth;
- prevent a stale local runtime ID from opening `MachineEditor`;
- leave normal remote-machine Edit/Remove behavior unchanged.

## Regression guard

The required `test:ui` suite now asserts that the desktop-owned machine remains visible/retriable but cannot enter edit/remove flows.

No daemon, ACP, provider, Session protocol, credential, persistence or remote-machine semantics are changed.

Merge only after complete final-head CI is green.

Refs #369