### PR TITLE
test(P2): exercise cross-machine continuation end to end

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,9 +302,9 @@ The Project/Session outcome surface provides bounded Git evidence for review: ch
 
 Desktop recovery supervises the embedded Machine daemon and can restart a stopped/unresponsive managed runtime while cleaning up its process tree and preserving managed OpenCode port ownership.
 
-The blocking Chromium product gate also exercises cross-machine continuation safety: target capability/model discovery, Project identity continuity and fail-closed behavior when the selected target resolves to a different repository.
+The blocking Chromium product gate exercises cross-machine continuation end to end: target capability/model discovery, Project identity continuity and mismatched-repository fail-closed behavior, then exactly-once target Session creation, dual-store lineage, bounded context and authority boundaries, first-prompt delivery and opening the writable target Session.
 
-Post-release work intentionally prioritizes Session correctness and maintainability over broad orchestration. Cross-machine handoff is a separate follow-up, and architectural cleanup must start from current `main` rather than reviving pre-release checkpoint/draft branches.
+Post-release development intentionally prioritizes Session correctness and maintainability over broad orchestration. Cross-machine federation is being hardened through explicit safety, recovery and browser gates rather than by introducing a second synthetic Session model.
 
 The automatic multi-agent launcher is still being expanded: the current release can expose one selected ACP-backed primary alongside managed OpenCode, while additional concurrent ACP host instances remain follow-up work.
 

--- a/docs/DEVELOPMENT_STATUS.md
+++ b/docs/DEVELOPMENT_STATUS.md
@@ -36,10 +36,11 @@ Implemented on the branch:
 - the first prompt must be delivered exactly once with its own durable request id and the bounded transferred Task Context;
 - the target Session must open writable in the production UI after the handoff;
 - a source-only permission sentinel is asserted absent from target creation, portable lineage and the target prompt;
-- portable controls must explicitly record source authority invalidation, target authorization re-evaluation and no attachment transfer;
-- no ACP adapter, Native Session writer semantics or harness runtime implementation is changed by this slice.
+- portable controls must explicitly record source authority invalidation, target authorization re-evaluation and no attachment transfer.
 
-Next gate: review the branch diff, then run full PR CI and merge to `codex/development-2026-09-11` only if every gate, including Debug APK, is green.
+The first full CI run exposed a real panel-state race before any mutation: a refreshed snapshot of the same target machine reloaded the Project catalog and cleared an explicit Project choice when more than one Project existed. The branch now preserves a still-valid Project selection across same-machine catalog refreshes, never carries a machine-local Project id to a different machine, and keeps the existing single-Project auto-selection behavior. A focused unit regression protects that selection rule. This UI-state fix does not change ACP adapters, Native Session writer semantics or handoff mutation ordering.
+
+Next gate: rerun the complete PR CI and merge to `codex/development-2026-09-11` only if every gate, including the end-to-end Chromium smoke and Debug APK, is green.
 
 ## P2 roadmap position
 

--- a/docs/DEVELOPMENT_STATUS.md
+++ b/docs/DEVELOPMENT_STATUS.md
@@ -13,28 +13,33 @@
 
 ## Current integration baseline
 
-- Integration head after PR #470: `b39c803375514ad3f31680a9c856a041ecc95ff6`.
+- Integration head after PR #471: `b30ccbd0c5a9dff878dc73a91870990b3bf01350`.
 - PR #468 added bounded recovery of the embedded desktop daemon and was validated on Zorin with a real `SIGSTOP` recovery test.
 - PR #469 added bounded Git aggregate outcome evidence: tracked files, insertions, deletions and binary files, with no raw diff/hunks/source sent to the client.
 - PR #470 fixed the universal Machines UX race: connection fields now appear only after an explicit **Add machine** action, including when Electron discovers its managed local machine asynchronously.
-- #469 and #470 both passed the complete PR gate before integration: Linux/web regressions, macOS/Windows bridge tests, Chromium product smoke and Debug APK.
+- PR #471 made cross-machine continuation safety a blocking Chromium regression: target model/capability discovery, Project identity continuity and mismatched-repository fail-closed behavior now run on every PR.
+- #469, #470 and #471 passed the complete PR gate before integration: Linux/web regressions, macOS/Windows bridge tests, Chromium product smoke and Debug APK.
 
 ## Work in progress
 
