### PR TITLE
test(P2): make cross-machine continuation smoke blocking

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -126,6 +126,10 @@ jobs:
           node scripts/native-session-outcome-browser-smoke.mjs
         working-directory: web
 
+      - name: Run cross-machine continuation safety smoke
+        run: node scripts/cross-machine-continuation-browser-smoke.mjs
+        working-directory: web
+
       - name: Run complete controls and screenshot smoke
         run: node scripts/v3-browser-controls-smoke.mjs
         working-directory: web

--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ The Project/Session outcome surface provides bounded Git evidence for review: ch
 
 Desktop recovery supervises the embedded Machine daemon and can restart a stopped/unresponsive managed runtime while cleaning up its process tree and preserving managed OpenCode port ownership.
 
+The blocking Chromium product gate also exercises cross-machine continuation safety: target capability/model discovery, Project identity continuity and fail-closed behavior when the selected target resolves to a different repository.
+
 Post-release work intentionally prioritizes Session correctness and maintainability over broad orchestration. Cross-machine handoff is a separate follow-up, and architectural cleanup must start from current `main` rather than reviving pre-release checkpoint/draft branches.
 
 The automatic multi-agent launcher is still being expanded: the current release can expose one selected ACP-backed primary alongside managed OpenCode, while additional concurrent ACP host instances remain follow-up work.

