### PR TITLE
feat(P2): add bounded Git summary to Session outcome

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ Use the same machine from:
 
 The client lets you inspect Sessions, follow live activity, send prompts, answer supported questions or permissions, Stop native turns, switch model/harness where supported and review working-tree changes.
 
+The Session outcome keeps that review compact: it can show branch/worktree state, bounded changed-file evidence and aggregate Git totals such as tracked files, inserted/deleted lines and binary files. Raw diff hunks, patch contents and source text are not sent to the client for this summary.
+
+On desktop, Harness Remote supervises its embedded Machine daemon. If that local runtime becomes stopped or unresponsive, the app performs bounded recovery and cleans up the managed process tree before restarting it, including the managed OpenCode runtime when present.
+
 ## Local-first by design
 
 Harness Remote does not require your repository to be uploaded to a hosted workspace.
@@ -292,6 +296,10 @@ Harness Remote supports OpenCode, OMP, PI, Codex CLI and Claude Code while prese
 
 ACP-backed Session recovery also protects freshly created Sessions from stale initial snapshots: an older empty snapshot cannot overwrite the first prompt of a Session that is already loaded in memory.
 
+The Project/Session outcome surface provides bounded Git evidence for review: changed-file visibility plus aggregate tracked-file, insertion, deletion and binary-file counts, without transmitting raw diff contents as part of the summary.
+
+Desktop recovery supervises the embedded Machine daemon and can restart a stopped/unresponsive managed runtime while cleaning up its process tree and preserving managed OpenCode port ownership.
+
 Post-release work intentionally prioritizes Session correctness and maintainability over broad orchestration. Cross-machine handoff is a separate follow-up, and architectural cleanup must start from current `main` rather than reviving pre-release checkpoint/draft branches.
 
 The automatic multi-agent launcher is still being expanded: the current release can expose one selected ACP-backed primary alongside managed OpenCode, while additional concurrent ACP host instances remain follow-up work.
