### PR TITLE
fix(P1): recover stopped embedded desktop daemon

### DIFF
--- a/web/electron/embedded-daemon-process-tree-recovery.test.mjs
+++ b/web/electron/embedded-daemon-process-tree-recovery.test.mjs
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import test from "node:test"
+
+const { EmbeddedDaemonRuntime } = await import("../dist-electron/electron/embedded-daemon.js")
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function readNumber(path) {
+  try { return Number(await readFile(path, "utf8")) || 0 } catch { return 0 }
+}
+
+function processExists(pid) {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    if (error?.code === "ESRCH") return false
+    throw error
+  }
+}
+
+test("hard recovery replaces the daemon process tree instead of leaving a managed child orphaned", {
+  skip: process.platform === "win32" ? "POSIX process-group supervision is tested on POSIX runners" : false
+}, async () => {
+  const root = await mkdtemp(join(tmpdir(), "hr-embedded-daemon-tree-"))
+  const stateDirectory = join(root, "state")
+  const daemonScript = join(root, "daemon.mjs")
+  const holderScript = join(root, "holder.mjs")
+  const generationFile = join(stateDirectory, "generation")
+  const holderPidFile = join(stateDirectory, "holder-pid")
+  const firstInternalPortFile = join(stateDirectory, "internal-port-1")
+  const secondInternalPortFile = join(stateDirectory, "internal-port-2")
+
+  await writeFile(holderScript, `
+import net from "node:net"
+const port = Number(process.argv[2])
+const server = net.createServer()
+server.listen(port, "127.0.0.1", () => process.stdout.write("READY\\n"))
+setInterval(() => {}, 1000)
+`, "utf8")
+
+  await writeFile(daemonScript, `
+import http from "node:http"
+import net from "node:net"
+import { spawn } from "node:child_process"
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+
+const port = Number(process.argv[process.argv.indexOf("--port") + 1])
+const internalPort = Number(process.argv[process.argv.indexOf("--opencode-port") + 1])
+const stateDirectory = process.argv[process.argv.indexOf("--state-dir") + 1]
+mkdirSync(stateDirectory, { recursive: true })
+const generationFile = join(stateDirectory, "generation")
+let generation = 0
+try { generation = Number(readFileSync(generationFile, "utf8")) || 0 } catch {}
+generation += 1
+writeFileSync(generationFile, String(generation))
+writeFileSync(join(stateDirectory, "internal-port-" + generation), String(internalPort))
+
+await new Promise((resolve, reject) => {
+  const probe = net.createServer()
+  probe.once("error", reject)
+  probe.listen(internalPort, "127.0.0.1", () => probe.close(resolve))
+})
+
+if (generation === 1) {
+  const holder = spawn(process.execPath, [${JSON.stringify(holderScript)}, String(internalPort)], {
+    stdio: ["ignore", "pipe", "ignore"]
+  })
+  await new Promise((resolve, reject) => {
+    let stdout = ""
+    const onData = (chunk) => {
+      stdout += String(chunk)
+      if (stdout.includes("READY")) {
+        holder.stdout.off("data", onData)
+        resolve()
+      }
+    }
+    holder.stdout.on("data", onData)
+    holder.once("error", reject)
+    holder.once("exit", (code, signal) => reject(new Error("holder exited before ready: " + (code ?? signal))))
+  })
+  writeFileSync(join(stateDirectory, "holder-pid"), String(holder.pid))
+}
+
+const expectedAuthorization = "Basic " + Buffer.from(process.env.HARNESS_REMOTE_USERNAME + ":" + process.env.HARNESS_REMOTE_PASSWORD).toString("base64")
+const server = http.createServer((request, response) => {
+  if (request.url !== "/v1/machine") { response.writeHead(404); response.end(); return }
+  if (request.headers.authorization !== expectedAuthorization) { response.writeHead(401); response.end(); return }
+  response.writeHead(200, { "Content-Type": "application/json" })
+  response.end(JSON.stringify({ machine: { id: "process-tree-test" }, agents: [] }))
+})
+server.listen(port, "127.0.0.1", () => {
+  process.stdout.write("Harness daemon ready at http://127.0.0.1:" + port + "\\n")
+})
+`, "utf8")
+
+  const exits = []
+  const runtime = new EmbeddedDaemonRuntime({
+    entryPath: daemonScript,
+    stateDirectory,
+    startupTimeoutMs: 2_000,
+    shutdownTimeoutMs: 250,
+    healthCheckIntervalMs: 20,
+    healthCheckTimeoutMs: 30,
+    healthFailureThreshold: 2,
+    recoveryRetryDelayMs: 20,
+    onExit: (details) => exits.push(details)
+  })
+
+  let holderPid = 0
+  try {
+    const first = await runtime.start()
+    holderPid = await readNumber(holderPidFile)
+    const firstInternalPort = await readNumber(firstInternalPortFile)
+    assert.ok(first.pid)
+    assert.ok(holderPid)
+    assert.ok(firstInternalPort)
+    assert.equal(processExists(holderPid), true)
+
+    process.kill(first.pid, "SIGSTOP")
+
+    let currentGeneration = 1
+    for (let index = 0; index < 600 && currentGeneration < 2; index += 1) {
+      assert.equal(runtime.isRunning, true)
+      await sleep(10)
+      currentGeneration = await readNumber(generationFile)
+    }
+    assert.equal(currentGeneration, 2, "health supervision should replace the stopped daemon")
+
+    for (let index = 0; index < 200 && processExists(holderPid); index += 1) await sleep(10)
+    assert.equal(processExists(holderPid), false, "hard recovery must terminate managed descendants with the abandoned daemon")
+
+    const second = await runtime.start()
+    const secondInternalPort = await readNumber(secondInternalPortFile)
+    assert.notEqual(second.pid, first.pid)
+    assert.ok(secondInternalPort)
+    assert.equal(second.endpoint.port, first.endpoint.port, "renderer-facing endpoint must remain stable")
+    assert.equal(second.endpoint.username, first.endpoint.username)
+    assert.equal(second.endpoint.password, first.endpoint.password)
+    assert.equal(await runtime.healthCheck(), true)
+    assert.deepEqual(exits, [])
+  } finally {
+    await runtime.stop()
+    if (holderPid && processExists(holderPid)) {
+      try { process.kill(holderPid, "SIGKILL") } catch {}
+    }
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/web/electron/embedded-daemon-sigstop-recovery.test.mjs
+++ b/web/electron/embedded-daemon-sigstop-recovery.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import test from "node:test"
+
+const { EmbeddedDaemonRuntime } = await import("../dist-electron/electron/embedded-daemon.js")
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function generation(path) {
+  try { return Number(await readFile(path, "utf8")) || 0 } catch { return 0 }
+}
+
+test("recovers a SIGSTOPed embedded daemon without dropping logical runtime liveness", {
+  skip: process.platform === "win32" ? "SIGSTOP is a POSIX-only desktop failure mode" : false
+}, async () => {
+  const root = await mkdtemp(join(tmpdir(), "hr-embedded-daemon-sigstop-"))
+  const script = join(root, "daemon.mjs")
+  const stateDirectory = join(root, "state")
+  const generationFile = join(stateDirectory, "generation")
+  await writeFile(script, `
+import http from "node:http"
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+
+const port = Number(process.argv[process.argv.indexOf("--port") + 1])
+const stateDirectory = process.argv[process.argv.indexOf("--state-dir") + 1]
+mkdirSync(stateDirectory, { recursive: true })
+const generationFile = join(stateDirectory, "generation")
+let generation = 0
+try { generation = Number(readFileSync(generationFile, "utf8")) || 0 } catch {}
+generation += 1
+writeFileSync(generationFile, String(generation))
+const expectedAuthorization = "Basic " + Buffer.from(process.env.HARNESS_REMOTE_USERNAME + ":" + process.env.HARNESS_REMOTE_PASSWORD).toString("base64")
+const server = http.createServer((request, response) => {
+  if (request.url !== "/v1/machine") { response.writeHead(404); response.end(); return }
+  if (request.headers.authorization !== expectedAuthorization) { response.writeHead(401); response.end(); return }
+  response.writeHead(200, { "Content-Type": "application/json" })
+  response.end(JSON.stringify({ machine: { id: "sigstop-test" }, agents: [] }))
+})
+server.listen(port, "127.0.0.1", () => {
+  process.stdout.write("Harness daemon ready at http://127.0.0.1:" + port + "\\n")
+})
+`, "utf8")
+
+  const exits = []
+  const runtime = new EmbeddedDaemonRuntime({
+    entryPath: script,
+    stateDirectory,
+    startupTimeoutMs: 2_000,
+    shutdownTimeoutMs: 250,
+    healthCheckIntervalMs: 20,
+    healthCheckTimeoutMs: 30,
+    healthFailureThreshold: 2,
+    onExit: (details) => exits.push(details)
+  })
+
+  try {
+    const first = await runtime.start()
+    assert.ok(first.pid)
+    assert.equal(await generation(generationFile), 1)
+    process.kill(first.pid, "SIGSTOP")
+
+    let currentGeneration = 1
+    for (let index = 0; index < 600 && currentGeneration < 2; index += 1) {
+      // Electron polls this logical liveness flag while the daemon is being supervised. It must not
+      // interpret the deliberate child replacement window as a permanent local-runtime crash.
+      assert.equal(runtime.isRunning, true)
+      await sleep(10)
+      currentGeneration = await generation(generationFile)
+    }
+    assert.equal(currentGeneration, 2, "health supervision should replace the stopped process")
+
+    const second = await runtime.start()
+    assert.notEqual(second.pid, first.pid)
+    assert.equal(second.endpoint.port, first.endpoint.port)
+    assert.equal(second.endpoint.username, first.endpoint.username)
+    assert.equal(second.endpoint.password, first.endpoint.password)
+    assert.equal(await runtime.healthCheck(), true)
+    assert.deepEqual(exits, [], "successful SIGSTOP recovery must not surface as an unexpected exit")
+  } finally {
+    await runtime.stop()
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/web/electron/embedded-daemon.ts
+++ b/web/electron/embedded-daemon.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from "node:child_process"
+import { spawn, spawnSync, type ChildProcess } from "node:child_process"
 import { randomBytes } from "node:crypto"
 import { createServer } from "node:net"
 import { join } from "node:path"
@@ -11,6 +11,8 @@ const DEFAULT_FORCE_KILL_EXIT_TIMEOUT_MS = 1_000
 const DEFAULT_HEALTH_CHECK_INTERVAL_MS = 10_000
 const DEFAULT_HEALTH_CHECK_TIMEOUT_MS = 2_000
 const DEFAULT_HEALTH_FAILURE_THRESHOLD = 3
+const DEFAULT_RECOVERY_ATTEMPTS = 3
+const DEFAULT_RECOVERY_RETRY_DELAY_MS = 250
 const MAX_CAPTURED_STDERR = 4_096
 
 export type EmbeddedDaemonEndpoint = {
@@ -119,6 +121,10 @@ function cleanErrorDetail(value: string): string {
   return lines.slice(-3).join(" | ").slice(0, 1_000)
 }
 
+function errorMessage(error: unknown): string {
+  return cleanErrorDetail(error instanceof Error ? error.message : String(error)) || "unknown recovery error"
+}
+
 export class EmbeddedDaemonRuntime {
   private child: ChildProcess | undefined
   private ready: EmbeddedDaemonReady | undefined
@@ -139,14 +145,16 @@ export class EmbeddedDaemonRuntime {
     healthCheckIntervalMs?: number
     healthCheckTimeoutMs?: number
     healthFailureThreshold?: number
+    recoveryAttempts?: number
+    recoveryRetryDelayMs?: number
     onExit?: (details: EmbeddedDaemonExit) => void
   }) {}
 
   get isRunning(): boolean {
-    // A supervised recovery deliberately keeps the same endpoint and credentials. Treat that short
-    // replacement window as logical runtime liveness so Electron does not discard the still-valid
-    // volatile profile while the child process is being replaced.
-    if (this.recovering) return true
+    // A supervised recovery deliberately keeps the same externally registered endpoint and
+    // credentials. Treat that short replacement window as logical runtime liveness so Electron does
+    // not discard the still-valid volatile profile while the child process tree is being replaced.
+    if (this.recovering && !this.stopRequested) return true
     return Boolean(this.child && this.child.exitCode === null && !this.child.killed && this.ready)
   }
 
@@ -202,7 +210,10 @@ export class EmbeddedDaemonRuntime {
     const child = spawn(this.options.executable ?? process.execPath, [this.options.entryPath, ...args], {
       env: embeddedDaemonEnvironment(environment, auth),
       stdio: ["ignore", "pipe", "pipe"],
-      windowsHide: true
+      windowsHide: true,
+      // On POSIX the embedded daemon owns harness subprocesses. Give that tree its own process group
+      // so a hard recovery can terminate the whole abandoned tree rather than only the daemon parent.
+      detached: process.platform !== "win32"
     })
     this.child = child
     let stderr = ""
@@ -245,7 +256,7 @@ export class EmbeddedDaemonRuntime {
       })
     } catch (error) {
       if (this.child === child) this.child = undefined
-      if (!child.killed && child.exitCode === null) child.kill("SIGTERM")
+      await this.terminateChild(child)
       throw error
     }
 
@@ -319,23 +330,58 @@ export class EmbeddedDaemonRuntime {
     this.recovering = (async () => {
       this.cancelHealthCheck()
       this.healthFailures = 0
-      // Keep the exact loopback endpoint and volatile credentials stable across recovery. The
-      // renderer/profile registry can therefore ride through a daemon restart without learning new
-      // secrets or creating a desktop-only reconnection protocol.
+      // Keep only the externally registered loopback endpoint and volatile credentials stable. The
+      // managed OpenCode port is internal to the daemon, so selecting a fresh free port on recovery
+      // prevents an escaped/stale descendant from blocking the entire local runtime.
       if (this.child === child) this.child = undefined
       if (this.ready === expectedReady) this.ready = undefined
       await this.terminateChild(child)
       if (this.stopRequested) return
-      try {
-        await this.launch(launchConfig)
-      } catch {
-        this.launchConfig = undefined
-        this.options.onExit?.({ code: null, signal: null })
+
+      const attempts = Math.max(1, Math.floor(this.options.recoveryAttempts ?? DEFAULT_RECOVERY_ATTEMPTS))
+      const retryDelayMs = Math.max(0, this.options.recoveryRetryDelayMs ?? DEFAULT_RECOVERY_RETRY_DELAY_MS)
+      let lastError: unknown
+      for (let attempt = 1; attempt <= attempts && !this.stopRequested; attempt += 1) {
+        try {
+          const openCodePort = await findLoopbackPort(4096, [launchConfig.port])
+          await this.launch({ ...launchConfig, openCodePort })
+          return
+        } catch (error) {
+          lastError = error
+          if (attempt < attempts && retryDelayMs > 0) {
+            await new Promise((resolve) => setTimeout(resolve, retryDelayMs * attempt))
+          }
+        }
       }
+
+      if (this.stopRequested) return
+      this.launchConfig = undefined
+      process.stderr.write(`[embedded-daemon] recovery failed after ${attempts} attempt${attempts === 1 ? "" : "s"}: ${errorMessage(lastError)}\n`)
+      this.options.onExit?.({ code: null, signal: null })
     })().finally(() => {
       this.recovering = undefined
     })
     return this.recovering
+  }
+
+  private forceKillChildTree(child: ChildProcess): void {
+    const pid = child.pid
+    if (Number.isInteger(pid) && process.platform === "win32") {
+      const result = spawnSync("taskkill", ["/pid", String(pid), "/t", "/f"], {
+        stdio: "ignore",
+        windowsHide: true
+      })
+      if (result.status === 0) return
+    }
+    if (Number.isInteger(pid) && process.platform !== "win32") {
+      try {
+        process.kill(-(pid as number), "SIGKILL")
+        return
+      } catch {
+        // Fall through to direct child kill if the process group has already disappeared.
+      }
+    }
+    child.kill("SIGKILL")
   }
 
   private async terminateChild(child: ChildProcess): Promise<void> {
@@ -357,9 +403,9 @@ export class EmbeddedDaemonRuntime {
           finish()
           return
         }
-        child.kill("SIGKILL")
-        // SIGKILL is asynchronous from Node's point of view. Do not immediately relaunch on the
-        // same port: wait for the child exit event so the OS has actually released its listener.
+        this.forceKillChildTree(child)
+        // Hard termination is asynchronous from Node's point of view. Do not immediately relaunch
+        // on the same external port: wait for the daemon exit event so the OS has released it.
         forceExitTimer = setTimeout(finish, DEFAULT_FORCE_KILL_EXIT_TIMEOUT_MS)
         forceExitTimer.unref?.()
       }

--- a/web/electron/embedded-daemon.ts
+++ b/web/electron/embedded-daemon.ts
@@ -7,6 +7,7 @@ export const EMBEDDED_DAEMON_HOST = "127.0.0.1"
 export const EMBEDDED_DAEMON_PROFILE_ID = "desktop-local-runtime"
 const DEFAULT_STARTUP_TIMEOUT_MS = 30_000
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 5_000
+const DEFAULT_FORCE_KILL_EXIT_TIMEOUT_MS = 1_000
 const DEFAULT_HEALTH_CHECK_INTERVAL_MS = 10_000
 const DEFAULT_HEALTH_CHECK_TIMEOUT_MS = 2_000
 const DEFAULT_HEALTH_FAILURE_THRESHOLD = 3
@@ -142,6 +143,10 @@ export class EmbeddedDaemonRuntime {
   }) {}
 
   get isRunning(): boolean {
+    // A supervised recovery deliberately keeps the same endpoint and credentials. Treat that short
+    // replacement window as logical runtime liveness so Electron does not discard the still-valid
+    // volatile profile while the child process is being replaced.
+    if (this.recovering) return true
     return Boolean(this.child && this.child.exitCode === null && !this.child.killed && this.ready)
   }
 
@@ -335,21 +340,31 @@ export class EmbeddedDaemonRuntime {
 
   private async terminateChild(child: ChildProcess): Promise<void> {
     if (child.exitCode !== null) return
-    const shutdownTimeoutMs = this.options.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS
+    const shutdownTimeoutMs = Math.max(0, this.options.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS)
     await new Promise<void>((resolve) => {
       let settled = false
+      let forceExitTimer: NodeJS.Timeout | undefined
       const finish = () => {
         if (settled) return
         settled = true
-        clearTimeout(timer)
+        clearTimeout(termTimer)
+        if (forceExitTimer) clearTimeout(forceExitTimer)
         child.off("exit", finish)
         resolve()
       }
-      const timer = setTimeout(() => {
-        if (child.exitCode === null) child.kill("SIGKILL")
-        finish()
-      }, shutdownTimeoutMs)
-      timer.unref?.()
+      const forceKill = () => {
+        if (child.exitCode !== null) {
+          finish()
+          return
+        }
+        child.kill("SIGKILL")
+        // SIGKILL is asynchronous from Node's point of view. Do not immediately relaunch on the
+        // same port: wait for the child exit event so the OS has actually released its listener.
+        forceExitTimer = setTimeout(finish, DEFAULT_FORCE_KILL_EXIT_TIMEOUT_MS)
+        forceExitTimer.unref?.()
+      }
+      const termTimer = setTimeout(forceKill, shutdownTimeoutMs)
+      termTimer.unref?.()
       child.once("exit", finish)
       if (child.exitCode !== null) {
         finish()

--- a/web/package.json
+++ b/web/package.json
@@ -40,7 +40,7 @@
     "test:completion-audio": "node src/completion-audio-regression.test.mjs",
     "test:completion-timing": "node --experimental-strip-types src/completion-audio-timing.test.mjs",
     "test:native-response": "node --experimental-strip-types src/native-response.test.mjs",
-    "test:desktop": "npm run build:electron && node --test electron/*.test.mjs && node scripts/run-vite-test.mjs src/desktop-workspace-bridge.test.mjs src/workspace-runtime-persistence.test.mjs",
+    "test:desktop": "npm run build:electron && node --test --test-concurrency=1 electron/*.test.mjs && node scripts/run-vite-test.mjs src/desktop-workspace-bridge.test.mjs src/workspace-runtime-persistence.test.mjs",
     "test:desktop:menu": "npm run build:electron && electron scripts/menu-smoke.mjs",
     "test:native-session-model-lifecycle": "node scripts/run-vite-test.mjs src/native-session-model-lifecycle.test.mjs",
     "test:ci:baseline": "npm run test:i18n && npm run test:config && npm run test:ui && npm run test:settings && npm run test:model && npm run test:events && npm run test:profiles",


### PR DESCRIPTION
## Summary

Fixes the real desktop recovery failure reproduced with a POSIX `SIGSTOP` against the embedded daemon.

### Root causes found by real-device testing

1. During supervised recovery, `EmbeddedDaemonRuntime` temporarily cleared child/readiness state, so Electron could misclassify the replacement window as a permanent local-runtime crash.
2. A `SIGSTOP`ed daemon cannot run its graceful shutdown handler. Killing only the daemon parent can therefore leave managed descendants (for example OpenCode or ACP harness processes) alive and holding internal resources/ports.
3. Recovery previously reused the same internal OpenCode port and attempted only one relaunch, so an escaped/stale descendant could make the replacement daemon exit immediately.

### Fix

- Keep logical runtime liveness during supervised replacement so the renderer-facing profile is preserved.
- On POSIX, launch the embedded daemon in its own process group; hard recovery kills the entire abandoned daemon/harness tree. On Windows, hard termination uses `taskkill /T /F` for the managed tree.
- Wait for hard-kill exit before reusing the renderer-facing daemon endpoint.
- Preserve the external loopback daemon port and volatile credentials, but select a fresh free internal OpenCode port on recovery.
- Use bounded recovery retries and fully clean up failed launch attempts.
- Emit a bounded local diagnostic if all recovery attempts fail.

### Regression coverage

- Real POSIX `SIGSTOP` recovery test: PID changes, external endpoint/credentials stay stable, health returns, and no unexpected-exit callback is emitted.
- Process-tree regression: generation 1 deliberately spawns a managed child that owns the internal port; after `SIGSTOP`, hard recovery must kill that descendant and bring generation 2 healthy.
- Existing HTTP-wedge, unexpected-exit, startup-failure and desktop/package tests remain in place.

No ACP, native Session, provider, routing or authorization semantics are changed. Target: `codex/development-2026-09-11` only. `main` remains untouched.