--- a/bridge/test/native-session-reliability-ci-contract.test.js
+++ b/bridge/test/native-session-reliability-ci-contract.test.js
@@ -28,7 +28,8 @@ const REQUIRED_BROWSER_SMOKES = [
   "scripts/native-opencode-real-regression-smoke.mjs",
   "scripts/native-opencode-permission-regression-smoke.mjs",
   "scripts/native-session-model-switch-smoke.mjs",
-  "scripts/native-session-outcome-browser-smoke.mjs"
+  "scripts/native-session-outcome-browser-smoke.mjs",
+  "scripts/cross-machine-continuation-browser-smoke.mjs"
 ]
 
 const REQUIRED_WEB_CONTRACTS = [

--- a/docs/DEVELOPMENT_STATUS.md
+++ b/docs/DEVELOPMENT_STATUS.md
@@ -13,37 +13,34 @@
 
 ## Current integration baseline
 
-- Integration head after PR #469: `03c275dbe35932991bb6869ae4c766350ca97b6f`
-- PR #468 (`fix(P1): recover stopped embedded desktop daemon`) is merged into the integration branch only.
-- Real Zorin validation covered stopping the embedded `daemon-cli.js` with `SIGSTOP`; automatic recovery succeeded.
-- The desktop recovery path also covers child/orphan process cleanup, managed OpenCode internal-port recovery and bounded recovery retries.
-- PR #469 (`feat(P2): add bounded Git summary to Session outcome`) is merged into the integration branch only after green Linux/web regressions, macOS/Windows bridge tests, Chromium product smoke and Debug APK.
-- Session outcome now includes bounded Git aggregate evidence (tracked files, insertions, deletions and binary-file count) without transmitting raw diff hunks, patch/source contents or raw numstat output.
+- Integration head after PR #470: `b39c803375514ad3f31680a9c856a041ecc95ff6`.
+- PR #468 added bounded recovery of the embedded desktop daemon and was validated on Zorin with a real `SIGSTOP` recovery test.
+- PR #469 added bounded Git aggregate outcome evidence: tracked files, insertions, deletions and binary files, with no raw diff/hunks/source sent to the client.
+- PR #470 fixed the universal Machines UX race: connection fields now appear only after an explicit **Add machine** action, including when Electron discovers its managed local machine asynchronously.
+- #469 and #470 both passed the complete PR gate before integration: Linux/web regressions, macOS/Windows bridge tests, Chromium product smoke and Debug APK.
 
 ## Work in progress
 
-### Machine creation form gating
+### P2 cross-machine browser gate
 
-Branch: `codex/p2-machine-manager-new-form-gating`
+Branch: `codex/p2-cross-machine-browser-gate`
 
-Goal: keep the Machines screen simple when a machine already exists or appears asynchronously.
+Goal: make the existing cross-machine continuation safety smoke a permanent blocking regression instead of an unexecuted standalone script.
 
 Implemented:
 
-- opening Machines no longer opens the new-machine fields automatically;
-- the editor appears only after the explicit Add machine action;
-- an empty install still opens the Machines screen, but first shows the simple empty state and Add machine action;
-- first-run button copy uses “Add machine” instead of “Add another machine”;
-- behavior is shared by Electron, web and Android rather than keyed to a desktop-only condition;
-- regression coverage prevents restoring the old `machines.length === 0 ? "new" : null` state race.
-
-This fixes the observed Electron startup case where the manager initially rendered before the managed local machine was discovered, leaving a stale blank creation form visible after the machine appeared.
+- `cross-machine-continuation-browser-smoke.mjs` is wired into the blocking Chromium product gate;
+- the smoke exercises the existing cross-machine planning surface, target model discovery, Project identity continuity and fail-closed behavior for a mismatched repository;
+- `native-session-reliability-ci-contract.test.js` now requires that smoke to remain present in the blocking workflow;
+- no ACP adapter, Native Session writer semantics or harness runtime behavior is changed.
 
 Next gate: full PR CI, then merge to `codex/development-2026-09-11` only if green.
 
-## Next P2 direction
+## P2 roadmap position
 
-Continue issue #371 from the existing Native Session Home read model instead of creating a second synthetic Session index. The next low-risk slice should make operational buckets/scopes clearer (Active, Needs attention, Failed/interrupted, Completed/recent; Project/model filtering) using already-discovered records only, with no transcript reads, ACP/writer changes or new per-Session N+1 calls.
+Do not restart federation work already completed in PRs #411-#413: operational buckets plus machine/Project/harness/model/state filtering already exist in the current Native Session Home. Cross-machine creation/recovery, Project identity, lineage/portable-state boundaries and the first outcome surface were also implemented by later P2 PRs.
+
+Continue issue #371 from the current code. Prefer small reliability/completeness slices that strengthen the existing Native Session model instead of creating a second synthetic Session index or changing ACP/writer behavior without real-harness validation.
 
 ## Product direction
 

--- a/web/scripts/cross-machine-continuation-browser-smoke.mjs
+++ b/web/scripts/cross-machine-continuation-browser-smoke.mjs
@@ -276,6 +276,19 @@ function stopServer(server) {
   try { server.close() } catch {}
 }
 
+async function waitForDisabledState(locator, disabled, label, timeout = 12_000) {
+  const deadline = Date.now() + timeout
+  let lastState
+  while (Date.now() < deadline) {
+    try {
+      lastState = await locator.isDisabled()
+      if (lastState === disabled) return
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  throw new Error(`${label}: expected disabled=${disabled}, observed disabled=${String(lastState)}`)
+}
+
 let sourceDaemon
 let targetDaemon
 let preview
@@ -314,7 +327,8 @@ try {
   const projectSelect = panel.locator('label').filter({ hasText: "Project" }).locator('select')
   await projectSelect.selectOption(MATCH_PROJECT)
 
-  await panel.getByText("Same repository, branch and HEAD verified; both worktrees are clean.", { exact: true }).waitFor({ state: "visible", timeout: 12_000 })
+  const readySummary = panel.getByText("Same repository, branch and HEAD verified; both worktrees are clean.", { exact: true })
+  await readySummary.waitFor({ state: "visible", timeout: 12_000 })
   await panel.getByText("Attachments and source permissions are not transferred.", { exact: true }).waitFor({ state: "visible", timeout: 12_000 })
 
   const modelButton = panel.locator('.tdw-model-trigger')
@@ -324,16 +338,25 @@ try {
   await page.keyboard.press("Escape")
   assert.match(await modelButton.innerText(), /Claude Target/, "target default model was not selected after catalog discovery")
 
+  const firstMessageText = "Continue the fix on the target machine"
   const firstMessage = panel.getByRole("textbox", { name: "First message on the target Session" })
-  await firstMessage.fill("Continue the fix on the target machine")
+  await firstMessage.fill(firstMessageText)
+  assert.equal(await firstMessage.inputValue(), firstMessageText, "target first-message input did not retain the requested text")
+  assert.equal(await toggle.isDisabled(), false, "source Session became non-interactive while the verified cross-machine plan was open")
+  assert.equal(await sourceComposer.isDisabled(), false, "source composer became non-interactive while the verified cross-machine plan was open")
+  assert.equal(await machineSelect.inputValue(), TARGET_MACHINE, "target machine selection changed while preparing the first message")
+  assert.equal(await projectSelect.inputValue(), MATCH_PROJECT, "target Project selection changed while preparing the first message")
+  assert.equal(await projectSelect.isDisabled(), false, "target Project unexpectedly returned to a loading state")
+  assert.equal(await modelButton.isDisabled(), false, "target model unexpectedly returned to a loading/unavailable state")
+  assert.match(await modelButton.innerText(), /Claude Target/, "target model selection changed while preparing the first message")
+  await readySummary.waitFor({ state: "visible", timeout: 12_000 })
+
   const continueButton = panel.getByRole("button", { name: "Continue on target machine" })
-  const continueHandle = await continueButton.elementHandle()
-  assert.ok(continueHandle, "cross-machine continue button was not mounted")
-  await page.waitForFunction((button) => button instanceof HTMLButtonElement && !button.disabled, continueHandle, { timeout: 12_000 })
+  await waitForDisabledState(continueButton, false, "verified matching workspace did not become sendable")
 
   await projectSelect.selectOption(DIFFERENT_PROJECT)
   await panel.getByText("This Project does not match the source repository/history. Cross-machine continuation is blocked.", { exact: true }).waitFor({ state: "visible", timeout: 12_000 })
-  await page.waitForFunction((button) => button instanceof HTMLButtonElement && button.disabled, continueHandle, { timeout: 12_000 })
+  await waitForDisabledState(continueButton, true, "mismatched repository did not disable cross-machine continuation")
   assert.equal(await sourceComposer.isDisabled(), false, "blocked cross-machine plan disabled the ordinary source composer")
   assert.deepEqual(pageErrors, [], `browser errors in cross-machine planning surface: ${pageErrors.join(" | ")}`)
 

--- a/web/scripts/cross-machine-continuation-browser-smoke.mjs
+++ b/web/scripts/cross-machine-continuation-browser-smoke.mjs
@@ -307,7 +307,10 @@ try {
   await toggle.click()
 
   const panel = page.locator('.hr-cross-machine-panel')
-  await panel.getByText("Target Machine", { exact: true }).first().waitFor({ state: "visible", timeout: 12_000 })
+  const machineSelect = panel.locator('select').first()
+  await machineSelect.waitFor({ state: "visible", timeout: 12_000 })
+  assert.equal(await machineSelect.inputValue(), TARGET_MACHINE, "cross-machine panel did not select the available target machine")
+  assert.equal((await machineSelect.locator('option:checked').textContent())?.trim(), "Target Machine", "selected target machine label is incorrect")
   const projectSelect = panel.locator('label').filter({ hasText: "Project" }).locator('select')
   await projectSelect.selectOption(MATCH_PROJECT)
 

--- a/web/scripts/cross-machine-continuation-browser-smoke.mjs
+++ b/web/scripts/cross-machine-continuation-browser-smoke.mjs
@@ -322,15 +322,18 @@ try {
   await modelButton.click()
   assert.match(await panel.locator('.tdw-model-picker').innerText(), /Claude Target/, "target route did not load the target harness model catalog")
   await page.keyboard.press("Escape")
+  assert.match(await modelButton.innerText(), /Claude Target/, "target default model was not selected after catalog discovery")
 
   const firstMessage = panel.getByRole("textbox", { name: "First message on the target Session" })
   await firstMessage.fill("Continue the fix on the target machine")
   const continueButton = panel.getByRole("button", { name: "Continue on target machine" })
-  assert.equal(await continueButton.isDisabled(), false, "verified matching workspace did not become sendable")
+  const continueHandle = await continueButton.elementHandle()
+  assert.ok(continueHandle, "cross-machine continue button was not mounted")
+  await page.waitForFunction((button) => button instanceof HTMLButtonElement && !button.disabled, continueHandle, { timeout: 12_000 })
 
   await projectSelect.selectOption(DIFFERENT_PROJECT)
   await panel.getByText("This Project does not match the source repository/history. Cross-machine continuation is blocked.", { exact: true }).waitFor({ state: "visible", timeout: 12_000 })
-  assert.equal(await continueButton.isDisabled(), true, "mismatched Project left the cross-machine mutation enabled")
+  await page.waitForFunction((button) => button instanceof HTMLButtonElement && button.disabled, continueHandle, { timeout: 12_000 })
   assert.equal(await sourceComposer.isDisabled(), false, "blocked cross-machine plan disabled the ordinary source composer")
   assert.deepEqual(pageErrors, [], `browser errors in cross-machine planning surface: ${pageErrors.join(" | ")}`)
 


### PR DESCRIPTION
## Summary

Promotes the existing cross-machine continuation browser smoke into the blocking Chromium PR gate.

- runs `cross-machine-continuation-browser-smoke.mjs` on every PR after the main native Session browser suite
- keeps Project identity continuity, target model/capability discovery and mismatched-repository fail-closed behavior covered by a real production-browser smoke
- extends `native-session-reliability-ci-contract.test.js` so the cross-machine smoke cannot silently disappear from the blocking workflow
- updates README and `docs/DEVELOPMENT_STATUS.md`

## Safety / scope

CI/reliability and documentation only. No ACP adapters, Native Session writer semantics, cross-machine runtime implementation or harness behavior are changed.

## Validation

Merge only after the complete PR CI is green, including Chromium product smoke and Debug APK.