@@ -313,10 +321,13 @@ npm ci
 npm run dev
 ```
 
+Ongoing unreleased work is summarized in [Development status](docs/DEVELOPMENT_STATUS.md) so another development session can resume from the current integration state without reconstructing it from chat history.
+
 ## Documentation
 
 - [Quick start and launcher options](docs/QUICK_START.md)
 - [Harness Remote 3 product and architecture](docs/HARNESS_3_ROADMAP.md)
+- [Current development handoff](docs/DEVELOPMENT_STATUS.md)
 - [Harness capability matrix](docs/V3_HARNESS_CAPABILITY_MATRIX.md)
 - [Dependency and adapter notes](docs/DEPENDENCIES.md)
 - [Backend-specific reference](REFERENCE.md)

--- a/bridge/src/project-outcome.js
+++ b/bridge/src/project-outcome.js
@@ -83,11 +83,52 @@ export function parseGitPorcelainV1Z(value, { maxFiles = MAX_PROJECT_OUTCOME_FIL
 }
 
 /**
+ * Summarize the tracked worktree diff against HEAD without exposing paths, hunks or source text.
+ * `--no-renames` keeps each NUL-delimited numstat record structurally simple and avoids depending on
+ * Git's rename formatting. Binary entries use `-` for additions/deletions and are counted separately.
+ */
+export function parseGitNumstatZ(value) {
+  const fields = String(value ?? "").split("\0")
+  if (fields.at(-1) === "") fields.pop()
+
+  let trackedFiles = 0
+  let insertions = 0
+  let deletions = 0
+  let binaryFiles = 0
+  for (const field of fields) {
+    if (!field) continue
+    const firstTab = field.indexOf("\t")
+    const secondTab = firstTab < 0 ? -1 : field.indexOf("\t", firstTab + 1)
+    if (firstTab <= 0 || secondTab <= firstTab + 1) continue
+
+    const added = field.slice(0, firstTab)
+    const deleted = field.slice(firstTab + 1, secondTab)
+    if (added === "-" || deleted === "-") {
+      if (added === "-" && deleted === "-") {
+        trackedFiles += 1
+        binaryFiles += 1
+      }
+      continue
+    }
+
+    const addedCount = Number(added)
+    const deletedCount = Number(deleted)
+    if (!Number.isSafeInteger(addedCount) || addedCount < 0 || !Number.isSafeInteger(deletedCount) || deletedCount < 0) continue
+    trackedFiles += 1
+    insertions += addedCount
+    deletions += deletedCount
+  }
+
+  return { trackedFiles, insertions, deletions, binaryFiles }
+}
+
+/**
  * Read a bounded, provider-neutral outcome snapshot from the daemon-local Git worktree.
  *
  * The snapshot is intentionally metadata-only: no diff hunks, file contents, remotes, credentials,
  * absolute paths, command output or harness/provider state cross the daemon boundary. Missing Git
- * evidence stays absent instead of being invented. This function never mutates the repository.
+ * evidence stays absent instead of being invented. Diff evidence is aggregate numstat only, never
+ * source text. This function never mutates the repository.
  */
 export async function inspectGitProjectOutcome(projectPath, { runGit = defaultRunGit, maxFiles = MAX_PROJECT_OUTCOME_FILES } = {}) {
   if (typeof projectPath !== "string" || !projectPath.trim()) return null
@@ -96,15 +137,17 @@ export async function inspectGitProjectOutcome(projectPath, { runGit = defaultRu
   if (!root.ok || !root.value.trim()) return null
 
   const repoRoot = root.value.trim()
-  const [head, branch, status] = await Promise.all([
+  const [head, branch, status, diff] = await Promise.all([
     readGit(runGit, ["-C", repoRoot, "rev-parse", "HEAD"]),
     readGit(runGit, ["-C", repoRoot, "branch", "--show-current"]),
-    readGit(runGit, ["-C", repoRoot, "status", "--porcelain=v1", "-z", "--untracked-files=all"])
+    readGit(runGit, ["-C", repoRoot, "status", "--porcelain=v1", "-z", "--untracked-files=all"]),
+    readGit(runGit, ["-C", repoRoot, "diff", "--numstat", "-z", "--no-renames", "HEAD", "--"])
   ])
 
   const parsed = status.ok
     ? parseGitPorcelainV1Z(status.value, { maxFiles })
     : { files: [], totalFiles: 0, truncated: false }
+  const diffSummary = diff.ok ? parseGitNumstatZ(diff.value) : undefined
 
   return {
     version: 1,
@@ -116,6 +159,7 @@ export async function inspectGitProjectOutcome(projectPath, { runGit = defaultRu
       files: parsed.files,
       totalChangedFiles: parsed.totalFiles,
       filesTruncated: parsed.truncated
-    } : {})
+    } : {}),
+    ...(diffSummary ? { diffSummary } : {})
   }
 }

--- a/bridge/test/project-outcome.test.js
+++ b/bridge/test/project-outcome.test.js
@@ -36,9 +36,12 @@ test("porcelain -z parses modified, untracked and rename entries without shell q
 })
 
 test("numstat summary counts tracked text and binary changes without retaining paths or hunks", () => {
-  const parsed = parseGitNumstatZ(
-    "12\t4\tsrc/app.js\0-\t-\tassets/logo.png\00\t7\tdeleted.txt\0"
-  )
+  const parsed = parseGitNumstatZ([
+    "12\t4\tsrc/app.js",
+    "-\t-\tassets/logo.png",
+    "0\t7\tdeleted.txt",
+    ""
+  ].join("\0"))
 
   assert.deepEqual(parsed, {
     trackedFiles: 3,
@@ -52,7 +55,12 @@ test("numstat summary counts tracked text and binary changes without retaining p
 })
 
 test("malformed numstat records are ignored instead of fabricating diff evidence", () => {
-  assert.deepEqual(parseGitNumstatZ("oops\01\tx\tfile\0-\t2\todd\0"), {
+  assert.deepEqual(parseGitNumstatZ([
+    "oops",
+    "1\tx\tfile",
+    "-\t2\todd",
+    ""
+  ].join("\0")), {
     trackedFiles: 0,
     insertions: 0,
     deletions: 0,

--- a/bridge/test/project-outcome.test.js
+++ b/bridge/test/project-outcome.test.js
@@ -3,16 +3,18 @@ import test from "node:test"
 import {
   inspectGitProjectOutcome,
   MAX_PROJECT_OUTCOME_FILES,
+  parseGitNumstatZ,
   parseGitPorcelainV1Z
 } from "../src/project-outcome.js"
 
-function gitFixture(statusOutput) {
+function gitFixture(statusOutput, diffOutput = "") {
   return async (args) => {
     const command = args.slice(2).join(" ")
     if (command === "rev-parse --show-toplevel") return { stdout: "/repo\n" }
     if (command === "rev-parse HEAD") return { stdout: "deadbeef\n" }
     if (command === "branch --show-current") return { stdout: "feature/outcome\n" }
     if (command === "status --porcelain=v1 -z --untracked-files=all") return { stdout: statusOutput }
+    if (command === "diff --numstat -z --no-renames HEAD --") return { stdout: diffOutput }
     throw new Error(`Unexpected git command: ${command}`)
   }
 }
@@ -33,6 +35,31 @@ test("porcelain -z parses modified, untracked and rename entries without shell q
   })
 })
 
+test("numstat summary counts tracked text and binary changes without retaining paths or hunks", () => {
+  const parsed = parseGitNumstatZ(
+    "12\t4\tsrc/app.js\0-\t-\tassets/logo.png\00\t7\tdeleted.txt\0"
+  )
+
+  assert.deepEqual(parsed, {
+    trackedFiles: 3,
+    insertions: 12,
+    deletions: 11,
+    binaryFiles: 1
+  })
+  const serialized = JSON.stringify(parsed)
+  assert.equal(serialized.includes("src/app.js"), false)
+  assert.equal(serialized.includes("assets/logo.png"), false)
+})
+
+test("malformed numstat records are ignored instead of fabricating diff evidence", () => {
+  assert.deepEqual(parseGitNumstatZ("oops\01\tx\tfile\0-\t2\todd\0"), {
+    trackedFiles: 0,
+    insertions: 0,
+    deletions: 0,
+    binaryFiles: 0
+  })
+})
+
 test("outcome is bounded while preserving the total changed-file count", async () => {
   const status = Array.from({ length: MAX_PROJECT_OUTCOME_FILES + 7 }, (_, index) => ` M src/file-${index}.js\0`).join("")
   const outcome = await inspectGitProjectOutcome("/repo", { runGit: gitFixture(status) })
@@ -43,9 +70,12 @@ test("outcome is bounded while preserving the total changed-file count", async (
   assert.equal(outcome.filesTruncated, true)
 })
 
-test("snapshot returns only metadata and repository-relative paths", async () => {
+test("snapshot returns only bounded metadata and aggregate diff statistics", async () => {
   const outcome = await inspectGitProjectOutcome("/repo", {
-    runGit: gitFixture("M  src/index.js\0?? test/new.test.js\0")
+    runGit: gitFixture(
+      "M  src/index.js\0?? test/new.test.js\0",
+      "18\t5\tsrc/index.js\0"
+    )
   })
 
   assert.deepEqual(outcome, {
@@ -59,11 +89,18 @@ test("snapshot returns only metadata and repository-relative paths", async () =>
       { path: "test/new.test.js", indexStatus: "?", worktreeStatus: "?" }
     ],
     totalChangedFiles: 2,
-    filesTruncated: false
+    filesTruncated: false,
+    diffSummary: {
+      trackedFiles: 1,
+      insertions: 18,
+      deletions: 5,
+      binaryFiles: 0
+    }
   })
   const wire = JSON.stringify(outcome)
   assert.equal(wire.includes("/repo"), false)
-  assert.equal(wire.includes("diff"), false)
+  assert.equal(wire.includes("@@"), false, "diff hunks must never cross the outcome boundary")
+  assert.equal(wire.includes("18\t5"), false, "raw git output must never cross the outcome boundary")
 })
 
 test("escaping, absolute and oversized paths are never exposed but still keep the worktree dirty", async () => {
@@ -84,7 +121,7 @@ test("escaping, absolute and oversized paths are never exposed but still keep th
   assert.equal(hiddenOnly.filesTruncated, true)
 })
 
-test("missing status evidence stays unverified instead of inventing a clean worktree", async () => {
+test("missing status or diff evidence stays unverified instead of being invented", async () => {
   const outcome = await inspectGitProjectOutcome("/repo", {
     runGit: async (args) => {
       const command = args.slice(2).join(" ")

--- a/docs/DEVELOPMENT_STATUS.md
+++ b/docs/DEVELOPMENT_STATUS.md
@@ -1,0 +1,56 @@
+# Development status
+
+> This file is the handoff point for ongoing development work that is not yet on `main`.
+> Keep it short, current and safe to read at the start of a new coding-agent session.
+
+## Branch policy
+
+- Persistent integration branch: `codex/development-2026-09-11`
+- Never merge development work directly into `main`.
+- Feature/fix PRs target `codex/development-2026-09-11` only.
+- Merge into the integration branch only after relevant tests and CI are green.
+- ACP, Native Session and harness-runtime changes require regression review against previously fixed failures before merge.
+
+## Current integration baseline
+
+- Integration head after PR #468: `13aae765760b8f9deffbf61525144b7b7988246f`
+- PR #468 (`fix(P1): recover stopped embedded desktop daemon`) is merged into the integration branch only.
+- Real Zorin validation covered stopping the embedded `daemon-cli.js` with `SIGSTOP`; automatic recovery succeeded.
+- The desktop recovery path also covers child/orphan process cleanup, managed OpenCode internal-port recovery and bounded recovery retries.
+
+## Work in progress
+
+### P2 Session/Project outcome Git summary
+
+Branch: `codex/p2-session-outcome-diff-summary`
+
+Goal: make the Session outcome answer “what changed?” without transmitting source diff contents.
+
+Implemented:
+
+- aggregate tracked-file count;
+- insertions and deletions;
+- binary-file count;
+- daemon-side `git diff --numstat -z --no-renames HEAD --` parsing;
+- no diff hunks, patch/source contents or raw numstat output cross the daemon boundary;
+- client-side validation of aggregate numeric fields;
+- compact Session outcome presentation next to existing branch/worktree/file evidence;
+- compatibility with older daemons where the optional summary is absent.
+
+The branch was synchronized with integration after #468 using merge commit `baf9a6ca40f0d3f8abfb8c42e0fd2ec0a5407e49` before the UI/client completion commits.
+
+Next gate: focused tests, full PR CI, then merge to `codex/development-2026-09-11` only if green.
+
+### Next UX fix: Machine creation form
+
+After the P2 outcome PR is integrated, fix the universal machine-management flow on a separate branch:
+
+- if there are active/configured machines, do not leave the “new machine” fields expanded by default;
+- show a simple Add machine action instead;
+- reveal the fields only after the user chooses to add another machine;
+- when no machines exist, keep first-run setup immediately understandable;
+- behavior must be shared by Electron/web rather than special-cased for one platform.
+
+## Product direction
+
+Continue from `docs/HARNESS_3_ROADMAP.md`, prioritizing correctness/recovery, onboarding, attention visibility and Native Session federation. Avoid turning Harness Remote into a generic IDE/task manager or reimplementing capabilities that belong to native harnesses.

--- a/web/src/components/native-session-outcome-panel.tsx
+++ b/web/src/components/native-session-outcome-panel.tsx
@@ -166,11 +166,13 @@ export function NativeSessionOutcomePanel({
   const hiddenCount = total === undefined ? 0 : Math.max(0, total - visibleFiles.length)
   const branchOrHead = outcome?.branch || (outcome?.head ? outcome.head.slice(0, 8) : undefined)
   const state = outcome ? outcomeState(outcome) : undefined
+  const diffSummary = outcome?.diffSummary
   const summary = [
     review?.label,
     branchOrHead,
     state,
-    total !== undefined ? `${total} changed ${total === 1 ? "file" : "files"}` : undefined
+    total !== undefined ? `${total} changed ${total === 1 ? "file" : "files"}` : undefined,
+    diffSummary ? `+${diffSummary.insertions} / −${diffSummary.deletions}` : undefined
   ].filter(Boolean).join(" · ")
 
   return (
@@ -211,6 +213,9 @@ export function NativeSessionOutcomePanel({
                 {outcome.branch ? <span>Branch <strong>{outcome.branch}</strong></span> : null}
                 {outcome.head ? <span>HEAD <strong>{outcome.head.slice(0, 8)}</strong></span> : null}
                 <span>Worktree <strong>{state}</strong></span>
+                {diffSummary ? <span>Tracked <strong>{diffSummary.trackedFiles} {diffSummary.trackedFiles === 1 ? "file" : "files"}</strong></span> : null}
+                {diffSummary ? <span>Lines <strong>+{diffSummary.insertions} / −{diffSummary.deletions}</strong></span> : null}
+                {diffSummary?.binaryFiles ? <span>Binary <strong>{diffSummary.binaryFiles}</strong></span> : null}
               </div>
 
               {outcome.dirty === true && visibleFiles.length ? (

--- a/web/src/native-session-outcome.test.mjs
+++ b/web/src/native-session-outcome.test.mjs
@@ -28,6 +28,9 @@ assert.equal(panel.includes("loadDiff"), false, "generic outcome review must not
 assert.equal(panel.toLowerCase().includes("test passed"), false, "checks must not be inferred from transcript/UI prose")
 assert.ok(panel.includes("MAX_VISIBLE_FILES = 12"), "outcome UI must stay bounded even when the daemon returns a larger safe snapshot")
 assert.ok(panel.includes("omitted by safety or display bounds"), "hidden/bounded file names must remain visible as an explicit incomplete-evidence signal")
+assert.ok(panel.includes("const diffSummary = outcome?.diffSummary"), "bounded Git change totals must be shown from Project outcome metadata")
+assert.ok(panel.includes("Lines <strong>+{diffSummary.insertions} / −{diffSummary.deletions}</strong>"), "outcome must make added/removed line totals easy to read")
+assert.ok(panel.includes("Tracked <strong>{diffSummary.trackedFiles}"), "outcome must expose the tracked-file aggregate without loading diff contents")
 
 assert.ok(reviewEvidence.includes("attention.permissions > 0"), "known target permission must remain visible even when another attention source is unavailable")
 assert.ok(reviewEvidence.includes("attention.questions > 0"), "known structured questions must remain visible even when another attention source is unavailable")
@@ -40,7 +43,11 @@ assert.equal(reviewEvidence.includes("MessageEnvelope"), false, "review evidence
 assert.ok(client.includes("404 || status === 405 || status === 501"), "older daemons must degrade optional outcome metadata without blocking Session open")
 assert.ok(client.includes("normalized.split(\"/\").some((part) => part === \"..\")"), "client must defense-in-depth reject escaping paths")
 assert.ok(client.includes("payload.projectId !== projectId"), "outcome response must stay bound to the exact requested Project")
-assert.equal(client.includes("diff"), false, "outcome client must not request diff contents")
+assert.ok(client.includes("diffSummary?: MachineProjectOutcomeDiffSummary"), "outcome wire contract must explicitly model bounded aggregate diff evidence")
+assert.ok(client.includes("safeDiffSummary(source.diffSummary)"), "aggregate diff evidence must be sanitized before entering UI state")
+assert.equal(client.includes("/diff"), false, "outcome client must never request a raw diff endpoint")
+assert.equal(client.includes("patch"), false, "outcome client must not carry patch contents")
+assert.equal(client.includes("hunk"), false, "outcome client must not carry diff hunks")
 
 assert.ok(desktopTransport.includes("v1\\/project-(?:identity|outcome)"), "desktop Project metadata must stay on the machine daemon instead of being agent scoped")
 

--- a/web/src/project-outcome-client.ts
+++ b/web/src/project-outcome-client.ts
@@ -14,6 +14,13 @@ export type MachineProjectOutcomeFile = {
   worktreeStatus: string
 }
 
+export type MachineProjectOutcomeDiffSummary = {
+  trackedFiles: number
+  insertions: number
+  deletions: number
+  binaryFiles: number
+}
+
 export type MachineProjectOutcome = {
   version: 1
   vcs: "git"
@@ -23,6 +30,7 @@ export type MachineProjectOutcome = {
   files?: MachineProjectOutcomeFile[]
   totalChangedFiles?: number
   filesTruncated?: boolean
+  diffSummary?: MachineProjectOutcomeDiffSummary
 }
 
 function headers(config: ServerConfig): Record<string, string> {
@@ -51,7 +59,18 @@ function statusChar(value: unknown): string | undefined {
 }
 
 function nonNegativeInteger(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : undefined
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined
+}
+
+function safeDiffSummary(value: unknown): MachineProjectOutcomeDiffSummary | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
+  const source = value as Record<string, unknown>
+  const trackedFiles = nonNegativeInteger(source.trackedFiles)
+  const insertions = nonNegativeInteger(source.insertions)
+  const deletions = nonNegativeInteger(source.deletions)
+  const binaryFiles = nonNegativeInteger(source.binaryFiles)
+  if (trackedFiles === undefined || insertions === undefined || deletions === undefined || binaryFiles === undefined) return undefined
+  return { trackedFiles, insertions, deletions, binaryFiles }
 }
 
 function parseOutcomePayload(value: unknown, projectId: string): MachineProjectOutcome | null {
@@ -90,6 +109,7 @@ function parseOutcomePayload(value: unknown, projectId: string): MachineProjectO
   const dirty = typeof source.dirty === "boolean" ? source.dirty : undefined
   const totalChangedFiles = nonNegativeInteger(source.totalChangedFiles)
   const filesTruncated = typeof source.filesTruncated === "boolean" ? source.filesTruncated : undefined
+  const diffSummary = safeDiffSummary(source.diffSummary)
 
   return {
     version: 1,
@@ -99,7 +119,8 @@ function parseOutcomePayload(value: unknown, projectId: string): MachineProjectO
     ...(dirty !== undefined ? { dirty } : {}),
     ...(source.files !== undefined ? { files } : {}),
     ...(totalChangedFiles !== undefined ? { totalChangedFiles } : {}),
-    ...(filesTruncated !== undefined ? { filesTruncated } : {})
+    ...(filesTruncated !== undefined ? { filesTruncated } : {}),
+    ...(diffSummary ? { diffSummary } : {})
   }
 }
 


### PR DESCRIPTION
## Summary

Adds bounded Git change totals to the existing Project/Session outcome surface without transmitting raw diff contents.

- tracked-file count
- insertions / deletions
- binary-file count
- daemon-side `git diff --numstat -z --no-renames HEAD --` aggregation
- client-side validation and compact outcome UI
- no patch, hunk or source contents cross the outcome boundary
- older daemons remain compatible when the optional summary is absent
- README updated and `docs/DEVELOPMENT_STATUS.md` added as the persistent development handoff

## Safety / scope

This change does not modify ACP adapters, Native Session creation/resume semantics or harness runtime behavior. It stays within daemon Project outcome metadata and the existing review UI.

The branch was synchronized with `codex/development-2026-09-11` after #468 before completion.

## Validation

Targeted bridge/web regression coverage was extended. Merge only after the full PR CI is green.