-### P2 cross-machine browser gate
+### P2 cross-machine browser execution
 
-Branch: `codex/p2-cross-machine-browser-gate`
+Branch: `codex/p2-cross-machine-browser-execution`
 
-Goal: make the existing cross-machine continuation safety smoke a permanent blocking regression instead of an unexecuted standalone script.
+Goal: extend the blocking cross-machine browser regression through the real continuation mutation path instead of stopping at planning readiness.
 
-Implemented:
+Implemented on the branch:
 
-- `cross-machine-continuation-browser-smoke.mjs` is wired into the blocking Chromium product gate;
-- the smoke exercises the existing cross-machine planning surface, target model discovery, Project identity continuity and fail-closed behavior for a mismatched repository;
-- `native-session-reliability-ci-contract.test.js` now requires that smoke to remain present in the blocking workflow;
-- no ACP adapter, Native Session writer semantics or harness runtime behavior is changed.
+- the smoke first proves mismatched Project continuity remains fail-closed and causes no target mutation;
+- an exact-workspace continuation then creates one target native Session with a durable request id;
+- the identical lineage edge must be stored on source and target machines before first-prompt delivery;
+- the first prompt must be delivered exactly once with its own durable request id and the bounded transferred Task Context;
+- the target Session must open writable in the production UI after the handoff;
+- a source-only permission sentinel is asserted absent from target creation, portable lineage and the target prompt;
+- portable controls must explicitly record source authority invalidation, target authorization re-evaluation and no attachment transfer;
+- no ACP adapter, Native Session writer semantics or harness runtime implementation is changed by this slice.
 
-Next gate: full PR CI, then merge to `codex/development-2026-09-11` only if green.
+Next gate: review the branch diff, then run full PR CI and merge to `codex/development-2026-09-11` only if every gate, including Debug APK, is green.
 
 ## P2 roadmap position
 

--- a/web/scripts/cross-machine-continuation-browser-smoke.mjs
+++ b/web/scripts/cross-machine-continuation-browser-smoke.mjs
@@ -460,7 +460,7 @@ try {
 
   const targetComposer = page.getByRole("textbox", { name: "Message Claude" })
   await targetComposer.waitFor({ state: "visible", timeout: 12_000 })
-  assert.equal(await targetComposer.isDisabled(), false, "new target Session opened without writable target authority")
+  await waitForDisabledState(targetComposer, false, "new target Session did not become writable after its live model catalog settled")
   await page.getByText("Handoff source", { exact: true }).waitFor({ state: "visible", timeout: 12_000 })
 
   assert.equal(targetCreateRequests.length, 1, "target Session creation was not exactly once")

--- a/web/scripts/cross-machine-continuation-browser-smoke.mjs
+++ b/web/scripts/cross-machine-continuation-browser-smoke.mjs
@@ -14,9 +14,13 @@ const SOURCE_PROJECT = "project-cross-source"
 const MATCH_PROJECT = "project-cross-match"
 const DIFFERENT_PROJECT = "project-cross-different"
 const SOURCE_DIRECTORY = "/work/source-repo"
+const TARGET_DIRECTORY = "/target/matching"
 const SESSION_ID = "cross-machine-source-session"
+const TARGET_SESSION_ID = "cross-machine-target-session"
 const SESSION_TITLE = "Cross-machine Source Session"
 const TRANSCRIPT_MARKER = "CROSS-MACHINE-SOURCE-TRANSCRIPT"
+const SOURCE_PERMISSION_SENTINEL = "SOURCE-ONLY-PERMISSION-MUST-NOT-CROSS"
+const FIRST_MESSAGE = "Continue the fix on the target machine"
 const REPOSITORY = "a".repeat(64)
 const HISTORY = "b".repeat(64)
 const OTHER_REPOSITORY = "c".repeat(64)
@@ -26,6 +30,7 @@ const sourceSession = {
   title: SESSION_TITLE,
   directory: SOURCE_DIRECTORY,
   external: true,
+  permission: [{ permission: "bash", pattern: SOURCE_PERMISSION_SENTINEL, action: "deny" }],
   time: { created: 1000, updated: 1001 }
 }
 
@@ -53,6 +58,12 @@ const CLAUDE_MODELS = [{
 }]
 
 const streams = new Set()
+const sourceLinks = []
+const targetLinks = []
+const targetCreateRequests = []
+const targetPromptRequests = []
+const mutationOrder = []
+let targetCreated = false
 
 function corsHeaders() {
   return {
@@ -67,6 +78,13 @@ function corsHeaders() {
 function json(response, status, value, extra = {}) {
   response.writeHead(status, { "Content-Type": "application/json", ...corsHeaders(), ...extra })
   response.end(JSON.stringify(value))
+}
+
+async function readJson(request) {
+  const chunks = []
+  for await (const chunk of request) chunks.push(chunk)
+  const raw = Buffer.concat(chunks).toString("utf8")
+  return raw ? JSON.parse(raw) : {}
 }
 
 function sse(request, response) {
@@ -95,8 +113,19 @@ function projectIdentity(repositoryFingerprint) {
   }
 }
 
+function targetSession() {
+  return {
+    id: TARGET_SESSION_ID,
+    title: SESSION_TITLE,
+    directory: TARGET_DIRECTORY,
+    external: false,
+    model: { providerID: "anthropic", id: "claude-cross-target" },
+    time: { created: 2000, updated: 2001 }
+  }
+}
+
 function startSourceDaemon() {
-  const server = http.createServer((request, response) => {
+  const server = http.createServer(async (request, response) => {
     if (request.method === "OPTIONS") {
       response.writeHead(204, corsHeaders())
       response.end()
@@ -127,6 +156,18 @@ function startSourceDaemon() {
     if (request.method === "GET" && url.pathname === "/v1/project-identity") {
       assert.equal(url.searchParams.get("projectId"), SOURCE_PROJECT)
       json(response, 200, projectIdentity(REPOSITORY))
+      return
+    }
+    if (request.method === "GET" && url.pathname === "/v1/session-links") {
+      json(response, 200, { links: sourceLinks })
+      return
+    }
+    if (request.method === "POST" && url.pathname === "/v1/session-links") {
+      const body = await readJson(request)
+      assert.ok(body.link, "source lineage registration omitted its link")
+      sourceLinks.push(body.link)
+      mutationOrder.push("source-link")
+      json(response, 200, { link: body.link })
       return
     }
     if (request.method === "GET" && url.pathname === "/v1/agents/codex/experimental/session") {
@@ -162,7 +203,7 @@ function startSourceDaemon() {
 }
 
 function startTargetDaemon() {
-  const server = http.createServer((request, response) => {
+  const server = http.createServer(async (request, response) => {
     if (request.method === "OPTIONS") {
       response.writeHead(204, corsHeaders())
       response.end()
@@ -189,7 +230,7 @@ function startTargetDaemon() {
     if (request.method === "GET" && url.pathname === "/v1/projects") {
       json(response, 200, {
         projects: [
-          { id: MATCH_PROJECT, machineId: TARGET_MACHINE, name: "Matching Project", path: "/target/matching", kind: "git", configured: true },
+          { id: MATCH_PROJECT, machineId: TARGET_MACHINE, name: "Matching Project", path: TARGET_DIRECTORY, kind: "git", configured: true },
           { id: DIFFERENT_PROJECT, machineId: TARGET_MACHINE, name: "Different Project", path: "/target/different", kind: "git", configured: true }
         ]
       })
@@ -202,12 +243,65 @@ function startTargetDaemon() {
       else json(response, 404, { error: "Unknown Project" })
       return
     }
+    if (request.method === "GET" && url.pathname === "/v1/session-links") {
+      json(response, 200, { links: targetLinks })
+      return
+    }
+    if (request.method === "POST" && url.pathname === "/v1/session-links") {
+      const body = await readJson(request)
+      assert.ok(body.link, "target lineage registration omitted its link")
+      targetLinks.push(body.link)
+      mutationOrder.push("target-link")
+      json(response, 200, { link: body.link })
+      return
+    }
+    if (request.method === "POST" && url.pathname === "/v1/session-handoff-target") {
+      const body = await readJson(request)
+      targetCreateRequests.push(body)
+      mutationOrder.push("create-target")
+      assert.equal(body.projectId, MATCH_PROJECT)
+      assert.equal(body.targetAgentID, "claude")
+      assert.deepEqual(body.source, {
+        machineID: SOURCE_MACHINE,
+        agentID: "codex",
+        sessionID: SESSION_ID,
+        directory: SOURCE_DIRECTORY
+      })
+      assert.equal(body.title, SESSION_TITLE)
+      assert.deepEqual(body.model, { providerID: "anthropic", modelID: "claude-cross-target" })
+      assert.equal(JSON.stringify(body).includes(SOURCE_PERMISSION_SENTINEL), false, "source permission crossed target-creation boundary")
+      targetCreated = true
+      json(response, 200, {
+        status: "accepted",
+        clientRequestId: body.clientRequestId,
+        result: {
+          target: {
+            machineID: TARGET_MACHINE,
+            agentID: "claude",
+            sessionID: TARGET_SESSION_ID,
+            directory: TARGET_DIRECTORY
+          }
+        }
+      })
+      return
+    }
     if (request.method === "GET" && url.pathname === "/v1/agents/claude/experimental/session") {
-      json(response, 200, [])
+      json(response, 200, targetCreated ? [targetSession()] : [])
       return
     }
     if (request.method === "GET" && url.pathname === "/v1/agents/claude/session/status") {
-      json(response, 200, {})
+      json(response, 200, targetCreated ? { [TARGET_SESSION_ID]: { type: "idle" } } : {})
+      return
+    }
+    if (request.method === "GET" && url.pathname === `/v1/agents/claude/session/${TARGET_SESSION_ID}/message`) {
+      json(response, 200, [], { "X-Has-More": "0" })
+      return
+    }
+    if (request.method === "POST" && url.pathname === `/v1/agents/claude/session/${TARGET_SESSION_ID}/prompt`) {
+      const body = await readJson(request)
+      targetPromptRequests.push(body)
+      mutationOrder.push("first-prompt")
+      json(response, 200, { status: "accepted", clientRequestId: body.clientRequestId })
       return
     }
     if (request.method === "GET" && url.pathname === "/v1/agents/claude/models") {
@@ -338,10 +432,9 @@ try {
   await page.keyboard.press("Escape")
   assert.match(await modelButton.innerText(), /Claude Target/, "target default model was not selected after catalog discovery")
 
-  const firstMessageText = "Continue the fix on the target machine"
   const firstMessage = panel.getByRole("textbox", { name: "First message on the target Session" })
-  await firstMessage.fill(firstMessageText)
-  assert.equal(await firstMessage.inputValue(), firstMessageText, "target first-message input did not retain the requested text")
+  await firstMessage.fill(FIRST_MESSAGE)
+  assert.equal(await firstMessage.inputValue(), FIRST_MESSAGE, "target first-message input did not retain the requested text")
   assert.equal(await toggle.isDisabled(), false, "source Session became non-interactive while the verified cross-machine plan was open")
   assert.equal(await sourceComposer.isDisabled(), false, "source composer became non-interactive while the verified cross-machine plan was open")
   assert.equal(await machineSelect.inputValue(), TARGET_MACHINE, "target machine selection changed while preparing the first message")
@@ -358,9 +451,65 @@ try {
   await panel.getByText("This Project does not match the source repository/history. Cross-machine continuation is blocked.", { exact: true }).waitFor({ state: "visible", timeout: 12_000 })
   await waitForDisabledState(continueButton, true, "mismatched repository did not disable cross-machine continuation")
   assert.equal(await sourceComposer.isDisabled(), false, "blocked cross-machine plan disabled the ordinary source composer")
-  assert.deepEqual(pageErrors, [], `browser errors in cross-machine planning surface: ${pageErrors.join(" | ")}`)
+  assert.equal(targetCreateRequests.length, 0, "blocked Project continuity mutated the target machine")
 
-  console.log("cross-machine continuation Project/model safety browser smoke passed")
+  await projectSelect.selectOption(MATCH_PROJECT)
+  await readySummary.waitFor({ state: "visible", timeout: 12_000 })
+  await waitForDisabledState(continueButton, false, "matching Project did not recover after a blocked selection")
+  await continueButton.click()
+
+  const targetComposer = page.getByRole("textbox", { name: "Message Claude" })
+  await targetComposer.waitFor({ state: "visible", timeout: 12_000 })
+  assert.equal(await targetComposer.isDisabled(), false, "new target Session opened without writable target authority")
+  await page.getByText("Handoff source", { exact: true }).waitFor({ state: "visible", timeout: 12_000 })
+
+  assert.equal(targetCreateRequests.length, 1, "target Session creation was not exactly once")
+  assert.equal(sourceLinks.length, 1, "source machine did not receive exactly one lineage edge")
+  assert.equal(targetLinks.length, 1, "target machine did not receive exactly one lineage edge")
+  assert.equal(targetPromptRequests.length, 1, "target first prompt was not exactly once")
+  assert.deepEqual(mutationOrder, ["create-target", "source-link", "target-link", "first-prompt"], "cross-machine mutations occurred out of safety order")
+
+  const createRequest = targetCreateRequests[0]
+  assert.ok(createRequest.clientRequestId, "target creation omitted its durable request id")
+  const sourceLink = sourceLinks[0]
+  const targetLink = targetLinks[0]
+  assert.deepEqual(targetLink, sourceLink, "source and target daemons did not receive the same lineage edge")
+  assert.deepEqual(sourceLink.source, {
+    machineID: SOURCE_MACHINE,
+    agentID: "codex",
+    sessionID: SESSION_ID,
+    directory: SOURCE_DIRECTORY
+  })
+  assert.deepEqual(sourceLink.target, {
+    machineID: TARGET_MACHINE,
+    agentID: "claude",
+    sessionID: TARGET_SESSION_ID,
+    directory: TARGET_DIRECTORY
+  })
+  assert.match(sourceLink.transferredContext || "", new RegExp(TRANSCRIPT_MARKER), "bounded handoff context omitted the source transcript")
+  assert.deepEqual(sourceLink.portableState?.controls, {
+    sourceAuthority: "invalidated",
+    targetAuthorization: "re_evaluate",
+    attachments: "not_transferred"
+  }, "portable handoff controls did not preserve the authority boundary")
+  assert.equal(sourceLink.portableState?.project?.decision, "automatic", "exact workspace continuation was not recorded as automatic")
+  assert.equal(sourceLink.portableState?.project?.reason, "exact_workspace", "exact workspace evidence was not retained")
+  assert.equal(JSON.stringify(sourceLink).includes(SOURCE_PERMISSION_SENTINEL), false, "source permission leaked into portable lineage")
+
+  const promptRequest = targetPromptRequests[0]
+  assert.ok(promptRequest.clientRequestId, "target first prompt omitted its durable request id")
+  assert.notEqual(promptRequest.clientRequestId, createRequest.clientRequestId, "target creation and first prompt reused one mutation identity")
+  assert.equal(promptRequest.directory, TARGET_DIRECTORY)
+  assert.deepEqual(promptRequest.model, { providerID: "anthropic", modelID: "claude-cross-target" })
+  assert.deepEqual(promptRequest.attachments, [], "cross-machine first prompt transferred attachments")
+  assert.match(promptRequest.text, /TRANSFERRED TASK CONTEXT/)
+  assert.match(promptRequest.text, new RegExp(TRANSCRIPT_MARKER))
+  assert.match(promptRequest.text, /USER INSTRUCTION/)
+  assert.match(promptRequest.text, new RegExp(FIRST_MESSAGE))
+  assert.equal(JSON.stringify(promptRequest).includes(SOURCE_PERMISSION_SENTINEL), false, "source permission leaked into target first prompt")
+  assert.deepEqual(pageErrors, [], `browser errors in cross-machine execution surface: ${pageErrors.join(" | ")}`)
+
+  console.log("cross-machine continuation planning, authority boundary, lineage and first-prompt browser smoke passed")
   await context.close()
 } finally {
   if (browser) await browser.close().catch(() => {})

--- a/web/src/components/cross-machine-continue-panel.tsx
+++ b/web/src/components/cross-machine-continue-panel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import { continueNativeSessionAcrossMachine } from "../cross-machine-continuation"
+import { reconcileCrossMachineProjectSelection } from "../cross-machine-project-selection"
 import {
   loadCrossMachineProjectRoute,
   requireTargetRouteProject,
@@ -99,6 +100,7 @@ export function CrossMachineContinuePanel({
   const [error, setError] = useState<string | null>(null)
   const [sending, setSending] = useState(false)
   const projectGeneration = useRef(0)
+  const projectMachineID = useRef("")
   const modelGeneration = useRef(0)
   const planGeneration = useRef(0)
 
@@ -130,8 +132,10 @@ export function CrossMachineContinuePanel({
 
   useEffect(() => {
     const generation = ++projectGeneration.current
+    const preserveProjectSelection = Boolean(open && machine && machineID && projectMachineID.current === machineID)
+    projectMachineID.current = open && machine ? machineID : ""
     setProjectRoute(null)
-    setProjectID("")
+    setProjectID((current) => preserveProjectSelection ? current : "")
     setPlan(null)
     setConfirmed(false)
     setError(null)
@@ -144,7 +148,11 @@ export function CrossMachineContinuePanel({
       .then((route) => {
         if (projectGeneration.current !== generation) return
         setProjectRoute(route)
-        if (route.targetProjects.length === 1) setProjectID(route.targetProjects[0].id)
+        setProjectID((current) => reconcileCrossMachineProjectSelection(
+          current,
+          route.targetProjects,
+          preserveProjectSelection
+        ))
       })
       .catch((reason) => {
         if (projectGeneration.current !== generation) return

--- a/web/src/cross-machine-project-selection.test.mjs
+++ b/web/src/cross-machine-project-selection.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { reconcileCrossMachineProjectSelection } from "./cross-machine-project-selection.ts"
+
+const projects = [
+  { id: "project-a", machineID: "machine-target", name: "Project A", kind: "git", configured: true },
+  { id: "project-b", machineID: "machine-target", name: "Project B", kind: "git", configured: true }
+]
+
+test("same-machine Project catalog refresh preserves an explicit valid selection", () => {
+  assert.equal(reconcileCrossMachineProjectSelection("project-b", projects, true), "project-b")
+})
+
+test("same-machine Project catalog refresh drops a selection that disappeared", () => {
+  assert.equal(reconcileCrossMachineProjectSelection("missing", projects, true), "")
+})
+
+test("machine switch never carries a machine-local Project id to the new target", () => {
+  assert.equal(reconcileCrossMachineProjectSelection("project-b", projects, false), "")
+})
+
+test("single-Project targets keep the existing automatic selection behavior", () => {
+  assert.equal(reconcileCrossMachineProjectSelection("", [projects[0]], false), "project-a")
+  assert.equal(reconcileCrossMachineProjectSelection("missing", [projects[0]], true), "project-a")
+})

--- a/web/src/cross-machine-project-selection.ts
+++ b/web/src/cross-machine-project-selection.ts
@@ -1,0 +1,19 @@
+import type { CrossMachineRouteProject } from "./cross-machine-route-projects"
+
+/**
+ * Keep an explicit target Project choice across refreshes of the same machine catalog.
+ *
+ * Machine snapshots can legitimately change while this panel is open (agent activity, live refresh,
+ * reconnect metadata). Re-reading the same target catalog must not erase the user's Project choice.
+ * A machine switch is different: Project ids are machine-local, so even an identical string must not
+ * be carried to another machine. The existing single-Project convenience remains unchanged.
+ */
+export function reconcileCrossMachineProjectSelection(
+  currentProjectID: string,
+  projects: CrossMachineRouteProject[],
+  preserveCurrent: boolean
+): string {
+  const current = currentProjectID.trim()
+  if (preserveCurrent && current && projects.some((project) => project.id === current)) return current
+  return projects.length === 1 ? projects[0].id : ""
+}


### PR DESCRIPTION
## Summary

Extends the blocking cross-machine Chromium smoke through the real continuation execution path and fixes the same-machine Project-selection refresh race it exposed.

- keeps mismatched Project continuity fail-closed and proves it causes no target mutation
- creates exactly one target native Session with the real durable handoff request path
- requires the same lineage edge on source and target machines before prompt delivery
- sends the first target prompt exactly once with its own durable request id and bounded transferred context
- opens the resulting target Session in the production UI and verifies it is writable
- verifies portable authority controls invalidate source authority, re-evaluate target authorization and transfer no attachments
- injects a source-only permission sentinel and proves it does not cross target creation, lineage or first-prompt boundaries
- preserves an explicit valid Project choice when the same target machine catalog refreshes, while never carrying a machine-local Project id across a machine switch
- adds a focused unit regression for Project-selection reconciliation
- updates README and the persistent development handoff

## Safety / scope

The only production change is UI selection reconciliation in the cross-machine planning panel. It does not change ACP adapters, Native Session writer semantics, target creation, lineage, first-prompt delivery, authority rules or harness runtime behavior.

## Validation

The first full CI run exposed the Project-selection refresh race before any target mutation. Merge only after the updated head passes the complete PR CI, including the full Chromium product suite and Debug APK.